### PR TITLE
Fixed commenting out one or multiple lines in query editor #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1283,8 +1283,6 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
  */
 - (void)commentOutCurrentQueryTakingSelection:(BOOL)takeSelection
 {
-    BOOL isUncomment = NO;
-    
     NSRange oldRange = [textView selectedRange];
     
     NSRange workingRange = oldRange;
@@ -1314,12 +1312,11 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         [n replaceOccurrencesOfRegex:@"\\s*\\*/ \\*/\\s*\\Z" withString:@""];
         // unescape *\/
         [n replaceOccurrencesOfRegex:@"\\*\\\\/" withString:@"*/"];
-        isUncomment = YES;
     }
     
     // Replace current query/selection by (un)commented string
     [textView insertText:[[NSAttributedString alloc] initWithString:n] replacementRange:workingRange];
-    [textView setSelectedRange:NSMakeRange(workingRange.location,n.length)];
+    [textView setSelectedRange:NSMakeRange(workingRange.location, n.length)];
 }
 
 /**


### PR DESCRIPTION
## Changes:
Basically, made commenting behave exactly like VSCode
- Fixed multi-line commenting out inserting a comment at the very end of the query
- When commenting out multiple lines, the previous selection will be preserved
- When commenting out a single line, the cursor will maintain its current position (to make it super easy to toggle back and forth between commenting and un-commenting a line)

## Closes following issues:
- Closes #639 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version:
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:
<img width="364" alt="Screen Shot 2020-12-23 at 12 28 02" src="https://user-images.githubusercontent.com/10710367/103034688-5015bc00-451a-11eb-89b5-9fa8afcd2c46.png">


## Additional notes:
