### PR TITLE
Data incorrectly display when table and column charsets differ, and are incompatible

### DIFF
--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -6942,11 +6942,11 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 			// tableEncoding == nil indicates that there was an error while retrieving table data
 			tableEncoding = [tableDataInstance tableEncoding];
 
-			// If encoding is set to Autodetect, update the connection character set encoding
-			// based on the newly selected table's encoding - but only if it differs from the current encoding.
+			// If encoding is set to Autodetect, update the connection character set encoding to utf8mb4
+			// This allows us to receive data encoded in various charsets as UTF-8 characters.
 			if ([[[NSUserDefaults standardUserDefaults] objectForKey:SPDefaultEncoding] intValue] == SPEncodingAutodetect) {
-				if (tableEncoding != nil && ![tableEncoding isEqualToString:previousEncoding]) {
-					[self setConnectionEncoding:tableEncoding reloadingViews:NO];
+				if (![@"utf8mb4" isEqualToString:previousEncoding]) {
+					[self setConnectionEncoding:@"utf8mb4" reloadingViews:NO];
 					changeEncoding = NO;
 				}
 			}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Bugfix: When user selects "Default encoding: Autodetect", whatever charset is used for the table, always load data using utf8mb4. This allows data encoded in different charsets to be converted to UTF-8 for displaying.

Does this close any currently open issues?
------------------------------------------
Fixes #130

Where has this been tested?
---------------------------
See https://github.com/Sequel-Ace/Sequel-Ace/issues/130#issuecomment-653886432 for my test case
