### PR TITLE
Fix connection controller and keychain getters #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2089,7 +2089,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 			}
 		}
 
-		// Only set the password if there is no Keychain item set and the connection is not being tested.
+		// Only set the password if there is no Keychain item set or the connection is being tested.
 		// The connection will otherwise ask the delegate for passwords in the Keychain.
 		if ((!connectionKeychainItemName || isTestingConnection) && [self password]) {
 			[mySQLConnection setPassword:[self password]];

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -326,27 +326,33 @@
 /**
  * Retrieve the keychain item name for a supplied name and id.
  */
-- (NSString *)nameForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId
-{
+- (NSString *)nameForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId {
+	if (!favoriteName || !favoriteId) {
+		return nil;
+	}
 	// Look up the keychain name using long longs to support 64-bit > 32-bit keychain usage
-	return [NSString stringWithFormat:@"Sequel Ace : %@ (%lld)", favoriteName ? favoriteName: @"", [favoriteId longLongValue]];
+	return [NSString stringWithFormat:@"Sequel Ace : %@ (%lld)", favoriteName, [favoriteId longLongValue]];
 }
 
 /**
  * Retrieve the keychain item account for a supplied user, host, and database - which can be nil.
  */
-- (NSString *)accountForUser:(NSString *)user host:(NSString *)host database:(NSString *)database
-{
-	return [NSString stringWithFormat:@"%@@%@/%@", user ? user : @"", host ? host : @"", database ? database : @""];
+- (NSString *)accountForUser:(NSString *)user host:(NSString *)host database:(NSString *)database {
+	if (!user || !host) {
+		return nil;
+	}
+	return [NSString stringWithFormat:@"%@@%@/%@", user, host, database ? database : @""];
 }
 
 /**
  * Retrieve the keychain SSH item name for a supplied name and id.
  */
-- (NSString *)nameForSSHForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId
-{
+- (NSString *)nameForSSHForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId {
+	if (!favoriteName || !favoriteId) {
+		return nil;
+	}
 	// Look up the keychain name using long longs to support 64-bit > 32-bit keychain usage
-	return [NSString stringWithFormat:@"Sequel Ace SSHTunnel : %@ (%lld)", favoriteName ? favoriteName: @"", [favoriteId longLongValue]];
+	return [NSString stringWithFormat:@"Sequel Ace SSHTunnel : %@ (%lld)", favoriteName, [favoriteId longLongValue]];
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Return nil if keychain is nil because we are not using favorite connection

## Closes following issues:
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/598

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [ ] 11.0
- Xcode version: 12.2