### PR TITLE
Address a couple of deprecations

### DIFF
--- a/Source/SPBundleCommandRunner.m
+++ b/Source/SPBundleCommandRunner.m
@@ -229,7 +229,7 @@
 		NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInteger:pid], @"pid",
 							  (contextInfo)?: @{}, @"contextInfo",
 							  @"bashcommand", @"type",
-							  [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]], @"starttime",
+							  [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:[NSLocale autoupdatingCurrentLocale]], @"starttime",
 							  nil];
 		[caller registerActivity:dict];
 	}

--- a/Source/SPDataImport.m
+++ b/Source/SPDataImport.m
@@ -373,7 +373,7 @@
  */
 - (void)importSQLFile:(NSString *)filename
 {
-	SPLog(@"Staring import....");
+	SPLog(@"Starting import....");
 	
 //	TODO: this is slowwwwwwww
 #ifdef DEBUG

--- a/Source/SPDateAdditions.h
+++ b/Source/SPDateAdditions.h
@@ -31,5 +31,6 @@
 @interface NSDate (SPDateAdditions)
 
 + (double)monotonicTimeInterval;
+-(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale;
 
 @end

--- a/Source/SPDateAdditions.m
+++ b/Source/SPDateAdditions.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #include <mach/mach_time.h>
+#include "SPDateAdditions.h"
 
 @implementation NSDate (SPDateAdditions)
 
@@ -67,5 +68,29 @@
     return (double)(elapsedNano * 1e-9);
 	
 }
+
+
+/**
+ *  Convenience method that returns a formatted string representing the receiver's date formatted to a given date format, time zone and locale
+ *
+ *  @param format   NSString - String representing the desired date format
+ *  @param timeZone NSTimeZone - Desired time zone
+ *  @param locale   NSLocale - Desired locale
+ *
+ *  @return NSString representing the formatted date string
+ */
+-(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale{
+    static NSDateFormatter *formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+    });
+
+    [formatter setDateFormat:format];
+    [formatter setTimeZone:timeZone];
+    [formatter setLocale:locale];
+    return [formatter stringFromDate:self];
+}
+
 
 @end

--- a/Source/SPExportController.m
+++ b/Source/SPExportController.m
@@ -2323,7 +2323,9 @@ set_input:
 			filename = @"query_result";
 			break;
 		case SPTableExport:
-			filename = [NSString stringWithFormat:@"%@_%@", [tableDocumentInstance database], [[NSDate date] descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil]];
+			filename = [NSString stringWithFormat:@"%@_%@", [tableDocumentInstance database], [[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd" timeZone:nil locale:nil]];
+			
+			;
 			break;
 	}
 
@@ -2418,15 +2420,15 @@ set_input:
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameYearTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil]];
+				[string appendString: [[NSDate date] formattedDateWithFormat:@"yyyy" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameMonthTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"MM" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameDayTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"dd" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameTimeTokenName]) {
@@ -2435,7 +2437,7 @@ set_input:
 				[string appendString:[dateFormatter stringFromDate:[NSDate date]]];
 			}
 			else if ([tokenContent isEqualToString:SPFileName24HourTimeTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:nil]];
 			}
 			else if ([tokenContent isEqualToString:SPFileNameFavoriteTokenName]) {
 				[string appendStringOrNil:[tableDocumentInstance name]];

--- a/Source/SPLogger.m
+++ b/Source/SPLogger.m
@@ -119,7 +119,7 @@ int _isSPLeaksLog(const struct direct *entry);
 	// synchronised to allow use across multiple executables or their frameworks.
 	[logFileHandle synchronizeFile];
 	[logFileHandle seekToEndOfFile];
-	[logFileHandle writeData:[[NSString stringWithFormat:@"%@ %@\n", [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]], logString] dataUsingEncoding:NSUTF8StringEncoding]];
+	[logFileHandle writeData:[[NSString stringWithFormat:@"%@ %@\n", [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:[NSLocale autoupdatingCurrentLocale]], logString] dataUsingEncoding:NSUTF8StringEncoding]];
 	[logFileHandle synchronizeFile];
 
 	[logString release];

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -72,6 +72,57 @@
 		
     }];
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)testOldvsNewDateFormat {
+	
+	NSString *str1 = [NSString stringWithFormat:@"%@%@",
+									SPImportClipboardTempFileNamePrefix,
+									[[NSDate  date] descriptionWithCalendarFormat:@"%H%M%S"
+											timeZone:nil
+											locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]]];
+	
+	NSString *str2 = [NSString stringWithFormat:@"%@%@",
+									SPImportClipboardTempFileNamePrefix,
+									[[NSDate date] formattedDateWithFormat:@"HHmmss"
+																  timeZone:nil
+																	locale:[NSLocale autoupdatingCurrentLocale]]];
+	
+	
+	XCTAssertEqualObjects(str1, str2);
+	
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd" timeZone:nil locale:nil];
+	
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"yyyy" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"MM" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"dd" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+
+
+}
+#pragma clang diagnostic pop
+
+
 // OLD method for testing
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -1,0 +1,88 @@
+//
+//  SPDateAdditions.m
+//  Unit Tests
+//
+//  Created by James on 15/7/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+#import <Cocoa/Cocoa.h>
+#include <mach/mach_time.h>
+
+#import <XCTest/XCTest.h>
+#import "SPDateAdditions.h"
+
+
+@interface SPDateAdditionsTests : XCTestCase
+
+@end
+
+@implementation SPDateAdditionsTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testOldvsNewMonotonicTimeInterval {
+
+	double startTimeOld = [self monotonicTimeIntervalOLD];
+	double startNew = [NSDate monotonicTimeInterval];
+	
+	SPLog(@"JIMMY startTimeOld: %f", startTimeOld);
+	SPLog(@"JIMMY startNew: %f", startNew);
+	
+	XCTAssertEqualWithAccuracy(startTimeOld, startNew, 0.0001);
+}
+
+- (void)testPerformanceMonotonicTimeIntervalOLD {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+		
+		int const iterations = 1000000;
+		
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				// exec on bg thread
+				double startTimeOld = [self monotonicTimeIntervalOLD];
+				startTimeOld = 0;
+			}
+		}
+		
+    }];
+}
+
+- (void)testPerformanceMonotonicTimeIntervalNEW {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+		
+		int const iterations = 1000000;
+		
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				// exec on bg thread
+				double startTimeNEW = [NSDate monotonicTimeInterval];
+				startTimeNEW = 0;
+			}
+		}
+		
+    }];
+}
+// OLD method for testing
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (double)monotonicTimeIntervalOLD{
+	
+	uint64_t elapsedTime_t = mach_absolute_time();
+	Nanoseconds nanosecondsElapsed = AbsoluteToNanoseconds(*(AbsoluteTime *)&(elapsedTime_t));
+
+	return (((double)UnsignedWideToUInt64(nanosecondsElapsed)) * 1e-9);
+	
+}
+#pragma clang diagnostic pop
+
+@end

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		1AB068B024A355CC00E2AAC2 /* client-key-lf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689824A355B500E2AAC2 /* client-key-lf.pem */; };
 		1AB068B124A355CC00E2AAC2 /* client-key-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689924A355B500E2AAC2 /* client-key-crlf.pem */; };
 		1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */; };
+		1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */; };
+		1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 58DF9F3215AB26C2003B4330 /* SPDateAdditions.m */; };
 		265446DF24A1616900376B48 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
 		296DC89F0F8FD336002A3258 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296DC89E0F8FD336002A3258 /* WebKit.framework */; };
 		296DC8B60F909194002A3258 /* MGTemplateEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DC8A70F909194002A3258 /* MGTemplateEngine.m */; };
@@ -795,6 +797,7 @@
 		1AB0689824A355B500E2AAC2 /* client-key-lf.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-key-lf.pem"; sourceTree = "<group>"; };
 		1AB0689924A355B500E2AAC2 /* client-key-crlf.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-key-crlf.pem"; sourceTree = "<group>"; };
 		1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPValidateKeyAndCertFiles.m; sourceTree = "<group>"; };
+		1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPDateAdditionsTests.m; sourceTree = "<group>"; };
 		296DC89E0F8FD336002A3258 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
 		296DC8A50F909194002A3258 /* MGTemplateMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGTemplateMarker.h; sourceTree = "<group>"; };
 		296DC8A60F909194002A3258 /* MGTemplateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGTemplateFilter.h; sourceTree = "<group>"; };
@@ -1806,6 +1809,7 @@
 				380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */,
 				1798F1C2155018D4004B0AB8 /* SPMutableArrayAdditionsTests.m */,
 				502D21F51BA50710000D4CE7 /* SPDataAdditionsTests.m */,
+				1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */,
 			);
 			name = "Category Additions";
 			sourceTree = "<group>";
@@ -3007,6 +3011,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */,
 				50837F771E50E007004FAE8A /* SPJSONFormatter.m in Sources */,
 				505F56901BCEE491007467DD /* SPOSInfo.m in Sources */,
 				505F568F1BCEE485007467DD /* SPFunctions.m in Sources */,
@@ -3018,6 +3023,7 @@
 				503B02CF1AE95C2C0060CAB1 /* SPTableFilterParserTest.m in Sources */,
 				50EA92681AB23EFC008D3C4F /* SPTableCopy.m in Sources */,
 				1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */,
+				1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */,
 				507FF1621BBF0D5000104523 /* SPTableCopyTest.m in Sources */,
 				50837F741E50DCD4004FAE8A /* SPJSONFormatterTests.m in Sources */,
 				50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Address a couple of deprecations:

1. update for AbsoluteToNanoseconds deprecation
2. update for descriptionWithCalendarFormat deprecation

Also a couple of main thread fixes.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
I added tests for the new methods.

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev


