### PR TITLE
Refactor legacy monotonic time handling

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -110,13 +110,13 @@
 
 		// Trigger a reconnect depending on connection usage recently.  If the connection has
 		// actively been used in the last couple of minutes, trigger a full reconnection attempt.
-		if (_elapsedSecondsSinceAbsoluteTime(lastConnectionUsedTime) < 60 * 2) {
+		if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 2) {
 			reconnectionThread = [[[NSThread alloc] initWithTarget:self selector:@selector(_reconnectAllowingRetries:) object:@YES] autorelease];
 			[reconnectionThread setName:@"SPMySQL reconnection thread (full)"];
 			[reconnectionThread start];
 
 		// If used within the last fifteen minutes, trigger a background/single reconnection attempt
-		} else if (_elapsedSecondsSinceAbsoluteTime(lastConnectionUsedTime) < 60 * 15) {
+		} else if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 15) {
 			reconnectionThread = [[[NSThread alloc] initWithTarget:self selector:@selector(_reconnectAfterBackgroundConnectionLoss) object:nil] autorelease];
 			[reconnectionThread setName:@"SPMySQL reconnection thread (limited)"];
 			[reconnectionThread start];

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -299,10 +299,10 @@
 
 		// While recording the overall execution time (including network lag!), run
 		// the raw query
-		uint64_t queryStartTime = mach_absolute_time();
+		uint64_t queryStartTime = _monotonicTime();
 		queryStatus = mysql_real_query(mySQLConnection, queryBytes, queryBytesLength);
-		queryExecutionTime = _elapsedSecondsSinceAbsoluteTime(queryStartTime);
-		lastConnectionUsedTime = mach_absolute_time();
+		queryExecutionTime = _timeIntervalSinceMonotonicTime(queryStartTime);
+		lastConnectionUsedTime = _monotonicTime();
 		
 		// "An integer greater than zero indicates the number of rows affected or retrieved.
 		//  Zero indicates that no records were updated for an UPDATE statement, no rows matched the WHERE clause in the query or that no query has yet been executed.

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
@@ -117,7 +117,7 @@
 
 	// Get the process list
 	MYSQL_RES *mysqlResult = mysql_list_processes(mySQLConnection);
-	lastConnectionUsedTime = mach_absolute_time();
+	lastConnectionUsedTime = _monotonicTime();
 
 	// Convert to SPMySQLResult
 	SPMySQLResult *theResult = [[SPMySQLResult alloc] initWithMySQLResult:mysqlResult stringEncoding:stringEncoding];

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLUtilities.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLUtilities.h
@@ -39,16 +39,15 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 
-/**
- * Define a project function to make it easier to use mach_absolute_time()
- * to track monotonically increasing time.
- */
-static double _elapsedSecondsSinceAbsoluteTime(uint64_t comparisonTime)
+static uint64_t _monotonicTime()
 {
-	uint64_t elapsedTime_t = mach_absolute_time() - comparisonTime;
-	Nanoseconds elapsedTime = AbsoluteToNanoseconds(*(AbsoluteTime *)&(elapsedTime_t));
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC);
+}
 
-	return (((double)UnsignedWideToUInt64(elapsedTime)) * 1e-9);
+static double _timeIntervalSinceMonotonicTime(uint64_t comparisonTime)
+{
+    uint64_t timeElapsed = _monotonicTime() - comparisonTime;
+    return (double)(timeElapsed * 1e-9);
 }
 
 #pragma clang diagnostic pop

--- a/Source/Other/CategoryAdditions/SPDateAdditions.h
+++ b/Source/Other/CategoryAdditions/SPDateAdditions.h
@@ -30,7 +30,8 @@
 
 @interface NSDate (SPDateAdditions)
 
-+ (double)monotonicTimeInterval;
++ (uint64_t)monotonicTime;
++ (NSTimeInterval)timeIntervalSinceMonotonicTime:(uint64_t)comparisonTime;
 -(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale;
 
 @end

--- a/Source/Other/CategoryAdditions/SPDateAdditions.m
+++ b/Source/Other/CategoryAdditions/SPDateAdditions.m
@@ -41,34 +41,16 @@
  * when the system time changes or synchs, but should never be used for absolute time
  * as it is based on the elapsed time since the system booted.
  */
-+ (double)monotonicTimeInterval
++ (uint64_t)monotonicTime
 {
-	
-	uint64_t elapsedNano;
-    static mach_timebase_info_data_t sTimebaseInfo;
-	uint64_t elapsedTime_t = mach_absolute_time();
-
-	// see: https://developer.apple.com/library/archive/qa/qa1398/_index.html
-	// Convert to nanoseconds.
-
-    // If this is the first time we've run, get the timebase.
-    // We can use denom == 0 to indicate that sTimebaseInfo is
-    // uninitialised because it makes no sense to have a zero
-    // denominator is a fraction.
-
-    if ( sTimebaseInfo.denom == 0 ) {
-        (void) mach_timebase_info(&sTimebaseInfo);
-    }
-	
-    // Do the maths. We hope that the multiplication doesn't
-    // overflow; the price you pay for working in fixed point.
-
-    elapsedNano = elapsedTime_t * sTimebaseInfo.numer / sTimebaseInfo.denom;
-
-    return (double)(elapsedNano * 1e-9);
-	
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC);
 }
 
++ (NSTimeInterval)timeIntervalSinceMonotonicTime:(uint64_t)comparisonTime
+{
+	uint64_t timeElapsed = [self monotonicTime] - comparisonTime;
+	return (NSTimeInterval)(timeElapsed * 1e-9);
+}
 
 /**
  *  Convenience method that returns a formatted string representing the receiver's date formatted to a given date format, time zone and locale

--- a/Source/Views/SPSplitView.h
+++ b/Source/Views/SPSplitView.h
@@ -40,7 +40,7 @@
 	NSUInteger collapsibleSubviewIndex;
 	BOOL collapsibleSubviewCollapsed;
 
-	double animationStartTime;
+	uint64_t animationStartTime;
 	double animationDuration;
 	NSTimer *animationTimer;
 	SPSplitViewAnimationRetainCycleBypass *animationRetainCycleBypassObject;

--- a/Source/Views/SPSplitView.m
+++ b/Source/Views/SPSplitView.m
@@ -241,7 +241,7 @@
 	} else {
 		if (animationTimer) (void)([animationTimer invalidate]), SPClear(animationTimer);
 		if (animationRetainCycleBypassObject) SPClear(animationRetainCycleBypassObject);
-		animationStartTime = [NSDate monotonicTimeInterval];
+		animationStartTime = [NSDate monotonicTime];
 
 		// Determine the animation length, in seconds, starting with a quarter of a second
 		animationDuration = 0.25f;
@@ -877,8 +877,7 @@
 		}
 
 		// The collapsible subview is collapsing or uncollapsing.  Prepare to update the sizes...
-		double currentTime = [NSDate monotonicTimeInterval];
-		float animationProgress = (float)((currentTime - animationStartTime) / animationDuration);
+		float animationProgress = (float)([NSDate timeIntervalSinceMonotonicTime:animationStartTime] / animationDuration);
 		if (animationProgress > 1) animationProgress = 1;
 
 		// If the animation has reached the end, ensure completion tasks are run

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -37,7 +37,7 @@
 			@autoreleasepool {
 				// exec on bg thread
 				uint64_t startTime = [NSDate monotonicTime];
-				startTimeNEW = 0;
+				startTime = 0;
 			}
 		}
 

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -26,50 +26,21 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-- (void)testOldvsNewMonotonicTimeInterval {
-
-	double startTimeOld = [self monotonicTimeIntervalOLD];
-	double startNew = [NSDate monotonicTimeInterval];
-	
-	SPLog(@"JIMMY startTimeOld: %f", startTimeOld);
-	SPLog(@"JIMMY startNew: %f", startNew);
-	
-	XCTAssertEqualWithAccuracy(startTimeOld, startNew, 0.0001);
-}
-
-- (void)testPerformanceMonotonicTimeIntervalOLD {
+- (void)testPerformanceMonotonicTimeInterval {
     // This is an example of a performance test case.
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
-		
-		int const iterations = 1000000;
-		
-		for (int i = 0; i < iterations; i++) {
-			@autoreleasepool {
-				// exec on bg thread
-				double startTimeOld = [self monotonicTimeIntervalOLD];
-				startTimeOld = 0;
-			}
-		}
-		
-    }];
-}
 
-- (void)testPerformanceMonotonicTimeIntervalNEW {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-		
 		int const iterations = 1000000;
-		
+
 		for (int i = 0; i < iterations; i++) {
 			@autoreleasepool {
 				// exec on bg thread
-				double startTimeNEW = [NSDate monotonicTimeInterval];
+				uint64_t startTime = [NSDate monotonicTime];
 				startTimeNEW = 0;
 			}
 		}
-		
+
     }];
 }
 
@@ -119,20 +90,6 @@
 	XCTAssertEqualObjects(str1, str2);
 
 
-}
-#pragma clang diagnostic pop
-
-
-// OLD method for testing
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (double)monotonicTimeIntervalOLD{
-	
-	uint64_t elapsedTime_t = mach_absolute_time();
-	Nanoseconds nanosecondsElapsed = AbsoluteToNanoseconds(*(AbsoluteTime *)&(elapsedTime_t));
-
-	return (((double)UnsignedWideToUInt64(nanosecondsElapsed)) * 1e-9);
-	
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Replaces outdated/deprecated code for generating monotonic timestamp with the recommended approach. I also looked at the source code for the method to verify what it does https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html.

Once we increase the minimum target to 10.12, we can switch over to CLOCK_MONOTONIC_RAW_APPROX, which is more accurate and faster because it doesn't require a system call.