### PR TITLE
Minor Language Tweaks

### DIFF
--- a/Interfaces/Base.lproj/Preferences.xib
+++ b/Interfaces/Base.lproj/Preferences.xib
@@ -1651,7 +1651,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fk8-1b-YVh">
                     <rect key="frame" x="18" y="340" width="524" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" title="This list shows all files, that Sequel Ace has access to." id="g1t-1Q-PEO">
+                    <textFieldCell key="cell" title="This list shows all the files that Sequel Ace has been granted access to." id="g1t-1Q-PEO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Interfaces/Base.lproj/Preferences.xib
+++ b/Interfaces/Base.lproj/Preferences.xib
@@ -78,7 +78,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="430" y="486" width="580" height="172"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1692"/>
             <value key="minSize" type="size" width="580" height="50"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="580" height="172"/>
@@ -93,7 +93,7 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="481" width="227" height="114"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1692"/>
             <value key="minSize" type="size" width="227" height="114"/>
             <value key="maxSize" type="size" width="247" height="124"/>
             <view key="contentView" id="1717">
@@ -178,7 +178,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="370" width="264" height="225"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1692"/>
             <value key="minSize" type="size" width="264" height="225"/>
             <value key="maxSize" type="size" width="264" height="274"/>
             <view key="contentView" id="1757">
@@ -1649,7 +1649,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fk8-1b-YVh">
-                    <rect key="frame" x="18" y="340" width="524" height="16"/>
+                    <rect key="frame" x="18" y="335" width="524" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" title="This list shows all the files that Sequel Ace has been granted access to." id="g1t-1Q-PEO">
                         <font key="font" metaFont="system"/>

--- a/Source/SPPreferencesUpgrade.m
+++ b/Source/SPPreferencesUpgrade.m
@@ -82,8 +82,7 @@ void SPApplyRevisionChanges(void)
 	
 	// This is how you add release notes and run specific migration steps
 	if (recordedVersionNumber < 2061) {
-		[importantUpdateNotes addObject:NSLocalizedString(@"There is a new option in Preferences->Alerts & Logs: \"Show warning before executing a query\"", @"Short important release note for new option in Preferences->Alerts & Logs")];
-		[importantUpdateNotes addObject:NSLocalizedString(@"When selected, you will be prompted to confirm that you want to execte an SQL query or edit a row.", @"Short important release note for why password prompts may occur")];
+		[importantUpdateNotes addObject:NSLocalizedString(@"There is a new option in Preferences->Alerts & Logs: \"Show warning before executing a query\". When enabled, you will be prompted to confirm that you want to execte an SQL query or edit a row.", @"Short important release note for new option in Preferences->Alerts & Logs")];
 	}
 
 	// Display any important release notes, if any.  Call this after a slight delay to prevent double help


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Tweaks the language of the popup release note introduced and tweaks the language for "granted files". Also fixes the bottom of the text on the files tab being cutoff slightly.



Where has this been tested?
---------------------------
**Devices/Simulators:** MacBook Pro 2016

**macOS Version:** macOS 10.15.5

**Sequel-Ace Version:** 2.1.3 beta


