### PR TITLE
Create NSAlert extension for default alerts, add Swift files support

### DIFF
--- a/Source/NSAlertExtension.swift
+++ b/Source/NSAlertExtension.swift
@@ -1,0 +1,36 @@
+//
+//  NSAlertExtension.swift
+//  Sequel Ace
+//
+//  Created by Jakub Kaspar on 05.07.2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objc extension NSAlert {
+	/// Creates an alert with primary colored button (also accepts "Enter" key) and cancel button (also accepts escape key), main title and informative subtitle message.
+	/// - Parameters:
+	///   - title: String for title of the alert
+	///   - message: String for informative message
+	///   - primaryButtonTitle: String for main confirm button
+	///   - primaryButtonHandler: Optional block that's invoked when user hits primary button or Enter
+	///   - cancelButtonHandler: Optional block that's invoked when user hits cancel button or Escape
+	/// - Returns: Nothing
+	static func createDefaultAlert(title: String,
+								   message: String,
+								   primaryButtonTitle: String,
+								   primaryButtonHandler: (() -> ())? = nil,
+								   cancelButtonHandler: (() -> ())? = nil) {
+		let alert = NSAlert()
+		alert.messageText = title
+		alert.informativeText = message
+		alert.addButton(withTitle: primaryButtonTitle)
+		alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "cancel button"))
+		if alert.runModal() == .alertFirstButtonReturn {
+			primaryButtonHandler?()
+		} else {
+			cancelButtonHandler?()
+		}
+	}
+}

--- a/Source/NSAlertExtension.swift
+++ b/Source/NSAlertExtension.swift
@@ -34,4 +34,21 @@ import AppKit
 			cancelButtonHandler?()
 		}
 	}
+
+	/// Creates an alert with primary colored OK button that triggers callback
+	/// - Parameters:
+	///   - title: String for title of the alert
+	///   - message: tring for informative message
+	///   - callback: Optional block that's invoked when user hits OK button
+	static func createWarningAlert(title: String,
+								   message: String,
+								   callback: (() -> ())? = nil) {
+		let alert = NSAlert()
+		alert.alertStyle = .critical
+		alert.messageText = title
+		alert.informativeText = message
+		alert.addButton(withTitle: NSLocalizedString("OK", comment: "OK button"))
+		alert.runModal()
+		callback?()
+	}
 }

--- a/Source/NSAlertExtension.swift
+++ b/Source/NSAlertExtension.swift
@@ -25,6 +25,7 @@ import AppKit
 		let alert = NSAlert()
 		alert.messageText = title
 		alert.informativeText = message
+		// Order of buttons matters! first button has "firstButtonReturn" return value from runModal()
 		alert.addButton(withTitle: primaryButtonTitle)
 		alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "cancel button"))
 		if alert.runModal() == .alertFirstButtonReturn {

--- a/Source/SPAboutController.m
+++ b/Source/SPAboutController.m
@@ -82,9 +82,8 @@ static NSString *SPShortVersionHashKey = @"SPVersionShortHash";
 /**
  * Display the license sheet.
  */
-- (IBAction)openApplicationLicenseSheet:(id)sender
-{
-	[NSApp beginSheet:appLicensePanel modalForWindow:[self window] modalDelegate:self didEndSelector:nil contextInfo:nil];
+- (IBAction)openApplicationLicenseSheet:(id)sender {
+	[self.window beginSheet:appLicensePanel completionHandler:nil];
 }
 
 /**

--- a/Source/SPUserManager.m
+++ b/Source/SPUserManager.m
@@ -511,25 +511,12 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 {
 	//copy block from stack to heap, otherwise it wouldn't live long enough to be invoked later.
 	void *heapCallback = callback? Block_copy(callback) : NULL;
-	
-	[NSApp beginSheet:[self window]
-	   modalForWindow:docWindow
-		modalDelegate:self
-	   didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:)
-		  contextInfo:heapCallback];
-}
 
-- (void)sheetDidEnd:(NSWindow *)sheet returnCode:(int)returnCode contextInfo:(void*)context
-{
-	//[NSApp endSheet...] does not close the window
-	[[self window] orderOut:self];
-	//notify delegate
-	if(context) {
-		void (^callback)(void) = context;
+	[docWindow beginSheet:self.window completionHandler:^(NSModalResponse returnCode) {
 		//directly invoking callback would risk that we are dealloc'd while still in this run loop iteration.
-		dispatch_async(dispatch_get_main_queue(), callback);
-		Block_release(callback);
-	}
+		dispatch_async(dispatch_get_main_queue(), heapCallback);
+		Block_release(heapCallback);
+	}];
 }
 
 #pragma mark -

--- a/Source/SPUserManager.m
+++ b/Source/SPUserManager.m
@@ -569,12 +569,8 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 	// Display any errors
 	if ([errorsString length]) {
 		[errorsTextView setString:errorsString];
-		
-		[NSApp beginSheet:errorsSheet 
-		   modalForWindow:[NSApp keyWindow] 
-			modalDelegate:nil 
-		   didEndSelector:NULL 
-			  contextInfo:nil];
+
+		[self.window beginSheet:errorsSheet completionHandler:nil];
 		
 		SPClear(errorsString);
 		

--- a/Source/SPUserManager.m
+++ b/Source/SPUserManager.m
@@ -41,6 +41,8 @@
 #import <SPMySQL/SPMySQL.h>
 #import <QueryKit/QueryKit.h>
 
+#import "Sequel_Ace-Swift.h"
+
 static NSString * const SPTableViewNameColumnID = @"NameColumn";
 
 static NSString *SPGeneralTabIdentifier = @"General";
@@ -1628,8 +1630,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 #pragma mark -
 #pragma mark Tab View Delegate methods
 
-- (BOOL)tabView:(NSTabView *)tabView shouldSelectTabViewItem:(NSTabViewItem *)tabViewItem
-{
+- (BOOL)tabView:(NSTabView *)tabView shouldSelectTabViewItem:(NSTabViewItem *)tabViewItem {
 	BOOL retVal = YES;
 
 	if ([[treeController selectedObjects] count] == 0) return NO;
@@ -1641,8 +1642,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 	// Currently selected object in tree
 	id selectedObject = [[treeController selectedObjects] objectAtIndex:0];
 
-	// If we are selecting a tab view that requires there be a child,
-	// make sure there is a child to select.  If not, don't allow it.
+	// If we are selecting a tab view that requires there be a child, make sure there is a child to select.  If not, don't allow it.
 	if ([[tabViewItem identifier] isEqualToString:SPGlobalPrivilegesTabIdentifier] ||
 		[[tabViewItem identifier] isEqualToString:SPResourcesTabIdentifier] ||
 		[[tabViewItem identifier] isEqualToString:SPSchemaPrivilegesTabIdentifier]) {
@@ -1652,15 +1652,10 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 		retVal = parent ? ([[parent children] count] > 0) : ([[selectedObject children] count] > 0);
 
 		if (!retVal) {
-			NSAlert *alert = [NSAlert alertWithMessageText:NSLocalizedString(@"User has no hosts", @"user has no hosts message")
-											 defaultButton:NSLocalizedString(@"Add Host", @"Add Host")
-										   alternateButton:NSLocalizedString(@"Cancel", @"cancel button")
-											   otherButton:nil
-								 informativeTextWithFormat:NSLocalizedString(@"This user doesn't have any hosts associated with it. It will be deleted unless one is added", @"user has no hosts informative message")];
 
-			if ([alert runModal] == NSAlertDefaultReturn) {
+			[NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"User has no hosts", @"user has no hosts message") message:NSLocalizedString(@"This user doesn't have any hosts associated with it. It will be deleted unless one is added", @"user has no hosts informative message") primaryButtonTitle:NSLocalizedString(@"Add Host", @"Add Host") primaryButtonHandler:^{
 				[self addHost:nil];
-			}
+			} cancelButtonHandler:nil];
 		}
 
 		// If this is the resources tab, enable or disable the controls based on the server's support for them

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -1,4 +1,29 @@
 //
+//  Sequel-Ace-Bridging-Header.h
+//  Sequel Ace
+//
+//  Created by Jakub Kaspar on 05.07.2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */; };
 		50EAB5B81A8FBB08008F627A /* SPOSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EAB5B71A8FBB08008F627A /* SPOSInfo.m */; };
 		50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 50F530511ABCF66B002F2C1A /* resetTemplate.pdf */; };
+		51F4AFBF24B26665006144D5 /* NSAlertExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */; };
 		5806B76411A991EC00813A88 /* SPDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5806B76311A991EC00813A88 /* SPDocumentController.m */; };
 		580E8DB711EA774B000D8427 /* SequelProTabClose_Pressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 580E8DAB11EA772C000D8427 /* SequelProTabClose_Pressed.png */; };
 		580E8DB811EA774B000D8427 /* SequelProTabClose_Rollover.png in Resources */ = {isa = PBXBuildFile; fileRef = 580E8DAC11EA772C000D8427 /* SequelProTabClose_Rollover.png */; };
@@ -873,6 +874,8 @@
 		50EAB5B61A8FBB08008F627A /* SPOSInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPOSInfo.h; sourceTree = "<group>"; };
 		50EAB5B71A8FBB08008F627A /* SPOSInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPOSInfo.m; sourceTree = "<group>"; };
 		50F530511ABCF66B002F2C1A /* resetTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = resetTemplate.pdf; sourceTree = "<group>"; };
+		51F4AFBD24B26665006144D5 /* Sequel-Ace-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sequel-Ace-Bridging-Header.h"; sourceTree = "<group>"; };
+		51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
 		5806B76211A991EC00813A88 /* SPDocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDocumentController.h; sourceTree = "<group>"; };
 		5806B76311A991EC00813A88 /* SPDocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDocumentController.m; sourceTree = "<group>"; };
 		580E8DAB11EA772C000D8427 /* SequelProTabClose_Pressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SequelProTabClose_Pressed.png; sourceTree = "<group>"; };
@@ -1830,6 +1833,7 @@
 			isa = PBXGroup;
 			children = (
 				17E641440EF01EB5001BC333 /* main.m */,
+				51F4AFBD24B26665006144D5 /* Sequel-Ace-Bridging-Header.h */,
 				17E641450EF01EB5001BC333 /* Sequel-Pro.pch */,
 				17E641470EF01EB8001BC333 /* Controllers */,
 				17E6415D0EF01EF9001BC333 /* Model */,
@@ -1929,6 +1933,7 @@
 		17E6416E0EF01F3B001BC333 /* Other */ = {
 			isa = PBXGroup;
 			children = (
+				51F4AFB924B26646006144D5 /* Extensions */,
 				507FF10E1BBCC4A900104523 /* Utility */,
 				1198F5B01174EDA700670590 /* Database Actions */,
 				583CE39511722B70008F148E /* File Compression */,
@@ -2292,6 +2297,14 @@
 				1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */,
 			);
 			name = Other;
+			sourceTree = "<group>";
+		};
+		51F4AFB924B26646006144D5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		583CE39511722B70008F148E /* File Compression */ = {
@@ -2699,6 +2712,7 @@
 				TargetAttributes = {
 					8D15AC270486D014006FF6A4 = {
 						DevelopmentTeam = NKQ4HJ66PX;
+						LastSwiftMigration = 1200;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -3182,6 +3196,7 @@
 				58A8A79111A036C000B95749 /* SPWindowController.m in Sources */,
 				5806B76411A991EC00813A88 /* SPDocumentController.m in Sources */,
 				173C837211AAD26E00B8B084 /* SPExportUtilities.m in Sources */,
+				51F4AFBF24B26665006144D5 /* NSAlertExtension.swift in Sources */,
 				173C837911AAD2AE00B8B084 /* SPDotExporter.m in Sources */,
 				173C837A11AAD2AE00B8B084 /* SPHTMLExporter.m in Sources */,
 				173C837B11AAD2AE00B8B084 /* SPPDFExporter.m in Sources */,
@@ -3640,6 +3655,7 @@
 		380F4EDB0FC0B50600B0BFD7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3675,6 +3691,7 @@
 		380F4EDC0FC0B50600B0BFD7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3707,6 +3724,7 @@
 		380F4EDD0FC0B50600B0BFD7 /* Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3869,6 +3887,7 @@
 		588593F10F7AEB6900ED0E67 /* Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "Sequel Ace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -3901,6 +3920,8 @@
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4160,6 +4181,7 @@
 		C05733C808A9546B00998B17 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "Sequel Ace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -4192,6 +4214,9 @@
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4200,6 +4225,7 @@
 		C05733C908A9546B00998B17 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "Sequel Ace.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -4233,6 +4259,8 @@
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SEPARATE_STRIP = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
- Replace user modal with new non-deprecated method (when opening Users modal)
- Replace user modal tapping "Apply" showing warning error with new non-deprecated method
- Create Bridging header and add support for swift files in project
- Create NSAlertExtension and implement new static method for default alert (via image below) with completion blocks to reduce number of errors
- Replace first warning with new static method
- Implement new static method for Warning alert with OK button, title and info message with optional callback block once OK is tapped

![Screen Shot 2020-07-05 at 22 22 13](https://user-images.githubusercontent.com/7204168/86541588-68633180-bf0e-11ea-8aa0-4ccf47972768.png)
