### PR TITLE
Correct ssh tunnel established check

### DIFF
--- a/Source/SPFilePreferencePane.m
+++ b/Source/SPFilePreferencePane.m
@@ -273,16 +273,6 @@
 					}
 				}
 			}
-			
-			// set the config path to the first selected file
-			if (idxURL == 0) {
-				// save the preferences
-				if (![[url path] length]) {
-					[prefs removeObjectForKey:SPSSHConfigFile];
-				} else {
-					[prefs setObject:[url path] forKey:SPSSHConfigFile];
-				}
-			}
 		}];
 		
 		[self loadBookmarks];

--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -568,8 +568,9 @@ static unsigned short getRandomPort();
 			[debugMessages addObject:[NSString stringWithString:message]];
 			[debugMessagesLock unlock];
 
-			if ([message rangeOfString:@"Local forwarding listening on"].location != NSNotFound
-				|| [message rangeOfString:@"mux_client_request_session: master session id: "].location != NSNotFound)
+			if (connectionState != SPMySQLProxyConnected &&
+				([message rangeOfString:@"Local forwarding listening on"].location != NSNotFound
+				|| [message rangeOfString:@"mux_client_request_session: master session id: "].location != NSNotFound))
 			{
 				connectionState = SPMySQLProxyConnected;
 				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];

--- a/Source/SPSSHTunnel.m
+++ b/Source/SPSSHTunnel.m
@@ -568,7 +568,7 @@ static unsigned short getRandomPort();
 			[debugMessages addObject:[NSString stringWithString:message]];
 			[debugMessagesLock unlock];
 
-			if ([message rangeOfString:@"Entering interactive session."].location != NSNotFound
+			if ([message rangeOfString:@"Local forwarding listening on"].location != NSNotFound
 				|| [message rangeOfString:@"mux_client_request_session: master session id: "].location != NSNotFound)
 			{
 				connectionState = SPMySQLProxyConnected;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request fixes some connection issues, when connecting through multiple ssh jump proxies. When one of the intermediate jump proxies enters an interactive session, the connection is closed, as the connection state is already set to established, even it is not fully established. Sequel Ace will the fail to connect to the mysql server and abort the ssh connection.

Another bug in the file preference tab was fixed. When adding a new file, it overrode the currently set ssh config file. This is not happening now, anymore.

Does this close any currently open issues?
------------------------------------------
This pr addresses and resolves issue https://github.com/Sequel-Ace/Sequel-Ace/issues/166


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** MacBook Pro 2019 "13

**macOS Version:** macOS 10.15.5

**Sequel-Ace Version:** 2.1.1 rc 2

**Update** I was too slow with the versioning.
