### PR TITLE
Insert Formatted SQL Inline

### DIFF
--- a/SharedSupport/Default Bundles/Format SQL.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Format SQL.spBundle/command.plist
@@ -24,7 +24,7 @@ echo json_decode($result,true)[&apos;result&apos;];</string>
 	<key>description</key>
 	<string>Send the current query or selection to https://sqlformat.org and replace the current query or selection of the first responder by the server&apos;s formatted output. If a parser error occurred alert that error and tries to jump to the error location.
 
-Version 1.0</string>
+Version 2.0</string>
 	<key>input</key>
 	<string>selectedtext</string>
 	<key>input_fallback</key>
@@ -43,7 +43,7 @@ Version 1.0</string>
 	<key>name</key>
 	<string>Format SQL</string>
 	<key>output</key>
-	<string>showashtml</string>
+	<string>replaceselection</string>
 	<key>scope</key>
 	<string>inputfield</string>
 	<key>tooltip</key>

--- a/Source/SPPreferencesUpgrade.m
+++ b/Source/SPPreferencesUpgrade.m
@@ -62,7 +62,6 @@ void SPApplyRevisionChanges(void)
 	currentVersionNumber = [[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] integerValue];
 	
 	// Get the current revision
-	if ([prefs objectForKey:@"lastUsedVersion"]) recordedVersionNumber = [[prefs objectForKey:@"lastUsedVersion"] integerValue];
 	if ([prefs objectForKey:SPLastUsedVersion]) recordedVersionNumber = [[prefs objectForKey:SPLastUsedVersion] integerValue];
 
 	// Skip processing if the current version matches or is less than recorded version
@@ -161,10 +160,6 @@ void SPApplyRevisionChanges(void)
 				[prefs removeObjectForKey:oldKey];
 			}
 		}
-		
-		// Remove outdated keys
-		[prefs removeObjectForKey:@"lastUsedVersion"];
-		[prefs removeObjectForKey:@"version"];
 	}
 	
 	// For versions prior to r567 (0.9.5), add a timestamp-based identifier to favorites and keychain entries


### PR DESCRIPTION
Fix to bundle config to insert resulting formatted SQL to replace as identified by @jamesstout 

It appeared for me, however, that the bundle was not automatically updated for the end user. We may need to investigate and fix that issue as part of this too (or the fix won't really actually go out to anyone)