### PR TITLE
Fix crash on ( character in < 10.15

### DIFF
--- a/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
+++ b/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
@@ -49,7 +49,7 @@
 	self.textView = textView;
 	self.pos1 = NSNotFound;
 	self.pos2 = NSNotFound;
-	self.highlightColor = [NSColor colorWithRed: 0xe6/255.0 green: 0xc9 /255.0 blue:0x09/255.0 alpha:1.0];
+	self.highlightColor = [NSColor systemTealColor];
 	self.enabled = YES;
 	return self;
 }

--- a/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
+++ b/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
@@ -38,8 +38,7 @@
 @property NSInteger pos1;
 @property NSInteger pos2;
 
-@property NSColor *highlightColor;
-
+@property(readwrite, strong) NSColor *highlightColor;
 
 @end
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -130,7 +130,7 @@
 		1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */; };
 		1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */; };
 		1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 58DF9F3215AB26C2003B4330 /* SPDateAdditions.m */; };
-		1AF5A261250AC401009885DF /* SPBracketHighlighter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25E250AC401009885DF /* SPBracketHighlighter.m */; };
+		1AF5A261250AC401009885DF /* SPBracketHighlighter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25E250AC401009885DF /* SPBracketHighlighter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1AF5A262250AC401009885DF /* SPBrackets.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25F250AC401009885DF /* SPBrackets.m */; };
 		265446DF24A1616900376B48 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
 		296DC89F0F8FD336002A3258 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296DC89E0F8FD336002A3258 /* WebKit.framework */; };


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Crash on typing a bracket in the query view on < 10.15

Does this close any currently open issues?
------------------------------------------
#413 

Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1 

**macOS Version:** 10.15.7 (19H2)

**Sequel-Ace Version:** latest main


