### PR TITLE
Fix color changes to favorites #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2607,13 +2607,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 			[favoriteCell setLabelColor:bgColor];
 		}
 	}
-
-	// If a favourite item is being edited, draw the text in bold to show state
-	if (isEditingConnection && ![node isGroup] && [outlineView rowForItem:item] == [outlineView selectedRow]) {
-		NSMutableAttributedString *editedCellString = [[cell attributedStringValue] mutableCopy];
-		[editedCellString addAttribute:NSForegroundColorAttributeName value:[NSColor colorWithDeviceWhite:0.25f alpha:1.f] range:NSMakeRange(0, [editedCellString length])];
-		[cell setAttributedStringValue:editedCellString];
-	}
 }
 
 - (CGFloat)outlineView:(NSOutlineView *)outlineView heightOfRowByItem:(id)item


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

This pull request removes the color changes to the selected favorite list item when editing or changing connection tabs.

## Changes:
- Code to change the text color of the selected favorite has been removed.

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version:
12.2 (12B45b)

## Screenshots:
Before:
![Old](https://user-images.githubusercontent.com/2276355/101263266-53e8c680-3744-11eb-95b5-386707ee16e2.gif)

After:
![New](https://user-images.githubusercontent.com/2276355/101263268-55b28a00-3744-11eb-846e-1168905bfa6d.gif)

## Additional notes:
The code comments indicate that the text should be bold when a favorite is being edited, this is does not appear to be the case now though. The favorites view needs to be focussed to reset the text color. Additionally, if the window appears over a dark background the translucency can make the favorite name invisible when the app is not in the foreground.