### PR TITLE
 fix editing query faves

### DIFF
--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -555,7 +555,8 @@
  */
 - (CGFloat)tableView:(NSTableView *)aTableView heightOfRow:(NSInteger)rowIndex
 {
-	return ([[favorites objectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? 20 : 18;
+
+	return ([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? 20 : 18;
 }
 
 /*
@@ -563,7 +564,8 @@
  */
 - (BOOL)tableView:(NSTableView *)aTableView shouldEditTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
-	if([[favorites objectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) {
+
+	if([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) {
 		return NO;
 	} else {
 		isTableCellEditing = YES;
@@ -585,7 +587,8 @@
  */
 - (BOOL)tableView:(NSTableView *)aTableView isGroupRow:(NSInteger)rowIndex
 {
-	return ([[favorites objectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? YES : NO;
+	
+	return ([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? YES : NO;
 }
 /*
  * Detect if inline editing was done - then ESC to close the sheet will be activate


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
You can now re-order the query favourites. 

there were out of bounds errors causing the drop to fail.
So now use objectOrNilAtIndex for accessing favourites array

Does this close any currently open issues?
------------------------------------------
#475 


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest

