### PR TITLE
Fixed #382 Updated lexfile to fix the color theme issue for the snippet parsing ${1:name}

### DIFF
--- a/Source/Other/Parsing/SPEditorTokens.l
+++ b/Source/Other/Parsing/SPEditorTokens.l
@@ -74,7 +74,7 @@ keywords	(X(OR|509|A)|S(MALLINT|SL|H(OW({s}(E(NGINE(S)?|RRORS)|M(ASTER|UTEX)|BIN
 
 
 \$\{1?[0-9]:						{ BEGIN(snippet); return SPT_OTHER; }
-<snippet>\\\}						{ return SPT_OTHER; }
+<snippet>{word}						{ return SPT_VARIABLE; }
 <snippet>\}							{ BEGIN(INITIAL); return SPT_OTHER; }
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Updated the lexer file so snippets will be detected correctly. I had no clue what that `\\\}` was doing there, it was at least not accepting the word correctly.. So by adding the {word} it will now accept a word between ${1: and the closing tag.


Does this close any currently open issues?
------------------------------------------
#382 


Any relevant logs, error output, etc?
-------------------------------------
![image](https://user-images.githubusercontent.com/1443527/99146410-34480c00-2678-11eb-9bb3-e05bed06c1a7.png)


Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**macOS Version:** 10.15.4

**Sequel-Ace Version:** code from main


