### PR TITLE
#fixed csv import crash

### DIFF
--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -949,8 +949,8 @@
 
 				// Set up index sets for use during row enumeration
 				for (i = 0; i < [fieldMappingArray count]; i++) {
-					if ([NSArrayObjectAtIndex(fieldMapperOperator, i) integerValue] == 0) {
-						NSString *fieldName = NSArrayObjectAtIndex(fieldMappingTableColumnNames, i);
+                    if ([[fieldMapperOperator safeObjectAtIndex:i] integerValue] == 0) {
+                        NSString *fieldName = [fieldMappingTableColumnNames safeObjectAtIndex:i];
 						if ([nullableNumericFields containsObject:fieldName]) {
 							[nullableNumericFieldsMapIndex addIndex:i];
 						}

--- a/Source/Other/CategoryAdditions/SPArrayAdditions.h
+++ b/Source/Other/CategoryAdditions/SPArrayAdditions.h
@@ -95,5 +95,5 @@ static inline void NSMutableArrayReplaceObject(NSArray *self, CFIndex idx, id an
  * @return The object located at index or nil.
  */
 - (id)objectOrNilAtIndex:(NSUInteger)index;
-
+- (id)safeObjectAtIndex:(NSUInteger)idx;
 @end

--- a/Source/Other/CategoryAdditions/SPArrayAdditions.m
+++ b/Source/Other/CategoryAdditions/SPArrayAdditions.m
@@ -143,9 +143,16 @@
 
 - (id)objectOrNilAtIndex:(NSUInteger)index
 {
-	if([self count] <= index)
+	if([self count] <= index) // JCS: shouldn't this be just less than?
 		return nil;
 	return [self objectAtIndex:index];
 }
+
+
+- (id)safeObjectAtIndex:(NSUInteger)idx
+{
+    return idx < self.count ? [self objectAtIndex:idx] : nil;
+}
+
 
 @end

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -31,7 +31,7 @@
 #import "SPObjectAdditions.h"
 #import "SPStringAdditions.h"
 #import "RegexKitLite.h"
-
+#import "SPArrayAdditions.h"
 #import "sequel-ace-Swift.h"
 
 #import <XCTest/XCTest.h>
@@ -138,24 +138,75 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 	}];
 }
 
-- (void)testPerformance_CaseInsensitiveSearch {
+// MARK: pretty much no difference between these methods
+// so I don't know why we are using NSArrayObjectAtIndex all over.
+// should switch to objectOrNilAtIndex for safety
+
+// 0.0263s
+- (void)testPerformanceNSArrayObjectAtIndex {
 	// this is on main thread
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
-		int const iterations = 1;
+		int const iterations = 10000;
 		
 		NSArray *queryHist = [self randomHistArray];
 		
 		for (int i = 0; i < iterations; i++) {
 			@autoreleasepool {
-				NSString *ran = [[NSProcessInfo processInfo] globallyUniqueString];
-				
-				for(NSString *str in queryHist){
-					BOOL __unused match = [str localizedCaseInsensitiveContainsString:ran];
-				}
+                id __unused ret = NSArrayObjectAtIndex(queryHist, i);
 			}
 		}
 	}];
+}
+
+//0.0259
+- (void)testPerformance_NormalNSArrayObjectAtIndex {
+    // this is on main thread
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+        int const iterations = 10000;
+
+        NSArray *queryHist = [self randomHistArray];
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                id __unused ret = [queryHist objectAtIndex:i];
+            }
+        }
+    }];
+}
+//0.0259
+- (void)testPerformance_NormalNSArrayObjectOrNilAtIndex {
+    // this is on main thread
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+        int const iterations = 10000;
+
+        NSArray *queryHist = [NSArray arrayWithArray:[self randomHistArray]];
+
+        for (NSUInteger i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                id __unused ret = [queryHist objectOrNilAtIndex:i];
+            }
+        }
+    }];
+}
+
+// 0.0264
+- (void)testPerformance_safeObjectAtIndex {
+    // this is on main thread
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+        int const iterations = 10000;
+
+        NSArray *queryHist = [NSArray arrayWithArray:[self randomHistArray]];
+
+        for (NSUInteger i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                id __unused ret = [queryHist safeObjectAtIndex:i];
+            }
+        }
+    }];
 }
 
 - (NSMutableArray *)randomHistArray {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
+		1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
 		1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53672584552F00526DED /* SPURLAdditionsTests.m */; };
 		1A19962A257A624200F5B0F1 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A199629257A624200F5B0F1 /* BundleExtension.swift */; };
 		1A1EE94A2551185D0056FECD /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
@@ -2988,6 +2989,7 @@
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
 				1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */,
 				502D21F61BA50710000D4CE7 /* SPDataAdditionsTests.m in Sources */,
+				1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */,
 				1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,


### PR DESCRIPTION
## Changes:
Added guard around array object at index

## Closes following issues:
FB crash: ad13116511d901668b46fcb663c627be

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [x] 10.15
  - [ ] 11.0
- Xcode version:12.2 (12B45b)

## Screenshots:


## Additional notes:
