### PR TITLE
_stringWithBytes: Don't return nil, return an empty string

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -313,7 +313,9 @@ static id NSNullPointer;
  */
 - (id)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
 {
-	return [[[NSString alloc] initWithBytes:bytes length:length encoding:stringEncoding] autorelease];
+    NSString *str = [[[NSString alloc] initWithBytes:bytes length:length encoding:stringEncoding] autorelease];
+    
+    return (str == nil) ? @"" : str;
 }
 #warning duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
 - (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`_stringWithBytes` could return nil if data == NULL and length > 0
So, quick test, if the str is nil, return `@""`

If nil is returned, fieldDefinitions crashes when trying to insert nil into a dict.

Does this close any currently open issues?
------------------------------------------
#224 

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev


