### PR TITLE
Release 2.1.4

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -313,7 +313,9 @@ static id NSNullPointer;
  */
 - (id)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
 {
-	return [[[NSString alloc] initWithBytes:bytes length:length encoding:stringEncoding] autorelease];
+    NSString *str = [[[NSString alloc] initWithBytes:bytes length:length encoding:stringEncoding] autorelease];
+    
+    return (str == nil) ? @"" : str;
 }
 #warning duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
 - (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy

--- a/Interfaces/Base.lproj/Preferences.xib
+++ b/Interfaces/Base.lproj/Preferences.xib
@@ -844,7 +844,7 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="117" name="value" keyPath="values.ShowWarningBeforeExecQuery" id="vid-6Z-YSC"/>
+                        <binding destination="117" name="value" keyPath="values.ShowWarningBeforeExecuteQuery" id="vid-6Z-YSC"/>
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1156">

--- a/Resources/Plists/Info.plist
+++ b/Resources/Plists/Info.plist
@@ -197,7 +197,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2068</string>
+	<string>2071</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Resources/Plists/PSMTabBar-Info.plist
+++ b/Resources/Plists/PSMTabBar-Info.plist
@@ -13,11 +13,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2068</string>
+	<string>2071</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -201,7 +201,7 @@
 	<false/>
 	<key>CopyContentOnTableCopy</key>
 	<false/>
-	<key>ShowWarningBeforeExecQuery</key>
-	<true/>
+	<key>ShowWarningBeforeExecuteQuery</key>
+	<false/>
 </dict>
 </plist>

--- a/Resources/Plists/Sequel Ace QLGenerator-Info.plist
+++ b/Resources/Plists/Sequel Ace QLGenerator-Info.plist
@@ -30,9 +30,9 @@
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2068</string>
+	<string>2071</string>
 	<key>CFPlugInDynamicRegisterFunction</key>
 	<string></string>
 	<key>CFPlugInDynamicRegistration</key>

--- a/Resources/Plists/TunnelAssistant-Info.plist
+++ b/Resources/Plists/TunnelAssistant-Info.plist
@@ -168,9 +168,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2068</string>
+	<string>2071</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Resources/Plists/Unit Tests-Info.plist
+++ b/Resources/Plists/Unit Tests-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2068</string>
+	<string>2071</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/Source/SPBundleCommandRunner.m
+++ b/Source/SPBundleCommandRunner.m
@@ -229,7 +229,7 @@
 		NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInteger:pid], @"pid",
 							  (contextInfo)?: @{}, @"contextInfo",
 							  @"bashcommand", @"type",
-							  [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]], @"starttime",
+							  [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:[NSLocale autoupdatingCurrentLocale]], @"starttime",
 							  nil];
 		[caller registerActivity:dict];
 	}

--- a/Source/SPConstants.m
+++ b/Source/SPConstants.m
@@ -112,7 +112,7 @@ NSString *SPFilterTableDefaultOperatorLastItems  = @"FilterTableDefaultOperatorL
 NSString *SPFavorites                            = @"favorites";
 
 // Notifications Prefpane
-NSString *SPQueryWarningEnabled                  = @"ShowWarningBeforeExecQuery";
+NSString *SPQueryWarningEnabled                  = @"ShowWarningBeforeExecuteQuery";
 NSString *SPShowNoAffectedRowsError              = @"ShowNoAffectedRowsError";
 NSString *SPConsoleEnableLogging                 = @"ConsoleEnableLogging";
 NSString *SPConsoleEnableInterfaceLogging        = @"ConsoleEnableInterfaceLogging";

--- a/Source/SPDataImport.m
+++ b/Source/SPDataImport.m
@@ -48,6 +48,8 @@
 
 #import <SPMySQL/SPMySQL.h>
 
+#import "Sequel_Ace-Swift.h"
+
 #define SP_FILE_READ_ERROR_STRING NSLocalizedString(@"File read error", @"File read error title (Import Dialog)")
 
 @interface SPDataImport ()
@@ -223,13 +225,13 @@
 
 	// Reset progress cancelled from any previous runs
 	progressCancelled = NO;
-
+	
 	NSString *importFileName = [NSString stringWithFormat:@"%@%@",
-									SPImportClipboardTempFileNamePrefix, 
-									[[NSDate  date] descriptionWithCalendarFormat:@"%H%M%S" 
-											timeZone:nil 
-											locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]]];
-
+									SPImportClipboardTempFileNamePrefix,
+									[[NSDate date] formattedDateWithFormat:@"HHmmss"
+																  timeZone:nil
+																	locale:[NSLocale autoupdatingCurrentLocale]]];
+		
 	// Write clipboard content to temp file using the connection encoding
 	NSStringEncoding encoding;
 	if ([[[importFormatPopup selectedItem] title] isEqualToString:@"SQL"])
@@ -371,6 +373,16 @@
  */
 - (void)importSQLFile:(NSString *)filename
 {
+	SPLog(@"Starting import....");
+	
+//	TODO: this is slowwwwwwww
+#ifdef DEBUG
+	NSDate *startDate;
+	NSDate *endDate;
+	NSTimeInterval interval;
+	startDate = [NSDate date];
+#endif
+	
 	NSAutoreleasePool *importPool;
 	SPFileHandle *sqlFileHandle;
 	NSMutableData *sqlDataBuffer;
@@ -674,15 +686,19 @@
 
 			// Increment the processed queries count
 			queriesPerformed++;
-
+#ifdef DEBUG
+			endDate = [NSDate date];
+			interval = [endDate timeIntervalSinceDate:startDate];
+			SPLog(@"JIMMY time taken: %@, for %ld queries", [NSString stringWithFormat:@"%.3f", interval], (long)queriesPerformed);
+#endif
 			// Update the progress bar
 			if (fileIsCompressed) {
-				[singleProgressBar setDoubleValue:[sqlFileHandle realDataReadLength]];
-				[singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown"),
+				[[singleProgressBar onMainThread] setDoubleValue:[sqlFileHandle realDataReadLength]];
+				[[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown"),
 					[NSString stringForByteSize:fileProcessedLength]]];
 			} else {
-				[singleProgressBar setDoubleValue:fileProcessedLength];
-				[singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"),
+				[[singleProgressBar onMainThread] setDoubleValue:fileProcessedLength];
+				[[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"),
 					[NSString stringForByteSize:fileProcessedLength], [NSString stringForByteSize:fileTotalLength]]];
 			}
 		}
@@ -753,6 +769,13 @@
 
 	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
 	[notification release];
+
+#ifdef DEBUG
+	endDate = [NSDate date];
+	interval = [endDate timeIntervalSinceDate:startDate];
+	SPLog(@"JIMMY total time taken: %@, for %ld queries", [NSString stringWithFormat:@"%.3f", interval], (long)queriesPerformed);
+#endif
+
 }
 
 #pragma mark -

--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -3574,9 +3574,15 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	if (contextInfo == nil) {
 		// Register and update query favorites, content filter, and history for the (new) file URL
 		NSMutableDictionary *preferences = [[NSMutableDictionary alloc] init];
-		[preferences setObject:[spfStructure objectForKey:SPQueryHistory] forKey:SPQueryHistory];
-		[preferences setObject:[spfStructure objectForKey:SPQueryFavorites] forKey:SPQueryFavorites];
-		[preferences setObject:[spfStructure objectForKey:SPContentFilters] forKey:SPContentFilters];
+		if([spfStructure objectForKey:SPQueryHistory]){
+			[preferences setObject:[spfStructure objectForKey:SPQueryHistory] forKey:SPQueryHistory];
+		}
+		if([spfStructure objectForKey:SPQueryFavorites]){
+			[preferences setObject:[spfStructure objectForKey:SPQueryFavorites] forKey:SPQueryFavorites];
+		}
+		if([spfStructure objectForKey:SPContentFilters]){
+			[preferences setObject:[spfStructure objectForKey:SPContentFilters] forKey:SPContentFilters];
+		}
 		[[SPQueryController sharedQueryController] registerDocumentWithFileURL:[NSURL fileURLWithPath:fileName] andContextInfo:preferences];
 
 		NSURL *newURL = [NSURL fileURLWithPath:fileName];
@@ -5080,9 +5086,17 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	}
 
 	// Move favourites and history into the data dictionary to pass to setState:
-	[data setObject:[spf objectForKey:SPQueryFavorites] forKey:SPQueryFavorites];
-	[data setObject:[spf objectForKey:SPQueryHistory] forKey:SPQueryHistory];
-	[data setObject:[spf objectForKey:SPContentFilters] forKey:SPContentFilters];
+	// SPQueryHistory is no longer saved to the SPF file, so it was causing an exception here (it was adding nil to the spf dict), skipping out of the method and not connecting
+	// or restoring the query screen content. See commit 96063541
+	if([spf objectForKey:SPQueryFavorites]){
+		[data setObject:[spf objectForKey:SPQueryFavorites] forKey:SPQueryFavorites];
+	}
+	if([spf objectForKey:SPQueryHistory]){
+		[data setObject:[spf objectForKey:SPQueryHistory] forKey:SPQueryHistory];
+	}
+	if([spf objectForKey:SPContentFilters]){
+		[data setObject:[spf objectForKey:SPContentFilters] forKey:SPContentFilters];
+	}
 
 	// Ensure the encryption status is stored in the spfDocData store for future saves
 	[spfDocData setObject:@NO forKey:@"encrypted"];

--- a/Source/SPDateAdditions.h
+++ b/Source/SPDateAdditions.h
@@ -31,5 +31,6 @@
 @interface NSDate (SPDateAdditions)
 
 + (double)monotonicTimeInterval;
+-(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale;
 
 @end

--- a/Source/SPDateAdditions.m
+++ b/Source/SPDateAdditions.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #include <mach/mach_time.h>
+#include "SPDateAdditions.h"
 
 @implementation NSDate (SPDateAdditions)
 
@@ -42,10 +43,54 @@
  */
 + (double)monotonicTimeInterval
 {
+	
+	uint64_t elapsedNano;
+    static mach_timebase_info_data_t sTimebaseInfo;
 	uint64_t elapsedTime_t = mach_absolute_time();
-	Nanoseconds nanosecondsElapsed = AbsoluteToNanoseconds(*(AbsoluteTime *)&(elapsedTime_t));
 
-	return (((double)UnsignedWideToUInt64(nanosecondsElapsed)) * 1e-9);
+	// see: https://developer.apple.com/library/archive/qa/qa1398/_index.html
+	// Convert to nanoseconds.
+
+    // If this is the first time we've run, get the timebase.
+    // We can use denom == 0 to indicate that sTimebaseInfo is
+    // uninitialised because it makes no sense to have a zero
+    // denominator is a fraction.
+
+    if ( sTimebaseInfo.denom == 0 ) {
+        (void) mach_timebase_info(&sTimebaseInfo);
+    }
+	
+    // Do the maths. We hope that the multiplication doesn't
+    // overflow; the price you pay for working in fixed point.
+
+    elapsedNano = elapsedTime_t * sTimebaseInfo.numer / sTimebaseInfo.denom;
+
+    return (double)(elapsedNano * 1e-9);
+	
 }
+
+
+/**
+ *  Convenience method that returns a formatted string representing the receiver's date formatted to a given date format, time zone and locale
+ *
+ *  @param format   NSString - String representing the desired date format
+ *  @param timeZone NSTimeZone - Desired time zone
+ *  @param locale   NSLocale - Desired locale
+ *
+ *  @return NSString representing the formatted date string
+ */
+-(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale{
+    static NSDateFormatter *formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+    });
+
+    [formatter setDateFormat:format];
+    [formatter setTimeZone:timeZone];
+    [formatter setLocale:locale];
+    return [formatter stringFromDate:self];
+}
+
 
 @end

--- a/Source/SPExportController.m
+++ b/Source/SPExportController.m
@@ -2323,7 +2323,9 @@ set_input:
 			filename = @"query_result";
 			break;
 		case SPTableExport:
-			filename = [NSString stringWithFormat:@"%@_%@", [tableDocumentInstance database], [[NSDate date] descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil]];
+			filename = [NSString stringWithFormat:@"%@_%@", [tableDocumentInstance database], [[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd" timeZone:nil locale:nil]];
+			
+			;
 			break;
 	}
 
@@ -2418,15 +2420,15 @@ set_input:
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameYearTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil]];
+				[string appendString: [[NSDate date] formattedDateWithFormat:@"yyyy" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameMonthTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"MM" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameDayTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"dd" timeZone:nil locale:nil]];
 
 			}
 			else if ([tokenContent isEqualToString:SPFileNameTimeTokenName]) {
@@ -2435,7 +2437,7 @@ set_input:
 				[string appendString:[dateFormatter stringFromDate:[NSDate date]]];
 			}
 			else if ([tokenContent isEqualToString:SPFileName24HourTimeTokenName]) {
-				[string appendString:[[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil]];
+				[string appendString:[[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:nil]];
 			}
 			else if ([tokenContent isEqualToString:SPFileNameFavoriteTokenName]) {
 				[string appendStringOrNil:[tableDocumentInstance name]];

--- a/Source/SPFilePreferencePane.m
+++ b/Source/SPFilePreferencePane.m
@@ -212,7 +212,13 @@
 	// retrieve the file manager in order to fetch the current user's home
 	// directory
 	NSFileManager *fileManager = [NSFileManager defaultManager];
-	
+	NSURL *homeDirectory = nil;
+	if ([fileManager respondsToSelector:@selector(homeDirectoryForCurrentUser)]) {
+		homeDirectory = [fileManager homeDirectoryForCurrentUser];
+	} else {
+		homeDirectory = [NSURL fileURLWithPath:NSHomeDirectory()];
+	}
+
 	_currentFilePanel = [NSOpenPanel openPanel];
 	[_currentFilePanel setTitle:@"Choose ssh config"];
 	[_currentFilePanel setCanChooseFiles:YES];
@@ -220,7 +226,7 @@
 	[_currentFilePanel setAllowsMultipleSelection:YES];
 	[_currentFilePanel setAccessoryView:hiddenFileView];
 	[_currentFilePanel setResolvesAliases:NO];
-	[_currentFilePanel setDirectoryURL:[fileManager.homeDirectoryForCurrentUser URLByAppendingPathComponent:@".ssh"]];
+	[_currentFilePanel setDirectoryURL:[homeDirectory URLByAppendingPathComponent:@".ssh"]];
 	[self updateHiddenFiles];
 	
 	[prefs addObserver:self

--- a/Source/SPLogger.m
+++ b/Source/SPLogger.m
@@ -119,7 +119,7 @@ int _isSPLeaksLog(const struct direct *entry);
 	// synchronised to allow use across multiple executables or their frameworks.
 	[logFileHandle synchronizeFile];
 	[logFileHandle seekToEndOfFile];
-	[logFileHandle writeData:[[NSString stringWithFormat:@"%@ %@\n", [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]], logString] dataUsingEncoding:NSUTF8StringEncoding]];
+	[logFileHandle writeData:[[NSString stringWithFormat:@"%@ %@\n", [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:[NSLocale autoupdatingCurrentLocale]], logString] dataUsingEncoding:NSUTF8StringEncoding]];
 	[logFileHandle synchronizeFile];
 
 	[logString release];

--- a/Source/SPNetworkPreferencePane.m
+++ b/Source/SPNetworkPreferencePane.m
@@ -295,6 +295,12 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	// retrieve the file manager in order to fetch the current user's home
 	// directory
 	NSFileManager *fileManager = [NSFileManager defaultManager];
+	NSURL *homeDirectory = nil;
+	if ([fileManager respondsToSelector:@selector(homeDirectoryForCurrentUser)]) {
+		homeDirectory = [fileManager homeDirectoryForCurrentUser];
+	} else {
+		homeDirectory = [NSURL fileURLWithPath:NSHomeDirectory()];
+	}
 	
 	_currentFilePanel = [NSOpenPanel openPanel];
 	[_currentFilePanel setTitle:@"Choose ssh config"];
@@ -303,7 +309,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	[_currentFilePanel setAllowsMultipleSelection:YES];
 	[_currentFilePanel setAccessoryView:hiddenFileView];
 	[_currentFilePanel setResolvesAliases:NO];
-	[_currentFilePanel setDirectoryURL:[fileManager.homeDirectoryForCurrentUser URLByAppendingPathComponent:@".ssh"]];
+	[_currentFilePanel setDirectoryURL:[homeDirectory URLByAppendingPathComponent:@".ssh"]];
 	[self updateHiddenFiles];
 	
 	[prefs addObserver:self

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -1,0 +1,139 @@
+//
+//  SPDateAdditions.m
+//  Unit Tests
+//
+//  Created by James on 15/7/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+#import <Cocoa/Cocoa.h>
+#include <mach/mach_time.h>
+
+#import <XCTest/XCTest.h>
+#import "SPDateAdditions.h"
+
+
+@interface SPDateAdditionsTests : XCTestCase
+
+@end
+
+@implementation SPDateAdditionsTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testOldvsNewMonotonicTimeInterval {
+
+	double startTimeOld = [self monotonicTimeIntervalOLD];
+	double startNew = [NSDate monotonicTimeInterval];
+	
+	SPLog(@"JIMMY startTimeOld: %f", startTimeOld);
+	SPLog(@"JIMMY startNew: %f", startNew);
+	
+	XCTAssertEqualWithAccuracy(startTimeOld, startNew, 0.0001);
+}
+
+- (void)testPerformanceMonotonicTimeIntervalOLD {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+		
+		int const iterations = 1000000;
+		
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				// exec on bg thread
+				double startTimeOld = [self monotonicTimeIntervalOLD];
+				startTimeOld = 0;
+			}
+		}
+		
+    }];
+}
+
+- (void)testPerformanceMonotonicTimeIntervalNEW {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+		
+		int const iterations = 1000000;
+		
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				// exec on bg thread
+				double startTimeNEW = [NSDate monotonicTimeInterval];
+				startTimeNEW = 0;
+			}
+		}
+		
+    }];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)testOldvsNewDateFormat {
+	
+	NSString *str1 = [NSString stringWithFormat:@"%@%@",
+									SPImportClipboardTempFileNamePrefix,
+									[[NSDate  date] descriptionWithCalendarFormat:@"%H%M%S"
+											timeZone:nil
+											locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]]];
+	
+	NSString *str2 = [NSString stringWithFormat:@"%@%@",
+									SPImportClipboardTempFileNamePrefix,
+									[[NSDate date] formattedDateWithFormat:@"HHmmss"
+																  timeZone:nil
+																	locale:[NSLocale autoupdatingCurrentLocale]]];
+	
+	
+	XCTAssertEqualObjects(str1, str2);
+	
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd" timeZone:nil locale:nil];
+	
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"yyyy" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"MM" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"dd" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+	
+	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil];
+	str2 = [[NSDate date] formattedDateWithFormat:@"HH:mm:ss" timeZone:nil locale:nil];
+
+	XCTAssertEqualObjects(str1, str2);
+
+
+}
+#pragma clang diagnostic pop
+
+
+// OLD method for testing
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (double)monotonicTimeIntervalOLD{
+	
+	uint64_t elapsedTime_t = mach_absolute_time();
+	Nanoseconds nanosecondsElapsed = AbsoluteToNanoseconds(*(AbsoluteTime *)&(elapsedTime_t));
+
+	return (((double)UnsignedWideToUInt64(nanosecondsElapsed)) * 1e-9);
+	
+}
+#pragma clang diagnostic pop
+
+@end

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		1AB068B024A355CC00E2AAC2 /* client-key-lf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689824A355B500E2AAC2 /* client-key-lf.pem */; };
 		1AB068B124A355CC00E2AAC2 /* client-key-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689924A355B500E2AAC2 /* client-key-crlf.pem */; };
 		1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */; };
+		1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */; };
+		1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 58DF9F3215AB26C2003B4330 /* SPDateAdditions.m */; };
 		265446DF24A1616900376B48 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
 		296DC89F0F8FD336002A3258 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296DC89E0F8FD336002A3258 /* WebKit.framework */; };
 		296DC8B60F909194002A3258 /* MGTemplateEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DC8A70F909194002A3258 /* MGTemplateEngine.m */; };
@@ -795,6 +797,7 @@
 		1AB0689824A355B500E2AAC2 /* client-key-lf.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-key-lf.pem"; sourceTree = "<group>"; };
 		1AB0689924A355B500E2AAC2 /* client-key-crlf.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-key-crlf.pem"; sourceTree = "<group>"; };
 		1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPValidateKeyAndCertFiles.m; sourceTree = "<group>"; };
+		1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPDateAdditionsTests.m; sourceTree = "<group>"; };
 		296DC89E0F8FD336002A3258 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
 		296DC8A50F909194002A3258 /* MGTemplateMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGTemplateMarker.h; sourceTree = "<group>"; };
 		296DC8A60F909194002A3258 /* MGTemplateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGTemplateFilter.h; sourceTree = "<group>"; };
@@ -1806,6 +1809,7 @@
 				380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */,
 				1798F1C2155018D4004B0AB8 /* SPMutableArrayAdditionsTests.m */,
 				502D21F51BA50710000D4CE7 /* SPDataAdditionsTests.m */,
+				1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */,
 			);
 			name = "Category Additions";
 			sourceTree = "<group>";
@@ -3007,6 +3011,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */,
 				50837F771E50E007004FAE8A /* SPJSONFormatter.m in Sources */,
 				505F56901BCEE491007467DD /* SPOSInfo.m in Sources */,
 				505F568F1BCEE485007467DD /* SPFunctions.m in Sources */,
@@ -3018,6 +3023,7 @@
 				503B02CF1AE95C2C0060CAB1 /* SPTableFilterParserTest.m in Sources */,
 				50EA92681AB23EFC008D3C4F /* SPTableCopy.m in Sources */,
 				1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */,
+				1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */,
 				507FF1621BBF0D5000104523 /* SPTableCopyTest.m in Sources */,
 				50837F741E50DCD4004FAE8A /* SPJSONFormatterTests.m in Sources */,
 				50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */,
@@ -3664,7 +3670,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/Frameworks",
 					"$(inherited)",
@@ -3699,7 +3705,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/Frameworks",
 					"$(inherited)",
@@ -3732,7 +3738,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/Frameworks",
 					"$(inherited)",
@@ -3764,7 +3770,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3785,7 +3791,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3806,7 +3812,7 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Source/Sequel-Pro.pch";
@@ -3845,7 +3851,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -3897,7 +3903,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
@@ -3919,7 +3925,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/SPMySQLFramework/MySQL\\ Client\\ Libraries/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 2.1.3;
+				MARKETING_VERSION = 2.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace";
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3937,9 +3943,9 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 2068;
+				DYLIB_CURRENT_VERSION = 2071;
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -3961,10 +3967,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 2068;
+				DYLIB_CURRENT_VERSION = 2071;
 				FRAMEWORK_VERSION = A;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3985,9 +3991,9 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 2068;
+				DYLIB_CURRENT_VERSION = 2071;
 				FRAMEWORK_VERSION = A;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -4009,7 +4015,7 @@
 				CODE_SIGN_ENTITLEMENTS = xibLocalizationPostprocessor.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -4035,7 +4041,7 @@
 				CODE_SIGN_ENTITLEMENTS = xibLocalizationPostprocessor.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -4060,7 +4066,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = xibLocalizationPostprocessor.entitlements;
 				CODE_SIGN_IDENTITY = "-";
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -4087,7 +4093,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Frameworks";
@@ -4122,7 +4128,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -4157,7 +4163,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Frameworks";
@@ -4191,7 +4197,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
@@ -4213,7 +4219,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/SPMySQLFramework/MySQL\\ Client\\ Libraries/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 2.1.3;
+				MARKETING_VERSION = 2.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace";
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4235,7 +4241,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = NKQ4HJ66PX;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -4258,7 +4264,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/SPMySQLFramework/MySQL\\ Client\\ Libraries/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 2.1.3;
+				MARKETING_VERSION = 2.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace";
 				PRODUCT_NAME = "Sequel Ace";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4296,7 +4302,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -4372,7 +4378,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2068;
+				CURRENT_PROJECT_VERSION = 2071;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
- Fix restoring query editor content from .SPF file (fixes #174)
- Fix accessible files bug in macOS 10.11 and 10.10 (fixes #234)
- Fix for a rare query editor crash (fixes #224)
- Default to not warning before queries (fixes #248)