### PR TITLE
Fix-299 keychain always used despite user selection

### DIFF
--- a/Resources/ssh_config
+++ b/Resources/ssh_config
@@ -1,7 +1,7 @@
 host *
     IgnoreUnknown AddKeysToAgent,UseKeychain
     AddKeysToAgent yes
-    UseKeychain yes
+    UseKeychain no
     IdentitiesOnly yes
     ## Specify a dummy id_rsa file so we don't try everything in the .ssh dir. TODO: Actually generate an id_rsa for each user
     IdentityFile ~/.keys/id_rsa


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Set use keychain to no in our default config file, so we don't save things to the keychain without user consent

Does this close any currently open issues?
------------------------------------------
#299


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**macOS Version:** …

**Sequel-Ace Version:** …


