### PR TITLE
Fix for the horizontal scroll position resetting after sorting on a column

### DIFF
--- a/Source/SPTableContent.m
+++ b/Source/SPTableContent.m
@@ -897,8 +897,6 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		}
 
 		[[tableContentView onMainThread] selectRowIndexes:selectionSet byExtendingSelection:NO];
-		// Scroll to selection (if needed)
-		[[tableContentView onMainThread] scrollRowToVisible:[[tableContentView onMainThread] selectedRow]];
 
 		tableRowsSelectable = previousTableRowsSelectable;
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
After sorting a column the scroll position should remain the same. There can still be a slight shift in the columns due to the dynamic width based on the content. But it looks like it's working the same again as it did in Sequel Pro.

Does this close any currently open issues?
------------------------------------------
#163 