### PR TITLE
Restrict query warning to destructive sql

### DIFF
--- a/Source/SPCustomQuery.h
+++ b/Source/SPCustomQuery.h
@@ -203,6 +203,7 @@
 - (NSRange)queryRangeAtPosition:(NSUInteger)position lookBehind:(BOOL *)doLookBehind;
 - (NSRange)queryTextRangeForQuery:(NSInteger)anIndex startPosition:(NSUInteger)position;
 - (void) updateStatusInterfaceWithDetails:(NSDictionary *)errorDetails;
+- (BOOL)queriesContainDestructiveSQL:(NSArray *)queries;
 
 // Interface setup
 - (void)updateQueryInteractionInterface;

--- a/Source/SPCustomQuery.m
+++ b/Source/SPCustomQuery.m
@@ -664,13 +664,13 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 			[query replaceOccurrencesOfRegex:@"/\\*(.|\n)*?\\*/" withString:@""];
 			
 			// trim leading spaces
-			[query setString:[query trimSubstringFromStart:@" "]];
-			[query setString:[query trimSubstringFromStart:@"\n"]];
-
+			[query setString:[query dropPrefixWithPrefix:@" "]];
+			[query setString:[query dropPrefixWithPrefix:@"\n"]];
+		
 			SPLog(@"query: [%@]", query);
 			
 			for (NSString *safeCommand in safeCommands){
-				if([query hasPrefix:safeCommand caseInsensitive:YES] == YES){
+				if([query hasPrefixWithPrefix:safeCommand caseSensitive:NO] == YES){
 					SPLog(@"Safe command: [%@], breaking", safeCommand);
 					retCode = NO;
 					break;

--- a/Source/SPCustomQuery.m
+++ b/Source/SPCustomQuery.m
@@ -656,7 +656,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 
 		if([obj isKindOfClass:[NSString class]] && [(NSString *)obj length]){
 			
-			NSMutableString *query = [NSMutableString stringWithString:obj];
+			NSMutableString *query = [obj mutableCopy];
 			
 			// remove comments
 			[query replaceOccurrencesOfRegex:@"--.*?\n" withString:@""];

--- a/Source/SPStringAdditions.h
+++ b/Source/SPStringAdditions.h
@@ -77,6 +77,7 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 - (NSString *)trimSubstringFromStart:(NSString *)needle;
 - (NSString *)trimSubstringFromEnd:(NSString *)needle;
 - (NSString *)trimSubstringFromBothEnds:(NSString *)needle;
+- (BOOL)hasPrefix:(NSString *)prefix caseInsensitive:(BOOL)caseInsensitive;
 
 - (NSString *)getGeomFromTextString;
 

--- a/Source/SPStringAdditions.h
+++ b/Source/SPStringAdditions.h
@@ -74,6 +74,9 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 - (NSArray *)lineRangesForRange:(NSRange)aRange;
 - (NSString *)createViewSyntaxPrettifier;
 - (NSString *)summarizeToLength:(NSUInteger)length withEllipsis:(BOOL)ellipsis;
+- (NSString *)trimSubstringFromStart:(NSString *)needle;
+- (NSString *)trimSubstringFromEnd:(NSString *)needle;
+- (NSString *)trimSubstringFromBothEnds:(NSString *)needle;
 
 - (NSString *)getGeomFromTextString;
 

--- a/Source/SPStringAdditions.h
+++ b/Source/SPStringAdditions.h
@@ -74,10 +74,6 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 - (NSArray *)lineRangesForRange:(NSRange)aRange;
 - (NSString *)createViewSyntaxPrettifier;
 - (NSString *)summarizeToLength:(NSUInteger)length withEllipsis:(BOOL)ellipsis;
-- (NSString *)trimSubstringFromStart:(NSString *)needle;
-- (NSString *)trimSubstringFromEnd:(NSString *)needle;
-- (NSString *)trimSubstringFromBothEnds:(NSString *)needle;
-- (BOOL)hasPrefix:(NSString *)prefix caseInsensitive:(BOOL)caseInsensitive;
 
 - (NSString *)getGeomFromTextString;
 

--- a/Source/SPStringAdditions.m
+++ b/Source/SPStringAdditions.m
@@ -382,6 +382,32 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 	return newString;
 }
 
+- (NSString *)trimSubstringFromStart:(NSString *)needle
+{
+	NSInteger needleLen = [needle length];
+	NSString *str = self;
+	while ([str hasPrefix:needle]){
+		str = [str substringFromIndex:needleLen];
+	}
+	return str;
+}
+
+- (NSString *)trimSubstringFromEnd:(NSString *)needle
+{
+	NSInteger needleLen = [needle length];
+	NSString *str = self;
+	while ([str hasSuffix:needle]){
+		str = [str substringToIndex:([str length] - needleLen)];
+	}
+	return str;
+}
+
+- (NSString *)trimSubstringFromBothEnds:(NSString *)needle
+{
+	return [[self trimSubstringFromStart:needle] trimSubstringFromEnd:needle];
+}
+
+
 - (NSString *)summarizeToLength:(NSUInteger)length withEllipsis:(BOOL)ellipsis
 {
 	NSString *str = self;

--- a/Source/SPStringAdditions.m
+++ b/Source/SPStringAdditions.m
@@ -382,45 +382,6 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 	return newString;
 }
 
-// from Apple: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/SearchingStrings.html#//apple_ref/doc/uid/20000149-SW7
-- (BOOL)hasPrefix:(NSString *)prefix caseInsensitive:(BOOL)caseInsensitive
-{
-	if (!caseInsensitive){
-        return [self hasPrefix:prefix];
-	}
-	
-    const NSStringCompareOptions options = NSAnchoredSearch|NSCaseInsensitiveSearch;
-	
-    NSRange prefixRange = [self rangeOfString:prefix options:options];
-    
-	return prefixRange.location == 0 && prefixRange.length > 0;
-}
-
-- (NSString *)trimSubstringFromStart:(NSString *)needle
-{
-	NSInteger needleLen = [needle length];
-	NSString *str = self;
-	while ([str hasPrefix:needle]){
-		str = [str substringFromIndex:needleLen];
-	}
-	return str;
-}
-
-- (NSString *)trimSubstringFromEnd:(NSString *)needle
-{
-	NSInteger needleLen = [needle length];
-	NSString *str = self;
-	while ([str hasSuffix:needle]){
-		str = [str substringToIndex:([str length] - needleLen)];
-	}
-	return str;
-}
-
-- (NSString *)trimSubstringFromBothEnds:(NSString *)needle
-{
-	return [[self trimSubstringFromStart:needle] trimSubstringFromEnd:needle];
-}
-
 
 - (NSString *)summarizeToLength:(NSUInteger)length withEllipsis:(BOOL)ellipsis
 {

--- a/Source/SPStringAdditions.m
+++ b/Source/SPStringAdditions.m
@@ -382,6 +382,20 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 	return newString;
 }
 
+// from Apple: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/SearchingStrings.html#//apple_ref/doc/uid/20000149-SW7
+- (BOOL)hasPrefix:(NSString *)prefix caseInsensitive:(BOOL)caseInsensitive
+{
+	if (!caseInsensitive){
+        return [self hasPrefix:prefix];
+	}
+	
+    const NSStringCompareOptions options = NSAnchoredSearch|NSCaseInsensitiveSearch;
+	
+    NSRange prefixRange = [self rangeOfString:prefix options:options];
+    
+	return prefixRange.location == 0 && prefixRange.length > 0;
+}
+
 - (NSString *)trimSubstringFromStart:(NSString *)needle
 {
 	NSInteger needleLen = [needle length];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Now only displays the query warning if the queries are not SHOW or SELECT. i.e. 'destructive'

Does this close any currently open issues?
------------------------------------------
#160


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev


