### PR TITLE
Allow SSH-Tunneled connections using MySQL Host = localhost

### DIFF
--- a/Source/SPConnectionController.m
+++ b/Source/SPConnectionController.m
@@ -1617,7 +1617,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
  */
 - (BOOL)_checkHost
 {
-	if ([self type] != SPSocketConnection && [[self host] isEqualToString:@"localhost"]) {
+	if ([self type] != SPSSHTunnelConnection && [self type] != SPSocketConnection && [[self host] isEqualToString:@"localhost"]) {
 		SPBeginAlertSheet(
 			NSLocalizedString(@"You have entered 'localhost' for a non-socket connection", @"title of error when using 'localhost' for a network connection"),
 			NSLocalizedString(@"Use 127.0.0.1", @"Use 127.0.0.1 button"), // Main button


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Simply skip the MySQL Host = `localhost` check, when connecting using a SSH Tunnel. That should be allowed.
Connecting using `127.0.0.1` connects to the same server, but if MySQL has `skip-name-resolve = 1`, it will NOT resolve that connection as coming from `localhost`, and since the default GRANTs are for `localhost`, the connection will be denied. Connecting to `localhost` instead resolves this problem, but before this PR, `localhost` was not allowed, for SSH-Tunneled connections.

Does this close any currently open issues?
------------------------------------------
Fixes #109