### PR TITLE
#fixed guard when taking substring of query

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -213,13 +213,13 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 	// Re-init sort order
 	isDesc = NO;
 	sortColumn = nil;
-	
+
 
 	// If the current selection is a single caret position, run the current query.
 	if (selectedRange.length == 0) {
 		// BOOL doLookBehind = YES;
 		// query = [self queryAtPosition:selectedRange.location lookBehind:&doLookBehind];
-		if(currentQueryRange.length)
+		if(currentQueryRange.length  && [textView string].length > currentQueryRange.length)
 			query = [[textView string] substringWithRange:currentQueryRange];
 		if (!query) {
 			NSBeep();


### PR DESCRIPTION
## Changes:
added guard around substring

## Closes following issues:
#641

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [x] 10.15
  - [ ] 11.0
- Xcode version: 12.2 (12B45b)

## Screenshots:


## Additional notes:
