### PR TITLE
Fixing [NSConnection registerName:] that returned NO

### DIFF
--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -85,7 +85,7 @@ static unsigned short getRandomPort();
 		connectionMuxingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:SPSSHEnableMuxingPreference];
 
 		// Set up a connection for use by the tunnel process
-		tunnelConnectionName = [[NSString alloc] initWithFormat:@"SequelAce-%lu", (unsigned long)[[NSString stringWithFormat:@"%f", [[NSDate date] timeIntervalSince1970]] hash]];
+		tunnelConnectionName = [[NSString alloc] initWithFormat:@"JKQ4HJ66PX.sequel-ace.SequelAce-%lu", (unsigned long)[[NSString stringWithFormat:@"%f", [[NSDate date] timeIntervalSince1970]] hash]];
 		tunnelConnectionVerifyHash = [[NSString alloc] initWithFormat:@"%lu", (unsigned long)[[NSString stringWithFormat:@"%f-seeded", [[NSDate date] timeIntervalSince1970]] hash]];
 		tunnelConnection = [NSConnection new];
 		


### PR DESCRIPTION
Fixes #10

The pointer on why this failed is hidden in the [App Sandbox in Depth](https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html) documentation page.  
In the `IPC and POSIX Semaphores and Shared Memory` section, there is this note:
> Mach port names must begin with the application group identifier, followed by a period (.), followed by a name of your choosing.
> For example, if your application group’s name is Z123456789.com.example.app-group, [...] You might create a Mach port named Z123456789.com.example.app-group.Port_of_Kobe.

So the fix is simply to use the app group name as the prefix of the connection name.

I think this requirement was added after this was published: [Cracking App Isolation on Apple: Unauthorized Cross-App Resource Access on MAC OS X and iOS](https://homes.luddy.indiana.edu/xw7/papers/xing2015cracking.pdf), which gives examples on how to access sandboxed apps using a fake NSConnection server listening using a hard-coded name.