### PR TITLE
Allow using LOAD DATA LOCAL INFILE

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -615,6 +615,9 @@ asm(".desc ___crashreporter_info__, 0x10");
     // Some servers have issues when we try caching_sha2_password first; let's always try mysql_native_password first; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/141
     mysql_options(theConnection, MYSQL_DEFAULT_AUTH, [@"mysql_native_password" UTF8String]);
 
+    // Allow using LOAD DATA LOCAL INFILE ...; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/245
+    mysql_options(theConnection, MYSQL_OPT_LOCAL_INFILE, [@"On" UTF8String]);
+
 	// Set up the connection variables in the format MySQL needs, from the class-wide variables
 	const char *theHost = NULL;
 	const char *theUsername = "";


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow using LOAD DATA LOCAL INFILE
(on the client side; it still needs to be enabled on the server side too)

Does this close any currently open issues?
------------------------------------------
Fixes #245

Any other comments?
-------------------
WIP; do not merge.
See discussion https://github.com/Sequel-Ace/Sequel-Ace/issues/245#issuecomment-659632758

Where has this been tested?
---------------------------
MySQL 5.7 (Docker)
MySQL 8 (Docker)