### PR TITLE
#fixed deriveQueryString crash

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2529,9 +2529,20 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			}
 		}
 
+        NSDictionary *userInfo = @{
+            NSLocalizedDescriptionKey: @"deriveQueryString fieldValue is nil",
+            @"rowObject":[rowObject description],
+        };
+        
+        if (fieldValue == nil || [fieldValue isNSNull]){
+            CLS_LOG(@"fieldValue is nil: %@", fieldValue);
+            SPLog(@"fieldValue is nil: %@", fieldValue);
+            [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:6 userInfo:userInfo]];
+        }
+
 		// Store the key and value in the ordered arrays for saving.
-		[rowFieldsToSave addObject:[fieldDefinition objectForKey:@"name"]];
-		[rowValuesToSave addObject:fieldValue];
+		[rowFieldsToSave safeAddObject:[fieldDefinition safeObjectForKey:@"name"]];
+		[rowValuesToSave safeAddObject:fieldValue];
 	}
 
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"SMySQLQueryWillBePerformed" object:tableDocumentInstance];


### PR DESCRIPTION
## Changes:
Added error logging and guard around adding nil object

## Closes following issues:
FB: ef53962509f1f54e5805fe6c8aa419aa

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
