### PR TITLE
Select previous selected tables in the tablesList after choose of "Open Table in New Tab" context menu item

### DIFF
--- a/Interfaces/Base.lproj/DBView.xib
+++ b/Interfaces/Base.lproj/DBView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -357,7 +357,7 @@
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
                                     <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="right" alignment="center" lineBreakMode="truncatingTail" state="on" inset="2" pullsDown="YES" arrowPosition="noArrow" selectedItem="7862" id="7860">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="system"/>
+                                        <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="7861">
                                             <items>
                                                 <menuItem state="on" image="button_actionTemplate" hidden="YES" id="7862"/>
@@ -710,7 +710,7 @@
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                                         <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="right" alignment="center" lineBreakMode="truncatingTail" state="on" inset="2" pullsDown="YES" arrowPosition="noArrow" selectedItem="8028" id="8026">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                            <font key="font" metaFont="system"/>
+                                                                            <font key="font" metaFont="menu"/>
                                                                             <menu key="menu" title="OtherViews" id="8027">
                                                                                 <items>
                                                                                     <menuItem state="on" image="button_actionTemplate" hidden="YES" id="8028"/>
@@ -1052,7 +1052,7 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" id="lwO-LP-RWZ">
                                                                             <rect key="frame" x="1" y="0.0" width="695" height="435"/>
-                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                            <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <tableView identifier="TableContentTableView" focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowHeight="16" headerView="3920" id="36" customClass="SPCopyTable">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="695" height="418"/>
@@ -1231,7 +1231,7 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="kdv-Wp-s5h">
                                                                             <rect key="frame" x="0.0" y="0.0" width="694" height="40"/>
-                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                            <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <ruleEditor nestingMode="compound" canRemoveAllRows="YES" rowHeight="29" id="FF9-z2-9od">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="694" height="40"/>
@@ -1313,7 +1313,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="right" alignment="center" lineBreakMode="truncatingTail" state="on" inset="2" pullsDown="YES" arrowPosition="noArrow" selectedItem="7978" id="7976">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
+                                                            <font key="font" metaFont="menu"/>
                                                             <menu key="menu" title="OtherViews" id="7977">
                                                                 <items>
                                                                     <menuItem state="on" image="button_actionTemplate" hidden="YES" id="7978"/>
@@ -1437,7 +1437,7 @@
                                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                                 <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="right" alignment="center" lineBreakMode="truncatingTail" inset="2" pullsDown="YES" arrowPosition="noArrow" autoenablesItems="NO" selectedItem="7236" id="7231">
                                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                                    <font key="font" metaFont="system"/>
+                                                                                                    <font key="font" metaFont="menu"/>
                                                                                                     <menu key="menu" title="OtherViews" autoenablesItems="NO" id="7232">
                                                                                                         <items>
                                                                                                             <menuItem image="button_actionTemplate" hidden="YES" id="7247"/>
@@ -1842,15 +1842,15 @@ Gw
                                                                         <rect key="frame" x="109" y="0.0" width="554" height="73"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" id="fhZ-nZ-AwI">
-                                                                            <rect key="frame" x="1" y="1" width="537" height="71"/>
+                                                                            <rect key="frame" x="1" y="1" width="552" height="71"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" continuousSpellChecking="YES" smartInsertDelete="YES" id="8236">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="537" height="71"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="552" height="71"/>
                                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <size key="minSize" width="537" height="71"/>
+                                                                                    <size key="minSize" width="552" height="71"/>
                                                                                     <size key="maxSize" width="1097" height="10000000"/>
                                                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <connections>
@@ -1888,15 +1888,15 @@ Gw
                                                                         <rect key="frame" x="109" y="0.0" width="554" height="200"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" drawsBackground="NO" id="nV8-ly-BSi">
-                                                                            <rect key="frame" x="1" y="1" width="537" height="198"/>
+                                                                            <rect key="frame" x="1" y="1" width="552" height="198"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                             <subviews>
                                                                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" id="8242" customClass="SPTextView">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="537" height="198"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="552" height="198"/>
                                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <size key="minSize" width="537" height="198"/>
+                                                                                    <size key="minSize" width="552" height="198"/>
                                                                                     <size key="maxSize" width="1097" height="10000000"/>
                                                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <connections>
@@ -3765,15 +3765,15 @@ DQ
                         <rect key="frame" x="-1" y="35" width="383" height="206"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="w4Z-p1-GZA">
-                            <rect key="frame" x="1" y="1" width="366" height="204"/>
+                            <rect key="frame" x="1" y="1" width="381" height="204"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" id="8219">
-                                    <rect key="frame" x="0.0" y="0.0" width="366" height="204"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="381" height="204"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="366" height="204"/>
+                                    <size key="minSize" width="381" height="204"/>
                                     <size key="maxSize" width="753" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <connections>
@@ -3945,15 +3945,15 @@ Gw
                         <rect key="frame" x="20" y="45" width="365" height="177"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="aEl-zD-ga2">
-                            <rect key="frame" x="1" y="1" width="348" height="175"/>
+                            <rect key="frame" x="1" y="1" width="363" height="175"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" id="8202">
-                                    <rect key="frame" x="0.0" y="0.0" width="348" height="175"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="363" height="175"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="348" height="175"/>
+                                    <size key="minSize" width="363" height="175"/>
                                     <size key="maxSize" width="717" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </textView>
@@ -4480,6 +4480,7 @@ Gw
                 <outlet property="tableSourceInstance" destination="69" id="137"/>
                 <outlet property="tableTriggersInstance" destination="6691" id="7042"/>
                 <outlet property="tableTypeButton" destination="5714" id="5743"/>
+                <outlet property="tablesListMenu" destination="6180" id="IBD-kg-ROX"/>
                 <outlet property="tablesListView" destination="22" id="138"/>
                 <outlet property="toolbarActionsButton" destination="7859" id="7943"/>
                 <outlet property="toolbarAddButton" destination="7850" id="7853"/>
@@ -4716,6 +4717,10 @@ Gw
                     </connections>
                 </menuItem>
             </items>
+            <connections>
+                <outlet property="delegate" destination="68" id="N1w-TS-Wqc"/>
+            </connections>
+            <point key="canvasLocation" x="139.5" y="152"/>
         </menu>
         <menu id="6219" userLabel="Table Indexes Menu">
             <items>

--- a/Source/SPTableView.m
+++ b/Source/SPTableView.m
@@ -131,8 +131,11 @@
 		
 		// Check for SPTablesList if right-click on header, then suppress context menu
 		if ([[[[self delegate] class] description] isEqualToString:@"SPTablesList"]) {
-			if ([NSArrayObjectAtIndex([(NSObject*)[self delegate] valueForKeyPath:@"tableTypes"], row) integerValue] == -1)
+			SPTablesList* delegate = (SPTablesList*)[self delegate];
+			if ([NSArrayObjectAtIndex([delegate valueForKeyPath:@"tableTypes"], row) integerValue] == -1)
 				return nil;
+			else
+				[delegate rightMouseDown:event];
 		}
 		
 		if ([[[[self delegate] class] description] isEqualToString:@"SPQueryFavoriteManager"]) {

--- a/Source/SPTablesList.h
+++ b/Source/SPTablesList.h
@@ -45,7 +45,7 @@
 @class SPTableTriggers;
 @class SPExtendedTableInfo;
 
-@interface SPTablesList : NSObject <NSTextFieldDelegate, NSTableViewDelegate>
+@interface SPTablesList : NSObject <NSTextFieldDelegate, NSMenuDelegate, NSTableViewDelegate>
 {
 	IBOutlet SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;

--- a/Source/SPTablesList.h
+++ b/Source/SPTablesList.h
@@ -59,6 +59,7 @@
 	IBOutlet SPTableInfo *tableInfoInstance;
 	IBOutlet SPTableTriggers *tableTriggersInstance;
 
+	IBOutlet NSMenu *tablesListMenu;
 	IBOutlet NSWindow *copyTableSheet;
 	IBOutlet SPTableView *tablesListView;
 	IBOutlet NSButton *copyTableButton;
@@ -122,6 +123,8 @@
 	BOOL tableListIsSelectable;
 	BOOL tableListContainsViews;
 	BOOL alertSheetOpened;
+	BOOL isMenuOpened;
+	NSInteger lastSelectedRow;
 
 	NSFont *smallSystemFont;
 	

--- a/Source/SPTablesList.h
+++ b/Source/SPTablesList.h
@@ -124,8 +124,8 @@
 	BOOL tableListContainsViews;
 	BOOL alertSheetOpened;
 	BOOL isMenuOpened;
-	NSInteger lastSelectedRow;
 
+	NSIndexSet *lastSelectedRows;
 	NSFont *smallSystemFont;
 	
 	SPCharsetCollationHelper *addTableCharsetHelper;

--- a/Source/SPTablesList.m
+++ b/Source/SPTablesList.m
@@ -104,7 +104,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		tableListContainsViews = NO;
 		selectedTableType = SPTableTypeNone;
 		selectedTableName = nil;
-		lastSelectedRow = -1;
+		lastSelectedRows = nil;
 		
 		prefs = [NSUserDefaults standardUserDefaults];
 
@@ -169,9 +169,8 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 - (void)resetTablesListSelectedIndex {
 	isMenuOpened = false;
 
-	if (lastSelectedRow != -1) {
-		NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:lastSelectedRow];
-		[tablesListView selectRowIndexes:indexSet byExtendingSelection:NO];
+	if (lastSelectedRows != nil) {
+		[tablesListView selectRowIndexes:lastSelectedRows byExtendingSelection:NO];
 	}
 }
 
@@ -1821,7 +1820,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		[[SPNavigatorController sharedNavigatorController] selectPath:schemaPath];
 	}
 
-	if (!isMenuOpened) lastSelectedRow = selectedRowIndex;
+	if (!isMenuOpened) lastSelectedRows = [tablesListView selectedRowIndexes];
 }
 
 /**

--- a/Source/SPTablesList.m
+++ b/Source/SPTablesList.m
@@ -169,7 +169,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 - (void)resetTablesListSelectedIndex {
 	isMenuOpened = false;
 
-	if (lastSelectedRows != nil) {
+	if (lastSelectedRows) {
 		[tablesListView selectRowIndexes:lastSelectedRows byExtendingSelection:NO];
 	}
 }
@@ -340,6 +340,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		tableListIsSelectable = YES;
 #ifndef SP_CODA /* ui manipulation */
 		[[tablesListView onMainThread] selectRowIndexes:[NSIndexSet indexSetWithIndex:itemToReselect] byExtendingSelection:NO];
+		lastSelectedRows = [[tablesListView onMainThread] selectedRowIndexes];
 #endif
 		tableListIsSelectable = previousTableListIsSelectable;
 		if (selectedTableName) [selectedTableName release];
@@ -1764,6 +1765,8 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
  */
 - (void)tableViewSelectionDidChange:(NSNotification *)aNotification
 {
+	if (!isMenuOpened) lastSelectedRows = [tablesListView selectedRowIndexes];
+
 	if ([tablesListView numberOfSelectedRows] != 1) {
 
 		// Ensure the state is cleared
@@ -1819,8 +1822,6 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		
 		[[SPNavigatorController sharedNavigatorController] selectPath:schemaPath];
 	}
-
-	if (!isMenuOpened) lastSelectedRows = [tablesListView selectedRowIndexes];
 }
 
 /**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When users select "Open Table in New Tab" from context menu of the Tables List, they gets two tabs with the same table.

Does this close any currently open issues?
------------------------------------------
#191 


Any other comments?
-------------------
Not sure it's a right direction to resolve this, sometimes buggy.

Where has this been tested?
---------------------------
**Devices/Simulators:** Intel

**macOS Version:** 10.15.6

**Sequel-Ace Version:** 2.1.6rc1


