### PR TITLE
121-Bug Deleted Bundles Not Immediately Available To Undelete

### DIFF
--- a/Interfaces/Base.lproj/BundleEditor.xib
+++ b/Interfaces/Base.lproj/BundleEditor.xib
@@ -636,9 +636,9 @@ CA
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="NAc-yU-wEX">
                             <rect key="frame" x="1" y="0.0" width="341" height="138"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="1118" id="1106">
+                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="1118" id="1106">
                                     <rect key="frame" x="0.0" y="0.0" width="341" height="121"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
@@ -646,7 +646,7 @@ CA
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn width="338" minWidth="40" maxWidth="1000" id="1108">
-                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Deleted Default Bundles">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>

--- a/Source/SPBundleEditorController.m
+++ b/Source/SPBundleEditorController.m
@@ -800,6 +800,7 @@
 
 - (IBAction)undeleteDefaultBundles:(id)sender
 {
+	[undeleteTableView reloadData];
 	[NSApp beginSheet:undeleteSheet
 	   modalForWindow:[self window] 
 		modalDelegate:self


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Causes the table view to reload before showing so that just-deleted bundles are available to undelete.
Also adds text to the previously empty header view that looked like a weird black bar.

Does this close any currently open issues?
------------------------------------------
#121



Where has this been tested?
---------------------------
**Devices/Simulators:** …
MacBook Pro 2016

**macOS Version:** …
10.15.5

**Sequel-Ace Version:** …
2.1.0

