### PR TITLE
Reset tab and window title on connection failure

### DIFF
--- a/Source/SPConnectionController.m
+++ b/Source/SPConnectionController.m
@@ -2582,6 +2582,11 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		// Initiate the connection after a half second delay to give the connection view a chance to resize
 		[self performSelector:@selector(initiateConnection:) withObject:self afterDelay:0.5];
 	}
+	
+	// we're not connecting anymore, it failed.
+	isConnecting = NO;
+	// update tab and window title
+	[dbDocument updateWindowTitle:self];
 }
 
 #pragma mark - SPConnectionHandlerPrivateAPI


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When a connection via ssh fails, the detail box comes up and the warning alert, but the tab in the main window still says "Connecting..." as does the main window title. This resets the titles to "Sequel Ace".


Does this close any currently open issues?
------------------------------------------
#198


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev


