### PR TITLE
 #fixed SPTableCopy _createTableStatementFor:inDatabase crash

### DIFF
--- a/Source/Other/DatabaseActions/SPTableCopy.m
+++ b/Source/Other/DatabaseActions/SPTableCopy.m
@@ -31,7 +31,7 @@
 #import "SPTableCopy.h"
 
 #import <SPMySQL/SPMySQL.h>
-@import Firebase;
+#import <FirebaseCrashlytics/FirebaseCrashlytics.h>
 
 @interface SPTableCopy ()
 

--- a/Source/Other/DatabaseActions/SPTableCopy.m
+++ b/Source/Other/DatabaseActions/SPTableCopy.m
@@ -31,6 +31,7 @@
 #import "SPTableCopy.h"
 
 #import <SPMySQL/SPMySQL.h>
+@import Firebase;
 
 @interface SPTableCopy ()
 
@@ -142,6 +143,21 @@
 
 - (NSString *)_createTableStatementFor:(NSString *)tableName inDatabase:(NSString *)sourceDatabase
 {
+
+    if([tableName respondsToSelector:@selector(backtickQuotedString)] == NO || [sourceDatabase respondsToSelector:@selector(backtickQuotedString)] == NO){
+        NSDictionary *userInfo = @{
+            NSLocalizedDescriptionKey: @"_createTableStatementFor: tableName or sourceDatabase does not respond to selector: backtickQuotedString",
+            @"tableName":tableName.class,
+            @"sourceDatabase":sourceDatabase.class
+        };
+
+        CLS_LOG(@"_createTableStatementFor: tableName or sourceDatabase does not respond to selector: backtickQuotedString");
+        SPLog(@"_createTableStatementFor: tableName or sourceDatabase does not respond to selector: backtickQuotedString");
+        [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"database" code:9 userInfo:userInfo]];
+
+        return  nil;
+    }
+
 	NSString *showCreateTableStatment = [NSString stringWithFormat:@"SHOW CREATE TABLE %@.%@", [sourceDatabase backtickQuotedString], [tableName backtickQuotedString]];
 	
 	SPMySQLResult *result = [connection queryString:showCreateTableStatment];


### PR DESCRIPTION
## Changes:
added guard around backtickQuotedString and added error logging.

## Closes following issues:
FB:e320aa784cf183254a06957b6e5313c5

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
