### PR TITLE
Fix Query Window Forgets Active Query #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -243,16 +243,6 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         }
     }
     
-    // Invoke textStorageDidProcessEditing: for syntax highlighting and auto-uppercase
-    // and preserve the selection
-    [textView setSelectedRange:NSMakeRange(selectedRange.location, 0)];
-    [textView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:@""]];
-    
-    // Inserting empty text may have cancelled a partial accent - range check before
-    // restoring the selection.
-    if (selectedRange.location > [[textView string] length]) selectedRange.location = [[textView string] length];
-    [textView setSelectedRange:selectedRange];
-    
     reloadingExistingResult = NO;
     [self clearResultViewDetailsToRestore];
     
@@ -1120,18 +1110,17 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     
     // Split the current text into ranges of queries
     // only if the textView was really changed, otherwise use the cache
-    if([[textView textStorage] editedMask] != 0 || [self textViewWasChanged]) {
+    if([[textView textStorage] editedMask] != 0 || [self textViewWasChanged] || currentQueryRanges != nil || currentQueryRanges.count == 0) {
         [self setTextViewWasChanged:NO];
         customQueryParser = [[SPSQLParser alloc] initWithString:[textView string]];
         [customQueryParser setDelimiterSupport:YES];
         queries = [[NSArray alloc] initWithArray:[customQueryParser splitStringIntoRangesByCharacter:';']];
         numberOfQueries = [queries count];
-        if(currentQueryRanges)
-            currentQueryRanges = [NSArray arrayWithArray:queries];
+        currentQueryRanges = [NSArray arrayWithArray:queries];
     } else {
         queries = [[NSArray alloc] initWithArray:currentQueryRanges];
     }
-    
+
     queryCount = [queries count];
     
     // Walk along the array of queries to identify the current query - taking into account

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1110,7 +1110,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     
     // Split the current text into ranges of queries
     // only if the textView was really changed, otherwise use the cache
-    if([[textView textStorage] editedMask] != 0 || [self textViewWasChanged] || currentQueryRanges != nil || currentQueryRanges.count == 0) {
+    if([[textView textStorage] editedMask] != 0 || [self textViewWasChanged] || currentQueryRanges == nil || currentQueryRanges.count == 0) {
         [self setTextViewWasChanged:NO];
         customQueryParser = [[SPSQLParser alloc] initWithString:[textView string]];
         [customQueryParser setDelimiterSupport:YES];


### PR DESCRIPTION

## Changes:
- May fix #640 in which the query editor seems to forget the selected query after running
- Basically, ensures we only use the cached set of split-up queries if they've actually been computed, and removes some weird text insertion code that was being run on query execution

## Closes following issues:
- Closes #640

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.1 (Big Sur)
- Xcode Version:
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
- Would be good to do a thorough review here and ensure this also fixes the issue for others as well.