### PR TITLE
File manager home directory for current user issue 234

### DIFF
--- a/Source/SPFilePreferencePane.m
+++ b/Source/SPFilePreferencePane.m
@@ -212,7 +212,13 @@
 	// retrieve the file manager in order to fetch the current user's home
 	// directory
 	NSFileManager *fileManager = [NSFileManager defaultManager];
-	
+	NSURL *homeDirectory = nil;
+	if ([fileManager respondsToSelector:@selector(homeDirectoryForCurrentUser)]) {
+		homeDirectory = [fileManager homeDirectoryForCurrentUser];
+	} else {
+		homeDirectory = [NSURL fileURLWithPath:NSHomeDirectory()];
+	}
+
 	_currentFilePanel = [NSOpenPanel openPanel];
 	[_currentFilePanel setTitle:@"Choose ssh config"];
 	[_currentFilePanel setCanChooseFiles:YES];
@@ -220,7 +226,7 @@
 	[_currentFilePanel setAllowsMultipleSelection:YES];
 	[_currentFilePanel setAccessoryView:hiddenFileView];
 	[_currentFilePanel setResolvesAliases:NO];
-	[_currentFilePanel setDirectoryURL:[fileManager.homeDirectoryForCurrentUser URLByAppendingPathComponent:@".ssh"]];
+	[_currentFilePanel setDirectoryURL:[homeDirectory URLByAppendingPathComponent:@".ssh"]];
 	[self updateHiddenFiles];
 	
 	[prefs addObserver:self

--- a/Source/SPNetworkPreferencePane.m
+++ b/Source/SPNetworkPreferencePane.m
@@ -295,6 +295,12 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	// retrieve the file manager in order to fetch the current user's home
 	// directory
 	NSFileManager *fileManager = [NSFileManager defaultManager];
+	NSURL *homeDirectory = nil;
+	if ([fileManager respondsToSelector:@selector(homeDirectoryForCurrentUser)]) {
+		homeDirectory = [fileManager homeDirectoryForCurrentUser];
+	} else {
+		homeDirectory = [NSURL fileURLWithPath:NSHomeDirectory()];
+	}
 	
 	_currentFilePanel = [NSOpenPanel openPanel];
 	[_currentFilePanel setTitle:@"Choose ssh config"];
@@ -303,7 +309,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	[_currentFilePanel setAllowsMultipleSelection:YES];
 	[_currentFilePanel setAccessoryView:hiddenFileView];
 	[_currentFilePanel setResolvesAliases:NO];
-	[_currentFilePanel setDirectoryURL:[fileManager.homeDirectoryForCurrentUser URLByAppendingPathComponent:@".ssh"]];
+	[_currentFilePanel setDirectoryURL:[homeDirectory URLByAppendingPathComponent:@".ssh"]];
 	[self updateHiddenFiles];
 	
 	[prefs addObserver:self


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Support for 10.10 & 10.11, when using file manager that opens the user's home folder (or a subfolder of).

Does this close any currently open issues?
------------------------------------------
#234

Where has this been tested?
---------------------------
**macOS Version:** 10.15
