### PR TITLE
Fix export screen customising filename cursor jumping to the end

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2860,8 +2860,16 @@ set_input:
 			length = [obj length];
 			isText = YES;
 			
+			// we already know this is an NSString, but anyway, safety first.
+			// hmmm, check for nil?
+			// see tests
+			// obj = (NSString*)obj; is twice as fast as:
+			// obj = [NSString cast:obj]; which is twice as fast as
+			// obj = [NSString stringWithString:obj];
+			obj = [NSString cast:obj]; // this doesn't leak, it uses the same memory address
+			
 			// only attempt tokenization if string contains a { or }
-			if([(NSString*)obj containsString:@"{"] == NO && [(NSString*)obj containsString:@"}"] == NO){
+			if([obj containsString:@"{"] == NO && [obj containsString:@"}"] == NO){
 				SPLog(@"string does not contain token delimiters");
 				return;
 			}

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2819,7 +2819,7 @@ set_input:
 				break; //we've hit an unterminated token
 			}
 			NSString *tokenString = [remainder substringToIndex:closeCurl.location+1];
-			SPExportFileNameTokenObject *tokenObject = [replacement objectForKey:tokenString];
+			SPExportFileNameTokenObject *tokenObject = [replacement objectForKey:[tokenString lowercaseString]];
 			if(tokenObject) {
 				[processedTokens addObject:tokenObject];
 			}

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2851,11 +2851,20 @@ set_input:
 
 	NSUInteger start = 0;
 	for(id obj in [exportCustomFilenameTokenField objectValue]) {
+		
+		SPLog(@"obj = %@", obj);
+		
 		NSUInteger length;
 		BOOL isText = NO;
 		if(IS_STRING(obj)) {
 			length = [obj length];
 			isText = YES;
+			
+			// only attempt tokenization if string contains a { or }
+			if([(NSString*)obj containsString:@"{"] == NO && [(NSString*)obj containsString:@"}"] == NO){
+				SPLog(@"string does not contain token delimiters");
+				return;
+			}
 		}
 		else if(IS_TOKEN(obj)) {
 			length = 1; // tokens are seen as one char by the textview

--- a/Source/Other/CategoryAdditions/SPObjectAdditions.h
+++ b/Source/Other/CategoryAdditions/SPObjectAdditions.h
@@ -31,6 +31,11 @@
 @interface  NSObject (SPObjectAdditions)
 
 /**
+ * "Safe" casting using `instancetype`.
+ */
++ (instancetype)cast:(id)object;
+
+/**
  * Detect whether an object is a NSNull instance.
  */
 - (BOOL)isNSNull;

--- a/Source/Other/CategoryAdditions/SPObjectAdditions.m
+++ b/Source/Other/CategoryAdditions/SPObjectAdditions.m
@@ -56,6 +56,11 @@
 	return [list containsObject:self];
 }
 
++ (instancetype)cast:(id)object
+{
+	return [object isKindOfClass:self] ? object : nil;
+}
+
 @end
 
 // method swizzling to try and reproduce #2297

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -28,6 +28,7 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
+#import "SPObjectAdditions.h"
 #import "SPStringAdditions.h"
 #import "RegexKitLite.h"
 
@@ -46,6 +47,57 @@
 static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 @implementation SPStringAdditionsTests
+
+
+- (void)testPerformance_StringWithString {
+	// this is on main thread
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 1000000;
+		
+		id obj = @"JIMMY";
+
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				obj = [NSString stringWithString:obj];
+			}
+		}
+	}];
+}
+
+// this cast method is twice as fast as stringWithString above
+- (void)testPerformance_cast {
+	
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 1000000;
+		
+		id obj = @"JIMMY";
+
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				obj = [NSString cast:obj];
+			}
+		}
+	}];
+}
+
+// this "unsafe" cast method is twice as fast as cast above
+- (void)testPerformance_cast2 {
+	
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 1000000;
+		
+		id obj = @"JIMMY";
+
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				obj = (NSString*)obj;
+			}
+		}
+	}];
+}
 
 /**
  * stringByRemovingCharactersInSet test case.

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		1A2711E82539E2BB0066ED58 /* local-connection.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A2711E72539E2BB0066ED58 /* local-connection.html */; };
 		1A3FA7962495FC2D00B7291A /* SPMainThreadTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 589582141154F8F400EDCC28 /* SPMainThreadTrampoline.m */; };
 		1A564F74237E2E4958CA593A /* SPPillAttachmentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */; };
+		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
 		1AB0689D24A355B600E2AAC2 /* client-cert-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0688F24A355B500E2AAC2 /* client-cert-crlf.pem */; };
 		1AB0689E24A355B600E2AAC2 /* client-cert-bad-end.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689024A355B500E2AAC2 /* client-cert-bad-end.pem */; };
@@ -3070,6 +3071,7 @@
 				1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */,
 				50D3C35D1A77217800B5429C /* SPParserUtils.c in Sources */,
 				380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */,
+				1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */,
 				1798F1C4155018E2004B0AB8 /* SPMutableArrayAdditionsTests.m in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
On the export screen, the cursor in the customising filename text field would jump to the end if you typed in the middle of the string. This is because the code attempted to tokenize the string, triggered by a return keypress, hence jumping to the end.

```
// if we are currently inside or at the end of a string segment we can
// call for tokenization to happen by simulating a return press
```

I've put a check in to see if the string contains a token delimiter [`{`|`}`], if not, the key press and tokenisation is not triggered, stopping the cursor jumping around.

Does this close any currently open issues?
------------------------------------------
#431 

Any other comments?
-------------------
Also fixed a usability issue with real token names:

The field now recognises capitalised tokens, like the examples.
Token examples are capitalised, but in the token field array in the code they are lowercase so typing `{Database}` would not be tokenized, only `{database}`, which doesn't match the example so could be confusing.

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:** 10.15.7 (19H2)

**Sequel-Ace Version:** latest main


