### PR TITLE
#fixed SPTableInfo crash

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -350,7 +350,18 @@
 - (id)tableView:(NSTableView *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex
 {
 	if (tableView == infoTable) {
-		return [info objectAtIndex:rowIndex];
+        if(info.count <= (NSUInteger)rowIndex){
+            NSDictionary *userInfo = @{
+                NSLocalizedDescriptionKey: @"info.count <= (NSUInteger)rowIndex",
+                @"info.count":@(info.count),
+                @"rowIndex":@(rowIndex),
+                @"info":info
+            };
+            CLS_LOG(@"info.count <= (NSUInteger)rowIndex: [%lu] vs [%li]", (unsigned long)info.count, (long)rowIndex);
+            SPLog(@"info.count <= (NSUInteger)rowIndex: [%lu] vs [%li]", (unsigned long)info.count, (long)rowIndex);
+            [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:4 userInfo:userInfo]];
+        }
+		return [info safeObjectAtIndex:rowIndex];
 	} 
 	else {
 		if (rowIndex == 0) {


### PR DESCRIPTION
## Changes:
added guard and error logging 

## Closes following issues:
FB: e24b1645f36e3ea2e597e387cf317a2d

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
