### PR TITLE
[Date|Number|NSDateComponents]Formatters are expensive, made them static

### DIFF
--- a/Source/Controllers/BundleSupport/SPBundleHTMLOutputController.m
+++ b/Source/Controllers/BundleSupport/SPBundleHTMLOutputController.m
@@ -34,7 +34,7 @@
 #import "SPAppController.h"
 #import "SPBundleCommandRunner.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 static NSString *SPSaveDocumentAction = @"SPSaveDocument";
 

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -50,6 +50,7 @@
 #import "SPDotExporterProtocol.h"
 #import "SPPDFExporterProtocol.h"
 #import "SPHTMLExporterProtocol.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 
@@ -2391,8 +2392,7 @@ set_input:
 {
 	NSMutableString *string = [NSMutableString string];
 
-	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-	[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
+	NSDateFormatter *dateFormatter = NSDateFormatter.mediumStyleFormatter;
 
 	// Walk through the token field, appending token replacements or strings
 	NSArray *representedFilenameParts = [exportCustomFilenameTokenField objectValue];
@@ -2466,7 +2466,7 @@ set_input:
 								options:NSLiteralSearch
 								  range:NSMakeRange(0, [string length])];
 
-	[dateFormatter release];
+	[dateFormatter release]; // ???
 
 	// Don't allow empty strings - if an empty string resulted, revert to the default string
 	if (![string length]) [string setString:[self generateDefaultExportFilename]];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2466,8 +2466,6 @@ set_input:
 								options:NSLiteralSearch
 								  range:NSMakeRange(0, [string length])];
 
-	[dateFormatter release]; // ???
-
 	// Don't allow empty strings - if an empty string resulted, revert to the default string
 	if (![string length]) [string setString:[self generateDefaultExportFilename]];
 

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -48,7 +48,7 @@
 
 #import <SPMySQL/SPMySQL.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #define SP_FILE_READ_ERROR_STRING NSLocalizedString(@"File read error", @"File read error title (Import Dialog)")
 

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -62,7 +62,7 @@
 #import "SPBracketHighlighter.h"
 
 #include <libkern/OSAtomic.h>
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 typedef struct {
 	NSUInteger query;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1268,9 +1268,14 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 	double timeSinceQueryStarted = [[NSDate date] timeIntervalSinceDate:queryStartDate];
 
-	NSDateComponentsFormatter *formatter = [[NSDateComponentsFormatter alloc] init];
-	formatter.allowedUnits = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
-	formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
+	static NSDateComponentsFormatter *formatter = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		formatter = [[NSDateComponentsFormatter alloc] init];
+		formatter.allowedUnits = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+		formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
+	});
+	
 	NSString *queryRunningTime = [formatter stringFromTimeInterval:timeSinceQueryStarted];
 	
 	NSShadow *textShadow = [[NSShadow alloc] init];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -84,7 +84,7 @@
 #import "SPHelpViewerClient.h"
 #import "SPHelpViewerController.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 
@@ -1268,15 +1268,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 	double timeSinceQueryStarted = [[NSDate date] timeIntervalSinceDate:queryStartDate];
 
-	static NSDateComponentsFormatter *formatter = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		formatter = [[NSDateComponentsFormatter alloc] init];
-		formatter.allowedUnits = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
-		formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
-	});
-	
-	NSString *queryRunningTime = [formatter stringFromTimeInterval:timeSinceQueryStarted];
+	NSString *queryRunningTime = [NSDateComponentsFormatter.hourMinSecFormatter stringFromTimeInterval:timeSinceQueryStarted];
 	
 	NSShadow *textShadow = [[NSShadow alloc] init];
 	[textShadow setShadowColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.75f]];
@@ -6874,11 +6866,7 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 
 		if (resultRows > rowLimit) {
 
-			NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-
-			[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-
-			NSString *message = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to print the current content view of the table '%@'?\n\nIt currently contains %@ rows, which may take a significant amount of time to print.", @"continue to print informative message"), [self table], [numberFormatter stringFromNumber:[NSNumber numberWithLongLong:resultRows]]];
+			NSString *message = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to print the current content view of the table '%@'?\n\nIt currently contains %@ rows, which may take a significant amount of time to print.", @"continue to print informative message"), [self table], [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithLongLong:resultRows]]];
 			[NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Continue to print?", @"continue to print message") message:message primaryButtonTitle:NSLocalizedString(@"Print", @"print button") primaryButtonHandler:^{
 				[self startPrintDocumentOperation];
 			} cancelButtonHandler:nil];

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -38,6 +38,7 @@
 #import "SPAlertSheets.h"
 #import "SPTableStructure.h"
 #import "SPServerSupport.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 
@@ -223,9 +224,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 {
 	[tableRowAutoIncrement setEditable:NO];
 	
-	NSNumberFormatter *fmt = [[[NSNumberFormatter alloc] init] autorelease];
-	[fmt setNumberStyle:NSNumberFormatterDecimalStyle];
-	NSNumber *value = [fmt numberFromString:[tableRowAutoIncrement stringValue]];
+	NSNumber *value = [NSNumberFormatter.decimalStyleFormatter numberFromString:[tableRowAutoIncrement stringValue]];
 	
 	[tableSourceInstance setAutoIncrementTo:value];
 }
@@ -710,18 +709,8 @@ static NSString *SPMySQLCommentField          = @"Comment";
 		else if ([key isEqualToString:SPMySQLCreateTimeField] ||
 				 [key isEqualToString:SPMySQLUpdateTimeField]) {
 
-			// Create date formatter
-			// Create date formatter - once
-			static NSDateFormatter *dateFormatter = nil;
-			static dispatch_once_t onceToken;
-			dispatch_once(&onceToken, ^{
-				dateFormatter = [[NSDateFormatter alloc] init];
-				[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
-				[dateFormatter setDateStyle:NSDateFormatterMediumStyle];
-				[dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
-			});
-			
-			value = [dateFormatter stringFromDate:[NSDate dateWithNaturalLanguageString:value]];
+
+			value = [NSDateFormatter.mediumStyleFormatter stringFromDate:[NSDate dateWithNaturalLanguageString:value]];
 			// 2020-06-30 14:14:11 is one example
 		}
 		// Format numbers
@@ -729,15 +718,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 				 [key isEqualToString:SPMySQLAverageRowLengthField] ||
 				 [key isEqualToString:SPMySQLAutoIncrementField]) {
 
-			
-			static NSNumberFormatter *numberFormatter = nil;
-			static dispatch_once_t onceToken;
-			dispatch_once(&onceToken, ^{
-				numberFormatter = [[NSNumberFormatter alloc] init];
-				[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-			});
-			
-			value = [numberFormatter stringFromNumber:[NSNumber numberWithLongLong:[value longLongValue]]];
+			value = [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithLongLong:[value longLongValue]]];
 
 			// Prefix number of rows with '~' if it is not an accurate count
 			if ([key isEqualToString:SPMySQLRowsField] && ![[infoDict objectForKey:@"RowsCountAccurate"] boolValue]) {

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -711,24 +711,32 @@ static NSString *SPMySQLCommentField          = @"Comment";
 				 [key isEqualToString:SPMySQLUpdateTimeField]) {
 
 			// Create date formatter
-			NSDateFormatter *dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
-
-			[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
-
-			[dateFormatter setDateStyle:NSDateFormatterMediumStyle];
-			[dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
-
+			// Create date formatter - once
+			static NSDateFormatter *dateFormatter = nil;
+			static dispatch_once_t onceToken;
+			dispatch_once(&onceToken, ^{
+				dateFormatter = [[NSDateFormatter alloc] init];
+				[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
+				[dateFormatter setDateStyle:NSDateFormatterMediumStyle];
+				[dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
+			});
+			
 			value = [dateFormatter stringFromDate:[NSDate dateWithNaturalLanguageString:value]];
+			// 2020-06-30 14:14:11 is one example
 		}
 		// Format numbers
 		else if ([key isEqualToString:SPMySQLRowsField] ||
 				 [key isEqualToString:SPMySQLAverageRowLengthField] ||
 				 [key isEqualToString:SPMySQLAutoIncrementField]) {
 
-			NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-
-			[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-
+			
+			static NSNumberFormatter *numberFormatter = nil;
+			static dispatch_once_t onceToken;
+			dispatch_once(&onceToken, ^{
+				numberFormatter = [[NSNumberFormatter alloc] init];
+				[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+			});
+			
 			value = [numberFormatter stringFromNumber:[NSNumber numberWithLongLong:[value longLongValue]]];
 
 			// Prefix number of rows with '~' if it is not an accurate count

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -61,7 +61,7 @@
 #import <SPMySQL/SPMySQL.h>
 #include <stdlib.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 
 /**
@@ -1004,21 +1004,15 @@ static void *TableContentKVOContext = &TableContentKVOContext;
  *
  * MUST BE CALLED ON THE UI THREAD!
  */
+// TODO: this is called A LOT, optimize
 - (void)updateCountText
 {
 	NSString *rowString;
 	NSMutableString *countString = [NSMutableString string];
 	
-	static NSNumberFormatter *numberFormatter = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		numberFormatter = [[NSNumberFormatter alloc] init];
-		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-	});
-	
 	// Set up a couple of common strings
-	NSString *tableCountString = [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:tableRowsCount]];
-	NSString *maxRowsString = [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:maxNumRows]];
+	NSString *tableCountString = [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:tableRowsCount]];
+	NSString *maxRowsString = [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:maxNumRows]];
 
 	// If the result is partial due to an error or query cancellation, show a very basic count
 	if (isInterruptedLoad) {
@@ -1037,7 +1031,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// If a limit is active, display a string suggesting a limit is active
 	} else if (!isFiltered && isLimited) {
 		NSUInteger limitStart = (contentPage-1)*[prefs integerForKey:SPLimitResultsValue] + 1;
-		[countString appendFormat:NSLocalizedString(@"Rows %@ - %@ of %@%@ from table", @"text showing how many rows are in the limited result"),  [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:limitStart]], [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:(limitStart+tableRowsCount-1)]], maxNumRowsIsEstimate?@"~":@"", maxRowsString];
+		[countString appendFormat:NSLocalizedString(@"Rows %@ - %@ of %@%@ from table", @"text showing how many rows are in the limited result"),  [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:limitStart]], [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:(limitStart+tableRowsCount-1)]], maxNumRowsIsEstimate?@"~":@"", maxRowsString];
 
 	// If just a filter is active, show a count and an indication a filter is active
 	} else if (isFiltered && !isLimited) {
@@ -1049,7 +1043,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// If both a filter and limit is active, display full string
 	} else {
 		NSUInteger limitStart = (contentPage-1)*[prefs integerForKey:SPLimitResultsValue] + 1;
-		[countString appendFormat:NSLocalizedString(@"Rows %@ - %@ from filtered matches", @"text showing how many rows are in the limited filter match"), [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:limitStart]], [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:(limitStart+tableRowsCount-1)]]];
+		[countString appendFormat:NSLocalizedString(@"Rows %@ - %@ from filtered matches", @"text showing how many rows are in the limited filter match"), [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:limitStart]], [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:(limitStart+tableRowsCount-1)]]];
 	}
 
 	// If rows are selected, append selection count
@@ -1060,7 +1054,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			rowString = [NSString stringWithString:NSLocalizedString(@"row", @"singular word for row")];
 		else
 			rowString = [NSString stringWithString:NSLocalizedString(@"rows", @"plural word for rows")];
-		[countString appendFormat:NSLocalizedString(@"%@ %@ selected", @"text showing how many rows are selected"), [numberFormatter stringFromNumber:[NSNumber numberWithInteger:selectedRows]], rowString];
+		[countString appendFormat:NSLocalizedString(@"%@ %@ selected", @"text showing how many rows are selected"), [NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithInteger:selectedRows]], rowString];
 	}
 
 	[countText setStringValue:countString];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1008,9 +1008,14 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 {
 	NSString *rowString;
 	NSMutableString *countString = [NSMutableString string];
-	NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-	[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-
+	
+	static NSNumberFormatter *numberFormatter = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		numberFormatter = [[NSNumberFormatter alloc] init];
+		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	});
+	
 	// Set up a couple of common strings
 	NSString *tableCountString = [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:tableRowsCount]];
 	NSString *maxRowsString = [numberFormatter stringFromNumber:[NSNumber numberWithUnsignedInteger:maxNumRows]];

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -50,7 +50,7 @@
 #import "SPIdMenu.h"
 #import "SPComboBoxCell.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -35,7 +35,7 @@
 #import "SPCategoryAdditions.h"
 #import "SPFunctions.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 // Constants
 static NSString *SPSaveColorScheme          = @"SaveColorScheme";

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -29,7 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPNetworkPreferencePane.h"
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 static NSString *SPSSLCipherListMarkerItem = @"--";
 static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -52,7 +52,7 @@
 #import "SPOSInfo.h"
 #import <PSMTabBar/PSMTabBarControl.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 @interface SPAppController ()
 

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -32,6 +32,7 @@
 #import "SPConsoleMessage.h"
 #import "SPCustomQuery.h"
 #import "SPAppController.h"
+#import "sequel-ace-Swift.h"
 
 #import "pthread.h"
 
@@ -620,12 +621,9 @@ static SPQueryController *sharedQueryController = nil;
 	[loggingDisabledTextField setStringValue:([prefs boolForKey:SPConsoleEnableLogging]) ? @"" : NSLocalizedString(@"Query logging is currently disabled", @"query logging disabled label")];
 
 	// Setup data formatter
-	dateFormatter = [[NSDateFormatter alloc] init];
-
-	[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
+	dateFormatter = NSDateFormatter.mediumStyleFormatter;
 
 	[dateFormatter setDateStyle:NSDateFormatterNoStyle];
-	[dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
 
 	// Set the process table view's vertical gridlines if required
 	[consoleTableView setGridStyleMask:([prefs boolForKey:SPDisplayTableViewVerticalGridlines]) ? NSTableViewSolidVerticalGridLineMask : NSTableViewGridNone];

--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -134,9 +134,13 @@
  */
 - (void)tableChanged:(NSNotification *)notification
 {
-	NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-	[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-
+	static NSNumberFormatter *numberFormatter = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		numberFormatter = [[NSNumberFormatter alloc] init];
+		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	});
+	
 	[info removeAllObjects];
 
 	if (![tableListInstance tableName]) {

--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -36,6 +36,7 @@
 #import "SPActivityTextFieldCell.h"
 #import "SPTableTextFieldCell.h"
 #import "SPAppController.h"
+#import "sequel-ace-Swift.h"
 
 @interface SPTableInfo ()
 
@@ -134,12 +135,6 @@
  */
 - (void)tableChanged:(NSNotification *)notification
 {
-	static NSNumberFormatter *numberFormatter = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		numberFormatter = [[NSNumberFormatter alloc] init];
-		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-	});
 	
 	[info removeAllObjects];
 
@@ -193,7 +188,7 @@
 			// Check for 'Rows' == NULL - information_schema database doesn't report row count for it's tables
 			if (![[tableStatus objectForKey:@"Rows"] isNSNull]) {
 				[info addObject:[NSString stringWithFormat:[[tableStatus objectForKey:@"RowsCountAccurate"] boolValue] ? NSLocalizedString(@"rows: %@", @"Table Info Section : number of rows (exact value)") : NSLocalizedString(@"rows: ~%@", @"Table Info Section : number of rows (estimated value)"),
-					[numberFormatter stringFromNumber:[NSNumber numberWithLongLong:[[tableStatus objectForKey:@"Rows"] longLongValue]]]]];
+					[NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithLongLong:[[tableStatus objectForKey:@"Rows"] longLongValue]]]]];
 			}
 			
 			// Check for 'Data_Length' == NULL (see PR #2606)
@@ -215,7 +210,7 @@
 			
 			if (![[tableStatus objectForKey:@"Auto_increment"] isNSNull]) {
 				[info addObject:[NSString stringWithFormat:NSLocalizedString(@"auto_increment: %@", @"Table Info Section : current value of auto_increment"),
-					[numberFormatter stringFromNumber:[NSNumber numberWithLongLong:[[tableStatus objectForKey:@"Auto_increment"] longLongValue]]]]];
+					[NSNumberFormatter.decimalStyleFormatter stringFromNumber:[NSNumber numberWithLongLong:[[tableStatus objectForKey:@"Auto_increment"] longLongValue]]]]];
 			}
 
 		}
@@ -472,9 +467,7 @@
 
 - (NSString *)_getUserDefinedDateStringFromMySQLDate:(NSString *)mysqlDate
 {
-	NSDateFormatter *dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
-
-	[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
+	NSDateFormatter *dateFormatter = NSDateFormatter.mediumStyleFormatter;
 
 	[dateFormatter setDateStyle:NSDateFormatterShortStyle];
 	[dateFormatter setTimeStyle:NSDateFormatterNoStyle];

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -54,7 +54,7 @@
 #import "SPCharsetCollationHelper.h"
 #import "SPConstants.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -41,7 +41,7 @@
 #import <SPMySQL/SPMySQL.h>
 #import <QueryKit/QueryKit.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 static NSString * const SPTableViewNameColumnID = @"NameColumn";
 

--- a/Source/Other/CategoryAdditions/SPStringAdditions.m
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.m
@@ -32,6 +32,8 @@
 #import "RegexKitLite.h"
 #include <stdlib.h>
 
+#import "sequel-ace-Swift.h"
+
 static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 
 @implementation NSString (SPStringAdditions)
@@ -42,49 +44,42 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 + (NSString *)stringForByteSize:(long long)byteSize
 {
 	double size = byteSize;
-	
-	static NSNumberFormatter *numberFormatter = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		numberFormatter = [[NSNumberFormatter alloc] init];
-		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-	});
-	
-	if (size < 1023) {
-		[numberFormatter setFormat:@"#,##0 B"];
 		
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:size]];
+	if (size < 1023) {
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0 B"];
+		
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(size)];
 	}
 	
 	size = (size / 1024);
 	
 	if (size < 1023) {
-		[numberFormatter setFormat:@"#,##0.0 KiB"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 KiB"];
 		
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:size]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(size)];
 	}
 	
 	size = (size / 1024);
 	
 	if (size < 1023) {
-		[numberFormatter setFormat:@"#,##0.0 MiB"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 MiB"];
 		
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:size]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(size)];
 	}
 	
 	size = (size / 1024);
 	
 	if (size < 1023) {
-		[numberFormatter setFormat:@"#,##0.0 GiB"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 GiB"];
 		
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:size]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(size)];
 	}
 
 	size = (size / 1024);
 	
-	[numberFormatter setFormat:@"#,##0.0 TiB"];
+	[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 TiB"];
 	
-	return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:size]];
+	return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(size)];
 }
 
 /**
@@ -92,63 +87,57 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
  */ 
 + (NSString *)stringForTimeInterval:(double)timeInterval
 {
-	static NSNumberFormatter *numberFormatter = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		numberFormatter = [[NSNumberFormatter alloc] init];
-		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-	});
 
 	// For time periods of less than one millisecond, display a localised "< 0.1 ms"
 	if (timeInterval < 0.0001) {
-		[numberFormatter setFormat:@"< #,##0.0 ms"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"< #,##0.0 ms"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:0.1]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@0.1];
 	}
 
 	if (timeInterval < 0.1) {
 		timeInterval = (timeInterval * 1000);
-		[numberFormatter setFormat:@"#,##0.0 ms"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 ms"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 	if (timeInterval < 1) {
 		timeInterval = (timeInterval * 1000);
-		[numberFormatter setFormat:@"#,##0 ms"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0 ms"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 	
 	if (timeInterval < 10) {
-		[numberFormatter setFormat:@"#,##0.00 s"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.00 s"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 
 	if (timeInterval < 100) {
-		[numberFormatter setFormat:@"#,##0.0 s"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0.0 s"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 
 	if (timeInterval < 300) {
-		[numberFormatter setFormat:@"#,##0 s"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0 s"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 
 	if (timeInterval < 3600) {
 		timeInterval = (timeInterval / 60);
-		[numberFormatter setFormat:@"#,##0 min"];
+		[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0 min"];
 
-		return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+		return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 	}
 
 	timeInterval = (timeInterval / 3600);
 	
-	[numberFormatter setFormat:@"#,##0 hours"];
+	[NSNumberFormatter.decimalStyleFormatter setFormat:@"#,##0 hours"];
 
-	return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:timeInterval]];
+	return [NSNumberFormatter.decimalStyleFormatter stringFromNumber:@(timeInterval)];
 }
 
 /**

--- a/Source/Other/CategoryAdditions/SPStringAdditions.m
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.m
@@ -43,9 +43,12 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 {
 	double size = byteSize;
 	
-	NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-	
-	[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	static NSNumberFormatter *numberFormatter = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		numberFormatter = [[NSNumberFormatter alloc] init];
+		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	});
 	
 	if (size < 1023) {
 		[numberFormatter setFormat:@"#,##0 B"];
@@ -89,9 +92,12 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
  */ 
 + (NSString *)stringForTimeInterval:(double)timeInterval
 {
-	NSNumberFormatter *numberFormatter = [[[NSNumberFormatter alloc] init] autorelease];
-
-	[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	static NSNumberFormatter *numberFormatter = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		numberFormatter = [[NSNumberFormatter alloc] init];
+		[numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
+	});
 
 	// For time periods of less than one millisecond, display a localised "< 0.1 ms"
 	if (timeInterval < 0.0001) {

--- a/Source/Other/DebuggingSupport/SPLogger.m
+++ b/Source/Other/DebuggingSupport/SPLogger.m
@@ -36,7 +36,7 @@
 #import <sys/dir.h>
 #import <sys/types.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 static SPLogger *logger = nil;
 

--- a/Source/Other/Extensions/DateComponentsFormatterExtension.swift
+++ b/Source/Other/Extensions/DateComponentsFormatterExtension.swift
@@ -14,7 +14,7 @@ extension DateComponentsFormatter {
 			
 		let formatter = DateComponentsFormatter()
 		formatter.allowedUnits = [.hour, .minute, .second]
-		formatter.zeroFormattingBehavior = ZeroFormattingBehavior.pad
+		formatter.zeroFormattingBehavior = .pad
 		return formatter
 	}()
 		

--- a/Source/Other/Extensions/DateComponentsFormatterExtension.swift
+++ b/Source/Other/Extensions/DateComponentsFormatterExtension.swift
@@ -1,0 +1,21 @@
+//
+//  DateComponentsFormatterExtension.swift
+//  Sequel Ace
+//
+//  Created by James on 3/11/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+extension DateComponentsFormatter {
+	
+	@objc public static var hourMinSecFormatter: DateComponentsFormatter = {
+			
+		let formatter = DateComponentsFormatter()
+		formatter.allowedUnits = [.hour, .minute, .second]
+		formatter.zeroFormattingBehavior = ZeroFormattingBehavior.pad
+		return formatter
+	}()
+		
+}

--- a/Source/Other/Extensions/DateFormatterExtension.swift
+++ b/Source/Other/Extensions/DateFormatterExtension.swift
@@ -13,9 +13,8 @@ extension DateFormatter {
 	@objc public static var mediumStyleFormatter: DateFormatter = {
 			
 		let formatter = DateFormatter()
-		formatter.formatterBehavior = Behavior.behavior10_4
-		formatter.dateStyle = Style.medium
-		formatter.timeStyle = Style.medium
+		formatter.dateStyle = .medium
+		formatter.timeStyle = .medium
 		return formatter
 	}()
 		

--- a/Source/Other/Extensions/DateFormatterExtension.swift
+++ b/Source/Other/Extensions/DateFormatterExtension.swift
@@ -1,0 +1,26 @@
+//
+//  DateFormatterExtension.swift
+//  Sequel Ace
+//
+//  Created by James on 3/11/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+extension DateFormatter {
+	
+	@objc public static var mediumStyleFormatter: DateFormatter = {
+			
+		let formatter = DateFormatter()
+		formatter.formatterBehavior = Behavior.behavior10_4
+		formatter.dateStyle = Style.medium
+		formatter.timeStyle = Style.medium
+		return formatter
+	}()
+		
+}
+	
+	
+	
+

--- a/Source/Other/Extensions/NumberFormatterExtention.swift
+++ b/Source/Other/Extensions/NumberFormatterExtention.swift
@@ -13,7 +13,7 @@ extension NumberFormatter {
 	@objc public static var decimalStyleFormatter: NumberFormatter = {
 			
 		let formatter = NumberFormatter()
-		formatter.numberStyle = Style.decimal
+		formatter.numberStyle = .decimal
 		return formatter
 	}()
 }

--- a/Source/Other/Extensions/NumberFormatterExtention.swift
+++ b/Source/Other/Extensions/NumberFormatterExtention.swift
@@ -1,0 +1,19 @@
+//
+//  NumberFormatterExtention.swift
+//  Sequel Ace
+//
+//  Created by James on 3/11/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+extension NumberFormatter {
+
+	@objc public static var decimalStyleFormatter: NumberFormatter = {
+			
+		let formatter = NumberFormatter()
+		formatter.numberStyle = Style.decimal
+		return formatter
+	}()
+}

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -51,7 +51,7 @@
 #import "pthread.h"
 #include <stdlib.h>
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 NSInteger SPEditMenuCopy               = 2001;
 NSInteger SPEditMenuCopyWithColumns    = 2002;

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -48,7 +48,7 @@
 #import "SPSyntaxParser.h"
 #import "SPHelpViewerClient.h"
 
-#import "Sequel_Ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #import <SPMySQL/SPMySQL.h>
 

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -49,6 +49,32 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 @implementation SPStringAdditionsTests
 
 
+- (void)testPerformance_stringForByteSizeStatic {
+	// this is on main thread
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				[NSString stringForByteSize:i];
+			}
+		}
+	}];
+}
+
+//- (void)testPerformance_stringForByteSize{
+//	// this is on main thread
+//	[self measureBlock:^{
+//		// Put the code you want to measure the time of here.
+//		int const iterations = 10000;
+//		for (int i = 0; i < iterations; i++) {
+//			@autoreleasepool {
+//				[NSString stringForByteSize2:i];
+//			}
+//		}
+//	}];
+//}
+
 - (void)testPerformance_StringWithString {
 	// this is on main thread
 	[self measureBlock:^{

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -32,7 +32,7 @@
 #import "SPStringAdditions.h"
 #import "RegexKitLite.h"
 
-//#import "sequel-ace-Swift.h"
+#import "sequel-ace-Swift.h"
 
 #import <XCTest/XCTest.h>
 
@@ -77,33 +77,33 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 	}];
 }
 
-// swift static - 0.24s
-- (void)testPerformance_stringForByteSizeStatic {
-	// this is on main thread
-	[self measureBlock:^{
-		// Put the code you want to measure the time of here.
-		int const iterations = 10000;
-		for (int i = 0; i < iterations; i++) {
-			@autoreleasepool {
-				[NSString stringForByteSize2:i];
-			}
-		}
-	}];
-}
-
-// swift static NumberLiterals - 0.239s
-- (void)testPerformance_stringForByteSizeSwiftStaticNumberLiterals {
-	// this is on main thread
-	[self measureBlock:^{
-		// Put the code you want to measure the time of here.
-		int const iterations = 10000;
-		for (int i = 0; i < iterations; i++) {
-			@autoreleasepool {
-				[NSString stringForByteSize2:i];
-			}
-		}
-	}];
-}
+//// swift static - 0.24s
+//- (void)testPerformance_stringForByteSizeStatic {
+//	// this is on main thread
+//	[self measureBlock:^{
+//		// Put the code you want to measure the time of here.
+//		int const iterations = 10000;
+//		for (int i = 0; i < iterations; i++) {
+//			@autoreleasepool {
+//				[NSString stringForByteSize2:i];
+//			}
+//		}
+//	}];
+//}
+//
+//// swift static NumberLiterals - 0.239s
+//- (void)testPerformance_stringForByteSizeSwiftStaticNumberLiterals {
+//	// this is on main thread
+//	[self measureBlock:^{
+//		// Put the code you want to measure the time of here.
+//		int const iterations = 10000;
+//		for (int i = 0; i < iterations; i++) {
+//			@autoreleasepool {
+//				[NSString stringForByteSize2:i];
+//			}
+//		}
+//	}];
+//}
 
 //- (void)testPerformance_stringForByteSize{
 //	// this is on main thread

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -32,6 +32,8 @@
 #import "SPStringAdditions.h"
 #import "RegexKitLite.h"
 
+//#import "sequel-ace-Swift.h"
+
 #import <XCTest/XCTest.h>
 
 @interface SPStringAdditionsTests : XCTestCase
@@ -48,8 +50,8 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 @implementation SPStringAdditionsTests
 
-
-- (void)testPerformance_stringForByteSizeStatic {
+// non static - 0.5s
+- (void)testPerformance_stringForByteSize {
 	// this is on main thread
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
@@ -57,6 +59,47 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 		for (int i = 0; i < iterations; i++) {
 			@autoreleasepool {
 				[NSString stringForByteSize:i];
+			}
+		}
+	}];
+}
+// obj c static - 0.241s
+- (void)testPerformance_stringForByteSizeObjCStatic {
+	// this is on main thread
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				[NSString stringForByteSize:i];
+			}
+		}
+	}];
+}
+
+// swift static - 0.24s
+- (void)testPerformance_stringForByteSizeStatic {
+	// this is on main thread
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				[NSString stringForByteSize2:i];
+			}
+		}
+	}];
+}
+
+// swift static NumberLiterals - 0.239s
+- (void)testPerformance_stringForByteSizeSwiftStaticNumberLiterals {
+	// this is on main thread
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				[NSString stringForByteSize2:i];
 			}
 		}
 	}];
@@ -123,6 +166,16 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 			}
 		}
 	}];
+}
+
+- (void)testnumberLiterals{
+	int const iterations = 1000000;
+	
+	for (int i = -100; i < iterations; i++) {
+		@autoreleasepool {
+			XCTAssertEqualObjects(@(i), [NSNumber numberWithDouble:i]);
+		}
+	}
 }
 
 /**

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -111,8 +111,6 @@
 		1A564F74237E2E4958CA593A /* SPPillAttachmentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */; };
 		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
-		1A9D837E25513FCB0024B563 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
-		1A9D838625513FDD0024B563 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
 		1A9D83A425514E740024B563 /* DateComponentsFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */; };
 		1AAF1DC32548485B0037AFDB /* SPReleaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF1DBF2548485B0037AFDB /* SPReleaseTests.m */; };
 		1AB068A824A355CC00E2AAC2 /* client-cert-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0688F24A355B500E2AAC2 /* client-cert-crlf.pem */; };
@@ -126,6 +124,8 @@
 		1AB068B024A355CC00E2AAC2 /* client-key-lf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689824A355B500E2AAC2 /* client-key-lf.pem */; };
 		1AB068B124A355CC00E2AAC2 /* client-key-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689924A355B500E2AAC2 /* client-key-crlf.pem */; };
 		1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */; };
+		1AB925922551550200063446 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
+		1AB9259A2551551100063446 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
 		1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */; };
 		1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 58DF9F3215AB26C2003B4330 /* SPDateAdditions.m */; };
 		1AF5A261250AC401009885DF /* SPBracketHighlighter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25E250AC401009885DF /* SPBracketHighlighter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3063,6 +3063,7 @@
 				1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */,
 				507FF1621BBF0D5000104523 /* SPTableCopyTest.m in Sources */,
 				50837F741E50DCD4004FAE8A /* SPJSONFormatterTests.m in Sources */,
+				1AB925922551550200063446 /* NumberFormatterExtention.swift in Sources */,
 				50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */,
 				50EA92651AB23EC8008D3C4F /* SPDatabaseAction.m in Sources */,
 				50EA92641AB23EAD008D3C4F /* SPDatabaseCopy.m in Sources */,
@@ -3089,6 +3090,7 @@
 				5080229B1BF7C0FE0052A9B2 /* MGTemplateEngine.m in Sources */,
 				5080229C1BF7C0FE0052A9B2 /* MGTemplateStandardMarkers.m in Sources */,
 				5080229D1BF7C0FE0052A9B2 /* MGTemplateStandardFilters.m in Sources */,
+				1AB9259A2551551100063446 /* NumberFormatterExtention.swift in Sources */,
 				507FF2A21BCD27AE00104523 /* SPOSInfo.m in Sources */,
 				507FF2A11BCD27A700104523 /* SPFunctions.m in Sources */,
 				50D3C3541A7715E600B5429C /* SPParserUtils.c in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -3709,7 +3709,7 @@
 		380F4EDB0FC0B50600B0BFD7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3739,6 +3739,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.tests";
 				PRODUCT_NAME = "Unit Tests";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -3746,7 +3747,7 @@
 		380F4EDC0FC0B50600B0BFD7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3773,6 +3774,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.tests";
 				PRODUCT_NAME = "Unit Tests";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -3780,7 +3782,7 @@
 		380F4EDD0FC0B50600B0BFD7 /* Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3807,6 +3809,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.tests";
 				PRODUCT_NAME = "Unit Tests";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Distribution;
@@ -3814,6 +3817,7 @@
 		584754C4120A04560057631F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -3826,8 +3830,10 @@
 				INSTALL_PATH = /Library/QuickLook;
 				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.qlgenerator";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "Sequel Ace";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Debug;
@@ -3835,6 +3841,7 @@
 		584754C5120A04560057631F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
@@ -3847,8 +3854,10 @@
 				INSTALL_PATH = /Library/QuickLook;
 				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.qlgenerator";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "Sequel Ace";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = qlgenerator;
 				ZERO_LINK = NO;
 			};
@@ -3857,6 +3866,7 @@
 		584754C6120A04560057631F /* Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2109;
@@ -3868,8 +3878,10 @@
 				INSTALL_PATH = /Library/QuickLook;
 				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.qlgenerator";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "Sequel Ace";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Distribution;
@@ -3937,6 +3949,7 @@
 				IBC_WARNINGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wmost";
@@ -3946,6 +3959,7 @@
 		588593F10F7AEB6900ED0E67 /* Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLY_RULES_IN_COPY_HEADERS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -3956,7 +3970,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2109;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = NKQ4HJ66PX;
+				DEVELOPMENT_TEAM = 7G8XW6MU88;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3986,7 +4000,7 @@
 				SEPARATE_STRIP = NO;
 				STRIP_PNG_TEXT = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Sequel_Ace-Swift.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -4319,6 +4333,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wmost";
@@ -4328,6 +4343,7 @@
 		96BC47C82500A84F003C8105 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLY_RULES_IN_COPY_HEADERS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -4338,7 +4354,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2109;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = NKQ4HJ66PX;
+				DEVELOPMENT_TEAM = 7G8XW6MU88;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4368,7 +4384,7 @@
 				SEPARATE_STRIP = NO;
 				STRIP_PNG_TEXT = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Sequel_Ace-Swift.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -4378,7 +4394,7 @@
 		96BC47C92500A84F003C8105 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -4405,6 +4421,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.tests";
 				PRODUCT_NAME = "Unit Tests";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Beta;
@@ -4496,6 +4513,7 @@
 		96BC47CD2500A84F003C8105 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2109;
@@ -4507,8 +4525,10 @@
 				INSTALL_PATH = /Library/QuickLook;
 				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sequel-ace.sequel-ace.qlgenerator";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "Sequel Ace";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Beta;
@@ -4516,6 +4536,7 @@
 		C05733C808A9546B00998B17 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLY_RULES_IN_COPY_HEADERS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -4525,7 +4546,7 @@
 				COMPRESS_PNG_FILES = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2109;
-				DEVELOPMENT_TEAM = NKQ4HJ66PX;
+				DEVELOPMENT_TEAM = 7G8XW6MU88;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4556,7 +4577,7 @@
 				SEPARATE_STRIP = NO;
 				STRIP_PNG_TEXT = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Sequel_Ace-Swift.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
@@ -4567,6 +4588,7 @@
 		C05733C908A9546B00998B17 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLY_RULES_IN_COPY_HEADERS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -4607,7 +4629,7 @@
 				SEPARATE_STRIP = NO;
 				STRIP_PNG_TEXT = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Source/Sequel-Ace-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Sequel_Ace-Swift.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -4686,6 +4708,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wmost";
@@ -4756,6 +4779,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PROJECT_NAME)-Swift.h";
 				VALID_ARCHS = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wmost";

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -102,12 +102,18 @@
 		17F90E2C1210B34900274C98 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 17F90E2B1210B34900274C98 /* Credits.rtf */; };
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
+		1A1EE94A2551185D0056FECD /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
+		1A1EE9582551249C0056FECD /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
+		1A1EE9AC255132E90056FECD /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C8597B24C8A31400A8C7C4 /* StringExtension.swift */; };
 		1A2711CF2539D9B10066ED58 /* SPReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2711CE2539D9B10066ED58 /* SPReachability.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1A2711E82539E2BB0066ED58 /* local-connection.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A2711E72539E2BB0066ED58 /* local-connection.html */; };
 		1A3FA7962495FC2D00B7291A /* SPMainThreadTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 589582141154F8F400EDCC28 /* SPMainThreadTrampoline.m */; };
 		1A564F74237E2E4958CA593A /* SPPillAttachmentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */; };
 		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
+		1A9D837E25513FCB0024B563 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
+		1A9D838625513FDD0024B563 /* NumberFormatterExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */; };
+		1A9D83A425514E740024B563 /* DateComponentsFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */; };
 		1AAF1DC32548485B0037AFDB /* SPReleaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF1DBF2548485B0037AFDB /* SPReleaseTests.m */; };
 		1AB068A824A355CC00E2AAC2 /* client-cert-crlf.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0688F24A355B500E2AAC2 /* client-cert-crlf.pem */; };
 		1AB068A924A355CC00E2AAC2 /* client-cert-bad-end.pem in Resources */ = {isa = PBXBuildFile; fileRef = 1AB0689024A355B500E2AAC2 /* client-cert-bad-end.pem */; };
@@ -780,12 +786,16 @@
 		17F90E471210B42700274C98 /* SPExportFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPExportFile.m; sourceTree = "<group>"; };
 		17FDB04A1280778B00DBBBC2 /* SPFontPreviewTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFontPreviewTextField.h; sourceTree = "<group>"; };
 		17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFontPreviewTextField.m; sourceTree = "<group>"; };
+		1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterExtension.swift; sourceTree = "<group>"; };
+		1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterExtention.swift; sourceTree = "<group>"; };
+		1A1EE986255131560056FECD /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
 		1A2711CD2539D9B10066ED58 /* SPReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPReachability.h; sourceTree = "<group>"; };
 		1A2711CE2539D9B10066ED58 /* SPReachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPReachability.m; sourceTree = "<group>"; };
 		1A2711E72539E2BB0066ED58 /* local-connection.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "local-connection.html"; sourceTree = "<group>"; };
 		1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPPillAttachmentCell.m; sourceTree = "<group>"; };
 		1A564C0C0FFB444D2E5CA447 /* SPPillAttachmentCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPPillAttachmentCell.h; sourceTree = "<group>"; };
 		1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSyncTests.m; sourceTree = "<group>"; };
+		1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateComponentsFormatterExtension.swift; sourceTree = "<group>"; };
 		1AAF1DBF2548485B0037AFDB /* SPReleaseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPReleaseTests.m; sourceTree = "<group>"; };
 		1AB0688F24A355B500E2AAC2 /* client-cert-crlf.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-cert-crlf.pem"; sourceTree = "<group>"; };
 		1AB0689024A355B500E2AAC2 /* client-cert-bad-end.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-cert-bad-end.pem"; sourceTree = "<group>"; };
@@ -2289,6 +2299,7 @@
 			children = (
 				38C613721C8977E600B3B6EF /* libz.tbd */,
 				1058C7A6FEA54F5311CA2CBB /* Linked Frameworks */,
+				1A1EE986255131560056FECD /* Quartz.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2335,6 +2346,9 @@
 			children = (
 				51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */,
 				51C8597B24C8A31400A8C7C4 /* StringExtension.swift */,
+				1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */,
+				1A1EE9572551249C0056FECD /* NumberFormatterExtention.swift */,
+				1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3083,6 +3097,7 @@
 				BC0E1486120AAB5600E52E25 /* SPDataAdditions.m in Sources */,
 				584754D3120A05910057631F /* GeneratePreviewForURL.m in Sources */,
 				584754D4120A05910057631F /* GenerateThumbnailForURL.m in Sources */,
+				1A1EE9AC255132E90056FECD /* StringExtension.swift in Sources */,
 				584754D5120A05910057631F /* main.c in Sources */,
 				584D88AC1515034200F24774 /* NSNotificationCenterThreadingAdditions.m in Sources */,
 			);
@@ -3152,6 +3167,7 @@
 				17E641840EF01FA8001BC333 /* SPTextView.m in Sources */,
 				58FEF16D0F23D66600518E8E /* SPSQLParser.m in Sources */,
 				1789343C0F30C1DD0097539A /* SPStringAdditions.m in Sources */,
+				1A1EE9582551249C0056FECD /* NumberFormatterExtention.swift in Sources */,
 				58FEF57E0F3B4E9700518E8E /* SPTableData.m in Sources */,
 				58C56EF50F438E120035701E /* SPDataCellFormatter.m in Sources */,
 				1A2711CF2539D9B10066ED58 /* SPReachability.m in Sources */,
@@ -3249,6 +3265,7 @@
 				17148565125F5FF500321285 /* SPDatabaseCharacterSets.m in Sources */,
 				17D38F701279E23A00672B13 /* SPTableFieldValidation.m in Sources */,
 				17D390C8127B65AF00672B13 /* SPGeneralPreferencePane.m in Sources */,
+				1A9D83A425514E740024B563 /* DateComponentsFormatterExtension.swift in Sources */,
 				17D390CB127B6BF800672B13 /* SPPreferencesUpgrade.m in Sources */,
 				51C8597C24C8A31400A8C7C4 /* StringExtension.swift in Sources */,
 				1785E9F7127D8C7500F468C8 /* SPPreferencePane.m in Sources */,
@@ -3280,6 +3297,7 @@
 				1798F1881550175B004B0AB8 /* SPFavoritesImporter.m in Sources */,
 				1798F1951550181B004B0AB8 /* SPGroupNode.m in Sources */,
 				1798F19815501838004B0AB8 /* SPMutableArrayAdditions.m in Sources */,
+				1A1EE94A2551185D0056FECD /* DateFormatterExtension.swift in Sources */,
 				1798F19B1550185B004B0AB8 /* SPTreeNode.m in Sources */,
 				1798F19E15501892004B0AB8 /* SPFlippedView.m in Sources */,
 				17D5B49E1553059F00EF3BB3 /* SPViewCopy.m in Sources */,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Made date, number, datecomponent formatters static

e.g. stringForByteSize is now twice as fast
Previously it was called and allocated 100s
of times when switching from table to table


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest


