### PR TITLE
Fix help not showing

### DIFF
--- a/Source/Controllers/DataControllers/SPDatabaseStructure.m
+++ b/Source/Controllers/DataControllers/SPDatabaseStructure.m
@@ -145,7 +145,7 @@
 /**
  * Updates the dict containing the structure of all available databases (mainly for completion/navigator)
  * executed on the helper connection.
- * Should always be executed on a background thread.
+ * Should always be executed on a background thread. // JCS: but it calls delegate getDbStructure which eventually calls initWithWindowNibName .. which needs to be on main
  */
 - (void)queryDbStructureWithUserInfo:(NSDictionary *)userInfo
 {

--- a/Source/Controllers/SubviewControllers/SPNavigatorController.m
+++ b/Source/Controllers/SubviewControllers/SPNavigatorController.m
@@ -65,9 +65,14 @@ static NSComparisonResult compareStrings(NSString *s1, NSString *s2, void* conte
 {
 	@synchronized(self) {
 		if (sharedNavigatorController == nil) {
-			SPMainQSync(^{ // JCS: alloc on main as it calls initWithWindowNibName
+			if (![NSThread isMainThread]){
+				SPMainQSync(^{ // JCS: alloc on main as it calls initWithWindowNibName
+					sharedNavigatorController = [[super allocWithZone:NULL] init];
+				});
+			}
+			else{
 				sharedNavigatorController = [[super allocWithZone:NULL] init];
-			});
+			}
 		}
 	}
 

--- a/Source/Controllers/SubviewControllers/SPNavigatorController.m
+++ b/Source/Controllers/SubviewControllers/SPNavigatorController.m
@@ -40,6 +40,7 @@
 #import "SPAppController.h"
 #import "SPDatabaseStructure.h"
 #import "SPThreadAdditions.h"
+#import "SPFunctions.h"
 
 #import <objc/message.h>
 #import <SPMySQL/SPMySQL.h>
@@ -64,7 +65,9 @@ static NSComparisonResult compareStrings(NSString *s1, NSString *s2, void* conte
 {
 	@synchronized(self) {
 		if (sharedNavigatorController == nil) {
-			sharedNavigatorController = [[super allocWithZone:NULL] init];
+			SPMainQSync(^{ // JCS: alloc on main as it calls initWithWindowNibName
+				sharedNavigatorController = [[super allocWithZone:NULL] init];
+			});
 		}
 	}
 

--- a/Source/ThirdParty/MGTemplateEngine/MGTemplateEngine.h
+++ b/Source/ThirdParty/MGTemplateEngine/MGTemplateEngine.h
@@ -54,7 +54,7 @@
 @property (nonatomic, copy) NSString *literalEndMarker;
 @property (nonatomic, readonly) NSRange remainingRange;
 @property (nonatomic, weak) id <MGTemplateEngineDelegate> delegate;	// weak ref
-@property (nonatomic, weak) id <MGTemplateEngineMatcher> matcher;
+@property (nonatomic, strong) id <MGTemplateEngineMatcher> matcher;
 @property (nonatomic, copy, readonly) NSString *templateContents;
 
 // Creation.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
I noticed the MySQL help was not showing on the arc branch. Due to a weak property. Fixed.


Any other comments?
-------------------
We may need to go through any singleton init code an ensure they are called on main.

Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** arc_updates latest


