### PR TITLE
Not sandboxing the SSH tunnel assistant

### DIFF
--- a/SequelAceTunnelAssistant.entitlements
+++ b/SequelAceTunnelAssistant.entitlements
@@ -3,20 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>NKQ4HJ66PX.sequel-ace</string>
-	</array>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.sequel-ace.sequel-ace</string>
-	</array>
+	<false/>
 </dict>
 </plist>

--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -364,7 +364,6 @@ static unsigned short getRandomPort();
 		
 		// Use a KnownHostsFile in the sandbox folder
 		TA(@"-o", [NSString stringWithFormat:@"UserKnownHostsFile=%@/.keys/ssh_known_hosts", NSHomeDirectory()]);
-		TA(@"-o", @"StrictHostKeyChecking=no");
 
 		// Specify an identity file if available
 		if (identityFilePath) {


### PR DESCRIPTION
Fixes password auth, host-key checks, and password prompts (for both password auth, and encrypted SSH keys)
 #20, #13