### PR TITLE
Use Custom Ssh Config File

### DIFF
--- a/Resources/ssh_config
+++ b/Resources/ssh_config
@@ -1,0 +1,7 @@
+host *
+    IgnoreUnknown AddKeysToAgent,UseKeychain
+    AddKeysToAgent yes
+    UseKeychain yes
+    IdentitiesOnly yes
+    ## Specify a dummy id_rsa file so we don't try everything in the .ssh dir. TODO: Actually generate an id_rsa for each user
+    IdentityFile ~/.keys/id_rsa

--- a/Source/SPConstants.h
+++ b/Source/SPConstants.h
@@ -277,6 +277,7 @@ extern NSString *SPHTMLPrintTemplate;
 extern NSString *SPHTMLTableInfoPrintTemplate;
 extern NSString *SPHTMLHelpTemplate;
 extern NSString *SPPreferenceDefaultsFile;
+extern NSString *SPSSHConfigFile;
 
 // SPF file types
 extern NSString *SPFExportSettingsContentType;

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -69,6 +69,7 @@ NSString *SPHTMLPrintTemplate                    = @"SPPrintTemplate";
 NSString *SPHTMLTableInfoPrintTemplate           = @"SPTableInfoPrintTemplate";
 NSString *SPHTMLHelpTemplate                     = @"SPMySQLHelpTemplate";
 NSString *SPPreferenceDefaultsFile               = @"PreferenceDefaults";
+NSString *SPSSHConfigFile                        = @"ssh_config";
 
 // Folder names
 NSString *SPThemesSupportFolder                  = @"Themes";

--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -365,6 +365,9 @@ static unsigned short getRandomPort();
 		// Use a KnownHostsFile in the sandbox folder
 		TA(@"-o", [NSString stringWithFormat:@"UserKnownHostsFile=%@/.keys/ssh_known_hosts", NSHomeDirectory()]);
 		TA(@"-o", @"StrictHostKeyChecking=no");
+		
+		// Use a custom ssh config file
+		TA(@"-F", [[NSBundle mainBundle] pathForResource:SPSSHConfigFile ofType:@""]);
 
 		// Specify an identity file if available
 		if (identityFilePath) {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -1791,6 +1791,7 @@
 				58D1006813A57FAE0092E019 /* Localization Strings Files */,
 				1740F8350FC3069700CF3699 /* Templates */,
 				584756F7120A1B0B0057631F /* QuickLook Plugin */,
+				96D494B8249C07940092F335 /* SSH Helpers */,
 				17F90E2B1210B34900274C98 /* Credits.rtf */,
 				17CC993A10B4C9C80034CD7A /* License.rtf */,
 				583A278D23F06F1000FBE97B /* Colors.xcassets */,
@@ -2229,7 +2230,6 @@
 		584756F7120A1B0B0057631F /* QuickLook Plugin */ = {
 			isa = PBXGroup;
 			children = (
-				964908C4249A77CF0052FC4A /* ssh_config */,
 				BCBB3C15121158790011F962 /* SPQLPluginConnectionBundleTemplate.html */,
 				584756FA120A1B290057631F /* SPQLPluginConnectionTemplate.html */,
 				584756FC120A1B290057631F /* SPQLPluginContentFiltersTemplate.html */,
@@ -2393,6 +2393,14 @@
 				73F70A951E4E547500636550 /* SPJSONFormatter.m */,
 			);
 			name = Parsing;
+			sourceTree = "<group>";
+		};
+		96D494B8249C07940092F335 /* SSH Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				964908C4249A77CF0052FC4A /* ssh_config */,
+			);
+			name = "SSH Helpers";
 			sourceTree = "<group>";
 		};
 		B57747D60F7A8990003B34F9 /* Category Additions */ = {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		8831EFCD2240175400D10172 /* button_actionTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFCB2240175300D10172 /* button_actionTemplate.pdf */; };
 		8831EFCE2240175400D10172 /* button_paginationTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFCC2240175300D10172 /* button_paginationTemplate.pdf */; };
 		8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
+		964908C8249A77D00052FC4A /* ssh_config in Resources */ = {isa = PBXBuildFile; fileRef = 964908C4249A77CF0052FC4A /* ssh_config */; };
 		9651262224926F1200E65B53 /* QueryKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17E5955314F304000054EE08 /* QueryKit.framework */; };
 		9651262324926F1200E65B53 /* QueryKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 17E5955314F304000054EE08 /* QueryKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9651262424926F1600E65B53 /* SPMySQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 584D876815140D3500F24774 /* SPMySQL.framework */; };
@@ -1033,6 +1034,7 @@
 		8831EFCB2240175300D10172 /* button_actionTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_actionTemplate.pdf; sourceTree = "<group>"; };
 		8831EFCC2240175300D10172 /* button_paginationTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_paginationTemplate.pdf; sourceTree = "<group>"; };
 		8D15AC370486D014006FF6A4 /* Sequel Ace.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sequel Ace.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		964908C4249A77CF0052FC4A /* ssh_config */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ssh_config; sourceTree = "<group>"; };
 		965125F424926B6300E65B53 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = en.lproj/Credits.rtf; sourceTree = "<group>"; };
 		965125F524926B6300E65B53 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		965125F624926B6300E65B53 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en; path = ../en.lproj/ContentFilters.plist; sourceTree = "<group>"; };
@@ -2227,6 +2229,7 @@
 		584756F7120A1B0B0057631F /* QuickLook Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				964908C4249A77CF0052FC4A /* ssh_config */,
 				BCBB3C15121158790011F962 /* SPQLPluginConnectionBundleTemplate.html */,
 				584756FA120A1B290057631F /* SPQLPluginConnectionTemplate.html */,
 				584756FC120A1B290057631F /* SPQLPluginContentFiltersTemplate.html */,
@@ -2821,6 +2824,7 @@
 				8831EFAE2240135400D10172 /* button_duplicateTemplate.pdf in Resources */,
 				C9C994491678B3E6001F5DA8 /* table-small-square.png in Resources */,
 				C9C9944A1678B3E6001F5DA8 /* table-small-square@2x.png in Resources */,
+				964908C8249A77D00052FC4A /* ssh_config in Resources */,
 				8831EFCA224016E000D10172 /* button_edit_modeTemplate.pdf in Resources */,
 				C9C9944D1678BCFA001F5DA8 /* table-small.png in Resources */,
 				C9C9944E1678BCFA001F5DA8 /* table-small@2x.png in Resources */,


### PR DESCRIPTION
This silences sandbox errors related to ssh being unable to access sandboxed keys. By specifying "IdentitiesOnly" ssh doesn't search the .ssh directory for keys. By specifying a dummy id_rsa file it doesn't try to access the user's default RSA key.
I made the note in the code but we should probably actually generate that id_rsa key for each user so that we're sending a real file, but it seems to be fine without it. We may want to be generating the file before merging this PR.