### PR TITLE
workerGetResponseForQuestion would crash due to deallocated vars

### DIFF
--- a/Source/Other/SSHTunnel/SPSSHTunnel.h
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.h
@@ -83,6 +83,12 @@
 @property (readonly) BOOL passwordPromptCancelled;
 @property (readonly) BOOL taskExitedUnexpectedly;
 
+@property (readwrite, retain) IBOutlet NSTextField *sshQuestionText;
+@property (readwrite, retain) IBOutlet NSWindow *sshQuestionDialog;
+@property (readwrite, retain) IBOutlet NSWindow *sshPasswordDialog;
+@property (readwrite, retain) IBOutlet NSTextField *sshPasswordText;
+@property (readwrite, retain) IBOutlet NSSecureTextField *sshPasswordField;
+
 - (id)initToHost:(NSString *)theHost port:(NSInteger)thePort login:(NSString *)theLogin tunnellingToPort:(NSInteger)targetPort onHost:(NSString *)targetHost;
 - (BOOL)setConnectionStateChangeSelector:(SEL)theStateChangeSelector delegate:(id)theDelegate;
 - (void)setParentWindow:(NSWindow *)theWindow;

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -52,7 +52,7 @@ static unsigned short getRandomPort(void);
 
 @synthesize passwordPromptCancelled;
 @synthesize taskExitedUnexpectedly;
-
+@synthesize sshQuestionText, sshQuestionDialog, sshPasswordText, sshPasswordDialog, sshPasswordField;
 /*
  * Initialise with the supplied connection details.  Host, login and port should all be provided.
  * The password can either be set later via setPassword:, which stores the password locally and is
@@ -838,6 +838,10 @@ static unsigned short getRandomPort(void);
 	// As this object is not a NSWindowController, use manual top-level nib item management
 	SPClear(sshQuestionDialog);
 	SPClear(sshPasswordDialog);
+	
+	SPClear(sshQuestionText);
+	SPClear(sshPasswordText);
+	SPClear(sshPasswordField);
 	
 	[super dealloc];
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
ssh tunnel would crash when asking a question


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest


