### PR TITLE
Changed default for ShowWarningBeforeExecQuery to NO

### DIFF
--- a/Interfaces/Base.lproj/Preferences.xib
+++ b/Interfaces/Base.lproj/Preferences.xib
@@ -844,7 +844,7 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="value" keyPath="values.ShowWarningBeforeExecQuery" id="vid-6Z-YSC"/>
+                        <binding destination="117" name="value" keyPath="values.ShowWarningBeforeExecuteQuery" id="vid-6Z-YSC"/>
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1156">

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -201,7 +201,7 @@
 	<false/>
 	<key>CopyContentOnTableCopy</key>
 	<false/>
-	<key>ShowWarningBeforeExecQuery</key>
+	<key>ShowWarningBeforeExecuteQuery</key>
 	<false/>
 </dict>
 </plist>

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -202,6 +202,6 @@
 	<key>CopyContentOnTableCopy</key>
 	<false/>
 	<key>ShowWarningBeforeExecQuery</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -112,7 +112,7 @@ NSString *SPFilterTableDefaultOperatorLastItems  = @"FilterTableDefaultOperatorL
 NSString *SPFavorites                            = @"favorites";
 
 // Notifications Prefpane
-NSString *SPQueryWarningEnabled                  = @"ShowWarningBeforeExecQuery";
+NSString *SPQueryWarningEnabled                  = @"ShowWarningBeforeExecuteQuery";
 NSString *SPShowNoAffectedRowsError              = @"ShowNoAffectedRowsError";
 NSString *SPConsoleEnableLogging                 = @"ConsoleEnableLogging";
 NSString *SPConsoleEnableInterfaceLogging        = @"ConsoleEnableInterfaceLogging";


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Change default for `ShowWarningBeforeExecQuery` to `NO`, and changed preference's name to `ShowWarningBeforeExecuteQuery` in order to go back to `NO` for users who used the 2.1.3 (beta or final).

Does this close any currently open issues?
------------------------------------------
Ref: https://github.com/Sequel-Ace/Sequel-Ace/pull/204#issuecomment-659611185