### PR TITLE
#fixed SPExtendedTableInfo loadTable crash

### DIFF
--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -323,7 +323,16 @@ static NSString *SPMySQLCommentField          = @"Comment";
 		// Populate type popup button
 		for (NSDictionary *engine in engines)
 		{
-			[tableTypePopUpButton addItemWithTitle:[engine objectForKey:SPMySQLEngineField]];
+            NSString *tmpEngine = [engine safeObjectForKey:SPMySQLEngineField];
+
+            if(tmpEngine == nil){
+                SPLog(@"engine string is nil: %@",engine );
+                CLS_LOG(@"engine string is nil: %@", engine);
+                // raise Crashyltics error?
+                continue;
+            }
+
+            [tableTypePopUpButton addItemWithTitle:tmpEngine];
 		}
 
 		[tableTypePopUpButton selectItemWithTitle:storageEngine];


### PR DESCRIPTION
## Changes:
added guard around engine being nil 

## Closes following issues:
FB: e942d93cd882bf1684843c692db5079b

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
