### PR TITLE
#fixed sp table structure load table crash

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1381,8 +1381,24 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 			for (NSDictionary *encoding in encodings)
 			{
-				NSString *encodingName = [encoding objectForKey:@"CHARACTER_SET_NAME"];
-				NSString *title = (![encoding objectForKey:@"DESCRIPTION"]) ? encodingName : [NSString stringWithFormat:@"%@ (%@)", [encoding objectForKey:@"DESCRIPTION"], encodingName];
+				NSString *encodingName = [encoding safeObjectForKey:@"CHARACTER_SET_NAME"];
+				NSString *title = (![encoding safeObjectForKey:@"DESCRIPTION"]) ? encodingName : [NSString stringWithFormat:@"%@ (%@)", [encoding safeObjectForKey:@"DESCRIPTION"], encodingName];
+
+                if(title == nil || [title isNSNull]){
+                    SPLog(@"title is nil");
+                    CLS_LOG(@"title is nil");
+
+                    NSDictionary *userInfo = @{
+                        NSLocalizedDescriptionKey: @"loadTable: title is nil, check CHARACTER_SET_NAME",
+                        @"encodingName":encodingName,
+                        @"encoding": encoding,
+                    };
+
+                    // default to empty string?
+                    title = @"";
+
+                    [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:7 userInfo:userInfo]];
+                }
 
 				[self->encodingPopupCell addItemWithTitle:title];
 				NSMenuItem *item = [self->encodingPopupCell lastItem];


### PR DESCRIPTION
## Changes:
guard around nil title and error logging

## Closes following issues:
FB: 968a3c45270288d2136dcee21ea18e3c

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
