### PR TITLE
fix-alias-completions #fixed

### DIFF
--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -836,7 +836,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			NSArray *allTables = [[dbs objectForKey:conID] allKeys];
 			// Check if found table name is known, if not parse for aliases
 			if(![allTables containsObject:[NSString stringWithFormat:@"%@%@%@", conID, SPUniqueSchemaDelimiter, tableName]]) {
-				NSString *currentQuery = [[self string] substringWithRange:[customQueryInstance currentQueryRange]];
+                NSString *currentQuery = [[self string] substringWithRange:NSMakeRange(0, self.string.length)];
 				NSString *re = [NSString stringWithFormat:@"(?i)[\\s,]`?(\\S+?)`?\\s+(AS\\s+)?`?%@`?\\b", tableName];
 				NSArray *matches = [currentQuery componentsMatchedByRegex:re];
 				for(NSString* m in matches) {

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -836,9 +836,8 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			NSArray *allTables = [[dbs objectForKey:conID] allKeys];
 			// Check if found table name is known, if not parse for aliases
 			if(![allTables containsObject:[NSString stringWithFormat:@"%@%@%@", conID, SPUniqueSchemaDelimiter, tableName]]) {
-                NSString *currentQuery = [[self string] substringWithRange:NSMakeRange(0, self.string.length)];
 				NSString *re = [NSString stringWithFormat:@"(?i)[\\s,]`?(\\S+?)`?\\s+(AS\\s+)?`?%@`?\\b", tableName];
-				NSArray *matches = [currentQuery componentsMatchedByRegex:re];
+				NSArray *matches = [[self string] componentsMatchedByRegex:re];
 				for(NSString* m in matches) {
 					NSRange aliasRange = [m rangeOfRegex:re capture:1L];
 					if(aliasRange.length) {


### PR DESCRIPTION
## Changes:
The code to search for aliases when performing completion, was not using the correct query range. This fixes that.

## Closes following issues:
Closes #633

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version: 12.2 (12B45b)

## Screenshots:


## Additional notes:
