### PR TITLE
Fix bracket highlighter color crash

### DIFF
--- a/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
+++ b/Source/Controllers/MainViewControllers/SPBracketHighlighter.m
@@ -49,7 +49,11 @@
 	self.textView = textView;
 	self.pos1 = NSNotFound;
 	self.pos2 = NSNotFound;
-	self.highlightColor = [NSColor systemTealColor];
+	if (@available(macOS 10.12, *)) {
+		self.highlightColor = [NSColor systemTealColor];
+	} else {
+		self.highlightColor = [NSColor systemYellowColor];
+	}
 	self.enabled = YES;
 	return self;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
#511 
Fallback on yellow bracket highlighter on macOS < 10.12
@pmarnik 

Does this close any currently open issues?
------------------------------------------
#511 


