### PR TITLE
69-FIX-SECURITY: Save Connection divulges query history without warning

### DIFF
--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -3433,7 +3433,8 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 		// Update the keys
 		[spf setObject:[[SPQueryController sharedQueryController] favoritesForFileURL:[self fileURL]] forKey:SPQueryFavorites];
-		[spf setObject:[[SPQueryController sharedQueryController] historyForFileURL:[self fileURL]] forKey:SPQueryHistory];
+		// DON'T SAVE QUERY HISTORY IN EXPORTS FOR SECURITY
+		// [spfStructure setObject:[stateDetails objectForKey:SPQueryHistory] forKey:SPQueryHistory];
 		[spf setObject:[[SPQueryController sharedQueryController] contentFilterForFileURL:[self fileURL]] forKey:SPContentFilters];
 
 		// Save it again
@@ -3504,7 +3505,8 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	// Retrieve details and add to the appropriate dictionaries
 	NSMutableDictionary *stateDetails = [NSMutableDictionary dictionaryWithDictionary:[self stateIncludingDetails:stateDetailsToSave]];
 	[spfStructure setObject:[stateDetails objectForKey:SPQueryFavorites] forKey:SPQueryFavorites];
-	[spfStructure setObject:[stateDetails objectForKey:SPQueryHistory] forKey:SPQueryHistory];
+	// DON'T SAVE QUERY HISTORY IN EXPORTS FOR SECURITY
+	// [spfStructure setObject:[stateDetails objectForKey:SPQueryHistory] forKey:SPQueryHistory];
 	[spfStructure setObject:[stateDetails objectForKey:SPContentFilters] forKey:SPContentFilters];
 	[stateDetails removeObjectsForKeys:@[SPQueryFavorites, SPQueryHistory, SPContentFilters]];
 	[spfData addEntriesFromDictionary:stateDetails];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…
Don't include query history in "Save Connection" as this can reveal personal and damaging information.

Does this close any currently open issues?
------------------------------------------
…
#69 

Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …
macOS

**macOS Version:** …
10.15.5

**Sequel-Ace Version:** …
2.1.0

