### PR TITLE
Delete a couple unused vars

### DIFF
--- a/Source/SPPreferencesUpgrade.m
+++ b/Source/SPPreferencesUpgrade.m
@@ -34,9 +34,6 @@
 #import "SPTreeNode.h"
 #import "SPFavoriteNode.h"
 
-static NSString *SPOldFavoritesKey       = @"favorites";
-static NSString *SPOldDefaultEncodingKey = @"DefaultEncoding";
-
 @implementation SPPreferencesUpgrade
 
 /**


### PR DESCRIPTION
Deleted two old vars that used to be used by Sequel Pro's old preferences migration scripts