### PR TITLE
kill tidb query and kill tidb connection support #added

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -569,6 +569,9 @@
 
 		// Build the kill query
 		NSMutableString *killQuery = [NSMutableString stringWithString:@"KILL"];
+        if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+            [killQuery appendString:@" TIDB"];
+        }
 		if (killQuerySupported) [killQuery appendString:@" QUERY"];
 		[killQuery appendFormat:@" %lu", mySQLConnection->thread_id];
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -569,9 +569,9 @@
 
 		// Build the kill query
 		NSMutableString *killQuery = [NSMutableString stringWithString:@"KILL"];
-        if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
-            [killQuery appendString:@" TIDB"];
-        }
+		if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+			[killQuery appendString:@" TIDB"];
+		}
 		if (killQuerySupported) [killQuery appendString:@" QUERY"];
 		[killQuery appendFormat:@" %lu", mySQLConnection->thread_id];
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
@@ -137,10 +137,10 @@
 {
 	// Note that mysql_kill has been deprecated, so use a query to perform this task.
 	NSMutableString *killQuery = [NSMutableString stringWithString:@"KILL"];
-    if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
-        [killQuery appendString:@" TIDB"];
-    }
-    else if ([self serverVersionIsGreaterThanOrEqualTo:5 minorVersion:0 releaseVersion:0]) {
+	if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+		[killQuery appendString:@" TIDB"];
+	}
+	else if ([self serverVersionIsGreaterThanOrEqualTo:5 minorVersion:0 releaseVersion:0]) {
 		[killQuery appendString:@" QUERY"];
 	}
 	[killQuery appendFormat:@" %lu", theThreadID];

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
@@ -137,7 +137,10 @@
 {
 	// Note that mysql_kill has been deprecated, so use a query to perform this task.
 	NSMutableString *killQuery = [NSMutableString stringWithString:@"KILL"];
-	if ([self serverVersionIsGreaterThanOrEqualTo:5 minorVersion:0 releaseVersion:0]) {
+    if ([[self serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+        [killQuery appendString:@" TIDB"];
+    }
+    else if ([self serverVersionIsGreaterThanOrEqualTo:5 minorVersion:0 releaseVersion:0]) {
 		[killQuery appendString:@" QUERY"];
 	}
 	[killQuery appendFormat:@" %lu", theThreadID];

--- a/Source/Controllers/SubviewControllers/SPProcessListController.m
+++ b/Source/Controllers/SubviewControllers/SPProcessListController.m
@@ -684,7 +684,12 @@ static NSString * const SPKillIdKey   = @"SPKillId";
 - (void)_killProcessQueryWithId:(long long)processId
 {
 	// Kill the query
-	[connection queryString:[NSString stringWithFormat:@"KILL QUERY %lld", processId]];
+	if ([[connection serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+		[connection queryString:[NSString stringWithFormat:@"KILL TIDB QUERY %lld", processId]];
+	}
+	else {
+		[connection queryString:[NSString stringWithFormat:@"KILL QUERY %lld", processId]];
+	}
 	
 	// Check for errors
 	if ([connection queryErrored]) {
@@ -701,7 +706,12 @@ static NSString * const SPKillIdKey   = @"SPKillId";
 - (void)_killProcessConnectionWithId:(long long)processId
 {
 	// Kill the connection
-	[connection queryString:[NSString stringWithFormat:@"KILL CONNECTION %lld", processId]];
+	if ([[connection serverVersionString] rangeOfString:@"TiDB"].location != NSNotFound) {
+		[connection queryString:[NSString stringWithFormat:@"KILL TIDB CONNECTION %lld", processId]];
+	}
+	else {
+		[connection queryString:[NSString stringWithFormat:@"KILL CONNECTION %lld", processId]];
+	}
 	
 	// Check for errors
 	if ([connection queryErrored]) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
-  - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- support statement KILL TIDB in TiDB.

## Closes following issues:
-

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version: 11.7

## Screenshots:
![Xnip2020-11-27_13-53-24](https://user-images.githubusercontent.com/7940795/100415798-f0adc300-30b7-11eb-8930-28c9203312b5.png)
![Xnip2020-11-27_13-52-30](https://user-images.githubusercontent.com/7940795/100415805-f3101d00-30b7-11eb-86c6-b462e3d0c790.png)


## Additional notes:
[TiDB](https://docs.pingcap.com/tidb/stable) (/’taɪdiːbi:/, "Ti" stands for Titanium) is an open-source, distributed, NewSQL database that supports Hybrid Transactional and Analytical Processing (HTAP) workloads. **It is MySQL compatible** and features horizontal scalability, strong consistency, and high availability. TiDB can be deployed on-premise or in-cloud.

I has used Sequel-Ace as tidb client several days, the only inconvenience is that the query process cannot be killed.

As the [link](https://docs.pingcap.com/tidb/stable/sql-statement-kill) say, I added some codes in this pr to support the KILL TIDB statement if the serverVersionString has 'TiDB' characters, I hope it will be useful, thanks.
