### PR TITLE
Added info on how to move "quick connect" connections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,17 @@ To install an unoffical community maintained [Homebrew](https://brew.sh) [Cask](
 brew cask install sequel-ace
 ```
 
+### Moving saved connection list from Sequel Pro
+
+To move your quick connect list from Sequel Pro to Sequel Ace just copy the file
+
+~/Library/Application Support/Sequel Pro/Data/Favorites.plist
+to ~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application Support/Sequel Ace/Data
+
+```cp ~/Library/Application\ Support/Sequel\ Pro/Data/Favorites.plist ~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application\ Support/Sequel\ Ace/Data```
+
+Note that passwords are not copied this way, because they are stored in Keychain.
+
 ## Contributing
 
 We have a lot of work to do, but we're here to provide, with your help, an always-free, macOS first SQL database tool for everyone.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
I stumbled upon the problem of moving quick connect connections from Sequel Pro to Sequel Ace. This notion in the readme addresses this issue.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
No
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
N/A

**Devices/Simulators:** …

**macOS Version:** …

**Sequel-Ace Version:** …


