### PR TITLE
More Filters Tweaks

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -408,21 +408,6 @@
                                         <menuItem title="Find..." tag="1" keyEquivalent="f" id="154">
                                             <connections>
                                                 <action selector="performFindPanelAction:" target="-1" id="922"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Find Next" tag="2" keyEquivalent="g" id="167">
-                                            <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="918"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="162">
-                                            <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="919"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="161">
-                                            <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="920"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Jump to Selection" keyEquivalent="j" id="155">

--- a/Source/SPCopyTable.m
+++ b/Source/SPCopyTable.m
@@ -1045,7 +1045,7 @@ static const NSInteger kBlobAsImageFile = 4;
 	NSInteger menuItemTag = [anItem tag];
 
 	if ([anItem action] == @selector(performFindPanelAction:)) {
-		return (menuItemTag == 1 && [[self delegate] isKindOfClass:[SPTableContent class]]);
+		return [[self delegate] isKindOfClass:[SPTableContent class]];
 	}
 
 	// Don't validate anything other than the copy commands

--- a/Source/SPDatabaseDocument.m
+++ b/Source/SPDatabaseDocument.m
@@ -2512,9 +2512,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)performFindPanelAction:(id)sender
 {
-	if ([sender tag] == 1 && [[self selectedToolbarItemIdentifier] isEqualToString:SPMainToolbarTableContent]) {
-		[tableContentInstance makeContentFilterHaveFocus];
-	}
+	[tableContentInstance makeContentFilterHaveFocus];
 }
 
 /**

--- a/Source/SPTableContent.m
+++ b/Source/SPTableContent.m
@@ -1392,6 +1392,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	else {
 		[ruleFilterController setEnabled:NO]; // disable it to not trigger any key bindings when hidden
 		[self updateFilterRuleEditorSize:0.0 animate:animate];
+		[[tableContentView window] makeFirstResponder:tableContentView];
 	}
 }
 


### PR DESCRIPTION
- Removed not implemented items from navigation bar for filtering (Find Next, Find Previous, and Use Selection for Find)
<img width="601" alt="Screen Shot 2020-07-19 at 19 09 48" src="https://user-images.githubusercontent.com/10710367/87887672-1f72a900-c9f5-11ea-9e33-627cb868d3d0.png">


- Made the table content view become first responder when the filters are hidden (so that the cmd+F shortcut works again to re-show filters)


Where has this been tested?
---------------------------
**Devices/Simulators:** 2016 MBP

**macOS Version:** 10.15.6

**Sequel-Ace Version:** 2.1.5beta


