### PR TITLE
Add trim to string extention

### DIFF
--- a/Source/SPCustomQuery.m
+++ b/Source/SPCustomQuery.m
@@ -663,10 +663,9 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 			[query replaceOccurrencesOfRegex:@"--.*?$" withString:@""];
 			[query replaceOccurrencesOfRegex:@"/\\*(.|\n)*?\\*/" withString:@""];
 			
-			// trim leading spaces
-			[query setString:[query dropPrefixWithPrefix:@" "]];
-			[query setString:[query dropPrefixWithPrefix:@"\n"]];
-		
+			// trim leading and trailing spaces and new lines
+			[query setString:[query trimWhitespacesAndNewlines]];
+
 			SPLog(@"query: [%@]", query);
 			
 			for (NSString *safeCommand in safeCommands){

--- a/Source/StringExtension.swift
+++ b/Source/StringExtension.swift
@@ -40,6 +40,11 @@ extension String {
 				return self.lowercased().hasSuffix(suffix.lowercased())
 		}
 	}
+	
+	// the string with new lines and spaces trimmed from BOTH ends
+	var trimmedString: String {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }
 
 @objc extension NSString {
@@ -57,5 +62,9 @@ extension String {
 
 	func hasSuffix(suffix: NSString, caseSensitive: Bool = true) -> Bool {
 		return (self as String).hasSuffix(suffix as String, caseSensitive: caseSensitive)
+	}
+	
+	func trimWhitespacesAndNewlines() -> NSString {
+		return (self as String).trimmedString as NSString
 	}
 }

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -108,6 +108,40 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 	XCTAssertTrue([string hasSuffixWithSuffix:@"Suffix" caseSensitive: NO]);
 }
 
+- (void)testHasSuffixCaseSensitive {
+	NSString *string = @"stringSuffix";
+	XCTAssertFalse([string hasSuffixWithSuffix:@"suffix" caseSensitive: YES]);
+	XCTAssertTrue([string hasSuffixWithSuffix:@"Suffix" caseSensitive: YES]);
+}
+
+- (void)testHasPrefixCaseSensitive {
+	NSString *string = @"prefixString";
+	XCTAssertFalse([string hasPrefixWithPrefix:@"Prefix" caseSensitive:YES]);
+	XCTAssertTrue([string hasPrefixWithPrefix:@"prefix" caseSensitive:YES]);
+}
+
+- (void)testTrim {
+	NSString *string = @"  \n\nstring\n\n  ";
+	string = [string trimWhitespacesAndNewlines];
+	XCTAssertTrue([string isEqualToString:@"string"]);
+	
+	string = @" \n \n string \n \n  ";
+	string = [string trimWhitespacesAndNewlines];
+	XCTAssertTrue([string isEqualToString:@"string"]);
+	
+	string = @"..  ..string... ";
+	string = [string trimWhitespacesAndNewlines];
+	XCTAssertTrue([string isEqualToString:@"..  ..string..."]);
+	
+	string = @"str ing";
+	string = [string trimWhitespacesAndNewlines];
+	XCTAssertTrue([string isEqualToString:@"str ing"]);
+	
+	string = @"\nstr\ning\n";
+	string = [string trimWhitespacesAndNewlines];
+	XCTAssertTrue([string isEqualToString:@"str\ning"]);
+
+}
 /**
  * createViewSyntaxPrettifier test case.
  */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds and uses new `trimWhitespacesAndNewlines` function from `StringExtension.swift` 

This function removes multiple spaces and new line characters from the query string.

Thanks to @Kaspik for his Swift help.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.5

**Sequel-Ace Version:** latest dev 


