### PR TITLE
Fix create database alert not creating a database

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1008,7 +1008,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	}
 
 	// Add a new database
-	else if ([contextInfo isEqualToString:@"addDatabase"]) {
+	if ([contextInfo isEqualToString:@"addDatabase"]) {
 		[addDatabaseCharsetHelper setEnabled:NO];
 
 		if (returnCode == NSModalResponseOK) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix create database by order out of the sheet that is not necessary anymore apparently

Does this close any currently open issues?
------------------------------------------
Yes, https://github.com/Sequel-Ace/Sequel-Ace/issues/402

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac 5K

**macOS Version:** 11.0 beta 10

**Sequel-Ace Version:** `main` branch


