### PR TITLE
Use entered password for favorite if it changed #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -303,7 +303,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	// for increased security.
 	if (connectionKeychainItemName && !isTestingConnection) {
 		if ([[keychain getPasswordForName:connectionKeychainItemName account:connectionKeychainItemAccount] isEqualToString:[self password]]) {
-			[self setPassword:[[NSString string] stringByPaddingToLength:[[self password] length] withString:@"sp" startingAtIndex:0]];
+			[self setPassword:@"SequelAceSecretPassword"];
 			
 			[[standardPasswordField undoManager] removeAllActionsWithTarget:standardPasswordField];
 			[[socketPasswordField undoManager] removeAllActionsWithTarget:socketPasswordField];
@@ -313,7 +313,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	
 	if (connectionSSHKeychainItemName && !isTestingConnection) {
 		if ([[keychain getPasswordForName:connectionSSHKeychainItemName account:connectionSSHKeychainItemAccount] isEqualToString:[self sshPassword]]) {
-			[self setSshPassword:[[NSString string] stringByPaddingToLength:[[self sshPassword] length] withString:@"sp" startingAtIndex:0]];
+			[self setSshPassword:@"SequelAceSecretPassword"];
 			[[sshSSHPasswordField undoManager] removeAllActionsWithTarget:sshSSHPasswordField];
 		}
 	}
@@ -2099,9 +2099,8 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 			}
 		}
 
-		// Only set the password if there is no Keychain item set or the connection is being tested.
-		// The connection will otherwise ask the delegate for passwords in the Keychain.
-		if ((!connectionKeychainItemName || isTestingConnection) && [self password]) {
+		// Only set the password if there is no Keychain item set or the connection is being tested or the password is different than in Keychain.
+		if ((isTestingConnection || !connectionKeychainItemName || (connectionKeychainItemName && ![[self password] isEqualToString:@"SequelAceSecretPassword"])) && [self password]) {
 			[mySQLConnection setPassword:[self password]];
 		}
 		
@@ -2291,11 +2290,11 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	
 	[sshTunnel setParentWindow:[dbDocument parentWindow]];
 
-	// Add keychain or plaintext password as appropriate - note the checks in initiateConnection.
-	if (connectionSSHKeychainItemName && !isTestingConnection) {
+    // Only set the password if there is no Keychain item set or the connection is being tested or the password is different than in Keychain.
+    if ((isTestingConnection || !connectionSSHKeychainItemName || (connectionSSHKeychainItemName && ![[self sshPassword] isEqualToString:@"SequelAceSecretPassword"])) && [self sshPassword]) {
+        [sshTunnel setPassword:[self sshPassword]];
+    } else if (connectionSSHKeychainItemName) {
 		[sshTunnel setPasswordKeychainName:connectionSSHKeychainItemName account:connectionSSHKeychainItemAccount];
-	} else if (sshPassword) {
-		[sshTunnel setPassword:[self sshPassword]];
 	}
 
 	// Set the public key path if appropriate

--- a/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
@@ -64,7 +64,7 @@ static NSString *SPDatabaseImage = @"database-small";
 /**
  * Updates the default favorite.
  */ 
-- (IBAction)updateDefaultFavorite:(id)sender
+- (IBAction)updateDefaultFavorite:(NSPopUpButton *)sender
 {		
 	for (NSMenuItem *item in [defaultFavoritePopup itemArray])
 	{

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -260,7 +260,7 @@ typedef enum {
 		if ([bitSheetNULLButton state] == NSOffState && maxBit <= [(NSString*)sheetEditData length])
 			for (i = 0; i < maxBit; i++)
 			{
-				[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]]
+				[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]]
 				 setState:([(NSString*)sheetEditData characterAtIndex:(maxBit - i - 1)] == '1') ? NSOnState : NSOffState];
 			}
 
@@ -1087,11 +1087,11 @@ typedef enum {
 	switch([sender tag]) {
 		case 0: // all to 1
 		for(i=0; i<maxBit; i++)
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOnState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOnState];
 		break;
 		case 1: // all to 0
 		for(i=0; i<maxBit; i++)
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOffState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOffState];
 		break;
 		case 2: // negate
 		for(i=0; i<maxBit; i++)
@@ -1101,27 +1101,27 @@ typedef enum {
 		for(i=maxBit-1; i>0; i--) {
 			[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i-1]] state]];
 		}
-		[[self valueForKeyPath:@"bitSheetBitButton0"] setState:NSOffState];
+		[(NSButton *)[self valueForKeyPath:@"bitSheetBitButton0"] setState:NSOffState];
 		break;
 		case 4: // shift right
 		for(i=0; i<maxBit-1; i++) {
 			[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i+1]] state]];
 		}
-		[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", maxBit-1]] setState:NSOffState];
+		[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", maxBit-1]] setState:NSOffState];
 		break;
 		case 5: // rotate left
 		aBit = [(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", maxBit-1]] state];
 		for(i=maxBit-1; i>0; i--) {
 			[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i-1]] state]];
 		}
-		[[self valueForKeyPath:@"bitSheetBitButton0"] setState:aBit];
+		[(NSButton *)[self valueForKeyPath:@"bitSheetBitButton0"] setState:aBit];
 		break;
 		case 6: // rotate right
 		aBit = [(NSButton*)[self valueForKeyPath:@"bitSheetBitButton0"] state];
 		for(i=0; i<maxBit-1; i++) {
 			[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:[(NSButton*)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i+1]] state]];
 		}
-		[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", maxBit-1]] setState:aBit];
+		[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", maxBit-1]] setState:aBit];
 		break;
 	}
 	[self updateBitSheet];
@@ -1187,7 +1187,7 @@ typedef enum {
 		NSUInteger intValue = (NSUInteger)strtoull([[bitSheetIntegerTextField stringValue] UTF8String], NULL, 0);
 
 		for(i=0; i<maxBit; i++)
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOffState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:NSOffState];
 
 		[bitSheetHexTextField setStringValue:[NSString stringWithFormat:@"%lX", (unsigned long)intValue]];
 		[bitSheetOctalTextField setStringValue:[NSString stringWithFormat:@"%llo", (long long)intValue]];
@@ -1195,7 +1195,7 @@ typedef enum {
 		i = 0;
 		while( intValue && i < maxBit )
 		{
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:( (intValue & 0x1) == 0) ? NSOffState : NSOnState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%lu", i]] setState:( (intValue & 0x1) == 0) ? NSOffState : NSOnState];
 			intValue >>= 1;
 			i++;
 		}
@@ -1211,7 +1211,7 @@ typedef enum {
 		[[NSScanner scannerWithString:[bitSheetHexTextField stringValue]] scanHexLongLong: &intValue];
 
 		for(i=0; i<maxBit; i++)
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]] setState:NSOffState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]] setState:NSOffState];
 
 		[bitSheetHexTextField setStringValue:[NSString stringWithFormat:@"%qX", intValue]];
 		[bitSheetOctalTextField setStringValue:[NSString stringWithFormat:@"%llo", intValue]];
@@ -1219,7 +1219,7 @@ typedef enum {
 		i = 0;
 		while( intValue && i < maxBit )
 		{
-			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]] setState:( (intValue & 0x1) == 0) ? NSOffState : NSOnState];
+			[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]] setState:( (intValue & 0x1) == 0) ? NSOffState : NSOnState];
 			intValue >>= 1;
 			i++;
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Use password entered into connection form even if you are editting favorite connection to allow users use prefilled favorite with no password and enter password manually

## Closes following issues:
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/675
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/674

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS versions:
  - [ ] 10.12
  - [ ] 10.13
  - [ ] 10.14
  - [ ] 10.15
  - [x] 11.1
- Xcode version: 12.3