### PR TITLE
fix tooltip font and size

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -2463,12 +2463,19 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 		}
 	}
 
+	NSDictionary *displayOptions = nil;
+
+    if([aCell isMemberOfClass:[SPTextAndLinkCell class]] == YES){
+        displayOptions = @{ @"fontsize" : @(((SPTextAndLinkCell*) aCell).font.pointSize),
+							@"fontname" : ((SPTextAndLinkCell*) aCell).font };
+	}
+	
 	// Show the cell string value as tooltip (including line breaks and tabs)
 	// by using the cell's font
 	[SPTooltip showWithObject:[aCell stringValue]
 			atLocation:pos
 				ofType:@"text"
-		displayOptions:nil];
+		displayOptions:displayOptions];
 
 	return nil;
 }

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4353,12 +4353,19 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			}
 		}
 
+		NSDictionary *displayOptions = nil;
+
+		if([aCell isMemberOfClass:[SPTextAndLinkCell class]] == YES){
+			displayOptions = @{ @"fontsize" : @(((SPTextAndLinkCell*) aCell).font.pointSize),
+								@"fontname" : ((SPTextAndLinkCell*) aCell).font };
+		}
+
 		// Show the cell string value as tooltip (including line breaks and tabs)
 		// by using the cell's font
 		[SPTooltip showWithObject:[aCell stringValue]
 		               atLocation:pos
 		                   ofType:@"text"
-		           displayOptions:nil];
+		           displayOptions:displayOptions];
 
 		return @"";
 	}

--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -33,7 +33,9 @@
 //
 //	[SPTooltip showWithObject:@"<h1>Hello</h1>I am a <b>tooltip</b>" ofType:@"html"
 //			displayOptions:[NSDictionary dictionaryWithObjectsAndKeys:
+//			SPDefaultMonospacedFontName, @"fontname",
 //			@"#EEEEEE", @"backgroundcolor",
+//			@"20", @"fontsize",
 //			@"transparent", @"transparent", nil]];
 //
 //	[SPTooltip  showWithObject:(id)content
@@ -47,7 +49,7 @@
 //			         if no caret could be found in the upper left corner of the current window
 //			   type: a NSString of: "text", "html", or "image"; no type - 'text' is default
 //	 displayOptions: a NSDictionary with the following keys (all values must be of type NSString):
-//	                        backgroundcolor (as #RRGGBB), transparent (any value)
+//	                       fontname, fontsize, backgroundcolor (as #RRGGBB), transparent (any value)
 //	                 if no displayOptions are passed or if a key doesn't exist the following default
 //	                 are taken:
 //	                       "Lucida Grande", "10", "#F9FBC5", NO
@@ -165,6 +167,10 @@ static CGFloat slow_in_out (CGFloat t)
 			if(fontSize < 5) fontSize = 5;
 			[text replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, [text length])];
 			[text replaceOccurrencesOfString:@"<" withString:@"&lt;" options:0 range:NSMakeRange(0, [text length])];
+			[text insertString:[NSString stringWithFormat:@"<pre style=\"font-family:'%@'; font-size: %dpx\">",
+							([displayOptions objectForKey:@"fontname"]) ? [displayOptions objectForKey:@"fontname"] : @"Lucida Grande", fontSize]
+							atIndex:0];
+			[text appendString:@"</pre>"];
 			html = text;
 		}
 		else
@@ -292,6 +298,8 @@ static CGFloat slow_in_out (CGFloat t)
 		} else {
 			pos = [[fr window] convertRectToScreen:(CGRect){.origin=oppositeOrigin}].origin;
 		}
+		NSFont* font = [fr font];
+		if(font) pos.y -= [font pointSize]*1.3f;
 		return pos;
 	// Otherwise return mouse location
 	} else {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Tooltips were not reflecting user font and size, this fixes that.


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest


