### PR TITLE
Stop wrapping in the textField used for filters values

### DIFF
--- a/Source/SPRuleFilterController.m
+++ b/Source/SPRuleFilterController.m
@@ -597,6 +597,8 @@ static BOOL _arrayContainsInViewHierarchy(NSArray *haystack, id needle);
 			[[textField cell] setSendsActionOnEndEditing:YES];
 			[[textField cell] setUsesSingleLineMode:YES];
 			[textField setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];
+			[[textField cell] setWraps:NO];
+			[[textField cell] setScrollable:YES];
 			[textField sizeToFit];
 			[textField setTarget:self];
 			[textField setAction:@selector(_textFieldAction:)];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The NSTextField used to enter filter values was wrapping, when long values were entered. Using (horizontal) scrolling is better.

Does this close any currently open issues?
------------------------------------------
Fixes #304