### PR TITLE
Sort table names in `Add Relation` popup

### DIFF
--- a/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
+++ b/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
@@ -272,7 +272,7 @@ static NSString *SPRelationOnDeleteKey   = @"on_delete";
 	// Get all InnoDB tables in the current database
 	if ([[tableDocumentInstance serverSupport] supportsInformationSchema]) {
 		//MySQL 5.0+
-		SPMySQLResult *result = [connection queryString:[NSString stringWithFormat:@"SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND engine = 'InnoDB' AND table_schema = %@", [[tableDocumentInstance database] tickQuotedString]]];
+		SPMySQLResult *result = [connection queryString:[NSString stringWithFormat:@"SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND engine = 'InnoDB' AND table_schema = %@ ORDER BY table_name ASC", [[tableDocumentInstance database] tickQuotedString]]];
 		[result setDefaultRowReturnType:SPMySQLResultRowAsArray];
 		[result setReturnDataAsStrings:YES]; // TODO: Workaround for #2699/#2700
 		for (NSArray *eachRow in result) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The list of reference table names in the `Add Relation` popup is currently unsorted. This approach makes sense of the columns fields in the same view which list the columns in the order they are defined in the table. The table list should be sorted though like in other parts of the app.
