### PR TITLE
Fix runtime crash on macOS 10.10 and 10.11

### DIFF
--- a/Frameworks/PSMTabBar/PSMRolloverButton.m
+++ b/Frameworks/PSMTabBar/PSMRolloverButton.m
@@ -92,9 +92,17 @@
 
 - (void)addTrackingRect
 {
-    // assign a tracking rect to watch for mouse enter/exit
+	// assign a tracking rect to watch for mouse enter/exit
+	NSPoint globalPoint;
+
+	if (@available(macOS 10.12, *)) {
+		globalPoint = [[self window] convertPointToScreen:[NSEvent mouseLocation]];
+	} else {
+		globalPoint = [[self window] convertRectToScreen:(CGRect){.origin=[NSEvent mouseLocation]}].origin;
+	}
+
 	NSRect	trackRect = [self bounds];
-	NSPoint	localPoint = [self convertPoint:[[self window] convertPointToScreen:[NSEvent mouseLocation]] fromView:nil];
+	NSPoint	localPoint = [self convertPoint:globalPoint fromView:nil];
 
 	BOOL mouseInside = NSPointInRect(localPoint, trackRect);
 	

--- a/Source/SPTooltip.m
+++ b/Source/SPTooltip.m
@@ -257,7 +257,15 @@ static CGFloat slow_in_out (CGFloat t)
 		NSRange glyphRange = [[fr layoutManager] glyphRangeForCharacterRange:range actualCharacterRange:NULL];
 		NSRect boundingRect = [[fr layoutManager] boundingRectForGlyphRange:glyphRange inTextContainer:[fr textContainer]];
 		boundingRect = [fr convertRect: boundingRect toView:NULL];
-		pos = [[fr window] convertPointToScreen: NSMakePoint(boundingRect.origin.x + boundingRect.size.width,boundingRect.origin.y + boundingRect.size.height)];
+
+		NSPoint oppositeOrigin = NSMakePoint(NSMaxX(boundingRect), NSMaxY(boundingRect));
+
+		if (@available(macOS 10.12, *)) {
+			pos = [[fr window] convertPointToScreen:oppositeOrigin];
+		} else {
+			pos = [[fr window] convertRectToScreen:(CGRect){.origin=oppositeOrigin}].origin;
+		}
+
 		NSFont* font = [fr font];
 		if(font) pos.y -= [font pointSize]*1.3f;
 		return pos;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
It attempts to fix crashes on macOS 10.10 and 10.11. I don't have those to test on but the used APIs are not available on macOS 10.10 or 10.11 while `convertRectToScreen:` is available back to macOS 10.7 and I tested the new APIs on Catalina (unguarded) to be sure they behaved the same.

Does this close any currently open issues?
------------------------------------------
Should fix #218


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Devices/Simulators:** MacBook Pro 2018

**macOS Version:** macOS 10.14

**Sequel-Ace Version:** 2.1.1


