### PR TITLE
fix duplicate database not working

### DIFF
--- a/Source/Controllers/DataControllers/SPDatabaseData.m
+++ b/Source/Controllers/DataControllers/SPDatabaseData.m
@@ -91,11 +91,15 @@ NSInteger _sortStorageEngineEntry(NSDictionary *itemOne, NSDictionary *itemTwo, 
 	
 	@synchronized(charsetCollationLock) {
 		
-		
-		
-		
-		
-		
+		// need to set these to nil
+		// otherwise leftover values are used
+		// in future queries
+		characterSetEncoding = nil;
+		defaultCollationForCharacterSet = nil;
+		defaultCharacterSetEncoding = nil;
+		defaultCollation = nil;
+		serverDefaultCharacterSetEncoding = nil;
+		serverDefaultCollation = nil;
 		
 		[collations removeAllObjects];
 		[characterSetEncodings removeAllObjects];


### PR DESCRIPTION
need to set these to nil
otherwise leftover values
are used in future queries


What does this implement/fix? Explain your changes.
---------------------------------------------------
fixes duplicate database not working

Does this close any currently open issues?
------------------------------------------
…




Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** arc_updates latest


