### PR TITLE
#temp: swizzle initFileURLWithPath: isDirectory

### DIFF
--- a/Source/Other/CategoryAdditions/SPURLAdditions.h
+++ b/Source/Other/CategoryAdditions/SPURLAdditions.h
@@ -1,0 +1,17 @@
+//
+//  SPURLAdditions.h
+//  Sequel Ace
+//
+//  Created by James on 12/12/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURL (SPURLAdditions)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Other/CategoryAdditions/SPURLAdditions.m
+++ b/Source/Other/CategoryAdditions/SPURLAdditions.m
@@ -1,0 +1,31 @@
+//
+//  SPURLAdditions.m
+//  Sequel Ace
+//
+//  Created by James on 12/12/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+#import "SPURLAdditions.h"
+#import "SPFunctions.h"
+#import <FirebaseCrashlytics/FirebaseCrashlytics.h>
+
+@implementation NSURL (SPURLAdditions)
+
++ (void)load
+{
+	SP_swizzleInstanceMethod(self, @selector(initFileURLWithPath: isDirectory:), @selector(SA_initFileURLWithPath: isDirectory:));
+}
+
+- (NSURL *)SA_initFileURLWithPath:(NSString *)path isDirectory:(BOOL)isDir{
+
+	if(path == nil){
+		CLS_LOG(@"initFileURLWithPath: path is nil");
+		@throw NSInternalInconsistencyException;
+	}
+
+	return [self SA_initFileURLWithPath:path isDirectory:isDir];
+}
+
+@end
+

--- a/Source/Other/Utility/SPFunctions.h
+++ b/Source/Other/Utility/SPFunctions.h
@@ -72,3 +72,5 @@ id SPBoxNil(id object);
 
 void executeOnBackgroundThread(void (^block)(void));
 void executeOnBackgroundThreadSync(void (^block)(void));
+
+void SP_swizzleInstanceMethod(Class c, SEL original, SEL replacement);

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -31,6 +31,7 @@
 #import "SPFunctions.h"
 #import <Security/SecRandom.h>
 #import "SPOSInfo.h"
+#import <objc/runtime.h>
 
 void SPMainQSync(void (^block)(void))
 {
@@ -113,4 +114,18 @@ id SPBoxNil(id object)
 	if(object == nil) return [NSNull null];
 	
 	return object;
+}
+
+void SP_swizzleInstanceMethod(Class c, SEL original, SEL replacement)
+{
+	Method a = class_getInstanceMethod(c, original);
+	Method b = class_getInstanceMethod(c, replacement);
+	if (class_addMethod(c, original, method_getImplementation(b), method_getTypeEncoding(b)))
+	{
+		class_replaceMethod(c, replacement, method_getImplementation(a), method_getTypeEncoding(a));
+	}
+	else
+	{
+		method_exchangeImplementations(a, b);
+	}
 }

--- a/UnitTests/SPURLAdditions.m
+++ b/UnitTests/SPURLAdditions.m
@@ -1,0 +1,58 @@
+//
+//  SPURLAdditions.m
+//  Unit Tests
+//
+//  Created by James on 12/12/2020.
+//  Copyright © 2020 Sequel-Ace. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface SPURLAdditions : XCTestCase
+
+@end
+
+@implementation SPURLAdditions
+
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+
+	NSURL *tmp = [NSURL fileURLWithPath:@"jimmy"];
+	NSURL *tmp2 = [NSURL fileURLWithPath:@"jimmy" isDirectory:NO];
+
+	XCTAssertEqualObjects(tmp, tmp2);
+}
+
+// 0.15 s
+- (void)testPerformanceSwizzle{
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				NSURL __unused *tmp2 = [NSURL fileURLWithPath:@"jimmy" isDirectory:NO];
+			}
+		}
+    }];
+}
+
+// 0.161 s
+- (void)testPerformanceNoSwizzle{
+	// This is an example of a performance test case.
+	[self measureBlock:^{
+		// Put the code you want to measure the time of here.
+
+		int const iterations = 10000;
+		for (int i = 0; i < iterations; i++) {
+			@autoreleasepool {
+				NSURL __unused *tmp2 = [NSURL fileURLWithPath:@"jimmy"];
+			}
+		}
+	}];
+}
+
+@end

--- a/UnitTests/SPURLAdditionsTests.m
+++ b/UnitTests/SPURLAdditionsTests.m
@@ -8,11 +8,11 @@
 
 #import <XCTest/XCTest.h>
 
-@interface SPURLAdditions : XCTestCase
+@interface SPURLAdditionsTests : XCTestCase
 
 @end
 
-@implementation SPURLAdditions
+@implementation SPURLAdditionsTests
 
 
 - (void)testExample {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -123,6 +123,10 @@
 		1A564F74237E2E4958CA593A /* SPPillAttachmentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */; };
 		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
+		1A8B53572584520800526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
+		1A8B53682584552F00526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53672584552F00526DED /* SPURLAdditions.m */; };
+		1A8B536D2584567C00526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
+		1A8B53732584573500526DED /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1A8B53722584573500526DED /* FirebaseCrashlytics */; };
 		1A94988E25516057000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498C125517191000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
@@ -745,6 +749,9 @@
 		1A56463D14569A0B56EE8BAC /* SPPillAttachmentCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPPillAttachmentCell.m; sourceTree = "<group>"; };
 		1A564C0C0FFB444D2E5CA447 /* SPPillAttachmentCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPPillAttachmentCell.h; sourceTree = "<group>"; };
 		1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSyncTests.m; sourceTree = "<group>"; };
+		1A8B53552584520800526DED /* SPURLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPURLAdditions.h; sourceTree = "<group>"; };
+		1A8B53562584520800526DED /* SPURLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditions.m; sourceTree = "<group>"; };
+		1A8B53672584552F00526DED /* SPURLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditions.m; sourceTree = "<group>"; };
 		1A94988D25516057000BC793 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateComponentsFormatterExtension.swift; sourceTree = "<group>"; };
 		1A9EB9AD25651F5000FE60FF /* SQLiteHistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteHistoryManager.swift; sourceTree = "<group>"; };
@@ -1205,6 +1212,7 @@
 				51DCBEF0257134190098E303 /* libz.tbd in Frameworks */,
 				502D22151BA62FA5000D4CE7 /* Security.framework in Frameworks */,
 				1717F9DB1558114D0065C036 /* OCMock.framework in Frameworks */,
+				1A8B53732584573500526DED /* FirebaseCrashlytics in Frameworks */,
 				1717FA43155831600065C036 /* libicucore.dylib in Frameworks */,
 				50EA92671AB23EE1008D3C4F /* SPMySQL.framework in Frameworks */,
 			);
@@ -1763,6 +1771,7 @@
 				1798F1C2155018D4004B0AB8 /* SPMutableArrayAdditionsTests.m */,
 				502D21F51BA50710000D4CE7 /* SPDataAdditionsTests.m */,
 				1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */,
+				1A8B53672584552F00526DED /* SPURLAdditions.m */,
 			);
 			name = "Category Additions";
 			sourceTree = "<group>";
@@ -2516,6 +2525,8 @@
 				500DA4BB1BF0CD57000773FE /* SPScreenAdditions.m */,
 				1A071B8B254D983700246912 /* SPNSMutableDictionaryAdditions.h */,
 				1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */,
+				1A8B53552584520800526DED /* SPURLAdditions.h */,
+				1A8B53562584520800526DED /* SPURLAdditions.m */,
 			);
 			name = "Category Additions";
 			path = CategoryAdditions;
@@ -2562,6 +2573,9 @@
 				518402D924A3FF4F004693B0 /* PBXTargetDependency */,
 			);
 			name = "Unit Tests";
+			packageProductDependencies = (
+				1A8B53722584573500526DED /* FirebaseCrashlytics */,
+			);
 			productName = "Unit Tests";
 			productReference = 380F4ED90FC0B50500B0BFD7 /* Unit Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -2987,6 +3001,7 @@
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
+				1A8B536D2584567C00526DED /* SPURLAdditions.m in Sources */,
 				502D21F61BA50710000D4CE7 /* SPDataAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,
@@ -3007,6 +3022,7 @@
 				1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */,
 				50D3C35D1A77217800B5429C /* SPParserUtils.c in Sources */,
 				380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */,
+				1A8B53682584552F00526DED /* SPURLAdditions.m in Sources */,
 				1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */,
 				1798F1C4155018E2004B0AB8 /* SPMutableArrayAdditionsTests.m in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
@@ -3197,6 +3213,7 @@
 				17D3C671128AD8160047709F /* SPSingleton.m in Sources */,
 				17D3C6D3128B1C900047709F /* SPFavoritesOutlineView.m in Sources */,
 				50D3C3521A77135F00B5429C /* SPParserUtils.c in Sources */,
+				1A8B53572584520800526DED /* SPURLAdditions.m in Sources */,
 				BC68BFC7128D4EAE004907D9 /* SPBundleEditorController.m in Sources */,
 				BC1944D01297291800A236CD /* SPBundleCommandTextView.m in Sources */,
 				BC77C5E4129AA69E009AD832 /* SPBundleHTMLOutputController.m in Sources */,
@@ -4708,6 +4725,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		1A8B53722584573500526DED /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5187ADE5257A60A200FF3A9A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
 		5187ADE6257A60A200FF3A9A /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5187ADE5257A60A200FF3A9A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
+		1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53672584552F00526DED /* SPURLAdditionsTests.m */; };
 		1A19962A257A624200F5B0F1 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A199629257A624200F5B0F1 /* BundleExtension.swift */; };
 		1A1EE94A2551185D0056FECD /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
 		1A1EE9582551249C0056FECD /* NumberFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9572551249C0056FECD /* NumberFormatterExtension.swift */; };
@@ -124,7 +125,6 @@
 		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
 		1A8B53572584520800526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
-		1A8B53682584552F00526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53672584552F00526DED /* SPURLAdditions.m */; };
 		1A8B53732584573500526DED /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1A8B53722584573500526DED /* FirebaseCrashlytics */; };
 		1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
 		1A94988E25516057000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
@@ -751,7 +751,7 @@
 		1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSyncTests.m; sourceTree = "<group>"; };
 		1A8B53552584520800526DED /* SPURLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPURLAdditions.h; sourceTree = "<group>"; };
 		1A8B53562584520800526DED /* SPURLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditions.m; sourceTree = "<group>"; };
-		1A8B53672584552F00526DED /* SPURLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditions.m; sourceTree = "<group>"; };
+		1A8B53672584552F00526DED /* SPURLAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditionsTests.m; sourceTree = "<group>"; };
 		1A94988D25516057000BC793 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1A9D83A325514E740024B563 /* DateComponentsFormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateComponentsFormatterExtension.swift; sourceTree = "<group>"; };
 		1A9EB9AD25651F5000FE60FF /* SQLiteHistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteHistoryManager.swift; sourceTree = "<group>"; };
@@ -1771,7 +1771,7 @@
 				1798F1C2155018D4004B0AB8 /* SPMutableArrayAdditionsTests.m */,
 				502D21F51BA50710000D4CE7 /* SPDataAdditionsTests.m */,
 				1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */,
-				1A8B53672584552F00526DED /* SPURLAdditions.m */,
+				1A8B53672584552F00526DED /* SPURLAdditionsTests.m */,
 			);
 			name = "Category Additions";
 			sourceTree = "<group>";
@@ -3003,6 +3003,7 @@
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
 				1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */,
 				502D21F61BA50710000D4CE7 /* SPDataAdditionsTests.m in Sources */,
+				1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,
 				519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */,
@@ -3022,7 +3023,6 @@
 				1AB068B424A3577C00E2AAC2 /* SPValidateKeyAndCertFiles.m in Sources */,
 				50D3C35D1A77217800B5429C /* SPParserUtils.c in Sources */,
 				380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */,
-				1A8B53682584552F00526DED /* SPURLAdditions.m in Sources */,
 				1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */,
 				1798F1C4155018E2004B0AB8 /* SPMutableArrayAdditionsTests.m in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -125,8 +125,8 @@
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
 		1A8B53572584520800526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
 		1A8B53682584552F00526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53672584552F00526DED /* SPURLAdditions.m */; };
-		1A8B536D2584567C00526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
 		1A8B53732584573500526DED /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1A8B53722584573500526DED /* FirebaseCrashlytics */; };
+		1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
 		1A94988E25516057000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498C125517191000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
@@ -3001,7 +3001,7 @@
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
-				1A8B536D2584567C00526DED /* SPURLAdditions.m in Sources */,
+				1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */,
 				502D21F61BA50710000D4CE7 /* SPDataAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,


### PR DESCRIPTION
## Changes:
swizzle initFileURLWithPath: isDirectory, so we can log when path is nil
will remove later.

## Closes following issues:
To help investigate #583 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [x] 10.15
  - [ ] 11.0
- Xcode version: 12.2 (12B45b)

## Screenshots:


## Additional notes:
