### PR TITLE
Auth default native password 141 final

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -611,6 +611,9 @@ asm(".desc ___crashreporter_info__, 0x10");
 	// Set the connection encoding
 	NSStringEncoding connectEncodingNS = [SPMySQLConnection stringEncodingForMySQLCharset:[encodingName UTF8String]];
 	mysql_options(theConnection, MYSQL_SET_CHARSET_NAME, [encodingName UTF8String]);
+    
+    // Some servers have issues when we try caching_sha2_password first; let's always try mysql_native_password first; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/141
+    mysql_options(theConnection, MYSQL_DEFAULT_AUTH, [@"mysql_native_password" UTF8String]);
 
 	// Set up the connection variables in the format MySQL needs, from the class-wide variables
 	const char *theHost = NULL;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Sets MYSQL_DEFAULT_AUTH=mysql_native_password, using mysql_options()
That should change only the default (first) auth plugin used. If server doesn't support that (some MySQL 8 can only support caching_sha2_password, for example), it should try the other plugins next.

Does this close any currently open issues?
------------------------------------------
Fixes #141

Any other comments?
-------------------
Previous fix was just broken. Not sure how I tested!!
@Jason-Morcos if a build with this works for you, please create a beta 3 for #141.