### PR TITLE
Optimise/tidy

### DIFF
--- a/Source/SPAppController.m
+++ b/Source/SPAppController.m
@@ -64,14 +64,14 @@
 - (void)openColorThemeFileAtPath:(NSString *)filePath;
 - (void)openUserBundleAtPath:(NSString *)filePath;
 
-@property (readwrite, retain) NSFileManager *fm;
+@property (readwrite, retain) NSFileManager *fileManager;
 
 @end
 
 @implementation SPAppController
 
 @synthesize lastBundleBlobFilesDirectory;
-@synthesize fm;
+@synthesize fileManager;
 
 #pragma mark -
 #pragma mark Initialisation
@@ -96,11 +96,11 @@
 		installedBundleUUIDs = [[NSMutableDictionary alloc] initWithCapacity:1];
 		runningActivitiesArray = [[NSMutableArray alloc] init];
 
-		fm = [NSFileManager defaultManager];
+		fileManager = [NSFileManager defaultManager];
 		
 		//Create runtime directiories
-		[fm createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"tmp"] withIntermediateDirectories:true attributes:nil error:nil];
-		[fm createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@".keys"] withIntermediateDirectories:true attributes:nil error:nil];
+		[fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"tmp"] withIntermediateDirectories:true attributes:nil error:nil];
+		[fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@".keys"] withIntermediateDirectories:true attributes:nil error:nil];
 
 		[NSApp setDelegate:self];
 	}
@@ -361,7 +361,7 @@
 - (void)openSQLFileAtPath:(NSString *)filePath
 {
 	// Check size and NSFileType
-	NSDictionary *attr = [fm attributesOfItemAtPath:filePath error:nil];
+	NSDictionary *attr = [fileManager attributesOfItemAtPath:filePath error:nil];
 
 	SPDatabaseDocument *frontDocument = [self frontDocument];
 
@@ -415,7 +415,7 @@
 		// Otherwise, attempt to autodetect the encoding
 	}
 	else {
-		sqlEncoding = [fm detectEncodingforFileAtPath:filePath];
+		sqlEncoding = [fileManager detectEncodingforFileAtPath:filePath];
 	}
 
 	NSError *error = nil;
@@ -479,8 +479,6 @@
 	}
 
 	if([spfs objectForKey:@"windows"] && [[spfs objectForKey:@"windows"] isKindOfClass:[NSArray class]]) {
-
-		NSFileManager *fileManager = fm;
 
 		// Retrieve Save Panel accessory view data for remembering them globally
 		NSMutableDictionary *spfsDocData = [NSMutableDictionary dictionary];
@@ -586,12 +584,12 @@
 
 - (void)openColorThemeFileAtPath:(NSString *)filePath
 {
-	NSString *themePath = [fm applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil];
+	NSString *themePath = [fileManager applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil];
 
 	if (!themePath) return;
 
-	if (![fm fileExistsAtPath:themePath isDirectory:nil]) {
-		if (![fm createDirectoryAtPath:themePath withIntermediateDirectories:YES attributes:nil error:nil]) {
+	if (![fileManager fileExistsAtPath:themePath isDirectory:nil]) {
+		if (![fileManager createDirectoryAtPath:themePath withIntermediateDirectories:YES attributes:nil error:nil]) {
 			NSBeep();
 			return;
 		}
@@ -599,8 +597,8 @@
 
 	NSString *newPath = [NSString stringWithFormat:@"%@/%@", themePath, [filePath lastPathComponent]];
 
-	if (![fm fileExistsAtPath:newPath isDirectory:nil]) {
-		if (![fm moveItemAtPath:filePath toPath:newPath error:nil]) {
+	if (![fileManager fileExistsAtPath:newPath isDirectory:nil]) {
+		if (![fileManager moveItemAtPath:filePath toPath:newPath error:nil]) {
 			NSBeep();
 			return;
 		}
@@ -614,12 +612,12 @@
 - (void)openUserBundleAtPath:(NSString *)filePath
 {
 
-	NSString *bundlePath = [fm applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder error:nil];
+	NSString *bundlePath = [fileManager applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder error:nil];
 
 	if (!bundlePath) return;
 
-	if (![fm fileExistsAtPath:bundlePath isDirectory:nil]) {
-		if (![fm createDirectoryAtPath:bundlePath withIntermediateDirectories:YES attributes:nil error:nil]) {
+	if (![fileManager fileExistsAtPath:bundlePath isDirectory:nil]) {
+		if (![fileManager createDirectoryAtPath:bundlePath withIntermediateDirectories:YES attributes:nil error:nil]) {
 			NSBeep();
 			NSLog(@"Couldn't create folder “%@”", bundlePath);
 			return;
@@ -668,7 +666,7 @@
 						  primaryButtonTitle:NSLocalizedString(@"Update", @"Open Files : Bundle : Already-Installed : Update button") primaryButtonHandler:^{
 			NSError *error = nil;
 			NSString *removePath = [[[installedBundleUUIDs objectForKey:[cmdData objectForKey:SPBundleFileUUIDKey]] objectForKey:@"path"] substringToIndex:([(NSString *)[[installedBundleUUIDs objectForKey:[cmdData objectForKey:SPBundleFileUUIDKey]] objectForKey:@"path"] length]-[SPBundleFileName length]-1)];
-			[fm removeItemAtPath:removePath error:&error];
+			[fileManager removeItemAtPath:removePath error:&error];
 
 			if (error != nil) {
 				[NSAlert createWarningAlertWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Error while moving “%@” to Trash.", @"Open Files : Bundle : Already-Installed : Delete-Old-Error : Could not delete old bundle before installing new version."), removePath] message:[error localizedDescription] callback:nil];
@@ -683,8 +681,8 @@
 
 	if (cmdData) [cmdData release];
 
-	if (![fm fileExistsAtPath:newPath isDirectory:nil]) {
-		if (![fm moveItemAtPath:filePath toPath:newPath error:nil]) {
+	if (![fileManager fileExistsAtPath:newPath isDirectory:nil]) {
+		if (![fileManager moveItemAtPath:filePath toPath:newPath error:nil]) {
 			NSBeep();
 			NSLog(@"Couldn't move “%@” to “%@”", filePath, newPath);
 			return;
@@ -807,8 +805,8 @@
 	if([command isEqualToString:@"chooseItemFromList"]) {
 		NSString *statusFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], (passedProcessID && [passedProcessID length]) ? passedProcessID : @""];
 		NSString *resultFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultPathHeader stringByExpandingTildeInPath], (passedProcessID && [passedProcessID length]) ? passedProcessID : @""];
-		[fm removeItemAtPath:statusFileName error:nil];
-		[fm removeItemAtPath:resultFileName error:nil];
+		[fileManager removeItemAtPath:statusFileName error:nil];
+		[fileManager removeItemAtPath:resultFileName error:nil];
 		NSString *result = @"";
 		NSString *status = @"0";
 		if([parameter count]) {
@@ -840,7 +838,7 @@
 		NSString *result = @"";
 		NSString *status = @"0";
 
-		if([fm fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
+		if([fileManager fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
 
 			if(inError == nil && query && [query length]) {
 				if([parameter count] > 0) {
@@ -852,10 +850,10 @@
 			}
 		}
 
-		[fm removeItemAtPath:queryFileName error:nil];
-		[fm removeItemAtPath:resultFileName error:nil];
-		[fm removeItemAtPath:metaFileName error:nil];
-		[fm removeItemAtPath:statusFileName error:nil];
+		[fileManager removeItemAtPath:queryFileName error:nil];
+		[fileManager removeItemAtPath:resultFileName error:nil];
+		[fileManager removeItemAtPath:metaFileName error:nil];
+		[fileManager removeItemAtPath:statusFileName error:nil];
 
 		if(![result writeToFile:resultFileName atomically:YES encoding:NSUTF8StringEncoding error:nil])
 			status = @"1";
@@ -958,10 +956,10 @@
 		);
 
 		usleep(5000);
-		[fm removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
-		[fm removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
-		[fm removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultMetaPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
-		[fm removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryInputPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
+		[fileManager removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
+		[fileManager removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
+		[fileManager removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultMetaPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
+		[fileManager removeItemAtPath:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryInputPathHeader stringByExpandingTildeInPath], passedProcessID] error:nil];
 
 
 
@@ -1104,7 +1102,7 @@
 		NSString *uuid = [NSString stringWithNewUUID];
 		NSString *bundleInputFilePath = [NSString stringWithFormat:@"%@_%@", [SPBundleTaskInputFilePath stringByExpandingTildeInPath], uuid];
 
-		[fm removeItemAtPath:bundleInputFilePath error:nil];
+		[fileManager removeItemAtPath:bundleInputFilePath error:nil];
 
 		NSMutableDictionary *env = [NSMutableDictionary dictionary];
 		[env setObject:[infoPath stringByDeletingLastPathComponent] forKey:SPBundleShellVariableBundlePath];
@@ -1142,7 +1140,7 @@
 																  uuid, SPBundleFileInternalexecutionUUID, nil]
 														   error:&err];
 
-		[fm removeItemAtPath:bundleInputFilePath error:nil];
+		[fileManager removeItemAtPath:bundleInputFilePath error:nil];
 
 		NSString *action = SPBundleOutputActionNone;
 		if([cmdData objectForKey:SPBundleFileOutputActionKey] && [(NSString *)[cmdData objectForKey:SPBundleFileOutputActionKey] length])
@@ -1550,7 +1548,7 @@
 	// First process all in Application Support folder installed ones then Default ones
 	NSError *appPathError = nil;
 	NSArray *bundlePaths = [NSArray arrayWithObjects:
-		[fm applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:YES error:&appPathError],
+		[fileManager applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:YES error:&appPathError],
 		[NSString stringWithFormat:@"%@/Contents/SharedSupport/Default Bundles", [[NSBundle mainBundle] bundlePath]],
 		nil];
 
@@ -1578,7 +1576,7 @@
 			SPLog(@"processing path: %@",bundlePath );
 
 			NSError *error = nil;
-			NSArray *foundBundles = [fm contentsOfDirectoryAtPath:bundlePath error:&error];
+			NSArray *foundBundles = [fileManager contentsOfDirectoryAtPath:bundlePath error:&error];
 			if (foundBundles && [foundBundles count] && error == nil) {
 
 				for(NSString* bundle in foundBundles) {
@@ -1667,7 +1665,7 @@
 
 											// Duplicate Bundle, change the UUID and rename the menu label
 											NSString *duplicatedBundle = [NSString stringWithFormat:@"%@/%@_%ld.%@", [bundlePaths objectAtIndex:0], [bundle substringToIndex:([bundle length] - [SPUserBundleFileExtension length] - 1)], (long)(random() % 35000), SPUserBundleFileExtension];
-											if(![fm copyItemAtPath:oldBundle toPath:duplicatedBundle error:nil]) {
+											if(![fileManager copyItemAtPath:oldBundle toPath:duplicatedBundle error:nil]) {
 												NSLog(@"Couldn't copy “%@” to update it", bundle);
 												NSBeep();
 												continue;
@@ -1703,7 +1701,7 @@
 											[dupData writeToFile:duplicatedBundleCommand atomically:YES];
 
 											error = nil;
-											[fm removeItemAtPath:oldBundle error:&error];
+											[fileManager removeItemAtPath:oldBundle error:&error];
 
 											if(error != nil) {
 												[NSAlert createWarningAlertWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Error while moving “%@” to Trash.", @"error while moving “%@” to trash"), [[installedBundleUUIDs objectForKey:[cmdDataOld objectForKey:SPBundleFileUUIDKey]] objectForKey:@"path"]] message:[error localizedDescription] callback:nil];
@@ -1713,7 +1711,7 @@
 										} else {
 											SPLog(@"default bundle not modified, delete and ....");
 											// If no modifications are done simply remove the old one
-											if(![fm removeItemAtPath:oldBundle error:nil]) {
+											if(![fileManager removeItemAtPath:oldBundle error:nil]) {
 												NSLog(@"Couldn't remove “%@” to update it", bundle);
 												NSBeep();
 												continue;
@@ -1728,10 +1726,10 @@
 									NSString *newInfoPath = [NSString stringWithFormat:@"%@/%@/%@", [bundlePaths objectAtIndex:0], bundle, SPBundleFileName];
 									NSString *orgPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:1], bundle];
 									NSString *newPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:0], bundle];
-									if([fm fileExistsAtPath:newPath isDirectory:&isDir] && isDir)
+									if([fileManager fileExistsAtPath:newPath isDirectory:&isDir] && isDir)
 										newPath = [NSString stringWithFormat:@"%@_%ld", newPath, (long)(random() % 35000)];
 									error = nil;
-									[fm copyItemAtPath:orgPath toPath:newPath error:&error];
+									[fileManager copyItemAtPath:orgPath toPath:newPath error:&error];
 									if(error != nil) {
 										NSBeep();
 										NSLog(@"Default Bundle “%@” couldn't be copied to '%@'", bundle, newInfoPath);
@@ -2131,7 +2129,7 @@
 	BOOL shouldSaveFavorites = NO;
 
 	if (lastBundleBlobFilesDirectory != nil) {
-		[fm removeItemAtPath:lastBundleBlobFilesDirectory error:nil];
+		[fileManager removeItemAtPath:lastBundleBlobFilesDirectory error:nil];
 	}
 
 	// Iterate through each open window
@@ -2196,7 +2194,7 @@
 	NSError *appPathError = nil;
 
     NSString *defaultThemesPath = [NSString stringWithFormat:@"%@/Contents/SharedSupport/Default Themes", [[NSBundle mainBundle] bundlePath]];
-    NSString *appSupportThemesPath = [fm applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder createIfNotExists:YES error:&appPathError];
+    NSString *appSupportThemesPath = [fileManager applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder createIfNotExists:YES error:&appPathError];
 
 	// If ~/Library/Application Path/Sequel Ace/Themes couldn't be created bail
 	if (appPathError != nil) {
@@ -2206,7 +2204,7 @@
 
     NSError *error = nil;
     NSError *copyError = nil;
-    NSArray *defaultThemes = [fm contentsOfDirectoryAtPath:defaultThemesPath error:&error];
+    NSArray *defaultThemes = [fileManager contentsOfDirectoryAtPath:defaultThemesPath error:&error];
 
     if (defaultThemes && [defaultThemes count] && error == nil) {
         for (NSString *defaultTheme in defaultThemes)
@@ -2216,9 +2214,9 @@
             NSString *defaultThemeFullPath = [NSString stringWithFormat:@"%@/%@", defaultThemesPath, defaultTheme];
             NSString *appSupportThemeFullPath = [NSString stringWithFormat:@"%@/%@", appSupportThemesPath, defaultTheme];
 
-            if ([fm fileExistsAtPath:appSupportThemeFullPath]) continue;
+            if ([fileManager fileExistsAtPath:appSupportThemeFullPath]) continue;
 
-			[fm copyItemAtPath:defaultThemeFullPath toPath:appSupportThemeFullPath error:&copyError];
+			[fileManager copyItemAtPath:defaultThemeFullPath toPath:appSupportThemeFullPath error:&copyError];
         }
     }
 
@@ -2485,7 +2483,7 @@
 	if (runningActivitiesArray)     SPClear(runningActivitiesArray);
 
 	SPClear(prefsController);
-	SPClear(fm);
+	SPClear(fileManager);
 
 	if (aboutController) SPClear(aboutController);
 	if (bundleEditorController) SPClear(bundleEditorController);

--- a/Source/SPBundleCommandRunner.m
+++ b/Source/SPBundleCommandRunner.m
@@ -78,7 +78,7 @@
  */
 + (NSString *)runBashCommand:(NSString *)command withEnvironment:(NSDictionary*)shellEnvironment atCurrentDirectoryPath:(NSString*)path callerInstance:(id)caller contextInfo:(NSDictionary*)contextInfo error:(NSError**)theError
 {
-	NSFileManager *fm = [NSFileManager defaultManager];
+	NSFileManager *fileManager = [NSFileManager defaultManager];
 
 	BOOL userTerminated = NO;
 	BOOL redirectForScript = NO;
@@ -90,10 +90,10 @@
 	NSString *stdoutFilePath = [NSString stringWithFormat:@"%@_%@", [SPBundleTaskOutputFilePath stringByExpandingTildeInPath], uuid];
 	NSString *scriptFilePath = [NSString stringWithFormat:@"%@_%@", [SPBundleTaskScriptCommandFilePath stringByExpandingTildeInPath], uuid];
 
-	[fm removeItemAtPath:scriptFilePath error:nil];
-	[fm removeItemAtPath:stdoutFilePath error:nil];
+	[fileManager removeItemAtPath:scriptFilePath error:nil];
+	[fileManager removeItemAtPath:stdoutFilePath error:nil];
 	if([SPAppDelegate lastBundleBlobFilesDirectory] != nil)
-		[fm removeItemAtPath:[SPAppDelegate lastBundleBlobFilesDirectory] error:nil];
+		[fileManager removeItemAtPath:[SPAppDelegate lastBundleBlobFilesDirectory] error:nil];
 
 	if([shellEnvironment objectForKey:SPBundleShellVariableBlobFileDirectory])
 		[SPAppDelegate setLastBundleBlobFilesDirectory:[shellEnvironment objectForKey:SPBundleShellVariableBlobFileDirectory]];
@@ -112,7 +112,7 @@
 		if([scriptHeaderArguments count])
 			scriptPath = [scriptHeaderArguments objectAtIndex:0];
 
-		if([scriptPath hasPrefix:@"/"] && [fm fileExistsAtPath:scriptPath isDirectory:&isDir] && !isDir) {
+		if([scriptPath hasPrefix:@"/"] && [fileManager fileExistsAtPath:scriptPath isDirectory:&isDir] && !isDir) {
 			NSString *script = [command substringWithRange:NSMakeRange(NSMaxRange(firstLineRange), [command length] - NSMaxRange(firstLineRange))];
 			NSError *writeError = nil;
 			[script writeToFile:scriptFilePath atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
@@ -209,7 +209,7 @@
 
 	if(path != nil)
 		[bashTask setCurrentDirectoryPath:path];
-	else if([shellEnvironment objectForKey:SPBundleShellVariableBundlePath] && [fm fileExistsAtPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath] isDirectory:&isDir] && isDir)
+	else if([shellEnvironment objectForKey:SPBundleShellVariableBundlePath] && [fileManager fileExistsAtPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath] isDirectory:&isDir] && isDir)
 		[bashTask setCurrentDirectoryPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath]];
 
 	// STDOUT will be redirected to SPBundleTaskOutputFilePath in order to avoid nasty pipe programming due to block size reading
@@ -264,17 +264,17 @@
 	}
 
 	// Remove files
-	[fm removeItemAtPath:scriptFilePath error:nil];
+	[fileManager removeItemAtPath:scriptFilePath error:nil];
 	if([theEnv objectForKey:SPBundleShellVariableQueryFile])
-		[fm removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryFile] error:nil];
+		[fileManager removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryFile] error:nil];
 	if([theEnv objectForKey:SPBundleShellVariableQueryResultFile])
-		[fm removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultFile] error:nil];
+		[fileManager removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultFile] error:nil];
 	if([theEnv objectForKey:SPBundleShellVariableQueryResultStatusFile])
-		[fm removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultStatusFile] error:nil];
+		[fileManager removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultStatusFile] error:nil];
 	if([theEnv objectForKey:SPBundleShellVariableQueryResultMetaFile])
-		[fm removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultMetaFile] error:nil];
+		[fileManager removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableQueryResultMetaFile] error:nil];
 	if([theEnv objectForKey:SPBundleShellVariableInputTableMetaData])
-		[fm removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableInputTableMetaData] error:nil];
+		[fileManager removeItemAtPath:[theEnv objectForKey:SPBundleShellVariableInputTableMetaData] error:nil];
 
 	// If return from bash re-activate Sequel Ace
 	[NSApp activateIgnoringOtherApps:YES];
@@ -284,7 +284,7 @@
 
 	// Check STDERR
 	if([errdata length] && (status < SPBundleRedirectActionNone || status > SPBundleRedirectActionLastCode)) {
-		[fm removeItemAtPath:stdoutFilePath error:nil];
+		[fileManager removeItemAtPath:stdoutFilePath error:nil];
 
 		if(status == 9 || userTerminated) return @"";
 		if(theError != NULL) {
@@ -303,10 +303,10 @@
 	}
 
 	// Read STDOUT saved to file
-	if([fm fileExistsAtPath:stdoutFilePath isDirectory:nil]) {
+	if([fileManager fileExistsAtPath:stdoutFilePath isDirectory:nil]) {
 		NSString *stdoutContent = [NSString stringWithContentsOfFile:stdoutFilePath encoding:NSUTF8StringEncoding error:nil];
 		if(bashTask) SPClear(bashTask);
-		[fm removeItemAtPath:stdoutFilePath error:nil];
+		[fileManager removeItemAtPath:stdoutFilePath error:nil];
 		if(stdoutContent != nil) {
 			if (status == 0) {
 				return stdoutContent;
@@ -336,7 +336,7 @@
 	}
 
 	if (bashTask) [bashTask release];
-	[fm removeItemAtPath:stdoutFilePath error:nil];
+	[fileManager removeItemAtPath:stdoutFilePath error:nil];
 	return @"";
 }
 

--- a/Source/SPBundleEditorController.m
+++ b/Source/SPBundleEditorController.m
@@ -62,7 +62,7 @@
 - (NSUInteger)_arrangedCategoryIndexForScopeIndex:(NSUInteger)scopeIndex andCategory:(NSString*)category;
 - (void)_metaSheetDidEnd:(NSWindow *)sheet returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo;
 
-@property (readwrite, retain) NSFileManager *fm;
+@property (readwrite, retain) NSFileManager *fileManager;
 
 @end
 
@@ -70,7 +70,7 @@
 
 @implementation SPBundleEditorController
 
-@synthesize fm;
+@synthesize fileManager;
 
 - (id)init
 {
@@ -81,7 +81,7 @@
 		oldBundleName = nil;
 		isTableCellEditing = NO;
 		deletedDefaultBundles = [[NSMutableArray alloc] initWithCapacity:1];
-		fm = [NSFileManager defaultManager];
+		fileManager = [NSFileManager defaultManager];
 
 	}
 	
@@ -105,7 +105,7 @@
 	// Init all needed variables; popup menus (with the chance for localization); and set
 	// defaults
 
-	bundlePath = [[fm applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:NO error:nil] retain];
+	bundlePath = [[fileManager applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:NO error:nil] retain];
 
 
 	touchedBundleArray = [[NSMutableArray alloc] initWithCapacity:1];
@@ -552,16 +552,16 @@
 		BOOL isDir;
 		BOOL copyingWasSuccessful = YES;
 		// Copy possible existing bundle with content
-		if([fm fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
-			if(![fm copyItemAtPath:possibleExisitingBundleFilePath toPath:newBundleFilePath error:nil])
+		if([fileManager fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
+			if(![fileManager copyItemAtPath:possibleExisitingBundleFilePath toPath:newBundleFilePath error:nil])
 				copyingWasSuccessful = NO;
 		}
 		if(!copyingWasSuccessful) {
 			// try again with new name
 			newFileName = [NSString stringWithFormat:@"%@_%ld", newFileName, (long)(random() % 35000)];
 			newBundleFilePath = [NSString stringWithFormat:@"%@/%@.%@", bundlePath, newFileName, SPUserBundleFileExtension];
-			if([fm fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
-				if([fm copyItemAtPath:possibleExisitingBundleFilePath toPath:newBundleFilePath error:nil])
+			if([fileManager fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
+				if([fileManager copyItemAtPath:possibleExisitingBundleFilePath toPath:newBundleFilePath error:nil])
 					copyingWasSuccessful = YES;
 			}
 		}
@@ -750,9 +750,9 @@
 		NSError *err = nil;
 		
 		// Copy possible existing bundle with content
-		if([fm fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
+		if([fileManager fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
 			//FIXME This will fail if savePath exists, but the user already consented overwriting in the save panel. We should use trashItemAtURL:... once we are 10.8+
-			if(![fm copyItemAtPath:possibleExisitingBundleFilePath toPath:savePath error:&err]) {
+			if(![fileManager copyItemAtPath:possibleExisitingBundleFilePath toPath:savePath error:&err]) {
 				//if we have an NSError that will provide the nicest error message.
 				if(err) {
 					[[NSAlert alertWithError:err] runModal];
@@ -922,13 +922,13 @@
 			return NO;
 		}
 		if(!bundlePath)
-			bundlePath = [[fm applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:YES error:nil] retain];
+			bundlePath = [[fileManager applicationSupportDirectoryForSubDirectory:SPBundleSupportFolder createIfNotExists:YES error:nil] retain];
 		aPath = [NSString stringWithFormat:@"%@/%@.%@", bundlePath, [bundle objectForKey:kBundleNameKey], SPUserBundleFileExtension];
 	}
 
 	// Create spBundle folder if it doesn't exist
-	if(![fm fileExistsAtPath:aPath isDirectory:&isDir]) {
-		if(![fm createDirectoryAtPath:aPath withIntermediateDirectories:YES attributes:nil error:nil])
+	if(![fileManager fileExistsAtPath:aPath isDirectory:&isDir]) {
+		if(![fileManager createDirectoryAtPath:aPath withIntermediateDirectories:YES attributes:nil error:nil])
 			return NO;
 		isDir = YES;
 		isNewBundle = YES;
@@ -981,7 +981,7 @@
 	}
 
 	// Remove a given old command.plist file
-	[fm removeItemAtPath:cmdFilePath error:nil];
+	[fileManager removeItemAtPath:cmdFilePath error:nil];
 	[saveDict writeToFile:cmdFilePath atomically:YES];
 
 	return YES;
@@ -1012,12 +1012,12 @@
 				// Move already installed Bundles to Trash
 				NSString *bundleName = [obj objectForKey:kBundleNameKey];
 				NSString *thePath = [NSString stringWithFormat:@"%@/%@.%@", bundlePath, bundleName, SPUserBundleFileExtension];
-				if([fm fileExistsAtPath:thePath isDirectory:nil]) {
+				if([fileManager fileExistsAtPath:thePath isDirectory:nil]) {
 					NSError *error = nil;
 
 					// Use a AppleScript script since NSWorkspace performFileOperation or NSFileManager moveItemAtPath 
 					// have problems probably due access rights.
-					[fm removeItemAtPath:thePath error:&error];
+					[fileManager removeItemAtPath:thePath error:&error];
 					
 					if(error != nil) {
 						
@@ -1118,7 +1118,7 @@
 {
 	// Remove temporary drag file if any
 	if(draggedFilePath) {
-		[fm removeItemAtPath:draggedFilePath error:nil];
+		[fileManager removeItemAtPath:draggedFilePath error:nil];
 		SPClear(draggedFilePath);
 	}
 	if(oldBundleName) SPClear(oldBundleName);
@@ -1390,14 +1390,14 @@
 	
 				BOOL isDir;
 				// Check for renaming
-				if([fm fileExistsAtPath:oldName isDirectory:&isDir] && isDir) {
-					if(![fm moveItemAtPath:oldName toPath:newName error:nil]) {
+				if([fileManager fileExistsAtPath:oldName isDirectory:&isDir] && isDir) {
+					if(![fileManager moveItemAtPath:oldName toPath:newName error:nil]) {
 						isValid = NO;
 					}
 				}
 				// Check if the new name already exists
 				else {
-					if([fm fileExistsAtPath:newName isDirectory:&isDir] && isDir) {
+					if([fileManager fileExistsAtPath:newName isDirectory:&isDir] && isDir) {
 						isValid = NO;
 					}
 				}
@@ -1503,7 +1503,7 @@
 
 	// Remove old temporary drag file if any
 	if(draggedFilePath) {
-		[fm removeItemAtPath:draggedFilePath error:nil];
+		[fileManager removeItemAtPath:draggedFilePath error:nil];
 		SPClear(draggedFilePath);
 	}
 
@@ -1519,8 +1519,8 @@
 	BOOL isDir;
 
 	// Copy possible existing bundle with content
-	if([fm fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
-		if(![fm copyItemAtPath:possibleExisitingBundleFilePath toPath:draggedFilePath error:nil])
+	if([fileManager fileExistsAtPath:possibleExisitingBundleFilePath isDirectory:&isDir] && isDir) {
+		if(![fileManager copyItemAtPath:possibleExisitingBundleFilePath toPath:draggedFilePath error:nil])
 			return NO;
 	}
 
@@ -1656,7 +1656,7 @@
 	// Load all installed bundle items
 	if(bundlePath) {
 		NSError *error = nil;
-		NSArray *foundBundles = [fm contentsOfDirectoryAtPath:bundlePath error:&error];
+		NSArray *foundBundles = [fileManager contentsOfDirectoryAtPath:bundlePath error:&error];
 		if (foundBundles && [foundBundles count]) {
 			for(NSString* bundle in foundBundles) {
 				if(![[[bundle pathExtension] lowercaseString] isEqualToString:[SPUserBundleFileExtension lowercaseString]]) continue;
@@ -2130,7 +2130,7 @@
 	
 	SPClear(shellVariableSuggestions);
 	SPClear(deletedDefaultBundles);
-	SPClear(fm);
+	SPClear(fileManager);
 	
 	if (touchedBundleArray) SPClear(touchedBundleArray);
 	if (commandBundleTree) SPClear(commandBundleTree);

--- a/Source/SPConnectionController.m
+++ b/Source/SPConnectionController.m
@@ -227,7 +227,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	// If triggered via the "Test Connection" button, set the state - otherwise clear it
 	isTestingConnection = (sender == testConnectButton);
 	
-	NSFileManager *fm = [NSFileManager defaultManager];
+	NSFileManager *fileManager = [NSFileManager defaultManager];
 	
 	// Ensure that host is not empty if this is a TCP/IP or SSH connection
 	if (([self type] == SPTCPIPConnection || [self type] == SPSSHTunnelConnection) && ![[self host] length]) {
@@ -251,7 +251,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 	// If an SSH key has been provided, verify it exists
 	if ([self type] == SPSSHTunnelConnection && sshKeyLocationEnabled && sshKeyLocation) {
-		if (![fm fileExistsAtPath:[sshKeyLocation stringByExpandingTildeInPath]]) {
+		if (![fileManager fileExistsAtPath:[sshKeyLocation stringByExpandingTildeInPath]]) {
 			[self setSshKeyLocationEnabled:NSOffState];
 			SPOnewayAlertSheet(
 				NSLocalizedString(@"SSH Key not found", @"SSH key check error"),
@@ -269,7 +269,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	if (([self type] == SPTCPIPConnection || [self type] == SPSocketConnection) && [self useSSL]) {
 		
 		if (sslKeyFileLocationEnabled && sslKeyFileLocation && 
-			![fm fileExistsAtPath:[sslKeyFileLocation stringByExpandingTildeInPath]])
+			![fileManager fileExistsAtPath:[sslKeyFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslKeyFileLocationEnabled:NSOffState];
 			[self setSslKeyFileLocation:nil];
@@ -284,7 +284,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		}
 		
 		if (sslCertificateFileLocationEnabled && sslCertificateFileLocation && 
-			![fm fileExistsAtPath:[sslCertificateFileLocation stringByExpandingTildeInPath]])
+			![fileManager fileExistsAtPath:[sslCertificateFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslCertificateFileLocationEnabled:NSOffState];
 			[self setSslCertificateFileLocation:nil];
@@ -299,7 +299,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		}
 		
 		if (sslCACertFileLocationEnabled && sslCACertFileLocation && 
-			![fm fileExistsAtPath:[sslCACertFileLocation stringByExpandingTildeInPath]])
+			![fileManager fileExistsAtPath:[sslCACertFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslCACertFileLocationEnabled:NSOffState];
 			[self setSslCACertFileLocation:nil];

--- a/Source/SPConnectionController.m
+++ b/Source/SPConnectionController.m
@@ -227,6 +227,8 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	// If triggered via the "Test Connection" button, set the state - otherwise clear it
 	isTestingConnection = (sender == testConnectButton);
 	
+	NSFileManager *fm = [NSFileManager defaultManager];
+	
 	// Ensure that host is not empty if this is a TCP/IP or SSH connection
 	if (([self type] == SPTCPIPConnection || [self type] == SPSSHTunnelConnection) && ![[self host] length]) {
 		SPOnewayAlertSheet(
@@ -249,7 +251,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 	// If an SSH key has been provided, verify it exists
 	if ([self type] == SPSSHTunnelConnection && sshKeyLocationEnabled && sshKeyLocation) {
-		if (![[NSFileManager defaultManager] fileExistsAtPath:[sshKeyLocation stringByExpandingTildeInPath]]) {
+		if (![fm fileExistsAtPath:[sshKeyLocation stringByExpandingTildeInPath]]) {
 			[self setSshKeyLocationEnabled:NSOffState];
 			SPOnewayAlertSheet(
 				NSLocalizedString(@"SSH Key not found", @"SSH key check error"),
@@ -267,7 +269,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	if (([self type] == SPTCPIPConnection || [self type] == SPSocketConnection) && [self useSSL]) {
 		
 		if (sslKeyFileLocationEnabled && sslKeyFileLocation && 
-			![[NSFileManager defaultManager] fileExistsAtPath:[sslKeyFileLocation stringByExpandingTildeInPath]])
+			![fm fileExistsAtPath:[sslKeyFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslKeyFileLocationEnabled:NSOffState];
 			[self setSslKeyFileLocation:nil];
@@ -282,7 +284,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		}
 		
 		if (sslCertificateFileLocationEnabled && sslCertificateFileLocation && 
-			![[NSFileManager defaultManager] fileExistsAtPath:[sslCertificateFileLocation stringByExpandingTildeInPath]])
+			![fm fileExistsAtPath:[sslCertificateFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslCertificateFileLocationEnabled:NSOffState];
 			[self setSslCertificateFileLocation:nil];
@@ -297,7 +299,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		}
 		
 		if (sslCACertFileLocationEnabled && sslCACertFileLocation && 
-			![[NSFileManager defaultManager] fileExistsAtPath:[sslCACertFileLocation stringByExpandingTildeInPath]])
+			![fm fileExistsAtPath:[sslCACertFileLocation stringByExpandingTildeInPath]])
 		{
 			[self setSslCACertFileLocationEnabled:NSOffState];
 			[self setSslCACertFileLocation:nil];

--- a/Source/SPCopyTable.m
+++ b/Source/SPCopyTable.m
@@ -179,9 +179,9 @@ static const NSInteger kBlobAsImageFile = 4;
 	__block NSUInteger rowCounter = 0;
 
 	if((withBlobHandling == kBlobAsFile || withBlobHandling == kBlobAsImageFile) && tmpBlobFileDirectory && [tmpBlobFileDirectory length]) {
-		NSFileManager *fm = [NSFileManager defaultManager];
-		[fm removeItemAtPath:tmpBlobFileDirectory error:nil];
-		[fm createDirectoryAtPath:tmpBlobFileDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
+		[fileManager removeItemAtPath:tmpBlobFileDirectory error:nil];
+		[fileManager createDirectoryAtPath:tmpBlobFileDirectory withIntermediateDirectories:YES attributes:nil error:nil];
 	}
 
 	BOOL hexBlobs = [prefs boolForKey:SPDisplayBinaryDataAsHex];
@@ -315,9 +315,9 @@ static const NSInteger kBlobAsImageFile = 4;
 	__block NSUInteger rowCounter = 0;
 
 	if((withBlobHandling == kBlobAsFile || withBlobHandling == kBlobAsImageFile) && tmpBlobFileDirectory && [tmpBlobFileDirectory length]) {
-		NSFileManager *fm = [NSFileManager defaultManager];
-		[fm removeItemAtPath:tmpBlobFileDirectory error:nil];
-		[fm createDirectoryAtPath:tmpBlobFileDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
+		[fileManager removeItemAtPath:tmpBlobFileDirectory error:nil];
+		[fileManager createDirectoryAtPath:tmpBlobFileDirectory withIntermediateDirectories:YES attributes:nil error:nil];
 	}
 
 	BOOL hexBlobs = [prefs boolForKey:SPDisplayBinaryDataAsHex];

--- a/Source/SPDataImport.m
+++ b/Source/SPDataImport.m
@@ -58,13 +58,13 @@
 - (void)_closeAndStopProgressSheet;
 - (NSString *)_getLineEndingForFile:(NSString *)filePath;
 
-@property (readwrite, retain) NSFileManager *fm;
+@property (readwrite, retain) NSFileManager *fileManager;
 
 @end
 
 @implementation SPDataImport
 
-@synthesize fm;
+@synthesize fileManager;
 
 #pragma mark -
 #pragma mark Initialisation
@@ -99,7 +99,7 @@
 		prefs = nil;
 		lastFilename = nil;
 		mainNibLoaded = NO;
-		fm = [NSFileManager defaultManager];
+		fileManager = [NSFileManager defaultManager];
 	}
 	
 	return self;
@@ -404,13 +404,13 @@
 			NSLocalizedString(@"The SQL file you selected could not be found or read.", @"SQL file open error")
 		);
 		if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-			[fm removeItemAtPath:filename error:nil];
+			[fileManager removeItemAtPath:filename error:nil];
 		return;
 	}
 	fileIsCompressed = ([sqlFileHandle compressionFormat] != SPNoCompression);
 
 	// Grab the file length
-	fileTotalLength = (NSUInteger)[[[fm attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
+	fileTotalLength = (NSUInteger)[[[fileManager attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 
 	SPMainQSync(^{
@@ -437,7 +437,7 @@
 	// Determine the file encoding.  The first item in the encoding menu is "Autodetect"; if
 	// this is selected, attempt to detect the encoding of the file
 	if (![[importEncodingPopup onMainThread]indexOfSelectedItem]) {
-	sqlEncoding = [fm detectEncodingforFileAtPath:filename];
+	sqlEncoding = [fileManager detectEncodingforFileAtPath:filename];
 		if ([SPMySQLConnection mySQLCharsetForStringEncoding:sqlEncoding]) {
 			connectionEncodingToRestore = [mySQLConnection encoding];
 			[mySQLConnection queryString:[NSString stringWithFormat:@"SET NAMES '%@'", [SPMySQLConnection mySQLCharsetForStringEncoding:sqlEncoding]]];
@@ -495,7 +495,7 @@
 			[sqlDataBuffer release];
 			[importPool drain];
 			[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
+			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fileManager removeItemAtPath:filename error:nil];
 			return;
 		}
 
@@ -551,7 +551,7 @@
 					[sqlDataBuffer release];
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
+					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fileManager removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -576,7 +576,7 @@
 		// Before entering the following loop, check that we actually have a connection.
 		// If not, check the connection if appropriate and then clean up and exit if appropriate.
 		if (![mySQLConnection isConnected] && ([mySQLConnection userTriggeredDisconnect] || ![mySQLConnection checkConnection])) {
-			if ([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
+			if ([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fileManager removeItemAtPath:filename error:nil];
 
 			[self _closeAndStopProgressSheet];
 			[errors appendString:NSLocalizedString(@"The connection to the server was lost during the import.  The import is only partially complete.", @"Connection lost during import error message")];
@@ -723,7 +723,7 @@
 	[sqlDataBuffer release];
 	[importPool drain];
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
+	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fileManager removeItemAtPath:filename error:nil];
 
 	// Close progress sheet
 	[self _closeAndStopProgressSheet];
@@ -822,12 +822,12 @@
 			NSLocalizedString(@"The CSV file you selected could not be found or read.", @"CSV file open error")
 		);
 		if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-			[fm removeItemAtPath:filename error:nil];
+			[fileManager removeItemAtPath:filename error:nil];
 		return;
 	}
 
 	// Grab the file length and status
-	fileTotalLength = (NSUInteger)[[[fm attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
+	fileTotalLength = (NSUInteger)[[[fileManager attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 	fileIsCompressed = ([csvFileHandle compressionFormat] != SPNoCompression);
 
@@ -863,7 +863,7 @@
 	});
 	// if "Autodetect" is selected, attempt to detect the encoding of the file.
 	if (!csvEncoding) {
-		csvEncoding = [fm detectEncodingforFileAtPath:filename];
+		csvEncoding = [fileManager detectEncodingforFileAtPath:filename];
 	}
 
 	// Read in the file in a loop.  The loop actually needs to perform three tasks: read in
@@ -919,7 +919,7 @@
 			[importPool drain];
 			[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-				[fm removeItemAtPath:filename error:nil];
+				[fileManager removeItemAtPath:filename error:nil];
 			return;
 		}
 
@@ -971,7 +971,7 @@
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-						[fm removeItemAtPath:filename error:nil];
+						[fileManager removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -1018,7 +1018,7 @@
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-						[fm removeItemAtPath:filename error:nil];
+						[fileManager removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -1095,7 +1095,7 @@
 				[importPool drain];
 				[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 				if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-					[fm removeItemAtPath:filename error:nil];
+					[fileManager removeItemAtPath:filename error:nil];
 				return;
 			}
 
@@ -1257,7 +1257,7 @@
 	[importPool drain];
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-		[fm removeItemAtPath:filename error:nil];
+		[fileManager removeItemAtPath:filename error:nil];
 
 	// Close progress sheet
 	[self _closeAndStopProgressSheet];
@@ -1902,7 +1902,7 @@ cleanup:
 	if (selectedTableTarget)           SPClear(selectedTableTarget);
 	
 	SPClear(nibObjectsToRelease);
-	SPClear(fm);
+	SPClear(fileManager);
 	
 	[super dealloc];
 }

--- a/Source/SPDataImport.m
+++ b/Source/SPDataImport.m
@@ -58,9 +58,13 @@
 - (void)_closeAndStopProgressSheet;
 - (NSString *)_getLineEndingForFile:(NSString *)filePath;
 
+@property (readwrite, retain) NSFileManager *fm;
+
 @end
 
 @implementation SPDataImport
+
+@synthesize fm;
 
 #pragma mark -
 #pragma mark Initialisation
@@ -95,6 +99,7 @@
 		prefs = nil;
 		lastFilename = nil;
 		mainNibLoaded = NO;
+		fm = [NSFileManager defaultManager];
 	}
 	
 	return self;
@@ -384,7 +389,7 @@
 	NSInteger dataBufferLastQueryEndPosition = 0;
 	BOOL fileIsCompressed;
 	BOOL allDataRead = NO;
-	BOOL ignoreSQLErrors = ([importSQLErrorHandlingPopup selectedTag] == SPSQLImportIgnoreErrors);
+	BOOL ignoreSQLErrors = ([[importSQLErrorHandlingPopup onMainThread] selectedTag] == SPSQLImportIgnoreErrors);
 	BOOL ignoreCharsetError = NO;
 	NSStringEncoding sqlEncoding = NSUTF8StringEncoding;
 	NSString *connectionEncodingToRestore = nil;
@@ -399,13 +404,13 @@
 			NSLocalizedString(@"The SQL file you selected could not be found or read.", @"SQL file open error")
 		);
 		if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-			[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+			[fm removeItemAtPath:filename error:nil];
 		return;
 	}
 	fileIsCompressed = ([sqlFileHandle compressionFormat] != SPNoCompression);
 
 	// Grab the file length
-	fileTotalLength = (NSUInteger)[[[[NSFileManager defaultManager] attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
+	fileTotalLength = (NSUInteger)[[[fm attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 
 	SPMainQSync(^{
@@ -431,8 +436,8 @@
 
 	// Determine the file encoding.  The first item in the encoding menu is "Autodetect"; if
 	// this is selected, attempt to detect the encoding of the file
-	if (![importEncodingPopup indexOfSelectedItem]) {
-		sqlEncoding = [[NSFileManager defaultManager] detectEncodingforFileAtPath:filename];
+	if (![[importEncodingPopup onMainThread]indexOfSelectedItem]) {
+	sqlEncoding = [fm detectEncodingforFileAtPath:filename];
 		if ([SPMySQLConnection mySQLCharsetForStringEncoding:sqlEncoding]) {
 			connectionEncodingToRestore = [mySQLConnection encoding];
 			[mySQLConnection queryString:[NSString stringWithFormat:@"SET NAMES '%@'", [SPMySQLConnection mySQLCharsetForStringEncoding:sqlEncoding]]];
@@ -490,7 +495,7 @@
 			[sqlDataBuffer release];
 			[importPool drain];
 			[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
 			return;
 		}
 
@@ -532,8 +537,8 @@
 
 					NSString *displayEncoding;
 
-					if (![importEncodingPopup indexOfSelectedItem]) {
-						displayEncoding = [NSString stringWithFormat:@"%@ - %@", [importEncodingPopup titleOfSelectedItem], [NSString localizedNameOfStringEncoding:sqlEncoding]];
+					if (![[importEncodingPopup onMainThread] indexOfSelectedItem]) {
+						displayEncoding = [NSString stringWithFormat:@"%@ - %@", [[importEncodingPopup onMainThread] titleOfSelectedItem], [NSString localizedNameOfStringEncoding:sqlEncoding]];
 					} else {
 						displayEncoding = [NSString localizedNameOfStringEncoding:sqlEncoding];
 					}
@@ -546,7 +551,7 @@
 					[sqlDataBuffer release];
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -571,7 +576,7 @@
 		// Before entering the following loop, check that we actually have a connection.
 		// If not, check the connection if appropriate and then clean up and exit if appropriate.
 		if (![mySQLConnection isConnected] && ([mySQLConnection userTriggeredDisconnect] || ![mySQLConnection checkConnection])) {
-			if ([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+			if ([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
 
 			[self _closeAndStopProgressSheet];
 			[errors appendString:NSLocalizedString(@"The connection to the server was lost during the import.  The import is only partially complete.", @"Connection lost during import error message")];
@@ -718,7 +723,7 @@
 	[sqlDataBuffer release];
 	[importPool drain];
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix]) [fm removeItemAtPath:filename error:nil];
 
 	// Close progress sheet
 	[self _closeAndStopProgressSheet];
@@ -817,12 +822,12 @@
 			NSLocalizedString(@"The CSV file you selected could not be found or read.", @"CSV file open error")
 		);
 		if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-			[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+			[fm removeItemAtPath:filename error:nil];
 		return;
 	}
 
 	// Grab the file length and status
-	fileTotalLength = (NSUInteger)[[[[NSFileManager defaultManager] attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
+	fileTotalLength = (NSUInteger)[[[fm attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 	fileIsCompressed = ([csvFileHandle compressionFormat] != SPNoCompression);
 
@@ -858,7 +863,7 @@
 	});
 	// if "Autodetect" is selected, attempt to detect the encoding of the file.
 	if (!csvEncoding) {
-		csvEncoding = [[NSFileManager defaultManager] detectEncodingforFileAtPath:filename];
+		csvEncoding = [fm detectEncodingforFileAtPath:filename];
 	}
 
 	// Read in the file in a loop.  The loop actually needs to perform three tasks: read in
@@ -914,7 +919,7 @@
 			[importPool drain];
 			[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 			if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-				[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+				[fm removeItemAtPath:filename error:nil];
 			return;
 		}
 
@@ -966,7 +971,7 @@
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-						[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+						[fm removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -1013,7 +1018,7 @@
 					[importPool drain];
 					[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 					if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-						[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+						[fm removeItemAtPath:filename error:nil];
 					return;
 				}
 
@@ -1090,7 +1095,7 @@
 				[importPool drain];
 				[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 				if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-					[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+					[fm removeItemAtPath:filename error:nil];
 				return;
 			}
 
@@ -1252,7 +1257,7 @@
 	[importPool drain];
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 	if([filename hasPrefix:SPImportClipboardTempFileNamePrefix])
-		[[NSFileManager defaultManager] removeItemAtPath:filename error:nil];
+		[fm removeItemAtPath:filename error:nil];
 
 	// Close progress sheet
 	[self _closeAndStopProgressSheet];
@@ -1897,6 +1902,7 @@ cleanup:
 	if (selectedTableTarget)           SPClear(selectedTableTarget);
 	
 	SPClear(nibObjectsToRelease);
+	SPClear(fm);
 	
 	[super dealloc];
 }

--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -5400,12 +5400,12 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 	if([command isEqualToString:@"ReloadContentTableWithWHEREClause"]) {
 		NSString *queryFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryInputPathHeader stringByExpandingTildeInPath], docProcessID];
-		NSFileManager *fm = [NSFileManager defaultManager];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
 		BOOL isDir;
-		if([fm fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
+		if([fileManager fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
 			NSError *inError = nil;
 			NSString *query = [NSString stringWithContentsOfFile:queryFileName encoding:NSUTF8StringEncoding error:&inError];
-			[fm removeItemAtPath:queryFileName error:nil];
+			[fileManager removeItemAtPath:queryFileName error:nil];
 			if(inError == nil && query && [query length]) {
 				[tableContentInstance filterTable:query];
 			}
@@ -5415,12 +5415,12 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 	if([command isEqualToString:@"RunQueryInQueryEditor"]) {
 		NSString *queryFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryInputPathHeader stringByExpandingTildeInPath], docProcessID];
-		NSFileManager *fm = [NSFileManager defaultManager];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
 		BOOL isDir;
-		if([fm fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
+		if([fileManager fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
 			NSError *inError = nil;
 			NSString *query = [NSString stringWithContentsOfFile:queryFileName encoding:NSUTF8StringEncoding error:&inError];
-			[fm removeItemAtPath:queryFileName error:nil];
+			[fileManager removeItemAtPath:queryFileName error:nil];
 			if(inError == nil && query && [query length]) {
 				[customQueryInstance performQueries:@[query] withCallback:NULL];
 			}
@@ -5436,7 +5436,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 			NSString *resultFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultPathHeader stringByExpandingTildeInPath], docProcessID];
 			NSString *metaFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultMetaPathHeader stringByExpandingTildeInPath], docProcessID];
 			NSString *statusFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], docProcessID];
-			NSFileManager *fm = [NSFileManager defaultManager];
+			NSFileManager *fileManager = [NSFileManager defaultManager];
 			NSString *status = @"0";
 			BOOL userTerminated = NO;
 			BOOL doSyntaxHighlighting = NO;
@@ -5549,10 +5549,10 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 				}
 			}
 			
-			[fm removeItemAtPath:queryFileName error:nil];
-			[fm removeItemAtPath:resultFileName error:nil];
-			[fm removeItemAtPath:metaFileName error:nil];
-			[fm removeItemAtPath:statusFileName error:nil];
+			[fileManager removeItemAtPath:queryFileName error:nil];
+			[fileManager removeItemAtPath:resultFileName error:nil];
+			[fileManager removeItemAtPath:metaFileName error:nil];
+			[fileManager removeItemAtPath:statusFileName error:nil];
 
 			if(userTerminated)
 				status = @"1";
@@ -5587,19 +5587,19 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 		NSString *resultFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultPathHeader stringByExpandingTildeInPath], docProcessID];
 		NSString *metaFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultMetaPathHeader stringByExpandingTildeInPath], docProcessID];
 		NSString *statusFileName = [NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], docProcessID];
-		NSFileManager *fm = [NSFileManager defaultManager];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
 		NSString *status = @"0";
 		BOOL isDir;
 		BOOL userTerminated = NO;
-		if([fm fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
+		if([fileManager fileExistsAtPath:queryFileName isDirectory:&isDir] && !isDir) {
 
 			NSError *inError = nil;
 			NSString *query = [NSString stringWithContentsOfFile:queryFileName encoding:NSUTF8StringEncoding error:&inError];
 
-			[fm removeItemAtPath:queryFileName error:nil];
-			[fm removeItemAtPath:resultFileName error:nil];
-			[fm removeItemAtPath:metaFileName error:nil];
-			[fm removeItemAtPath:statusFileName error:nil];
+			[fileManager removeItemAtPath:queryFileName error:nil];
+			[fileManager removeItemAtPath:resultFileName error:nil];
+			[fileManager removeItemAtPath:metaFileName error:nil];
+			[fileManager removeItemAtPath:statusFileName error:nil];
 
 			if(inError == nil && query && [query length]) {
 

--- a/Source/SPEditorPreferencePane.m
+++ b/Source/SPEditorPreferencePane.m
@@ -51,9 +51,14 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 - (void)_saveColorThemeAtPath:(NSString *)path;
 - (BOOL)_loadColorSchemeFromFile:(NSString *)filename;
 
+@property (readwrite, retain) NSFileManager *fm;
+
 @end
 
 @implementation SPEditorPreferencePane
+
+@synthesize fm;
+
 
 #pragma mark -
 #pragma mark Initialisation
@@ -62,7 +67,9 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 {
 	if ((self = [super init])) {
 		
-		themePath = [[[NSFileManager defaultManager] applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil] retain];
+		fm = [NSFileManager defaultManager];
+
+		themePath = [[fm applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil] retain];
 		
 		editThemeListItems = [[NSArray arrayWithArray:[self _getAvailableThemes]] retain];
 		
@@ -202,9 +209,7 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	if ([editThemeListTable numberOfSelectedRows] != 1) return;
 	
 	NSString *selectedPath = [NSString stringWithFormat:@"%@/%@_copy.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension];
-	
-	NSFileManager *fm = [NSFileManager defaultManager];
-	
+		
 	if (![fm fileExistsAtPath:selectedPath isDirectory:nil]) {
 		if ([fm copyItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension] toPath:selectedPath error:nil]) {
 			
@@ -229,9 +234,7 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	if ([editThemeListTable numberOfSelectedRows] != 1) return;
 	
 	NSString *selectedPath = [NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension];
-	
-	NSFileManager *fm = [NSFileManager defaultManager];
-	
+		
 	if ([fm fileExistsAtPath:selectedPath isDirectory:nil]) {
 		if ([fm removeItemAtPath:selectedPath error:nil]) {
 			
@@ -511,7 +514,6 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	
 	if ([contextInfo isEqualToString:SPSaveColorScheme]) {
 		if (returnCode == NSModalResponseOK) {
-			NSFileManager *fm = [NSFileManager defaultManager];
 			
 			if (![fm fileExistsAtPath:themePath isDirectory:nil]) {
 				NSError *error = nil;
@@ -584,8 +586,6 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 		}
 		
 		// Rename theme file
-		NSFileManager *fm = [NSFileManager defaultManager];
-		
 		if (![fm moveItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:rowIndex], SPColorThemeFileExtension] toPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, newName, SPColorThemeFileExtension] error:nil]) {
 			NSBeep();
 			[editThemeListTable reloadData];
@@ -775,8 +775,6 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 - (NSArray *)_getAvailableThemes
 {
 	// Read ~/Library/Application Support/Sequel Ace/Themes
-	NSFileManager *fm = [NSFileManager defaultManager];
-	
 	if ([fm fileExistsAtPath:themePath isDirectory:nil]) {
 		NSError *error = nil;
 		NSArray *allItemsRaw = [fm contentsOfDirectoryAtPath:themePath error:&error];

--- a/Source/SPEditorPreferencePane.m
+++ b/Source/SPEditorPreferencePane.m
@@ -51,13 +51,13 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 - (void)_saveColorThemeAtPath:(NSString *)path;
 - (BOOL)_loadColorSchemeFromFile:(NSString *)filename;
 
-@property (readwrite, retain) NSFileManager *fm;
+@property (readwrite, retain) NSFileManager *fileManager;
 
 @end
 
 @implementation SPEditorPreferencePane
 
-@synthesize fm;
+@synthesize fileManager;
 
 
 #pragma mark -
@@ -67,9 +67,9 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 {
 	if ((self = [super init])) {
 		
-		fm = [NSFileManager defaultManager];
+		fileManager = [NSFileManager defaultManager];
 
-		themePath = [[fm applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil] retain];
+		themePath = [[fileManager applicationSupportDirectoryForSubDirectory:SPThemesSupportFolder error:nil] retain];
 		
 		editThemeListItems = [[NSArray arrayWithArray:[self _getAvailableThemes]] retain];
 		
@@ -210,8 +210,8 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	
 	NSString *selectedPath = [NSString stringWithFormat:@"%@/%@_copy.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension];
 		
-	if (![fm fileExistsAtPath:selectedPath isDirectory:nil]) {
-		if ([fm copyItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension] toPath:selectedPath error:nil]) {
+	if (![fileManager fileExistsAtPath:selectedPath isDirectory:nil]) {
+		if ([fileManager copyItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension] toPath:selectedPath error:nil]) {
 			
 			if (editThemeListItems) SPClear(editThemeListItems);
 			
@@ -235,8 +235,8 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	
 	NSString *selectedPath = [NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:[editThemeListTable selectedRow]], SPColorThemeFileExtension];
 		
-	if ([fm fileExistsAtPath:selectedPath isDirectory:nil]) {
-		if ([fm removeItemAtPath:selectedPath error:nil]) {
+	if ([fileManager fileExistsAtPath:selectedPath isDirectory:nil]) {
+		if ([fileManager removeItemAtPath:selectedPath error:nil]) {
 			
 			// Refresh current color theme setting name
 			if ([[[prefs objectForKey:SPCustomQueryEditorThemeName] lowercaseString] isEqualToString:[[editThemeListItems objectAtIndex:[editThemeListTable selectedRow]] lowercaseString]]) {
@@ -515,9 +515,9 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	if ([contextInfo isEqualToString:SPSaveColorScheme]) {
 		if (returnCode == NSModalResponseOK) {
 			
-			if (![fm fileExistsAtPath:themePath isDirectory:nil]) {
+			if (![fileManager fileExistsAtPath:themePath isDirectory:nil]) {
 				NSError *error = nil;
-				if (![fm createDirectoryAtPath:themePath withIntermediateDirectories:YES attributes:nil error:&error]) {
+				if (![fileManager createDirectoryAtPath:themePath withIntermediateDirectories:YES attributes:nil error:&error]) {
 					SPLog(@"Failed to create directory '%@'. error=%@", themePath, error);
 					NSBeep();
 					return;
@@ -586,7 +586,7 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 		}
 		
 		// Rename theme file
-		if (![fm moveItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:rowIndex], SPColorThemeFileExtension] toPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, newName, SPColorThemeFileExtension] error:nil]) {
+		if (![fileManager moveItemAtPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, [editThemeListItems objectAtIndex:rowIndex], SPColorThemeFileExtension] toPath:[NSString stringWithFormat:@"%@/%@.%@", themePath, newName, SPColorThemeFileExtension] error:nil]) {
 			NSBeep();
 			[editThemeListTable reloadData];
 			return;
@@ -775,9 +775,9 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 - (NSArray *)_getAvailableThemes
 {
 	// Read ~/Library/Application Support/Sequel Ace/Themes
-	if ([fm fileExistsAtPath:themePath isDirectory:nil]) {
+	if ([fileManager fileExistsAtPath:themePath isDirectory:nil]) {
 		NSError *error = nil;
-		NSArray *allItemsRaw = [fm contentsOfDirectoryAtPath:themePath error:&error];
+		NSArray *allItemsRaw = [fileManager contentsOfDirectoryAtPath:themePath error:&error];
 		
 		if(!allItemsRaw || error) {
 			SPLog(@"Failed to list contents of path '%@'. error=%@", themePath, error);

--- a/Source/SPExportFile.m
+++ b/Source/SPExportFile.m
@@ -112,7 +112,7 @@
 	NSFileManager *fileManager = [NSFileManager defaultManager];
 	
 	if ([fileManager fileExistsAtPath:[self exportFilePath]]) {
-		return [[NSFileManager defaultManager] removeItemAtPath:[self exportFilePath] error:nil];
+		return [fileManager removeItemAtPath:[self exportFilePath] error:nil];
 	}
 	
 	return NO;
@@ -216,7 +216,7 @@
 	exportFileHandle = [[SPFileHandle fileHandleForWritingAtPath:[self exportFilePath]] retain];
 	
 	if (!exportFileHandle) {
-		[[NSFileManager defaultManager] removeItemAtPath:[self exportFilePath] error:nil];
+		[fileManager removeItemAtPath:[self exportFilePath] error:nil];
 		
 		return SPExportFileHandleFailed;
 	}

--- a/Source/SPExtendedTableInfo.m
+++ b/Source/SPExtendedTableInfo.m
@@ -544,6 +544,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 
 /**
  * NSTextView delegate. Used to change the selected table's comment.
+ * THIS GETS CALLED A LOT - jcs
  */
 - (void)textDidEndEditing:(NSNotification *)notification
 {
@@ -555,8 +556,10 @@ static NSString *SPMySQLCommentField          = @"Comment";
 		NSString *newComment = [[tableCommentsTextView string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
 		// Check that the user actually changed the tables comment
-		if (![currentComment isEqualToString:newComment]) {
-
+		// what if the new comment is "" and the current is nil?
+		// or current is not nil and new new is "" or nil?
+		if (([currentComment isEqualToString:newComment] == NO && newComment.length > 0) ||(newComment.length == 0 && currentComment.length > 0) ) {
+																							
 			// Alter table's comment
 			[connection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ COMMENT = %@", [selectedTable backtickQuotedString], [connection escapeAndQuoteString:newComment]]];
 

--- a/Source/SPTableData.m
+++ b/Source/SPTableData.m
@@ -1062,7 +1062,7 @@
 				//FIXME that error should really show only when trying to view the table content, but we don't even try to load that if Rows==NULL
 				SPOnewayAlertSheet(
 					NSLocalizedString(@"Querying row count failed", @"table status : row count query failed : error title"),
-					[NSApp mainWindow],
+					[[NSApp onMainThread] mainWindow],
 					[NSString stringWithFormat:NSLocalizedString(@"An error occured while trying to determine the number of rows for “%@”.\nMySQL said: %@ (%lu)", @"table status : row count query failed : error message"),[tableListInstance tableName],[mySQLConnection lastErrorMessage],[mySQLConnection lastErrorID]]
 				);
 			}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Object allocation is expensive. I've added properties to a few classes that repeatedly called `[NSFileManager defaultManager]`
Fixed one UI call on a background thread
Don't update table comments unnecessarily - the checks where not testing for nil or length.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev branch


