### PR TITLE
Fix reopening window when last window is closed #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.h
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.h
@@ -118,8 +118,6 @@ typedef NS_ENUM(NSInteger, SPConnectionTimeZoneMode) {
 	NSString *connectionSSHKeychainItemName;
 	NSString *connectionSSHKeychainItemAccount;
 
-	NSMutableArray *nibObjectsToRelease;
-
 	IBOutlet NSView *connectionView;
 	IBOutlet SPSplitView *connectionSplitView;
 	IBOutlet NSScrollView *connectionDetailsScrollView;

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -3419,15 +3419,9 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 - (void)loadNib
 {
 
-	// Load the connection nib, keeping references to the top-level objects for later release
-	nibObjectsToRelease = [[NSMutableArray alloc] init];
-
 	NSArray *connectionViewTopLevelObjects = nil;
 	NSNib *nibLoader = [[NSNib alloc] initWithNibNamed:SPConnectionViewNibName bundle:[NSBundle mainBundle]];
-
 	[nibLoader instantiateWithOwner:self topLevelObjects:&connectionViewTopLevelObjects];
-	[nibObjectsToRelease addObjectsFromArray:connectionViewTopLevelObjects];
-
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -188,7 +188,6 @@
 	NSString *mySQLVersion;
 	NSString *selectedDatabaseEncoding;
 	NSUserDefaults *prefs;
-	NSMutableArray *nibObjectsToRelease;
 	NSUndoManager *undoManager;
 
 	NSMenu *selectEncodingMenu;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -225,14 +225,12 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 		statusValues = nil;
 		printThread = nil;
 		windowTitleStatusViewIsVisible = NO;
-		nibObjectsToRelease = [[NSMutableArray alloc] init];
 
 		// As this object is not an NSWindowController subclass, top-level objects in loaded nibs aren't
 		// automatically released.  Keep track of the top-level objects for release on dealloc.
 		NSArray *dbViewTopLevelObjects = nil;
 		NSNib *nibLoader = [[NSNib alloc] initWithNibNamed:@"DBView" bundle:[NSBundle mainBundle]];
 		[nibLoader instantiateWithOwner:self topLevelObjects:&dbViewTopLevelObjects];
-		[nibObjectsToRelease addObjectsFromArray:dbViewTopLevelObjects];
 
 		databaseStructureRetrieval = [[SPDatabaseStructure alloc] initWithDelegate:self];
 	}
@@ -295,19 +293,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 	// Load additional nibs, keeping track of the top-level objects to allow correct release
 	NSArray *connectionDialogTopLevelObjects = nil;
 	NSNib *nibLoader = [[NSNib alloc] initWithNibNamed:@"ConnectionErrorDialog" bundle:[NSBundle mainBundle]];
-	if (![nibLoader instantiateWithOwner:self topLevelObjects:&connectionDialogTopLevelObjects]) {
-		NSLog(@"Connection error dialog could not be loaded; connection failure handling will not function correctly.");
-	} else {
-		[nibObjectsToRelease addObjectsFromArray:connectionDialogTopLevelObjects];
-	}
+	[nibLoader instantiateWithOwner:self topLevelObjects:&connectionDialogTopLevelObjects];
 
 	NSArray *progressIndicatorLayerTopLevelObjects = nil;
 	nibLoader = [[NSNib alloc] initWithNibNamed:@"ProgressIndicatorLayer" bundle:[NSBundle mainBundle]];
-	if (![nibLoader instantiateWithOwner:self topLevelObjects:&progressIndicatorLayerTopLevelObjects]) {
-		NSLog(@"Progress indicator layer could not be loaded; progress display will not function correctly.");
-	} else {
-		[nibObjectsToRelease addObjectsFromArray:progressIndicatorLayerTopLevelObjects];
-	}
+	[nibLoader instantiateWithOwner:self topLevelObjects:&progressIndicatorLayerTopLevelObjects];
 
 	// Set up the progress indicator child window and layer - change indicator color and size
 	[taskProgressIndicator setForeColor:[NSColor whiteColor]];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -6537,7 +6537,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 /**
  * Close the connection - should be performed on the main thread.
  */
-- (void) closeAndDisconnect
+- (void)closeAndDisconnect
 {
 	NSWindow *theParentWindow = [self parentWindow];
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1281,7 +1281,6 @@
 		[self newWindow:self];
 		return NO;
 	}
-
 	// Return YES to the automatic opening
 	return YES;
 }

--- a/Source/Controllers/Window/SPWindowController.h
+++ b/Source/Controllers/Window/SPWindowController.h
@@ -43,7 +43,6 @@
 	NSMenuItem *closeTabMenuItem;
 
 	NSMutableArray *managedDatabaseConnections;
-	SPDatabaseDocument *selectedTableDocument;
 }
 
 @property (readonly, strong) IBOutlet PSMTabBarControl *tabBar;
@@ -54,16 +53,6 @@
 - (IBAction)moveSelectedTabInNewWindow:(id)sender;
 
 - (SPDatabaseDocument *)addNewConnection;
-
-/**
- * @danger THIS IS NOT RETAINED!!! 
- *
- * Ever only directly use it on the main thread! 
- * Do not cache it without retaining first!
- * For background threads get it and retain it via the main thread!
- *   Release it on the main thread again.
- */
-- (SPDatabaseDocument *)selectedTableDocument;
 
 - (void)updateSelectedTableDocument;
 - (void)updateAllTabTitles:(id)sender;

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -521,7 +521,6 @@
  */
 - (void)windowWillClose:(NSNotification *)notification
 {
-	[self.selectedTableDocument setParentWindow:nil];
 	self.selectedTableDocument = nil;
 	for (NSTabViewItem *eachItem in [tabView tabViewItems])
 	{

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -498,7 +498,7 @@
  * Go through the tabs in this window, and ask the database connection view
  * in each one if it can be closed, returning YES only if all can be closed.
  */
-- (BOOL)windowShouldClose:(id)sender
+- (BOOL)windowShouldClose:(NSWindow *)sender
 {
 	for (NSTabViewItem *eachItem in [tabView tabViewItems])
 	{
@@ -512,7 +512,7 @@
 		[SPAppDelegate setSessionURL:nil];
 		[SPAppDelegate setSpfSessionDocData:nil];
 	}
-
+	[sender setReleasedWhenClosed:YES];
 	return YES;
 }
 
@@ -521,7 +521,6 @@
  */
 - (void)windowWillClose:(NSNotification *)notification
 {
-	self.selectedTableDocument = nil;
 	for (NSTabViewItem *eachItem in [tabView tabViewItems])
 	{
 		[tabView removeTabViewItem:eachItem];

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -45,6 +45,8 @@
 - (void)_switchOutSelectedTableDocument:(SPDatabaseDocument *)newDoc;
 - (void)_selectedTableDocumentDeallocd:(NSNotification *)notification;
 
+@property (readwrite, strong) SPDatabaseDocument *selectedTableDocument;
+
 #pragma mark - SPWindowControllerDelegate
 
 - (void)tabDragStarted:(id)sender;
@@ -131,21 +133,13 @@
 }
 
 /**
- * Retrieve the currently connection view in the window.
- */
-- (SPDatabaseDocument *)selectedTableDocument
-{
-	return selectedTableDocument;
-}
-
-/**
  * Update the currently selected connection view
  */
 - (void)updateSelectedTableDocument
 {
 	[self _switchOutSelectedTableDocument:[[tabView selectedTabViewItem] identifier]];
 	
-	[selectedTableDocument didBecomeActiveTabInWindow];
+	[self.selectedTableDocument didBecomeActiveTabInWindow];
 }
 
 /**
@@ -174,7 +168,7 @@
 	// If there are multiple tabs, close the front tab.
 	if ([tabView numberOfTabViewItems] > 1) {
 		// Return if the selected tab shouldn't be closed
-		if (![selectedTableDocument parentTabShouldClose]) return;
+		if (![self.selectedTableDocument parentTabShouldClose]) return;
 		[tabView removeTabViewItem:[tabView selectedTabViewItem]];
 	} 
 	else {
@@ -309,7 +303,7 @@
 	}
 	
 	// See if the front document blocks validation of this item
-	if (![selectedTableDocument validateMenuItem:menuItem]) return NO;
+	if (![self.selectedTableDocument validateMenuItem:menuItem]) return NO;
 
 	return YES;
 }
@@ -349,8 +343,8 @@
  */
 - (void)openDatabaseInNewTab
 {
-	if ([selectedTableDocument database]) {
-		[selectedTableDocument openDatabaseInNewTab:self];
+	if ([self.selectedTableDocument database]) {
+		[self.selectedTableDocument openDatabaseInNewTab:self];
 	}
 }
 
@@ -360,8 +354,8 @@
 {
 	BOOL collapse = NO;
  
-	if (selectedTableDocument.getConnection) {
-		if (selectedTableDocument.connectionController.colorIndex != -1) {
+	if (self.selectedTableDocument.getConnection) {
+		if (self.selectedTableDocument.connectionController.colorIndex != -1) {
 			collapse = YES;
 		}
 	}
@@ -383,11 +377,11 @@
 {
 	SEL theSelector = [theInvocation selector];
 	
-	if (![selectedTableDocument respondsToSelector:theSelector]) {
+	if (![self.selectedTableDocument respondsToSelector:theSelector]) {
 		[self doesNotRecognizeSelector:theSelector];
 	}
 	
-	[theInvocation invokeWithTarget:selectedTableDocument];
+	[theInvocation invokeWithTarget:self.selectedTableDocument];
 }
 
 /**
@@ -398,7 +392,7 @@
 {
 	NSMethodSignature *defaultSignature = [super methodSignatureForSelector:theSelector];
 	
-	return defaultSignature ? defaultSignature : [selectedTableDocument methodSignatureForSelector:theSelector];
+	return defaultSignature ? defaultSignature : [self.selectedTableDocument methodSignatureForSelector:theSelector];
 }
 
 /**
@@ -407,7 +401,7 @@
  */
 - (BOOL)respondsToSelector:(SEL)theSelector
 {
-	return ([super respondsToSelector:theSelector] || [selectedTableDocument respondsToSelector:theSelector]);
+	return ([super respondsToSelector:theSelector] || [self.selectedTableDocument respondsToSelector:theSelector]);
 }
 
 /**
@@ -477,16 +471,16 @@
 	NSAssert([NSThread isMainThread], @"Switching the selectedTableDocument via a background thread is not supported!");
 	
 	// shortcut if there is nothing to do
-	if(selectedTableDocument == newDoc) return;
+	if(self.selectedTableDocument == newDoc) return;
 	
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	if(selectedTableDocument) {
-		[nc removeObserver:self name:SPDocumentWillCloseNotification object:selectedTableDocument];
-		selectedTableDocument = nil;
+	if(self.selectedTableDocument) {
+		[nc removeObserver:self name:SPDocumentWillCloseNotification object:self.selectedTableDocument];
+		self.selectedTableDocument = nil;
 	}
 	if(newDoc) {
 		[nc addObserver:self selector:@selector(_selectedTableDocumentDeallocd:) name:SPDocumentWillCloseNotification object:newDoc];
-		selectedTableDocument = newDoc;
+		self.selectedTableDocument = newDoc;
 	}
 	
 	[self updateTabBar];
@@ -527,6 +521,8 @@
  */
 - (void)windowWillClose:(NSNotification *)notification
 {
+	[self.selectedTableDocument setParentWindow:nil];
+	self.selectedTableDocument = nil;
 	for (NSTabViewItem *eachItem in [tabView tabViewItems])
 	{
 		[tabView removeTabViewItem:eachItem];
@@ -539,7 +535,7 @@
  */
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
-	[selectedTableDocument tabDidBecomeKey];
+	[self.selectedTableDocument tabDidBecomeKey];
 
 	// Update the "Close window" item
 	[closeWindowMenuItem setTitle:NSLocalizedString(@"Close Window", @"Close Window menu item")];
@@ -595,7 +591,7 @@
  */
 - (void)windowWillEnterFullScreen:(NSNotification *)notification
 {
-	[selectedTableDocument updateTitlebarStatusVisibilityForcingHide:YES];
+	[self.selectedTableDocument updateTitlebarStatusVisibilityForcingHide:YES];
 }
 
 /**
@@ -603,7 +599,7 @@
  */
 - (void)windowDidExitFullScreen:(NSNotification *)notification
 {
-	[selectedTableDocument updateTitlebarStatusVisibilityForcingHide:NO];
+	[self.selectedTableDocument updateTitlebarStatusVisibilityForcingHide:NO];
 }
 
 #pragma mark -
@@ -614,7 +610,7 @@
  */
 - (void)tabView:(NSTabView *)tabView willSelectTabViewItem:(NSTabViewItem *)tabViewItem
 {
-	[selectedTableDocument willResignActiveTabInWindow];
+	[self.selectedTableDocument willResignActiveTabInWindow];
 }
 
 /**
@@ -625,9 +621,9 @@
 	if ([[PSMTabDragAssistant sharedDragAssistant] isDragging]) return;
 
 	[self _switchOutSelectedTableDocument:[tabViewItem identifier]];
-	[selectedTableDocument didBecomeActiveTabInWindow];
+	[self.selectedTableDocument didBecomeActiveTabInWindow];
 
-	if ([[self window] isKeyWindow]) [selectedTableDocument tabDidBecomeKey];
+	if ([[self window] isKeyWindow]) [self.selectedTableDocument tabDidBecomeKey];
 
 	[self updateAllTabTitles:self];
 }
@@ -901,8 +897,7 @@
 
 #pragma mark -
 
-- (void)dealloc
-{
+- (void)dealloc {
 	[self _switchOutSelectedTableDocument:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	
@@ -910,7 +905,6 @@
 	
 	// Tear down the animations on the tab bar to stop redraws
 	[tabBar destroyAnimations];
-
 }
 
 @end


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- switch to property for selectedDocument
- mark window as `retainWhenClosed`
- remove nib holders

## Closes following issues:
- ✘

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version: 12.2

## Additional notes:
There is a memory leak when last window is closed, but it's currently impossible to fix due to ARC changes that require memory holding, which we don't do now. We need to rewrite AppController to hold it's windows., and not leave windows live their own life.