### PR TITLE
Add More Default Bundles

### DIFF
--- a/SharedSupport/Default Bundles/Copy as CSV.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Copy as CSV.spBundle/command.plist
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Liviu Tudor</string>
+	<key>category</key>
+	<string>Copy</string>
+	<key>command</key>
+	<string>cat | perl -e '
+
+# read first line to get the column names (header)
+$firstLine = &lt;&gt;;
+
+# bail if nothing could read
+if(!defined($firstLine)) {
+	exit 0;
+}
+
+# store the column names
+chomp($firstLine);
+$firstLine =~ s/\"/\\\"/g;  # escape "
+@header = split(/\t/, $firstLine);
+
+$h_cnt = $#header;     # number of columns
+
+# get the column definitions
+open(META, $ENV{"SP_BUNDLE_INPUT_TABLE_METADATA"}) or die $!;
+@meta = ();
+while(&lt;META&gt;) {
+	chomp();
+	my @arr = split(/\t/);
+	push @meta, \@arr;
+}
+close(META);
+
+for($i=0; $i&lt;=$h_cnt; $i++) {
+	print "\"$header[$i]\"";
+	if( $i&lt;$h_cnt) {
+		print ";";
+	} else {
+		print "\n";
+	}
+}
+
+# read row data of each selected row
+$rowData=&lt;&gt;;
+while($rowData) {
+
+	# remove line ending
+	chomp($rowData);
+
+	# escape "
+	$rowData=~s/\"/\\\"/g;
+
+	# split column data which are tab-delimited
+	@data = split(/\t/, $rowData);
+	for($i=0; $i&lt;=$h_cnt; $i++) {
+		# re-escape \t and \n
+		$cellData = $data[$i];
+		$cellData =~ s/↵/\n/g;
+		$cellData =~ s/⇥/\t/g;
+
+		# check for data types
+		if($cellData eq "NULL") {
+			print "NULL";
+		} else {
+			chomp($cellData);
+			print "\"$cellData\"";
+		}
+		if($i&lt;$h_cnt) {
+			print ";";
+		} else {
+			print "\n";
+		}
+	}
+
+	# get next row
+	$rowData=&lt;&gt;;
+}
+
+print "\n"; 
+' | __CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbcopy</string>
+	<key>contact</key>
+	<string>yvivh.ghqbe@tznvy.pbz</string>
+	<key>description</key>
+	<string>Copies the selected rows to clipboard as CSV separating data by semi-colon</string>
+	<key>input</key>
+	<string>selectedtablerowsastab</string>
+	<key>keyEquivalent</key>
+	<string></string>
+	<key>name</key>
+	<string>Copy as CSV</string>
+	<key>output</key>
+	<string>none</string>
+	<key>scope</key>
+	<string>datatable</string>
+	<key>tooltip</key>
+	<string>Copy as CSV</string>
+	<key>trigger</key>
+	<string>none</string>
+	<key>uuid</key>
+	<string>E24C4537-0AAB-4C17-B5F9-C5054CADA77C</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/Copy as Markdown.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Copy as Markdown.spBundle/command.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>David Buxton</string>
+	<key>category</key>
+	<string>Copy</string>
+	<key>command</key>
+	<string>#!/usr/bin/python2.7
+
+import os
+import subprocess
+import sys
+
+# Force pasteboard to treat this text as UTF-8 encoded.
+os.environ['LANG'] = 'en_US.UTF-8'
+
+rows = [line.strip().split('\t') for line in sys.stdin]
+longest = [max(len(v) for v in col) for col in zip(*rows)]
+out_rows = [' | '.join(v.ljust(l) for l, v in zip(longest, row)) + ' |' for row in rows]
+out_rows.insert(1, '|'.join('-' * (l + 2) for l in longest)[1:] + '|')
+out_value = '\n'.join(out_rows)
+
+proc = subprocess.Popen(['/usr/bin/pbcopy'], stdin=subprocess.PIPE)
+proc.communicate(input=out_value)
+</string>
+	<key>contact</key>
+	<string>qnivq@tnfznex6.pbz</string>
+	<key>description</key>
+	<string>Generates a text table in Markdown format. The text is sent to the pasteboard.</string>
+	<key>input</key>
+	<string>selectedtablerowsastab</string>
+	<key>name</key>
+	<string>Copy as Markdown</string>
+	<key>scope</key>
+	<string>datatable</string>
+	<key>uuid</key>
+	<string>0314E554-3CDB-49D2-93FC-A28231AC9BB9</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/CopyAsHTML.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyAsHTML.spBundle/command.plist
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Liviu Tudor</string>
+	<key>category</key>
+	<string>Copy</string>
+	<key>command</key>
+	<string>cat | perl -e '
+
+# read first line to get the column names (header)
+$firstLine = &lt;&gt;;
+
+# bail if nothing could read
+if(!defined($firstLine)) {
+	exit 0;
+}
+
+# store the column names
+chomp($firstLine);
+$firstLine =~ s/\"/\\\"/g;  # escape "
+@header = split(/\t/, $firstLine);
+
+$h_cnt = $#header;     # number of columns
+
+# get the column definitions
+open(META, $ENV{"SP_BUNDLE_INPUT_TABLE_METADATA"}) or die $!;
+@meta = ();
+while(&lt;META&gt;) {
+	chomp();
+	my @arr = split(/\t/);
+	push @meta, \@arr;
+}
+close(META);
+
+print "&lt;table border=\"1\" cellpadding=\"0\" cellspacing=\"0\"&gt;\n";
+print "&lt;tr&gt;";
+for($i=0; $i&lt;=$h_cnt; $i++) {
+	print "&lt;th&gt;$header[$i]&lt;/th&gt;";
+}
+print "&lt;/tr&gt;\n";
+
+# read row data of each selected row
+$rowData=&lt;&gt;;
+while($rowData) {
+
+	print "&lt;tr&gt;";
+
+	# remove line ending
+	chomp($rowData);
+
+	# escape "
+	$rowData=~s/\"/\\\"/g;
+
+	# split column data which are tab-delimited
+	@data = split(/\t/, $rowData);
+	for($i=0; $i&lt;=$h_cnt; $i++) {
+		# re-escape \t and \n
+		$cellData = $data[$i];
+		$cellData =~ s/↵/\n/g;
+		$cellData =~ s/⇥/\t/g;
+
+		print "&lt;td&gt;";
+		# check for data types
+		if($cellData eq "NULL") {
+			print "NULL";
+		} else {
+			chomp($cellData);
+			print "$cellData";
+		}
+		print "&lt;/td&gt;";
+	}
+
+	print "&lt;/tr&gt;\n";
+
+	# get next row
+	$rowData=&lt;&gt;;
+}
+
+print "&lt;/table&gt;\n"; 
+' | __CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbcopy</string>
+	<key>contact</key>
+	<string>yvivh.ghqbe@tznvy.pbz</string>
+	<key>description</key>
+	<string>Copies the selected rows to clipboard as html</string>
+	<key>input</key>
+	<string>selectedtablerowsastab</string>
+	<key>keyEquivalent</key>
+	<string></string>
+	<key>name</key>
+	<string>Copy as HTML</string>
+	<key>output</key>
+	<string>none</string>
+	<key>scope</key>
+	<string>datatable</string>
+	<key>tooltip</key>
+	<string>Copy as HTML</string>
+	<key>trigger</key>
+	<string>none</string>
+	<key>uuid</key>
+	<string>31FD6D95-CED5-4870-9A19-5A1396216C37</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/CopyAsWiki.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyAsWiki.spBundle/command.plist
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Liviu Tudor</string>
+	<key>category</key>
+	<string>Copy</string>
+	<key>command</key>
+	<string>cat | perl -e '
+
+# read first line to get the column names (header)
+$firstLine = &lt;&gt;;
+
+# bail if nothing could read
+if(!defined($firstLine)) {
+	exit 0;
+}
+
+# store the column names
+chomp($firstLine);
+$firstLine =~ s/\"/\\\"/g;  # escape "
+@header = split(/\t/, $firstLine);
+
+$h_cnt = $#header;     # number of columns
+
+# get the column definitions
+open(META, $ENV{"SP_BUNDLE_INPUT_TABLE_METADATA"}) or die $!;
+@meta = ();
+while(&lt;META&gt;) {
+	chomp();
+	my @arr = split(/\t/);
+	push @meta, \@arr;
+}
+close(META);
+
+print "||";
+for($i=0; $i&lt;=$h_cnt; $i++) {
+	print " *$header[$i]* ||";
+}
+print "\n";
+
+# read row data of each selected row
+$rowData=&lt;&gt;;
+while($rowData) {
+
+	print "||";
+
+	# remove line ending
+	chomp($rowData);
+
+	# escape "
+	$rowData=~s/\"/\\\"/g;
+
+	# split column data which are tab-delimited
+	@data = split(/\t/, $rowData);
+	for($i=0; $i&lt;=$h_cnt; $i++) {
+		# re-escape \t and \n
+		$cellData = $data[$i];
+		$cellData =~ s/↵/\n/g;
+		$cellData =~ s/⇥/\t/g;
+
+		# check for data types
+		if($cellData eq "NULL") {
+			print " _NULL_ ";
+		} else {
+			chomp($cellData);
+			print " *$cellData* ";
+		}
+		print "||";
+	}
+
+	print "\n";
+
+	# get next row
+	$rowData=&lt;&gt;;
+}
+
+print "\n"; 
+' | __CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbcopy</string>
+	<key>contact</key>
+	<string>yvivh.ghqbe@tznvy.pbz</string>
+	<key>description</key>
+	<string>Copies the selected rows to clipboard as wiki table</string>
+	<key>input</key>
+	<string>selectedtablerowsastab</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>C</string>
+		<key>keyCode</key>
+		<integer>8</integer>
+		<key>modifierFlags</key>
+		<integer>262144</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>^c</string>
+	<key>name</key>
+	<string>Copy as Wiki</string>
+	<key>output</key>
+	<string>none</string>
+	<key>scope</key>
+	<string>datatable</string>
+	<key>tooltip</key>
+	<string>Copy as Wiki</string>
+	<key>trigger</key>
+	<string>none</string>
+	<key>uuid</key>
+	<string>5B20D1B9-9C60-4D9F-B51B-5F742665557E</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/CopyIDs.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyIDs.spBundle/command.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Matt Dolan</string>
+	<key>category</key>
+	<string>Copy</string>
+	<key>command</key>
+	<string>cat | awk 'BEGIN {
+	ORS = "";
+}
+{
+	id = $1;
+	if (NR &gt; 2) {
+		print ","
+	}
+	if (NR &gt; 1) {
+		print id
+	}
+}' | __CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbcopy
+</string>
+	<key>contact</key>
+	<string>zngg@uhyynonybb.pb.hx</string>
+	<key>description</key>
+	<string>Copies the ID (assumed to be the first field) from each record, as a comma separated string.
+
+Ideal for using in a subsequent query, e.g.:
+UPDATE ... WHERE id IN (1,2,3,4)</string>
+	<key>input</key>
+	<string>selectedtablerowsastab</string>
+	<key>keyEquivalent</key>
+	<string></string>
+	<key>name</key>
+	<string>Copy IDs</string>
+	<key>output</key>
+	<string>showastexttooltip</string>
+	<key>scope</key>
+	<string>datatable</string>
+	<key>uuid</key>
+	<string>3C9F6E07-DF65-44D3-B0F2-8220E9BE009C</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/Deserialize php.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Deserialize php.spBundle/command.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Andrew Fulton</string>
+	<key>category</key>
+	<string>Format</string>
+	<key>command</key>
+	<string>#!/usr/bin/php
+
+&lt;pre&gt;
+&lt;?php
+function goFormatVarExport($string) {
+	return preg_replace(array(
+		'/=&gt;\s+array\(/im',
+		'/array\(\s+\)/im',
+	), array(
+		'=&gt; array(',
+		'array()',
+	), str_replace('array (', 'array(', $string));
+}
+
+print_r(goFormatVarExport(var_export(unserialize(fgets(STDIN)), TRUE)));
+?&gt;
+&lt;/pre&gt;</string>
+	<key>contact</key>
+	<string>ns@zbaxvv.pbz</string>
+	<key>description</key>
+	<string>Deserializes those PHP objects that drupal loves so much.</string>
+	<key>input</key>
+	<string>selectedtext</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>D</string>
+		<key>keyCode</key>
+		<integer>2</integer>
+		<key>modifierFlags</key>
+		<integer>1179648</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>$@D</string>
+	<key>name</key>
+	<string>Deserialize PHP</string>
+	<key>output</key>
+	<string>showashtml</string>
+	<key>scope</key>
+	<string>inputfield</string>
+	<key>uuid</key>
+	<string>8F858F4D-9DCC-488A-B01C-D9F7FA32FE32</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/Lorem Ipsum Paragraph.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Lorem Ipsum Paragraph.spBundle/command.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Boris Guéry</string>
+	<key>category</key>
+	<string>Lorem Ipsum</string>
+	<key>command</key>
+	<string>#!/usr/bin/ruby
+
+print "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel mi lacus. Sed vitae lacus et mauris vulputate auctor. Nulla facilisi. Phasellus ac lacus mi, cursus dapibus odio. Suspendisse sem justo, elementum ut interdum ut, auctor in velit. Donec id purus id urna vestibulum mollis. Nunc pellentesque sapien et lorem fermentum lacinia. Vivamus erat nisl, auctor mollis pretium id, dapibus et ipsum. Nunc convallis sodales massa, vitae tincidunt elit accumsan in. Duis sit amet lorem nunc, vel viverra eros. Integer scelerisque gravida quam ut venenatis. Etiam sit amet purus metus, quis rhoncus libero."</string>
+	<key>contact</key>
+	<string>threl.o@tznvy.pbz</string>
+	<key>description</key>
+	<string>Generate a Lorem Ipsum paragraph of  92 words and 611 characters, best suited for TEXT type.</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>P</string>
+		<key>keyCode</key>
+		<integer>35</integer>
+		<key>modifierFlags</key>
+		<integer>393216</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>^$P</string>
+	<key>name</key>
+	<string>Paragraph</string>
+	<key>output</key>
+	<string>insertastext</string>
+	<key>scope</key>
+	<string>inputfield</string>
+	<key>uuid</key>
+	<string>C73F7EA3-4CDC-4F3F-B9EE-FEED7E3F0B71</string>
+</dict>
+</plist>

--- a/SharedSupport/Default Bundles/Lorem Ipsum Two Words.spBundle/command.plist
+++ b/SharedSupport/Default Bundles/Lorem Ipsum Two Words.spBundle/command.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Boris Guéry</string>
+	<key>category</key>
+	<string>Lorem Ipsum</string>
+	<key>command</key>
+	<string>#!/usr/bin/ruby
+
+print "Lorem Ipsum"</string>
+	<key>contact</key>
+	<string>threl.o@tznvy.pbz</string>
+	<key>description</key>
+	<string>Insert Lorem Ipsum. Best suited for VARCHAR type.</string>
+	<key>input</key>
+	<string>none</string>
+	<key>internalKeyEquivalent</key>
+	<dict>
+		<key>characters</key>
+		<string>T</string>
+		<key>keyCode</key>
+		<integer>17</integer>
+		<key>modifierFlags</key>
+		<integer>393216</integer>
+	</dict>
+	<key>keyEquivalent</key>
+	<string>^$T</string>
+	<key>name</key>
+	<string>Two Words</string>
+	<key>output</key>
+	<string>insertastext</string>
+	<key>scope</key>
+	<string>inputfield</string>
+	<key>uuid</key>
+	<string>8F858F4D-9DCC-488A-B01C-D9F7FA32FE32</string>
+</dict>
+</plist>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Carries over several contributed bundles from Sequel Pro (https://github.com/sequelpro/Bundles) and makes them default bundles in Sequel Ace. This makes it simpler for new users who might not know they have to go out and search for bundles.

I chose not to carry forward the Base 64 Encode/Decode bundles as they caused the app to get in a "default bundles updated" alert loop. We can implement these bundles ourselves in the future if we want them!

Does this close any currently open issues?
------------------------------------------
Nope


Where has this been tested?
---------------------------
**Devices/Simulators:** …
on device

**macOS Version:** …
10.15.5

**Sequel-Ace Version:** …
2.1.0



<img width="295" alt="Screen Shot 2020-06-26 at 10 07 41" src="https://user-images.githubusercontent.com/10710367/85866388-4e4e8400-b795-11ea-96e5-55f13e2c5c62.png">
