### PR TITLE
119-Don't Hard Set Bundle Update

### DIFF
--- a/Source/SPAppController.m
+++ b/Source/SPAppController.m
@@ -1620,7 +1620,6 @@
 
 	NSMutableString *infoAboutUpdatedDefaultBundles = [NSMutableString string];
 	BOOL doBundleUpdate = ([[NSUserDefaults standardUserDefaults] objectForKey:@"doBundleUpdate"]) ? YES : NO;
-	doBundleUpdate = YES;
 
 	for(NSString* bundlePath in bundlePaths) {
 		if([bundlePath length]) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
I think part of the problem with the bundles was we were hard setting a full bundle update every time the bundles were reloaded. This hard set should only happen when the build number is incremented (and looks like it should). Removing this hard check seems to make bundles not appear duplicated for me - probably because they appear duplicated the first time but the bundles are reloaded a second time at startup behind the scenes and un-duplicated. Not sure that we want to call this the full #119 fix, but I feel it's probably at least part of it.

Does this close any currently open issues?
------------------------------------------
#119 (maybe)


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …
MacBook Pro 2016

**macOS Version:** …
10.15.5

**Sequel-Ace Version:** …
2.2.2

