### PR TITLE
Only show import warning dialog when importing SQL files

### DIFF
--- a/Source/SPDataImport.m
+++ b/Source/SPDataImport.m
@@ -320,7 +320,7 @@
 		if (importFileName == nil) return;
 		
 		// Check to see if current connection has existing tables, if so warn
-		if([[tablesListInstance tables] count] > 1){
+		if([[tablesListInstance tables] count] > 1 && [[[importFormatPopup selectedItem] title] isEqualToString:@"SQL"]){
 			SPBeginAlertSheet(NSLocalizedString(@"The current database already has existing tables, importing may overwrite data. Are you sure you want to continue?", @"title of warning when trying to import data when tables already exist"),
 							  NSLocalizedString(@"Yes, continue anyway", @"Yes, continue anyway"),	// Main button
 							  NSLocalizedString(@"Cancel import", @"Cancel import"),	// Alternate button


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
I'd agree with issue #230 that the warning is just an annoyance when importing CSV files because you get a detail window for selecting the table and columns after accepting the warning. Since I'm not a macOS developer this was an easy first issue to try out. Any feedback is welcome.

Does this close any currently open issues?
------------------------------------------
#230 

Where has this been tested?
---------------------------
**macOS Version:** …
macOS 10.15.5
