### PR TITLE
Speedup loading list of the tables #fixed

### DIFF
--- a/Source/Views/Cells/SPTableTextFieldCell.m
+++ b/Source/Views/Cells/SPTableTextFieldCell.m
@@ -37,9 +37,7 @@
  */
 - (id) initWithCoder:(NSCoder *)coder
 {
-	self = [super initWithCoder:coder];
-	if (self) {
-//		noteButton = nil;
+	if (self = [super initWithCoder:coder]) {
 		noteButton = [[NSCell alloc] init];
 		[noteButton setTitle:@""];
 		[noteButton setBordered:NO];
@@ -104,7 +102,7 @@
 	
 }
 
-- (void) setNote:(NSString *)lableText
+- (void)setNote:(NSString *)lableText
 {
 	if (noteButton != nil)
 	{


### PR DESCRIPTION
- show comments only if it's enabled
- load tables faster if comments are disabled
- fix check for NSArray

Related: https://github.com/Sequel-Ace/Sequel-Ace/issues/194

Motivation:
```
Looks like SHOW TABLE STATUS on a database server with more than 100k tables takes at least several minutes to complete.

SHOW TABLES will get full list in less than 0,2 seconds.
```