### PR TITLE
Extra logging and a guard on the connection error text

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2444,7 +2444,9 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		}
 	}
 
-	if (errorDetail) [errorDetailText setString:errorDetail];
+    CLS_LOG(@"errorDetail: %@", errorDetail);
+    
+	if (errorDetail && [errorDetail length] > 0) [errorDetailText setString:errorDetail];
 
 	// Inform the delegate that the connection attempt failed
 	if (delegate && [delegate respondsToSelector:@selector(connectionControllerConnectAttemptFailed:)]) {

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -38,6 +38,7 @@
 #import "SPTableStructure.h"
 #import "SPServerSupport.h"
 #import "sequel-ace-Swift.h"
+@import Firebase;
 
 #import <SPMySQL/SPMySQL.h>
 
@@ -238,6 +239,10 @@ static NSString *SPMySQLCommentField          = @"Comment";
 
 	// Retrieve the table status information via the table data cache
 	NSDictionary *statusFields = [tableDataInstance statusValues];
+
+    CLS_LOG(@"tableTypePopUpButton numberOfItems: %li", (long)tableTypePopUpButton.numberOfItems);
+    CLS_LOG(@"tableEncodingPopUpButton numberOfItems: %li", (long)tableTypePopUpButton.numberOfItems);
+    CLS_LOG(@"tableCollationPopUpButton numberOfItems: %li", (long)tableTypePopUpButton.numberOfItems);
 
 	[tableTypePopUpButton removeAllItems];
 	[tableEncodingPopUpButton removeAllItems];


### PR DESCRIPTION
## Changes:
Added extra FB logging and a guard on the error text

## Closes following issues:
FB 2e6a6208cff5b0135b8924eb838287ea
FB 77a21a5217eeb5b91b2bb4c4e70aeae7

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [x] 10.15
  - [ ] 11.0
- Xcode version: 12.2 (12B45b)

## Screenshots:


## Additional notes:
