### PR TITLE
Save query to history on close

### DIFF
--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -1935,7 +1935,6 @@ cleanup:
 	if (selectedTableTarget)           SPClear(selectedTableTarget);
 	
 	SPClear(nibObjectsToRelease);
-	SPClear(fileManager);
 	
 	[super dealloc];
 }

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -283,20 +283,22 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	[self _addPreferenceObservers];
 
 	// Register for notifications
-	[[NSNotificationCenter defaultCenter] addObserver:self
-	                                         selector:@selector(willPerformQuery:)
-	                                             name:@"SMySQLQueryWillBePerformed"
-	                                           object:self];
-
-	[[NSNotificationCenter defaultCenter] addObserver:self
-	                                         selector:@selector(hasPerformedQuery:)
-	                                             name:@"SMySQLQueryHasBeenPerformed"
-	                                           object:self];
-
-	[[NSNotificationCenter defaultCenter] addObserver:self
-	                                         selector:@selector(applicationWillTerminate:)
-	                                             name:@"NSApplicationWillTerminateNotification"
-	                                           object:nil];
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	
+	[nc addObserver:self
+		   selector:@selector(willPerformQuery:)
+			   name:@"SMySQLQueryWillBePerformed"
+			 object:self];
+	
+	[nc addObserver:self
+		   selector:@selector(hasPerformedQuery:)
+			   name:@"SMySQLQueryHasBeenPerformed"
+			 object:self];
+	
+	[nc addObserver:self
+		   selector:@selector(applicationWillTerminate:)
+			   name:@"NSApplicationWillTerminateNotification"
+			 object:nil];
 
 	// Find the Database -> Database Encoding menu (it's not in our nib, so we can't use interface builder)
 	selectEncodingMenu = [[[[[NSApp mainMenu] itemWithTag:SPMainMenuDatabase] submenu] itemWithTag:1] submenu];
@@ -2678,23 +2680,35 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 	SPTableViewType theView = NSNotFound;
 
 	// -selectedTabViewItem is a UI method according to Xcode 9.2!
-	// jamesstout note - this is called a LOT. 
+	// jamesstout note - this is called a LOT.
+	// using tableViewTypeEnumFromString is 5-7x faster than if/else isEqualToString:
 	NSString *viewName = [[[tableTabView onMainThread] selectedTabViewItem] identifier];
-
-	if ([viewName isEqualToString:@"source"]) {
-		theView = SPTableViewStructure;
-	} else if ([viewName isEqualToString:@"content"]) {
-		theView = SPTableViewContent;
-	} else if ([viewName isEqualToString:@"customQuery"]) {
-		theView = SPTableViewCustomQuery;
-	} else if ([viewName isEqualToString:@"status"]) {
-		theView = SPTableViewStatus;
-	} else if ([viewName isEqualToString:@"relations"]) {
-		theView = SPTableViewRelations;
-	} else if ([viewName isEqualToString:@"triggers"]) {
-		theView = SPTableViewTriggers;
+	
+	SPTableViewType enumValue = [viewName tableViewTypeEnumFromString];
+	
+	switch (enumValue) {
+		case SPTableViewStructure:
+			theView = SPTableViewStructure;
+			break;
+		case SPTableViewContent:
+			theView = SPTableViewContent;
+			break;
+		case SPTableViewCustomQuery:
+			theView = SPTableViewCustomQuery;
+			break;
+		case SPTableViewStatus:
+			theView = SPTableViewStatus;
+			break;
+		case SPTableViewRelations:
+			theView = SPTableViewRelations;
+			break;
+		case SPTableViewTriggers:
+			theView = SPTableViewTriggers;
+			break;
+		default:
+			theView = SPTableViewInvalid;
 	}
-
+		
 	return theView;
 }
 
@@ -4125,13 +4139,12 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
 - (void)parentTabDidClose
 {
 	// if tab closed and there is text in the query view, safe to history
-	
 	NSString *queryString = [self->customQueryTextView.textStorage string];
 	
 	if([queryString length] > 0){
 		[[SPQueryController sharedQueryController] addHistory:queryString forFileURL:[self fileURL]];
 	}
-	
+		
 	// Cancel autocompletion trigger
 	if([prefs boolForKey:SPCustomQueryAutoComplete]) {
 		[NSObject cancelPreviousPerformRequestsWithTarget:[customQueryInstance valueForKeyPath:@"textView"]

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -4124,6 +4124,14 @@ static int64_t SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)parentTabDidClose
 {
+	// if tab closed and there is text in the query view, safe to history
+	
+	NSString *queryString = [self->customQueryTextView.textStorage string];
+	
+	if([queryString length] > 0){
+		[[SPQueryController sharedQueryController] addHistory:queryString forFileURL:[self fileURL]];
+	}
+	
 	// Cancel autocompletion trigger
 	if([prefs boolForKey:SPCustomQueryAutoComplete]) {
 		[NSObject cancelPreviousPerformRequestsWithTarget:[customQueryInstance valueForKeyPath:@"textView"]

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -63,7 +63,9 @@
 {
 	[self _switchOutSelectedTableDocument:nil];
 	
-	[[self window] setCollectionBehavior:[[self window] collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary];
+	NSWindow *window = [self window];
+	
+	[window setCollectionBehavior:[window collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary];
 
 	// Disable automatic cascading - this occurs before the size is set, so let the app
 	// controller apply cascading after frame autosaving.
@@ -75,18 +77,20 @@
 	[self _setUpTabBar];
 
 	// Retrieve references to the 'Close Window' and 'Close Tab' menus.  These are updated as window focus changes.
-	closeWindowMenuItem = [[[[NSApp mainMenu] itemWithTag:SPMainMenuFile] submenu] itemWithTag:SPMainMenuFileClose];
-	closeTabMenuItem = [[[[NSApp mainMenu] itemWithTag:SPMainMenuFile] submenu] itemWithTag:SPMainMenuFileCloseTab];
+	NSMenu *mainMenu = [NSApp mainMenu];
+	closeWindowMenuItem = [[[mainMenu itemWithTag:SPMainMenuFile] submenu] itemWithTag:SPMainMenuFileClose];
+	closeTabMenuItem = [[[mainMenu itemWithTag:SPMainMenuFile] submenu] itemWithTag:SPMainMenuFileCloseTab];
 
 	// Register for drag start and stop notifications - used to show/hide tab bars
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tabDragStarted:) name:PSMTabDragDidBeginNotification object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tabDragStopped:) name:PSMTabDragDidEndNotification object:nil];
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	[nc addObserver:self selector:@selector(tabDragStarted:) name:PSMTabDragDidBeginNotification object:nil];
+	[nc addObserver:self selector:@selector(tabDragStopped:) name:PSMTabDragDidEndNotification object:nil];
 
 	// Because we are a document-based app we automatically adopt window restoration on 10.7+.
 	// However that causes a race condition with our own window setup code.
 	// Remove this when we actually support restoration.
-	if([[self window] respondsToSelector:@selector(setRestorable:)])
-		[[self window] setRestorable:NO];
+	if([window respondsToSelector:@selector(setRestorable:)])
+		[window setRestorable:NO];
 }
 
 #pragma mark -

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -35,6 +35,7 @@
  * type checking when used and cannot be tested for equality.
  */
 
+
 // View modes
 typedef enum {
 	SPStructureViewMode	  = 1,
@@ -121,6 +122,9 @@ typedef NS_ENUM(NSInteger, SPTableViewType)
 	SPTableViewInvalid     = NSNotFound
 };
 
+@interface NSString (TableViewTypeEnumParser)
+- (SPTableViewType)tableViewTypeEnumFromString;
+@end
 // SSH tunnel password modes
 typedef enum
 {

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -30,6 +30,31 @@
 
 #import "SPConstants.h"
 
+@implementation NSString (TableViewTypeEnumParser)
+
+- (SPTableViewType)tableViewTypeEnumFromString{
+	
+	static NSDictionary<NSString*,NSNumber*> *tableViewType = nil;
+	
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		tableViewType = [@{
+			@"source"		: @(SPTableViewStructure),
+			@"content"		: @(SPTableViewContent),
+			@"customQuery"	: @(SPTableViewCustomQuery),
+			@"status"		: @(SPTableViewStatus),
+			@"relations"	: @(SPTableViewRelations),
+			@"triggers"		: @(SPTableViewTriggers),
+			@"SPTableViewInvalid": @(NSNotFound)
+		} copy]; // TODO: won't need this copy under ARC
+	});
+	
+	return tableViewType[self].integerValue;
+}
+
+@end
+
+
 // Narrow down completion max rows
 const NSUInteger SPNarrowDownCompletionMaxRows   = 15;
 const NSUInteger SPMaxQueryLengthForWarning 	 = 1000;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When a tab or the window is closed, any queries left in the query window are saved to history.

Does this close any currently open issues?
------------------------------------------
#455 

Any other comments?
-------------------
Didn't manage to convert the enum thing to swift yet

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest


