### PR TITLE
Disable Appearance Pop-Up Button on macOS < 10.14

### DIFF
--- a/Interfaces/Base.lproj/Preferences.xib
+++ b/Interfaces/Base.lproj/Preferences.xib
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SPPreferenceController">
             <connections>
+                <outlet property="appearanceMacOSVersionLabel" destination="A54-fI-5jD" id="Nlw-9j-e2K"/>
+                <outlet property="appearancePopUp" destination="YpU-KB-oKj" id="FIo-db-OfV"/>
                 <outlet property="editorPreferencePane" destination="2144" id="2148"/>
                 <outlet property="filePreferencePane" destination="bKg-6I-v9A" id="wt8-L0-QxT"/>
                 <outlet property="generalPreferencePane" destination="2074" id="2076"/>
@@ -319,7 +321,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Last Used" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1449" id="1422">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="1423">
                             <items>
                                 <menuItem title="Last Used" state="on" id="1449">
@@ -455,7 +457,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" autoenablesItems="NO" id="570">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" autoenablesItems="NO" id="571"/>
                     </popUpButtonCell>
                     <connections>
@@ -487,7 +489,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="25">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="26">
                             <items>
                                 <menuItem title="Autodetect" id="50"/>
@@ -543,47 +545,66 @@ Gw
                         </binding>
                     </connections>
                 </popUpButton>
-                <box autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="m2t-AW-wZp">
-                    <rect key="frame" x="204" y="41" width="357" height="5"/>
+                <box fixedFrame="YES" boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
+                    <rect key="frame" x="13" y="0.0" width="567" height="50"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <view key="contentView" id="8QO-1r-5jB">
+                        <rect key="frame" x="0.0" y="0.0" width="567" height="50"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <box autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="m2t-AW-wZp">
+                                <rect key="frame" x="190" y="44" width="357" height="5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            </box>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zSn-Pq-u9O">
+                                <rect key="frame" x="3" y="16" width="181" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="tAt-dD-bAQ">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A54-fI-5jD">
+                                <rect key="frame" x="439" y="17" width="91" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="macOS 10.14+" id="GI3-PC-8Vn">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YpU-KB-oKj">
+                                <rect key="frame" x="188" y="11" width="254" height="25"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <popUpButtonCell key="cell" type="push" title="Light" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" enabled="NO" state="on" borderStyle="border" tag="1" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="eKV-qw-xZ9" id="qEs-4C-bPo">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" title="OtherViews" id="kke-hm-U3J">
+                                        <items>
+                                            <menuItem title="Light" state="on" tag="1" id="eKV-qw-xZ9">
+                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                            </menuItem>
+                                            <menuItem title="Dark" tag="2" id="fo9-Ml-cF0">
+                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                            </menuItem>
+                                            <menuItem title="Auto" id="dTB-Qx-h4w">
+                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                            </menuItem>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <binding destination="117" name="selectedTag" keyPath="values.Appearance" id="ETY-Mb-qdJ">
+                                        <dictionary key="options">
+                                            <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </popUpButton>
+                        </subviews>
+                    </view>
                 </box>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zSn-Pq-u9O">
-                    <rect key="frame" x="17" y="20" width="181" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="tAt-dD-bAQ">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YpU-KB-oKj">
-                    <rect key="frame" x="201" y="13" width="254" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <popUpButtonCell key="cell" type="push" title="Light" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="border" tag="1" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="eKV-qw-xZ9" id="qEs-4C-bPo">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                        <menu key="menu" title="OtherViews" id="kke-hm-U3J">
-                            <items>
-                                <menuItem title="Light" state="on" tag="1" id="eKV-qw-xZ9">
-                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                </menuItem>
-                                <menuItem title="Dark" tag="2" id="fo9-Ml-cF0">
-                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                </menuItem>
-                                <menuItem title="Auto" id="dTB-Qx-h4w">
-                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                </menuItem>
-                            </items>
-                        </menu>
-                    </popUpButtonCell>
-                    <connections>
-                        <binding destination="117" name="selectedTag" keyPath="values.Appearance" id="ETY-Mb-qdJ">
-                            <dictionary key="options">
-                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                            </dictionary>
-                        </binding>
-                    </connections>
-                </popUpButton>
             </subviews>
             <point key="canvasLocation" x="230" y="479.5"/>
         </customView>
@@ -775,7 +796,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Only use additional queries for small tables" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="1474" id="1471">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" title="OtherViews" id="1472">
                             <items>
                                 <menuItem title="Never use additional queries for table row counts" id="1473"/>
@@ -990,7 +1011,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundRect" title="Change…" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MhF-tS-nrE">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="label" size="12"/>
+                        <font key="font" metaFont="cellTitle"/>
                     </buttonCell>
                     <connections>
                         <action selector="pickSSHClient:" target="2146" id="zcA-5j-KFq"/>
@@ -1098,7 +1119,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="X7v-6X-VbB" id="KPx-1M-u3e">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="X6f-Ih-yPF">
                             <items>
                                 <menuItem title="Item 1" state="on" id="X7v-6X-VbB"/>

--- a/Resources/en.lproj/Credits.rtf
+++ b/Resources/en.lproj/Credits.rtf
@@ -1,9 +1,9 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2512
+{\rtf1\ansi\ansicpg1252\cocoartf2513
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 LucidaGrande-Bold;\f1\fnil\fcharset0 LucidaGrande;\f2\fnil\fcharset128 HiraKakuProN-W3;
 \f3\fmodern\fcharset0 Courier;}
 {\colortbl;\red255\green255\blue255;\red25\green25\blue25;\red0\green27\blue199;}
 {\*\expandedcolortbl;;\csgenericrgb\c9804\c9804\c9804;\csgenericrgb\c0\c10588\c78039;}
-\paperw12240\paperh15840\vieww16180\viewh13320\viewkind0
+\vieww16180\viewh13320\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 
 \f0\b\fs30 \cf2 Current Developers
@@ -16,9 +16,9 @@
 \pard\pardeftab720\qc\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/gboudreau"}}{\fldrslt \cf0 Guillaume Boudreau}}\
 \pard\pardeftab720\qc\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/stychos"}}{\fldrslt \cf0 Dan Ray}}\
-\pard\pardeftab720\qc\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/Kaspik"}}{\fldrslt \cf0 Jakub Ka\'9apar}}\
+\pard\pardeftab720\qc\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://github.com/stychos"}}{\fldrslt \cf0 Daniel Luchinets}}\
 \
 \pard\pardeftab720\qc\partightenfactor0
 
@@ -231,7 +231,8 @@ Copyright (c) 2006-2020\
 \pard\pardeftab720\qc\partightenfactor0
 
 \f1\b0 \cf0 Copyright (c) 2013\
-{\field{\*\fldinst{HYPERLINK "https://github.com/jdorn"}}{\fldrslt Jeremy Doorn}}\
+\pard\pardeftab720\qc\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://github.com/jdorn"}}{\fldrslt \cf0 Jeremy Doorn}}\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 \cf0 \
 \pard\pardeftab720\qc\partightenfactor0

--- a/Resources/en.lproj/Credits.rtf
+++ b/Resources/en.lproj/Credits.rtf
@@ -1,9 +1,9 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2513
+{\rtf1\ansi\ansicpg1252\cocoartf2512
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 LucidaGrande-Bold;\f1\fnil\fcharset0 LucidaGrande;\f2\fnil\fcharset128 HiraKakuProN-W3;
 \f3\fmodern\fcharset0 Courier;}
 {\colortbl;\red255\green255\blue255;\red25\green25\blue25;\red0\green27\blue199;}
 {\*\expandedcolortbl;;\csgenericrgb\c9804\c9804\c9804;\csgenericrgb\c0\c10588\c78039;}
-\vieww16180\viewh13320\viewkind0
+\paperw12240\paperh15840\vieww16180\viewh13320\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 
 \f0\b\fs30 \cf2 Current Developers
@@ -231,8 +231,7 @@ Copyright (c) 2006-2020\
 \pard\pardeftab720\qc\partightenfactor0
 
 \f1\b0 \cf0 Copyright (c) 2013\
-\pard\pardeftab720\qc\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/jdorn"}}{\fldrslt \cf0 Jeremy Doorn}}\
+{\field{\*\fldinst{HYPERLINK "https://github.com/jdorn"}}{\fldrslt Jeremy Doorn}}\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 \cf0 \
 \pard\pardeftab720\qc\partightenfactor0

--- a/Source/SPAppController.m
+++ b/Source/SPAppController.m
@@ -102,11 +102,14 @@
 		[fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"tmp"] withIntermediateDirectories:true attributes:nil error:nil];
 		[fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@".keys"] withIntermediateDirectories:true attributes:nil error:nil];
 
-		//Switch Appearance on Application startup (prevent Appearance blink)
-		[self switchAppearance];
+		//Handle Appearance on macOS 10.14+
+		if (@available(macOS 10.14, *)) {
+			//Switch Appearance on Application startup (prevent Appearance blink)
+			[self switchAppearance];
 
-		//Register an observer to switch Appearance at runtime
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
+			//Register an observer to switch Appearance at runtime
+			[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
+		}
 
 		[NSApp setDelegate:self];
 	}

--- a/Source/SPPreferenceController.h
+++ b/Source/SPPreferenceController.h
@@ -53,6 +53,8 @@
 	IBOutlet SPEditorPreferencePane <SPPreferencePaneProtocol>        *editorPreferencePane;
 	IBOutlet SPNetworkPreferencePane <SPPreferencePaneProtocol>       *networkPreferencePane;
 	IBOutlet SPFilePreferencePane <SPPreferencePaneProtocol>          *filePreferencePane;
+    IBOutlet NSPopUpButton                                            *appearancePopUp;
+    IBOutlet NSTextField                                              *appearanceMacOSVersionLabel;
 
 	NSToolbar *toolbar;
 	NSArray *preferencePanes;

--- a/Source/SPPreferenceController.h
+++ b/Source/SPPreferenceController.h
@@ -53,8 +53,8 @@
 	IBOutlet SPEditorPreferencePane <SPPreferencePaneProtocol>        *editorPreferencePane;
 	IBOutlet SPNetworkPreferencePane <SPPreferencePaneProtocol>       *networkPreferencePane;
 	IBOutlet SPFilePreferencePane <SPPreferencePaneProtocol>          *filePreferencePane;
-    IBOutlet NSPopUpButton                                            *appearancePopUp;
-    IBOutlet NSTextField                                              *appearanceMacOSVersionLabel;
+	IBOutlet NSPopUpButton                                            *appearancePopUp;
+	IBOutlet NSTextField                                              *appearanceMacOSVersionLabel;
 
 	NSToolbar *toolbar;
 	NSArray *preferencePanes;

--- a/Source/SPPreferenceController.m
+++ b/Source/SPPreferenceController.m
@@ -68,11 +68,11 @@
 {		
 	[self _setupToolbar];
 
-    if (@available(macOS 10.14, *)) {
-        [appearancePopUp setEnabled:YES];
-    } else {
-        [appearanceMacOSVersionLabel setHidden:NO];
-    }
+	if (@available(macOS 10.14, *)) {
+		[appearancePopUp setEnabled:YES];
+	} else {
+		[appearanceMacOSVersionLabel setHidden:NO];
+	}
 
 	preferencePanes = [[NSArray alloc] initWithObjects:
 					   generalPreferencePane,

--- a/Source/SPPreferenceController.m
+++ b/Source/SPPreferenceController.m
@@ -71,6 +71,7 @@
 	if (@available(macOS 10.14, *)) {
 		[appearancePopUp setEnabled:YES];
 	} else {
+		[appearancePopUp setEnabled:NO];
 		[appearanceMacOSVersionLabel setHidden:NO];
 	}
 

--- a/Source/SPPreferenceController.m
+++ b/Source/SPPreferenceController.m
@@ -68,6 +68,12 @@
 {		
 	[self _setupToolbar];
 
+    if (@available(macOS 10.14, *)) {
+        [appearancePopUp setEnabled:YES];
+    } else {
+        [appearanceMacOSVersionLabel setHidden:NO];
+    }
+
 	preferencePanes = [[NSArray alloc] initWithObjects:
 					   generalPreferencePane,
 					   tablesPreferencePane,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--
Sets Appearance PopUp Enabled property to NO and sets it to YES only on macOS >= 10.14

Does this close any currently open issues?
--
Close #340 

Any other comments?
--
Tried to implement hiding, but it leaves empty space at the bottom.

Where has this been tested?
---------------------------
**macOS Version:** 10.15.6, 10.13.6

