### PR TITLE
use fontname

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -2467,7 +2467,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 
     if([aCell isMemberOfClass:[SPTextAndLinkCell class]] == YES){
         displayOptions = @{ @"fontsize" : @(((SPTextAndLinkCell*) aCell).font.pointSize),
-							@"fontname" : ((SPTextAndLinkCell*) aCell).font };
+							@"fontname" : ((SPTextAndLinkCell*) aCell).font.fontName };
 	}
 	
 	// Show the cell string value as tooltip (including line breaks and tabs)

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4357,7 +4357,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		if([aCell isMemberOfClass:[SPTextAndLinkCell class]] == YES){
 			displayOptions = @{ @"fontsize" : @(((SPTextAndLinkCell*) aCell).font.pointSize),
-								@"fontname" : ((SPTextAndLinkCell*) aCell).font };
+								@"fontname" : ((SPTextAndLinkCell*) aCell).font.fontName };
 		}
 
 		// Show the cell string value as tooltip (including line breaks and tabs)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Tooltips were not reflecting user font(!) this fixes that.


Where has this been tested?
---------------------------
**Devices/Simulators:** iMac19,1

**macOS Version:**: 10.15.7 (19H2)

**Sequel-Ace Version:** main latest

