### PR TITLE
33-Darken Yellow and Green Light Mode Favorite Colors

### DIFF
--- a/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.686",
           "alpha" : "1.000",
-          "blue" : "0.467",
-          "green" : "0.843"
+          "blue" : "0.354",
+          "green" : "0.696",
+          "red" : "0.508"
         }
-      }
+      },
+      "idiom" : "mac"
     },
     {
-      "idiom" : "mac",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,15 +22,15 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.686",
           "alpha" : "1.000",
-          "blue" : "0.467",
-          "green" : "0.843"
+          "blue" : "0.354",
+          "green" : "0.696",
+          "red" : "0.508"
         }
-      }
+      },
+      "idiom" : "mac"
     },
     {
-      "idiom" : "mac",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -45,12 +40,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.380",
           "alpha" : "1.000",
           "blue" : "0.337",
-          "green" : "0.459"
+          "green" : "0.459",
+          "red" : "0.380"
         }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.890",
           "alpha" : "1.000",
-          "blue" : "0.467",
-          "green" : "0.835"
+          "blue" : "0.385",
+          "green" : "0.689",
+          "red" : "0.734"
         }
-      }
+      },
+      "idiom" : "mac"
     },
     {
-      "idiom" : "mac",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,15 +22,15 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.890",
           "alpha" : "1.000",
-          "blue" : "0.467",
-          "green" : "0.835"
+          "blue" : "0.385",
+          "green" : "0.689",
+          "red" : "0.734"
         }
-      }
+      },
+      "idiom" : "mac"
     },
     {
-      "idiom" : "mac",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -45,12 +40,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.529",
           "alpha" : "1.000",
           "blue" : "0.314",
-          "green" : "0.459"
+          "green" : "0.459",
+          "red" : "0.529"
         }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Darkens the yellow and green favorite colors in light mode

Does this close any currently open issues?
------------------------------------------
#127 


<img width="212" alt="Screen Shot 2020-06-28 at 11 44 02" src="https://user-images.githubusercontent.com/10710367/85952067-eafb5800-b934-11ea-8af3-4302cd496574.png">
<img width="206" alt="Screen Shot 2020-06-28 at 11 44 09" src="https://user-images.githubusercontent.com/10710367/85952069-eb93ee80-b934-11ea-8334-0d6bf214fe6e.png">

Where has this been tested?
---------------------------
**Devices/Simulators:** …
MacBook Pro

**macOS Version:** …
10.15.5

**Sequel-Ace Version:** …
2.1.0


