### PR TITLE
Various fixes/changes #fixed

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2126,7 +2126,7 @@ set_input:
 		NSString *extension = [self currentDefaultExportFileExtension];
 
 		//note that there will be no tableName if the export is done from a query result without a database selected (or empty).
-		filename = [self expandCustomFilenameFormatUsingTableName:[[tablesListInstance tables] objectOrNilAtIndex:1]];
+		filename = [self expandCustomFilenameFormatUsingTableName:[[tablesListInstance tables] safeObjectAtIndex:1]];
 
 		if (![[self customFilenamePathExtension] length] && [extension length] > 0) filename = [filename stringByAppendingPathExtension:extension];
 	}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -994,7 +994,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 {
 	NSArray *nodes = [self selectedFavoriteNodes];
 	
-	return (SPTreeNode *)[nodes objectOrNilAtIndex:0];
+	return (SPTreeNode *)[nodes safeObjectAtIndex:0];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -48,6 +48,7 @@
 #import "SPPillAttachmentCell.h"
 #import "SPIdMenu.h"
 #import "SPComboBoxCell.h"
+@import Firebase;
 
 #import "sequel-ace-Swift.h"
 
@@ -1410,9 +1411,9 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			// MySQL 5.7 manual:
 			// "MySQL handles strings used in JSON context using the utf8mb4 character set and utf8mb4_bin collation.
 			//  Strings in other character set are converted to utf8mb4 as necessary."
-			[theField setObject:@"utf8mb4" forKey:@"encodingName"];
-			[theField setObject:@"utf8mb4_bin" forKey:@"collationName"];
-			[theField setObject:@1 forKey:@"binary"];
+			[theField safeSetObject:@"utf8mb4" forKey:@"encodingName"];
+			[theField safeSetObject:@"utf8mb4_bin" forKey:@"collationName"];
+			[theField safeSetObject:@1 forKey:@"binary"];
 		}
 		else if ([fieldValidation isFieldTypeString:type]) {
 			// The MySQL 4.1 manual says:
@@ -1447,9 +1448,20 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 
 			// MySQL < 4.1 does not support collations (they are part of the charset), it will be nil there
-
-			[theField setObject:encoding forKey:@"encodingName"];
-			[theField setObject:collation forKey:@"collationName"];
+            if(collation != nil){
+                [theField safeSetObject:collation forKey:@"collationName"];
+            }
+            else{
+                SPLog(@"collation was nil");
+                CLS_LOG(@"collation was nil");
+            }
+            if(encoding != nil){
+                [theField safeSetObject:encoding forKey:@"encodingName"];
+            }
+            else{
+                SPLog(@"encoding was nil");
+                CLS_LOG(@"encoding was nil");
+            }
 
 			// Set BINARY if collation ends with _bin for convenience
 			if ([collation hasSuffix:@"_bin"]) {

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -2227,7 +2227,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 - (void)_displayFieldTypeHelpIfPossible:(SPComboBoxCell *)cell
 {
-	NSString *selected = [typeSuggestions objectOrNilAtIndex:[cell indexOfSelectedItem]];
+	NSString *selected = [typeSuggestions safeObjectAtIndex:[cell indexOfSelectedItem]];
 
 	const SPFieldTypeHelp *help = [[self class] helpForFieldType:selected];
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -219,6 +219,21 @@
 		}
 	}
 
+    executeOnBackgroundThread(^{
+        NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+        FIRCrashlytics *crashlytics = FIRCrashlytics.crashlytics;
+
+        // set some keys to help us diagnose issues
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryAutoComplete, prefs)) forKey:@"CustomQueryAutoComplete"];
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryEnableSyntaxHighlighting, prefs)) forKey:@"CustomQueryEnableSyntaxHighlighting"];
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryAutoIndent, prefs)) forKey:@"CustomQueryAutoIndent"];
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryAutoUppercaseKeywords, prefs)) forKey:@"CustomQueryAutoUppercaseKeywords"];
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryEnableBracketHighlighting, prefs)) forKey:@"CustomQueryEnableBracketHighlighting"];
+        [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryEditorCompleteWithBackticks, prefs)) forKey:@"CustomQueryEditorCompleteWithBackticks"];
+        [crashlytics setCustomValue:[[NSLocale currentLocale] localeIdentifier] forKey:@"localeIdentifier"];
+        [crashlytics setCustomValue:[[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode] forKey:@"localeLanguageCode"];
+    });
+
 
     [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(externalApplicationWantsToOpenADatabaseConnection:) name:@"ExternalApplicationWantsToOpenADatabaseConnection" object:nil];
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -220,7 +220,7 @@
 	}
 
 
-	[[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(externalApplicationWantsToOpenADatabaseConnection:) name:@"ExternalApplicationWantsToOpenADatabaseConnection" object:nil];
+    [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(externalApplicationWantsToOpenADatabaseConnection:) name:@"ExternalApplicationWantsToOpenADatabaseConnection" object:nil];
 
 	[sharedSPBundleManager reloadBundles:self];
     [self _copyDefaultThemes];

--- a/Source/Controllers/SubviewControllers/SPCharsetCollationHelper.m
+++ b/Source/Controllers/SubviewControllers/SPCharsetCollationHelper.m
@@ -141,8 +141,10 @@
 			NSString *charsetId     = [encoding objectForKey:@"CHARACTER_SET_NAME"];
 			NSString *description   = [encoding objectForKey:@"DESCRIPTION"];
 			NSString *menuItemTitle = (![description length]) ? charsetId : [NSString stringWithFormat:@"%@ (%@)", description, charsetId];
-			
-			NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:menuItemTitle action:NULL keyEquivalent:@""];
+
+            // initWithTitle param cannot be nil
+            // This value must not be nil (if there is no title, specify an empty NSString).
+            NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:(menuItemTitle) ? : @"" action:NULL keyEquivalent:@""];
 			[menuItem setRepresentedObject:charsetId];
 			
 			//store the menu item that we want to select (we'll do that when the list is stable)

--- a/Source/Controllers/SubviewControllers/SPGotoDatabaseController.m
+++ b/Source/Controllers/SubviewControllers/SPGotoDatabaseController.m
@@ -197,10 +197,10 @@ static BOOL StringQualifiesForWordSearch(NSString *s);
 	id attrValue;
 
 	if (isFiltered) {
-		attrValue = [(SPGotoFilteredItem *)[filteredList objectOrNilAtIndex:row] string];
+		attrValue = [(SPGotoFilteredItem *)[filteredList safeObjectAtIndex:row] string];
 	}
 	else {
-		attrValue = [unfilteredList objectOrNilAtIndex:row];
+		attrValue = [unfilteredList safeObjectAtIndex:row];
 	}
 
 	return attrValue;

--- a/Source/Controllers/SubviewControllers/SPNavigatorController.m
+++ b/Source/Controllers/SubviewControllers/SPNavigatorController.m
@@ -365,7 +365,7 @@ static NSComparisonResult compareStrings(NSString *s1, NSString *s2, void* conte
 				[syncButton setState:NSOffState];
 
 				// Select the database and table
-				[doc selectDatabase:[pathArray objectAtIndex:1] item:[pathArray objectOrNilAtIndex:2]];
+				[doc selectDatabase:[pathArray objectAtIndex:1] item:[pathArray safeObjectAtIndex:2]];
 
 				if(oldState == NSOnState)
 					[self performSelector:@selector(_setSyncButtonOn) withObject:nil afterDelay:0.1];

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -546,7 +546,7 @@
 - (CGFloat)tableView:(NSTableView *)aTableView heightOfRow:(NSInteger)rowIndex
 {
 
-	return ([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? 20 : 18;
+	return ([[favorites safeObjectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? 20 : 18;
 }
 
 /*
@@ -555,7 +555,7 @@
 - (BOOL)tableView:(NSTableView *)aTableView shouldEditTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
 
-	if([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) {
+	if([[favorites safeObjectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) {
 		return NO;
 	} else {
 		isTableCellEditing = YES;
@@ -578,7 +578,7 @@
 - (BOOL)tableView:(NSTableView *)aTableView isGroupRow:(NSInteger)rowIndex
 {
 	
-	return ([[favorites objectOrNilAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? YES : NO;
+	return ([[favorites safeObjectAtIndex:rowIndex] objectForKey:@"headerOfFileURL"]) ? YES : NO;
 }
 /*
  * Detect if inline editing was done - then ESC to close the sheet will be activate

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -939,9 +939,9 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	if(!display) return; // abort if unset
 
 	// try to restore the value from the previous displayValue for input fields
-	RuleNode *oldCriterion = [oldCriteria objectOrNilAtIndex:0];
+	RuleNode *oldCriterion = [oldCriteria safeObjectAtIndex:0];
 	if([curCriterion type] == RuleNodeTypeArgument && oldCriterion && [curCriterion type] == [oldCriterion type]) {
-		NSTextField *oldField = [oldDisplayValues objectOrNilAtIndex:0];
+		NSTextField *oldField = [oldDisplayValues safeObjectAtIndex:0];
 		if(oldField) [display setStringValue:[oldField stringValue]];
 	}
 	[displayValues addObject:display];
@@ -957,7 +957,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		NSArray *nextOldDisplayValues = ([oldDisplayValues count] > 1 ? [oldDisplayValues subarrayWithRange:NSMakeRange(1, [oldDisplayValues count] - 1)] : [NSArray array]);
 
 		// if the user changed the column, try to retain the previously selected operation
-		RuleNode *nextOldCriterion = [nextOldCriteria objectOrNilAtIndex:0];
+		RuleNode *nextOldCriterion = [nextOldCriteria safeObjectAtIndex:0];
 		if(nextOldCriterion && [nextOldCriterion type] == RuleNodeTypeOperator && [curCriterion type] == RuleNodeTypeColumn) {
 			NSString *opName = [(OpNode *)nextOldCriterion name];
 			OpNode *op = [self _operatorNamed:opName forColumn:(ColumnNode *)curCriterion];
@@ -1709,9 +1709,9 @@ BOOL SerIsGroup(NSDictionary *dict)
 
 		SPTableFilterParser *parser = [[SPTableFilterParser alloc] initWithFilterClause:[filter objectForKey:@"Clause"]
 		                                                              numberOfArguments:[[filter objectForKey:@"NumberOfArguments"] integerValue]];
-		[parser setArgument:[values objectOrNilAtIndex:0]];
-		[parser setFirstBetweenArgument:[values objectOrNilAtIndex:0]];
-		[parser setSecondBetweenArgument:[values objectOrNilAtIndex:1]];
+		[parser setArgument:[values safeObjectAtIndex:0]];
+		[parser setFirstBetweenArgument:[values safeObjectAtIndex:0]];
+		[parser setSecondBetweenArgument:[values safeObjectAtIndex:1]];
 		[parser setSuppressLeadingTablePlaceholder:[[filter objectForKey:@"SuppressLeadingFieldPlaceholder"] boolValue]];
 		[parser setCaseSensitive:isBINARY];
 		[parser setCurrentField:[in objectForKey:SerFilterExprColumn]];

--- a/Source/Other/CategoryAdditions/SPArrayAdditions.h
+++ b/Source/Other/CategoryAdditions/SPArrayAdditions.h
@@ -91,9 +91,8 @@ static inline void NSMutableArrayReplaceObject(NSArray *self, CFIndex idx, id an
  * just returning nil instead.
  *
  * @warning This method is NOT thread-safe.
- * @param index  An index
+ * @param idx  An index
  * @return The object located at index or nil.
  */
-- (id)objectOrNilAtIndex:(NSUInteger)index;
 - (id)safeObjectAtIndex:(NSUInteger)idx;
 @end

--- a/Source/Other/CategoryAdditions/SPArrayAdditions.m
+++ b/Source/Other/CategoryAdditions/SPArrayAdditions.m
@@ -141,18 +141,9 @@
 	return subArray;
 }
 
-- (id)objectOrNilAtIndex:(NSUInteger)index
-{
-	if([self count] <= index) // JCS: shouldn't this be just less than?
-		return nil;
-	return [self objectAtIndex:index];
-}
-
-
 - (id)safeObjectAtIndex:(NSUInteger)idx
 {
     return idx < self.count ? [self objectAtIndex:idx] : nil;
 }
-
 
 @end

--- a/Source/Views/Controls/SPColorSelectorView.m
+++ b/Source/Views/Controls/SPColorSelectorView.m
@@ -233,7 +233,7 @@ enum trackingAreaIDs
 		NSRect colorSquareRect = [self rectForColorViewAtIndex:index];
 		
 		//make sure the color at index is actually defined
-		if(index >= 0 && [colorList objectOrNilAtIndex:index] == nil)
+		if(index >= 0 && [colorList safeObjectAtIndex:index] == nil)
 			continue;
 		
 		//do not draw a selection around the X item

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -140,7 +140,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // MARK: pretty much no difference between these methods
 // so I don't know why we are using NSArrayObjectAtIndex all over.
-// should switch to objectOrNilAtIndex for safety
+// should switch to safeObjectAtIndex for safety
 
 // 0.0263s
 - (void)testPerformanceNSArrayObjectAtIndex {
@@ -171,22 +171,6 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
         for (int i = 0; i < iterations; i++) {
             @autoreleasepool {
                 id __unused ret = [queryHist objectAtIndex:i];
-            }
-        }
-    }];
-}
-//0.0259
-- (void)testPerformance_NormalNSArrayObjectOrNilAtIndex {
-    // this is on main thread
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-        int const iterations = 10000;
-
-        NSArray *queryHist = [NSArray arrayWithArray:[self randomHistArray]];
-
-        for (NSUInteger i = 0; i < iterations; i++) {
-            @autoreleasepool {
-                id __unused ret = [queryHist objectOrNilAtIndex:i];
             }
         }
     }];

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -2923,6 +2923,10 @@
 			inputPaths = (
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
 				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+				"${DWARF_DSYM_FOLDER_PATH}/SequelAceTunnelAssistant.dSYM/Contents/Resources/DWARF/SequelAceTunnelAssistant",
+				"${DWARF_DSYM_FOLDER_PATH}/PSMTabBar.framework.dSYM/Contents/Resources/DWARF/PSMTabBar",
+				"${DWARF_DSYM_FOLDER_PATH}/SPMySQL.framework.dSYM/Contents/Resources/DWARF/SPMySQL",
+				"${DWARF_DSYM_FOLDER_PATH}/xibLocalizationPostprocessor.dSYM/Contents/Resources/DWARF/xibLocalizationPostprocessor",
 			);
 			name = "Run Crashlytics";
 			outputFileListPaths = (


### PR DESCRIPTION
## Changes:

- added the rest of the dSYMs to the Crashlytics upload
- changed all objectOrNilAtIndex -> safeObjectAtIndex
- fix SPTableStructure loadTable crash
- set some crashlytics keys to help us diagnose issues e.g. server version, encoding, TZ,  connectionType, various query editor prefs
- fix charset helper crash

## Closes following issues:
FB 2eee25d24021b87c5bbdb3ffdbdcd429, 903850b2ff44849461f311076bcc4fc8

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [ ] 11.1
  - [x] 11.2 Beta (20D5029f)
- Xcode version: 12.3 (12C33)

## Screenshots:


## Additional notes:
