### PR TITLE
Re-implement double click functionality for Query editor #added

### DIFF
--- a/Source/Views/TextViews/SPTextStorage.swift
+++ b/Source/Views/TextViews/SPTextStorage.swift
@@ -1,0 +1,72 @@
+//
+//  SPTextStorage.swift
+//  Sequel Ace
+//
+//  Created by Jakub Kaspar on 04.12.2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+@objc final class SPTextStorage: NSTextStorage {
+
+	private var storage = NSTextStorage()
+
+	// MARK: NSTextStorage Primitive Methods
+	// https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/TextStorageLayer/Tasks/Subclassing.html
+
+	override var string: String {
+		return storage.string
+	}
+
+	override func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedString.Key : Any] {
+		return storage.attributes(at: location, effectiveRange: range)
+	}
+
+	override func replaceCharacters(in range: NSRange, with str: String) {
+		beginEditing()
+		storage.replaceCharacters(in: range, with: str)
+		edited(.editedCharacters, range: range, changeInLength: (str as NSString).length - range.length)
+		endEditing()
+	}
+
+	override func setAttributes(_ attrs: [NSAttributedString.Key : Any]?, range: NSRange) {
+		beginEditing()
+		storage.setAttributes(attrs, range: range)
+		edited(.editedAttributes, range: range, changeInLength: 0)
+		endEditing()
+	}
+
+	override func doubleClick(at location: Int) -> NSRange {
+
+		// Call super to get location of the double click
+		var range = super.doubleClick(at: location)
+		let stringCopy = self.string
+
+		// If the user double-clicked a period, just return the range of the period
+		let locationIndex = stringCopy.index(stringCopy.startIndex, offsetBy: location)
+		guard stringCopy[locationIndex] != "." else {
+			return NSMakeRange(location, 1)
+		}
+
+		// The case where super's behavior is wrong involves the dot operator; x.y should not be considered a word.
+		// So we check for a period before or after the anchor position, and trim away the periods and everything
+		// past them on both sides. This will correctly handle longer sequences like foo.bar.baz.is.a.test.
+		let candidateRangeBeforeLocation = NSMakeRange(range.location, location - range.location)
+		let candidateRangeAfterLocation = NSMakeRange(location + 1, NSMaxRange(range) - (location + 1))
+		let periodBeforeRange = (stringCopy as NSString).range(of: ".", options: .backwards, range: candidateRangeBeforeLocation)
+		let periodAfterRange = (stringCopy as NSString).range(of: ".", options: [], range: candidateRangeAfterLocation)
+
+		if periodBeforeRange.location != NSNotFound {
+			// Change range to start after the preceding period; fix its length so its end remains unchanged
+			range.length -= (periodBeforeRange.location + 1 - range.location)
+			range.location = periodBeforeRange.location + 1
+		}
+		if periodAfterRange.location != NSNotFound {
+			// Change range to end before the following period
+			range.length -= (NSMaxRange(range) - periodAfterRange.location);
+		}
+
+		return range
+	}
+}

--- a/Source/Views/TextViews/SPTextStorage.swift
+++ b/Source/Views/TextViews/SPTextStorage.swift
@@ -12,8 +12,7 @@ import Foundation
 
 	private var storage = NSTextStorage()
 
-	// MARK: NSTextStorage Primitive Methods
-	// https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/TextStorageLayer/Tasks/Subclassing.html
+	// MARK: - Required overrides for NSTextStorage
 
 	override var string: String {
 		return storage.string
@@ -36,6 +35,8 @@ import Foundation
 		edited(.editedAttributes, range: range, changeInLength: 0)
 		endEditing()
 	}
+
+	// MARK: - DOuble click functionality
 
 	override func doubleClick(at location: Int) -> NSRange {
 

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -116,6 +116,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 - (void) awakeFromNib
 {
+	[[self layoutManager] replaceTextStorage:[[SPTextStorage alloc] init]];
 	prefs = [NSUserDefaults standardUserDefaults];
 	[self setFont:[NSUnarchiver unarchiveObjectWithData:[prefs dataForKey:SPCustomQueryEditorFont]]];
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */; };
 		50EAB5B81A8FBB08008F627A /* SPOSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EAB5B71A8FBB08008F627A /* SPOSInfo.m */; };
 		50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 50F530511ABCF66B002F2C1A /* resetTemplate.pdf */; };
+		512FBAA7257ABDC800F4B358 /* SPTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512FBAA6257ABDC800F4B358 /* SPTextStorage.swift */; };
 		517412302573E10C00EB6935 /* SPPrintUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 5174122F2573E10C00EB6935 /* SPPrintUtility.m */; };
 		517412382573E8F900EB6935 /* EditorQuickLookTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */; };
 		517E4512257A954000ED333B /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
@@ -838,6 +839,7 @@
 		50EAB5B61A8FBB08008F627A /* SPOSInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPOSInfo.h; sourceTree = "<group>"; };
 		50EAB5B71A8FBB08008F627A /* SPOSInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPOSInfo.m; sourceTree = "<group>"; };
 		50F530511ABCF66B002F2C1A /* resetTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = resetTemplate.pdf; sourceTree = "<group>"; };
+		512FBAA6257ABDC800F4B358 /* SPTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPTextStorage.swift; sourceTree = "<group>"; };
 		5174122E2573E10C00EB6935 /* SPPrintUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPPrintUtility.h; sourceTree = "<group>"; };
 		5174122F2573E10C00EB6935 /* SPPrintUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPPrintUtility.m; sourceTree = "<group>"; };
 		517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EditorQuickLookTypes.plist; sourceTree = "<group>"; };
@@ -1741,6 +1743,7 @@
 				BC1847E90FE6EC8400094BFB /* SPEditSheetTextView.m */,
 				BC1944CE1297291800A236CD /* SPBundleCommandTextView.h */,
 				BC1944CF1297291800A236CD /* SPBundleCommandTextView.m */,
+				512FBAA6257ABDC800F4B358 /* SPTextStorage.swift */,
 			);
 			name = "Text Views";
 			path = TextViews;
@@ -3110,6 +3113,7 @@
 				4D90B79A101E0CDF00D116A1 /* SPUserManager.m in Sources */,
 				4D90B79E101E0CF200D116A1 /* SPUserManager.xcdatamodel in Sources */,
 				4D90B79F101E0CF200D116A1 /* SPUserMO.m in Sources */,
+				512FBAA7257ABDC800F4B358 /* SPTextStorage.swift in Sources */,
 				584192A1101E57BB0089807F /* NSMutableArray-MultipleSort.m in Sources */,
 				589235321020C1230011DE00 /* SPHistoryController.m in Sources */,
 				BCA6271C1031B9D40047E5D5 /* SPTooltip.m in Sources */,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Implement custom text storage to have double-click select functionality
- Implement SPTextStorage as subclass of NSTextStorage
- Implement double click functionality to select only word, not whole string

## Closes following issues:
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/377

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version: 12.2