### PR TITLE
#fixed tableViewColumnDidResize crash

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3970,6 +3970,19 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	NSString *database = [NSString stringWithFormat:@"%@@%@", [tableDocumentInstance database], [tableDocumentInstance host]];
 	NSString *table = [tablesListInstance tableName];
 
+
+    if (database == nil || table == nil){
+        CLS_LOG(@"database or table is nil");
+        SPLog(@"database or table is nil");
+        NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] initWithCapacity:3];
+
+        [userInfo setObject:@"tableViewColumnDidResize: database or table is nil" forKey:NSLocalizedDescriptionKey];
+        [userInfo safeSetObject:@"database" forKey:database];
+        [userInfo safeSetObject:@"table" forKey:table];
+
+        [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:8 userInfo:userInfo]];
+    }
+
 	// Get tableColumnWidths object
 	if ([prefs objectForKey:SPTableColumnWidths] != nil ) {
 		tableColumnWidths = [NSMutableDictionary dictionaryWithDictionary:[prefs objectForKey:SPTableColumnWidths]];
@@ -3979,25 +3992,25 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	}
 
 	// Get the database object
-	if  ([tableColumnWidths objectForKey:database] == nil) {
-		[tableColumnWidths setObject:[NSMutableDictionary dictionary] forKey:database];
+	if  ([tableColumnWidths safeObjectForKey:database] == nil) {
+		[tableColumnWidths safeSetObject:[NSMutableDictionary dictionary] forKey:database];
 	}
 	else {
-		[tableColumnWidths setObject:[NSMutableDictionary dictionaryWithDictionary:[tableColumnWidths objectForKey:database]] forKey:database];
+		[tableColumnWidths safeSetObject:[NSMutableDictionary dictionaryWithDictionary:[tableColumnWidths safeObjectForKey:database]] forKey:database];
 	}
 
 	// Get the table object
-	if  ([[tableColumnWidths objectForKey:database] objectForKey:table] == nil) {
-		[[tableColumnWidths objectForKey:database] setObject:[NSMutableDictionary dictionary] forKey:table];
+	if  ([[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table] == nil) {
+		[[tableColumnWidths safeObjectForKey:database] safeSetObject:[NSMutableDictionary dictionary] forKey:table];
 	}
 	else {
-		[[tableColumnWidths objectForKey:database] setObject:[NSMutableDictionary dictionaryWithDictionary:[[tableColumnWidths objectForKey:database] objectForKey:table]] forKey:table];
+		[[tableColumnWidths safeObjectForKey:database] safeSetObject:[NSMutableDictionary dictionaryWithDictionary:[[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table]] forKey:table];
 	}
 
 	// Save column size
-	[[[tableColumnWidths objectForKey:database] objectForKey:table]
-	 setObject:[NSNumber numberWithDouble:[(NSTableColumn *)[[notification userInfo] objectForKey:@"NSTableColumn"] width]]
-	 forKey:[[[[notification userInfo] objectForKey:@"NSTableColumn"] headerCell] stringValue]];
+	[[[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table]
+     safeSetObject:[NSNumber numberWithDouble:[(NSTableColumn *)[[notification userInfo] safeObjectForKey:@"NSTableColumn"] width]]
+	 forKey:[[[[notification userInfo] safeObjectForKey:@"NSTableColumn"] headerCell] stringValue]];
 	[prefs setObject:tableColumnWidths forKey:SPTableColumnWidths];
 }
 


### PR DESCRIPTION
## Changes:
guards around nil keys and error logging

## Closes following issues:
FB: 18b0bf44d0defba22a4df6a770dc1690

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
