### PR TITLE
Fix printing entitlements

### DIFF
--- a/Sequel Ace.entitlements
+++ b/Sequel Ace.entitlements
@@ -10,13 +10,15 @@
 	</array>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<key>com.apple.security.print</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>


### PR DESCRIPTION
- Add printing to entitlements to allow Sequel Ace to use printing (we have Print option in settings, we have shortcuts, but since sandboxing it wasn't allowed)