### PR TITLE
Added clear filters and add filter buttons

### DIFF
--- a/Interfaces/Base.lproj/DBView.xib
+++ b/Interfaces/Base.lproj/DBView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -1237,6 +1237,7 @@
                                                                                     <rect key="frame" x="0.0" y="0.0" width="694" height="40"/>
                                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                                                     <connections>
+                                                                                        <action selector="_menuItemInRuleEditorClicked:" target="ki9-Po-bdr" id="mgx-03-h4w"/>
                                                                                         <outlet property="delegate" destination="ki9-Po-bdr" id="rFd-07-AiC"/>
                                                                                     </connections>
                                                                                 </ruleEditor>
@@ -1251,15 +1252,26 @@
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                         </scroller>
                                                                     </scrollView>
-                                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GJn-1I-e7O" customClass="SPFillView">
+                                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GJn-1I-e7O" customClass="SPButtonBar">
                                                                         <rect key="frame" x="0.0" y="30" width="695" height="1"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="string" keyPath="systemColorOfName" value="gridColor"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                     </customView>
+                                                                    <button toolTip="Clear filters" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4rb-LV-wk6" userLabel="Clear Filters">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                                                                        <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="button_clearTemplate" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="xch-cX-dFF">
+                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" metaFont="system"/>
+                                                                        </buttonCell>
+                                                                        <connections>
+                                                                            <action selector="resetFilter:" target="ki9-Po-bdr" id="1w5-ri-92x"/>
+                                                                        </connections>
+                                                                    </button>
                                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4676">
-                                                                        <rect key="frame" x="616" y="5" width="54" height="19"/>
+                                                                        <rect key="frame" x="622" y="6" width="54" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                                         <buttonCell key="cell" type="roundRect" title="Filter" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4677">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1267,6 +1279,17 @@
                                                                         </buttonCell>
                                                                         <connections>
                                                                             <action selector="filterTable:" target="ki9-Po-bdr" id="eAC-YD-du3"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xVl-jD-jgc">
+                                                                        <rect key="frame" x="548" y="6" width="66" height="19"/>
+                                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                                                        <buttonCell key="cell" type="roundRect" title="Add Filter" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MCE-yX-CGu">
+                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" metaFont="message" size="11"/>
+                                                                        </buttonCell>
+                                                                        <connections>
+                                                                            <action selector="addFilter:" target="ki9-Po-bdr" id="K6X-Ba-Xld"/>
                                                                         </connections>
                                                                     </button>
                                                                 </subviews>
@@ -1819,15 +1842,15 @@ Gw
                                                                         <rect key="frame" x="109" y="0.0" width="554" height="73"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" id="fhZ-nZ-AwI">
-                                                                            <rect key="frame" x="1" y="1" width="552" height="71"/>
+                                                                            <rect key="frame" x="1" y="1" width="537" height="71"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" continuousSpellChecking="YES" smartInsertDelete="YES" id="8236">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="552" height="71"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="537" height="71"/>
                                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <size key="minSize" width="552" height="71"/>
+                                                                                    <size key="minSize" width="537" height="71"/>
                                                                                     <size key="maxSize" width="1097" height="10000000"/>
                                                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <connections>
@@ -1865,15 +1888,15 @@ Gw
                                                                         <rect key="frame" x="109" y="0.0" width="554" height="200"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" drawsBackground="NO" id="nV8-ly-BSi">
-                                                                            <rect key="frame" x="1" y="1" width="552" height="198"/>
+                                                                            <rect key="frame" x="1" y="1" width="537" height="198"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" id="8242" customClass="SPTextView">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="552" height="198"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="537" height="198"/>
                                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <size key="minSize" width="552" height="198"/>
+                                                                                    <size key="minSize" width="537" height="198"/>
                                                                                     <size key="maxSize" width="1097" height="10000000"/>
                                                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <connections>
@@ -3742,15 +3765,15 @@ DQ
                         <rect key="frame" x="-1" y="35" width="383" height="206"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="w4Z-p1-GZA">
-                            <rect key="frame" x="1" y="1" width="381" height="204"/>
+                            <rect key="frame" x="1" y="1" width="366" height="204"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" id="8219">
-                                    <rect key="frame" x="0.0" y="0.0" width="381" height="204"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="366" height="204"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="381" height="204"/>
+                                    <size key="minSize" width="366" height="204"/>
                                     <size key="maxSize" width="753" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <connections>
@@ -3922,15 +3945,15 @@ Gw
                         <rect key="frame" x="20" y="45" width="365" height="177"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="aEl-zD-ga2">
-                            <rect key="frame" x="1" y="1" width="363" height="175"/>
+                            <rect key="frame" x="1" y="1" width="348" height="175"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" id="8202">
-                                    <rect key="frame" x="0.0" y="0.0" width="363" height="175"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="348" height="175"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="363" height="175"/>
+                                    <size key="minSize" width="348" height="175"/>
                                     <size key="maxSize" width="717" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </textView>
@@ -4134,7 +4157,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <popUpButtonCell key="cell" type="roundTextured" title="Choose Database..." bezelStyle="texturedRounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="3998" id="3996">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="titleBar" size="12"/>
+                        <font key="font" metaFont="label" size="12"/>
                         <menu key="menu" title="OtherViews" id="3997">
                             <items>
                                 <menuItem title="Choose Database..." state="on" id="3998"/>
@@ -4384,8 +4407,10 @@ Gw
         </customObject>
         <customObject id="ki9-Po-bdr" userLabel="SPRuleFilter" customClass="SPRuleFilterController">
             <connections>
+                <outlet property="addFilterButton" destination="xVl-jD-jgc" id="hoX-nP-wFM"/>
                 <outlet property="filterButton" destination="4676" id="9tZ-dW-BR3"/>
                 <outlet property="filterRuleEditor" destination="FF9-z2-9od" id="RW4-XM-XQS"/>
+                <outlet property="resetButton" destination="4rb-LV-wk6" id="cH9-7g-geZ"/>
                 <outlet property="tableContentViewBelow" destination="36" id="ZGh-dM-J6C"/>
                 <outlet property="tableDataInstance" destination="4702" id="e69-W6-UwN"/>
                 <outlet property="tableDocumentInstance" destination="-2" id="2Xe-WU-zRw"/>
@@ -4755,12 +4780,12 @@ Gw
                         <action selector="copy:" target="36" id="6342"/>
                     </connections>
                 </menuItem>
-		<menuItem title="Copy as SQL INSERT (no auto_inc)" tag="2004" id="8MG-Mb-qpD">
-		    <modifierMask key="keyEquivalentModifierMask"/>
-		    <connections>
-			<action selector="copy:" target="36" id="vef-dB-uno"/>
-		    </connections>
-		</menuItem>
+                <menuItem title="Copy as SQL INSERT (no auto_inc)" tag="2004" id="8MG-Mb-qpD">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="copy:" target="36" id="vef-dB-uno"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="7796"/>
                 <menuItem title="Add New Row" id="7795">
                     <modifierMask key="keyEquivalentModifierMask"/>
@@ -4803,18 +4828,18 @@ Gw
                         <action selector="copy:" target="-1" id="7483"/>
                     </connections>
                 </menuItem>
-		<menuItem title="Copy as SQL INSERT (no auto_inc)" tag="2004" id="0Tv-Br-8JO">
-		    <modifierMask key="keyEquivalentModifierMask"/>
-		    <connections>
-			<action selector="copy:" target="-1" id="6ey-zg-Cgj"/>
-		    </connections>
-		</menuItem>
+                <menuItem title="Copy as SQL INSERT (no auto_inc)" tag="2004" id="0Tv-Br-8JO">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="copy:" target="-1" id="6ey-zg-Cgj"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" hidden="YES" id="7472"/>
                 <menuItem title="Delete Row" hidden="YES" id="7473">
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
             </items>
-	    <point key="canvasLocation" x="139" y="-34"/>
+            <point key="canvasLocation" x="139" y="-34"/>
         </menu>
         <menu id="6232" userLabel="Table Relations Menu">
             <items>
@@ -4960,6 +4985,7 @@ Gw
         <image name="button_actionTemplate" width="18" height="10"/>
         <image name="button_addTemplate" width="10" height="10"/>
         <image name="button_bar_handleTemplate" width="6" height="10"/>
+        <image name="button_clearTemplate" width="10" height="10"/>
         <image name="button_duplicateTemplate" width="15" height="10"/>
         <image name="button_editTemplate" width="11" height="10"/>
         <image name="button_edit_modeTemplate" width="10" height="10"/>

--- a/Source/SPRuleFilterController.m
+++ b/Source/SPRuleFilterController.m
@@ -1319,6 +1319,8 @@ BOOL _arrayContainsInViewHierarchy(NSArray *haystack, id needle)
 	[self _doChangeToRuleEditorData:^{
 		[filterRuleEditor insertRowAtIndex:0 withType:NSRuleEditorRowTypeSimple asSubrowOfRow:-1 animate:NO];
 	}];
+	
+	[self focusFirstInputField];
 }
 
 - (NSRuleEditor *)view

--- a/Source/SPRuleFilterController.m
+++ b/Source/SPRuleFilterController.m
@@ -880,12 +880,6 @@ static BOOL _arrayContainsInViewHierarchy(NSArray *haystack, id needle);
 	}
 
 	if(nodeIndex < [criteria count]) {
-		// yet another uglyness: if one of the displayValues is an input and currently the first responder
-		// we have to manually restore that for the new input we create for UX reasons.
-		// However an NSTextField is seldom a first responder, usually it's an invisible subview of the text field...
-		id firstResponder = [[filterRuleEditor window] firstResponder];
-		BOOL hasFirstResponderInRow = _arrayContainsInViewHierarchy(displayValues, firstResponder);
-
 		//remove previous node and everything that follows and append new node
 		NSRange stripRange = NSMakeRange(nodeIndex, ([criteria count] - nodeIndex));
 
@@ -914,14 +908,12 @@ static BOOL _arrayContainsInViewHierarchy(NSArray *haystack, id needle);
 			[filterRuleEditor setCriteria:criteria andDisplayValues:displayValues forRowAtIndex:row];
 		}];
 
-		if(hasFirstResponderInRow) {
-			// make the next possible object after the opnode the new next responder (since the previous one is gone now)
-			for (NSUInteger j = nodeIndex + 1; j < [displayValues count]; ++j) {
-				id obj = [displayValues objectAtIndex:j];
-				if([obj respondsToSelector:@selector(acceptsFirstResponder)] && [obj acceptsFirstResponder]) {
-					[[filterRuleEditor window] makeFirstResponder:obj];
-					break;
-				}
+		// make the next possible object after the opnode the new next responder (since the previous one is gone now)
+		for (NSUInteger j = nodeIndex + 1; j < [displayValues count]; ++j) {
+			id obj = [displayValues objectAtIndex:j];
+			if([obj respondsToSelector:@selector(acceptsFirstResponder)] && [obj acceptsFirstResponder]) {
+				[[filterRuleEditor window] makeFirstResponder:obj];
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
I've added the reset filters button for removing all filters and the add filter button when there are no rows in the rule editor. I think they got removed when it wasn't allowed to remove the last filter, but now that is possible again. I think those buttons are useful and the methods where already implemented.

I also connected the Rule Editor to the _menuItemInRuleEditorClicked action and changed it so it always selects the input field when changing the rules. I'm not sure where the method was originally used for, but I don't see any side effects connecting it to the rule editor.

Does this close any currently open issues?
------------------------------------------
#241 
