### PR TITLE
Fix Query ruler view and rows count #fixed

### DIFF
--- a/Source/ThirdParty/Views/NoodleLineNumberView.m
+++ b/Source/ThirdParty/Views/NoodleLineNumberView.m
@@ -171,6 +171,7 @@ typedef NSRange (*RangeOfLineIMP)(id object, SEL selector, NSRange range);
 		clientView     = (NSTextView*)[self clientView];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textDidChange:) name:NSTextStorageDidProcessEditingNotification object:[clientView textStorage]];
+		lineIndices = nil;
 	}
 
 }
@@ -181,6 +182,12 @@ typedef NSRange (*RangeOfLineIMP)(id object, SEL selector, NSRange range);
 {
 
 	if(!clientView) return;
+
+	// Invalidate the line indices only if text view was changed in length but not if the font was changed.
+	// They will be recalculated and recached on demand.
+	if ([[clientView textStorage] editedMask] != 1) {
+		lineIndices = nil;
+	}
 
 	[self setNeedsDisplayInRect:[self bounds]];
 
@@ -263,17 +270,7 @@ typedef NSRange (*RangeOfLineIMP)(id object, SEL selector, NSRange range);
 
 - (void)drawHashMarksAndLabelsInRect:(NSRect)aRect
 {
-	[super drawHashMarksAndLabelsInRect:aRect];
 	NSRect bounds = [self bounds];
-
-	// if (backgroundColor != nil)
-	// {
-	// 	[backgroundColor set];
-	// 	NSRectFill(bounds);
-	// 
-	// 	[[NSColor colorWithCalibratedWhite:0.58 alpha:1.0] set];
-	// 	[NSBezierPath strokeLineFromPoint:NSMakePoint(NSMaxX(bounds) - 0.5, NSMinY(bounds)) toPoint:NSMakePoint(NSMaxX(bounds) - 0.5, NSMaxY(bounds))];
-	// }
 
 	if ([clientView isKindOfClass:[NSTextView class]])
 	{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- removed calling super to not draw ruler itself
- added back invalidation of indicies to calculate new lines

## Closes following issues:
- None

## Tested:
- [x] iMac / MacBook
- macOS version: 11.0.1
- XCode version: 12.2

## Screenshots:
<img width="2162" alt="Screen Shot 2020-11-22 at 16 08 35" src="https://user-images.githubusercontent.com/7204168/99907462-309e3000-2cdd-11eb-8433-860aef13e2b0.png">