### PR TITLE
#fixed - tableChanged NSNull Collation crash

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -196,8 +196,20 @@
 				[info addObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSString stringForByteSize:[[tableStatus objectForKey:@"Data_length"] longLongValue]]]];
 			}
 
+            if([[tableStatus objectForKey:@"Collation"] isNSNull]){
+                NSDictionary *userInfo = @{
+                    NSLocalizedDescriptionKey: @"tableStatus Collation is NSNull" ,
+                    @"serverVersion" : tableDocumentInstance.mySQLVersion,
+                };
+
+                [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:4 userInfo:userInfo]];
+            }
+
+            SPLog(@"tableStatus: %@", tableStatus);
+            CLS_LOG(@"tableStatus: %@", tableStatus);
+
 			NSString *tableEnc = [tableDataInstance tableEncoding];
-			NSString *tableColl = [tableStatus objectForKey:@"Collation"];
+			NSString *tableColl = [tableStatus safeObjectForKey:@"Collation"];
 
 			if([tableColl length]) {
 				// instead of @"latin1 (latin1_german_ci)" we can just show @"latin1 (german_ci)"


### PR DESCRIPTION
## Changes:
guard table Collation being NSNull
plus error logging 

## Closes following issues:
FB: 33bff5b0a99f1f114ba25f9456e554ad

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
