### PR TITLE
Fix couple of Crashlytics crashes #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -723,10 +723,10 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 		SEL                          callbackMethod = NULL;
 		NSString                    *taskButtonString;
 
-		NSUInteger i, totalQueriesRun = 0, totalAffectedRows = 0;
+		NSUInteger __block i, totalQueriesRun = 0, totalAffectedRows = 0;
 		double executionTime = 0;
 		NSInteger firstErrorOccurredInQuery = -1;
-		BOOL suppressErrorSheet = NO;
+		BOOL __block suppressErrorSheet = NO;
 		BOOL tableListNeedsReload = NO;
 		BOOL databaseWasChanged = NO;
 		// BOOL queriesSeparatedByDelimiter = NO;
@@ -858,37 +858,39 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 						[[errorTextTitle onMainThread] setStringValue:NSLocalizedString(@"Last Error Message", @"Last Error Message")];
 						[[errorText onMainThread] setString:errors];
 
-						// ask the user to continue after detecting an error
-						if (![mySQLConnection lastQueryWasCancelled]) {
-
-							[tableDocumentInstance setTaskIndicatorShouldAnimate:NO];
-
-							NSAlert *alert = [[NSAlert alloc] init];
-							[alert setMessageText:NSLocalizedString(@"MySQL Error", @"mysql error message")];
-							[alert setInformativeText:[mySQLConnection lastErrorMessage]];
-
-							// Order of buttons matters! first button has "firstButtonReturn" return value from runModal()
-							[alert addButtonWithTitle:NSLocalizedString(@"Run All", @"run all button")];
-							[alert addButtonWithTitle:NSLocalizedString(@"Continue", @"continue button")];
-							[alert addButtonWithTitle:NSLocalizedString(@"Stop", @"stop button")];
-
-							NSInteger alertReturnCode = [alert runModal];
-
-							[tableDocumentInstance setTaskIndicatorShouldAnimate:YES];
-
-							switch (alertReturnCode) {
-								case NSAlertFirstButtonReturn:
-									suppressErrorSheet = YES;
-								case NSAlertSecondButtonReturn:
-									break;
-								default:
-									if (i < queryCount-1) {
-										// output that message only if it was not the last one
-										[errors appendString:NSLocalizedString(@"Execution stopped!\n", @"execution stopped message")];
-									}
-									i = queryCount; // break for loop; for safety reasons stop the execution of the following queries
-							}
-						}
+                        SPMainQSync(^{
+                            // ask the user to continue after detecting an error
+                            if (![self->mySQLConnection lastQueryWasCancelled]) {
+                                
+                                [self->tableDocumentInstance setTaskIndicatorShouldAnimate:NO];
+                                
+                                NSAlert *alert = [[NSAlert alloc] init];
+                                [alert setMessageText:NSLocalizedString(@"MySQL Error", @"mysql error message")];
+                                [alert setInformativeText:[self->mySQLConnection lastErrorMessage]];
+                                
+                                // Order of buttons matters! first button has "firstButtonReturn" return value from runModal()
+                                [alert addButtonWithTitle:NSLocalizedString(@"Run All", @"run all button")];
+                                [alert addButtonWithTitle:NSLocalizedString(@"Continue", @"continue button")];
+                                [alert addButtonWithTitle:NSLocalizedString(@"Stop", @"stop button")];
+                                
+                                NSInteger alertReturnCode = [alert runModal];
+                                
+                                [self->tableDocumentInstance setTaskIndicatorShouldAnimate:YES];
+                                
+                                switch (alertReturnCode) {
+                                    case NSAlertFirstButtonReturn:
+                                        suppressErrorSheet = YES;
+                                    case NSAlertSecondButtonReturn:
+                                        break;
+                                    default:
+                                        if (i < queryCount-1) {
+                                            // output that message only if it was not the last one
+                                            [errors appendString:NSLocalizedString(@"Execution stopped!\n", @"execution stopped message")];
+                                        }
+                                        i = queryCount; // break for loop; for safety reasons stop the execution of the following queries
+                                }
+                            }
+                        });
 					} else {
 						[errors appendFormat:NSLocalizedString(@"[ERROR in query %ld] %@\n", @"error text when multiple custom query failed"),
 						                     (long)(i+1),

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3877,7 +3877,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 }
 
 /**
- * Validates the toolbar items
+ * Validates the toolbar items - JCS NOTE: this is called loads!
  */
 - (BOOL)validateToolbarItem:(NSToolbarItem *)toolbarItem
 {
@@ -3895,6 +3895,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 			if ([queryWindow isVisible]) {
 				[toolbarItem setImage:[NSImage imageNamed:@"showconsole"]];
 			} else {
+                CLS_LOG(@"macOS < 11 and queryWindow is NOT Visible");
 				[toolbarItem setImage:[NSImage imageNamed:@"hideconsole"]];
 			}
 		}

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -5933,101 +5933,140 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 //WARNING: Might be called from code in background threads
 - (IBAction)viewStructure:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![[self onMainThread] couldCommitCurrentViewActions]) {
-		[[mainToolbar onMainThread] setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
-
-	[[tableTabView onMainThread] selectTabViewItemAtIndex:0];
-	[[mainToolbar onMainThread] setSelectedItemIdentifier:SPMainToolbarTableStructure];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	[prefs setInteger:SPStructureViewMode forKey:SPLastViewMode];
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewStructure from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![[self onMainThread] couldCommitCurrentViewActions]) {
+            [[self->mainToolbar onMainThread] setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [[self->tableTabView onMainThread] selectTabViewItemAtIndex:0];
+        [[self->mainToolbar onMainThread] setSelectedItemIdentifier:SPMainToolbarTableStructure];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        
+        [self->prefs setInteger:SPStructureViewMode forKey:SPLastViewMode];
+    });
 }
 
 - (IBAction)viewContent:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![self couldCommitCurrentViewActions]) {
-		[mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
-
-	[tableTabView selectTabViewItemAtIndex:1];
-	[mainToolbar setSelectedItemIdentifier:SPMainToolbarTableContent];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	[prefs setInteger:SPContentViewMode forKey:SPLastViewMode];
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewContent from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![self couldCommitCurrentViewActions]) {
+            [self->mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [self->tableTabView selectTabViewItemAtIndex:1];
+        [self->mainToolbar setSelectedItemIdentifier:SPMainToolbarTableContent];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        [self->prefs setInteger:SPContentViewMode forKey:SPLastViewMode];
+    });
 }
 
 - (IBAction)viewQuery:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![self couldCommitCurrentViewActions]) {
-		[mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewQuery from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![self couldCommitCurrentViewActions]) {
+            [self->mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [self->tableTabView selectTabViewItemAtIndex:2];
+        [self->mainToolbar setSelectedItemIdentifier:SPMainToolbarCustomQuery];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        
+        // Set the focus on the text field
+        [self->parentWindow makeFirstResponder:self->customQueryTextView];
+        
+        [self->prefs setInteger:SPQueryEditorViewMode forKey:SPLastViewMode];
+    });
 
-	[tableTabView selectTabViewItemAtIndex:2];
-	[mainToolbar setSelectedItemIdentifier:SPMainToolbarCustomQuery];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	// Set the focus on the text field
-	[parentWindow makeFirstResponder:customQueryTextView];
-
-	[prefs setInteger:SPQueryEditorViewMode forKey:SPLastViewMode];
 }
 
 - (IBAction)viewStatus:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![self couldCommitCurrentViewActions]) {
-		[mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
+    
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewStatus from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![self couldCommitCurrentViewActions]) {
+            [self->mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [self->tableTabView selectTabViewItemAtIndex:3];
+        [self->mainToolbar setSelectedItemIdentifier:SPMainToolbarTableInfo];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        
+        if ([[self table] length]) {
+            [self->extendedTableInfoInstance loadTable:[self table]];
+        }
+        
+        [self->parentWindow makeFirstResponder:[self->extendedTableInfoInstance valueForKeyPath:@"tableCreateSyntaxTextView"]];
+        
+        [self->prefs setInteger:SPTableInfoViewMode forKey:SPLastViewMode];
+    });
 
-	[tableTabView selectTabViewItemAtIndex:3];
-	[mainToolbar setSelectedItemIdentifier:SPMainToolbarTableInfo];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	if ([[self table] length]) {
-		[extendedTableInfoInstance loadTable:[self table]];
-	}
-
-	[parentWindow makeFirstResponder:[extendedTableInfoInstance valueForKeyPath:@"tableCreateSyntaxTextView"]];
-
-	[prefs setInteger:SPTableInfoViewMode forKey:SPLastViewMode];
 }
 
 - (IBAction)viewRelations:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![self couldCommitCurrentViewActions]) {
-		[mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewStatus from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![self couldCommitCurrentViewActions]) {
+            [self->mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [self->tableTabView selectTabViewItemAtIndex:4];
+        [self->mainToolbar setSelectedItemIdentifier:SPMainToolbarTableRelations];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        
+        [self->prefs setInteger:SPRelationsViewMode forKey:SPLastViewMode];
+    });
 
-	[tableTabView selectTabViewItemAtIndex:4];
-	[mainToolbar setSelectedItemIdentifier:SPMainToolbarTableRelations];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	[prefs setInteger:SPRelationsViewMode forKey:SPLastViewMode];
 }
 
 - (IBAction)viewTriggers:(id)sender
 {
-	// Cancel the selection if currently editing a view and unable to save
-	if (![self couldCommitCurrentViewActions]) {
-		[mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[prefs integerForKey:SPLastViewMode]]];
-		return;
-	}
-
-	[tableTabView selectTabViewItemAtIndex:5];
-	[mainToolbar setSelectedItemIdentifier:SPMainToolbarTableTriggers];
-	[spHistoryControllerInstance updateHistoryEntries];
-
-	[prefs setInteger:SPTriggersViewMode forKey:SPLastViewMode];
+    if (![NSThread isMainThread]) {
+        CLS_LOG(@"Calling viewTriggers from background thread");
+    }
+    
+    SPMainQSync(^{
+        // Cancel the selection if currently editing a view and unable to save
+        if (![self couldCommitCurrentViewActions]) {
+            [self->mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
+            return;
+        }
+        
+        [self->tableTabView selectTabViewItemAtIndex:5];
+        [self->mainToolbar setSelectedItemIdentifier:SPMainToolbarTableTriggers];
+        [self->spHistoryControllerInstance updateHistoryEntries];
+        
+        [self->prefs setInteger:SPTriggersViewMode forKey:SPLastViewMode];
+    });
 }
 
 /**

--- a/Source/Controllers/Other/SPHistoryController.m
+++ b/Source/Controllers/Other/SPHistoryController.m
@@ -33,6 +33,7 @@
 #import "SPTablesList.h"
 #import "SPHistoryController.h"
 #import "SPThreadAdditions.h"
+@import Firebase;
 
 @implementation SPHistoryController
 
@@ -153,18 +154,25 @@
 	// Ensure history navigation is permitted - trigger end editing and any required saves
 	if (![theDocument couldCommitCurrentViewActions]) return;
 
-	switch ([theControl selectedSegment]) 
-	{
-		// Back button clicked:
-		case 0:
-			[self goBackInHistory];
-			break;
-
-		// Forward button clicked:
-		case 1:
-			[self goForwardInHistory];
-			break;
-	}
+    
+    if ([theControl respondsToSelector:@selector(selectedSegment)]) {
+        switch ([theControl selectedSegment])
+        {
+                // Back button clicked:
+            case 0:
+                [self goBackInHistory];
+                break;
+                
+                // Forward button clicked:
+            case 1:
+                [self goForwardInHistory];
+                break;
+        }
+    }
+    else {
+        SPLog(@"theControl does not respondToSelector: selectedSegment. theControl class: %@", [theControl class]);
+        CLS_LOG(@"theControl does not respondToSelector: selectedSegment. theControl class: %@", [theControl class]);
+    }
 }
 
 /**

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -38,8 +38,9 @@
 #import "SPCustomQuery.h"
 #import "SPTableContent.h"
 #import "SPJSONFormatter.h"
-
+@import Firebase;
 #import <SPMySQL/SPMySQL.h>
+#import "SPFunctions.h"
 
 #import "sequel-ace-Swift.h"
 
@@ -528,17 +529,33 @@ typedef enum {
 		case JsonSegment:
 			[usedSheet makeFirstResponder:jsonTextView];
 			if([[jsonTextView string] isEqualToString:@""]) {
-				NSError *error;
-				NSData *jsonData = [sheetEditData dataUsingEncoding:NSUTF8StringEncoding];
-				id jsonObject = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingMutableContainers error:&error];
-				
-				if([NSJSONSerialization isValidJSONObject:jsonObject]){
-					NSData *prettyJsonData = [NSJSONSerialization dataWithJSONObject:jsonObject options:NSJSONWritingPrettyPrinted error:&error];
-					NSString *prettyPrintedJson = [NSString stringWithUTF8String:[prettyJsonData bytes]];
-					[jsonTextView setString:prettyPrintedJson];
-				}else{
-					[jsonTextView setString:sheetEditData];
-				}
+                if([sheetEditData isKindOfClass:[NSData class]]) {
+                    if ([sheetEditData respondsToSelector:@selector(dataUsingEncoding:)]) {
+                        NSError *error;
+                        NSData *jsonData = [sheetEditData dataUsingEncoding:NSUTF8StringEncoding];
+                        id jsonObject = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingMutableContainers error:&error];
+                        
+                        if([NSJSONSerialization isValidJSONObject:jsonObject]){
+                            NSData *prettyJsonData = [NSJSONSerialization dataWithJSONObject:jsonObject options:NSJSONWritingPrettyPrinted error:&error];
+                            NSString *prettyPrintedJson = [NSString stringWithUTF8String:[prettyJsonData bytes]];
+                            [jsonTextView setString:prettyPrintedJson];
+                        }else{
+                            [jsonTextView setString:sheetEditData];
+                        }
+                    }
+                    else{
+                        SPLog(@"sheetEditData does not respond to dataUsingEncoding: %@", [sheetEditData class]);
+                        CLS_LOG(@"sheetEditData does not respond dataUsingEncoding: %@", [sheetEditData class]);
+#ifdef DEBUG
+                        NSArray *arr = DumpObjCMethods(sheetEditData);
+                        SPLog(@"sheetEditData class methods = %@", arr);
+#endif
+                    }
+                }
+                else{
+                    SPLog(@"sheetEditData not of NSData class: %@", [sheetEditData class]);
+                    CLS_LOG(@"sheetEditData not of NSData class: %@", [sheetEditData class]);
+                }
 			}
 			[editTextView setHidden:YES];
 			[editTextScrollView setHidden:YES];

--- a/Source/Other/Utility/SPFunctions.h
+++ b/Source/Other/Utility/SPFunctions.h
@@ -74,3 +74,5 @@ void executeOnBackgroundThread(void (^block)(void));
 void executeOnBackgroundThreadSync(void (^block)(void));
 
 void SP_swizzleInstanceMethod(Class c, SEL original, SEL replacement);
+
+id DumpObjCMethods(Class clz);

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -129,3 +129,23 @@ void SP_swizzleInstanceMethod(Class c, SEL original, SEL replacement)
 		method_exchangeImplementations(a, b);
 	}
 }
+
+id DumpObjCMethods(Class clz) {
+    
+    unsigned int i=0;
+    unsigned int mc = 0;
+    Method * mlist = class_copyMethodList(object_getClass(clz), &mc);
+    
+    NSMutableArray *arr = [[NSMutableArray alloc] initWithCapacity:mc];
+    
+    SPLog(@"%d class methods", mc);
+    for(i=0;i<mc;i++){
+        SPLog(@"Class Method no #%d: %s", i, sel_getName(method_getName(mlist[i])));
+        [arr addObject:[[NSString alloc] initWithCString:sel_getName(method_getName(mlist[i])) encoding:NSUTF8StringEncoding]];
+    }
+    
+    free(mlist);
+    
+    return arr;
+}
+

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -446,13 +446,22 @@ static const NSInteger kBlobAsImageFile = 4;
 		NSString *t = [NSArrayObjectAtIndex(columnDefinitions, columnMappings[c]) objectForKey:@"typegrouping"];
 		
 		if(foundAutoIncColumn == NO && skipAutoIncrementColumn == YES){
-			autoIncrement = [NSArrayObjectAtIndex(columnDefinitions, columnMappings[c]) boolForKey:@"autoincrement"];
-			// the columnDefinitions array contains dictionaries with different keys when copying from the table view (autoincrement)
-			// or the query view (AUTO_INCREMENT_FLAG)
-			// so we need this extra check
-			if(autoIncrement == NO){
-				autoIncrement = [NSArrayObjectAtIndex(columnDefinitions, columnMappings[c]) boolForKey:@"AUTO_INCREMENT_FLAG"];
-			}
+            
+            id obj = NSArrayObjectAtIndex(columnDefinitions, columnMappings[c]);
+                        
+            if ([obj respondsToSelector:@selector(boolForKey:)]) {
+                autoIncrement = [obj boolForKey:@"autoincrement"];
+                // the columnDefinitions array contains dictionaries with different keys when copying from the table view (autoincrement)
+                // or the query view (AUTO_INCREMENT_FLAG)
+                // so we need this extra check
+                if(autoIncrement == NO){
+                    autoIncrement = [obj boolForKey:@"AUTO_INCREMENT_FLAG"];
+                }
+            }
+            else{
+                CLS_LOG(@"object does not respond to boolForKey. obj class: %@\n Description: %@", [obj class], [obj description]);
+                CLS_LOG(@"columnDefinitions: %@", columnDefinitions);
+            }
 		}
 
 		// Numeric data

--- a/sequel-ace.xcodeproj/xcshareddata/xcschemes/Sequel Ace Local Testing.xcscheme
+++ b/sequel-ace.xcodeproj/xcshareddata/xcschemes/Sequel Ace Local Testing.xcscheme
@@ -78,7 +78,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"


### PR DESCRIPTION
## Changes:
fix SPCopyTable rowsAsSqlInsertsOnlySelectedRows:skipAutoIncrementColumn crash
fix numerous background thread crashes
fixed SPFieldEditorController segmentControllerChanged crash
handle SPHistoryController historyControlClicked crash
fix SPCustomQuery performQueriesTask crash

## Closes following issues:
-

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.0
- Xcode version: 12.3 (12C33)

## Screenshots:


## Additional notes:
