### PR TITLE
Improvements to Console #changed

### DIFF
--- a/Interfaces/Console.xib
+++ b/Interfaces/Console.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,11 +23,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Console" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="3" userLabel="Console" customClass="NSPanel">
+        <window title="Console" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" titlebarAppearsTransparent="YES" id="3" userLabel="Console" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowCollectionBehavior key="collectionBehavior" participatesInCycle="YES" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="426" y="331" width="575" height="203"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
             <value key="minSize" type="size" width="575" height="130"/>
             <view key="contentView" id="4">
                 <rect key="frame" x="0.0" y="0.0" width="575" height="203"/>
@@ -53,11 +54,11 @@
                         <rect key="frame" x="0.0" y="32" width="576" height="134"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="Jw2-4l-Mr3">
-                            <rect key="frame" x="1" y="0.0" width="574" height="133"/>
+                            <rect key="frame" x="1" y="1" width="574" height="132"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" rowHeight="16" headerView="112" id="14">
-                                    <rect key="frame" x="0.0" y="0.0" width="574" height="116"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="574" height="115"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -236,7 +237,10 @@
                     </button>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="139.5" y="161.5"/>
+            <connections>
+                <outlet property="delegate" destination="-2" id="9BU-PA-RsE"/>
+            </connections>
+            <point key="canvasLocation" x="-55" y="139"/>
         </window>
         <customView id="49" userLabel="saveLogView">
             <rect key="frame" x="0.0" y="0.0" width="278" height="79"/>
@@ -277,7 +281,14 @@
                         <action selector="copy:" target="-2" id="69"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Copy Raw Query" id="dsy-Yk-yWd">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="copyQueryOnly:" target="-2" id="h9k-0G-NSI"/>
+                    </connections>
+                </menuItem>
             </items>
+            <point key="canvasLocation" x="-197" y="150"/>
         </menu>
         <userDefaultsController representsSharedInstance="YES" id="89"/>
         <menu id="DCA-JR-zjw" userLabel="Table Header Context Menu">
@@ -322,7 +333,7 @@
         </menu>
     </objects>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="NSStopProgressFreestandingTemplate" width="14" height="14"/>
+        <image name="NSActionTemplate" width="15" height="15"/>
+        <image name="NSStopProgressFreestandingTemplate" width="15" height="15"/>
     </resources>
 </document>

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3404,6 +3404,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 	// Show/hide console
 	if (action == @selector(toggleConsole:)) {
 		[menuItem setTitle:([[[SPQueryController sharedQueryController] window] isVisible] && [[[NSApp keyWindow] windowController] isKindOfClass:[SPQueryController class]]) ? NSLocalizedString(@"Hide Console", @"hide console") : NSLocalizedString(@"Show Console", @"show console")];
+        return YES;
 	}
 	
 	// Clear console

--- a/Source/Controllers/SubviewControllers/SPQueryController.h
+++ b/Source/Controllers/SubviewControllers/SPQueryController.h
@@ -82,6 +82,7 @@ extern NSString *SPTableViewDatabaseColumnID;
  * puts the output into the general Pasteboard (only if non-empty)
  */
 - (IBAction)copy:(id)sender;
+- (IBAction)copyQueryOnly:(id)sender;
 - (IBAction)clearConsole:(id)sender;
 - (IBAction)saveConsoleAs:(id)sender;
 - (IBAction)toggleShowTimeStamps:(id)sender;
@@ -111,7 +112,7 @@ extern NSString *SPTableViewDatabaseColumnID;
  *
  * THIS METHOD IS NOT THREAD-SAFE!
  */
-- (NSString *)sqlStringForRowIndexes:(NSIndexSet *)indexes;
+- (NSString *)infoStringForRowIndexes:(NSIndexSet *)rows includeTimestamps:(BOOL)includeTimestamps includeConnections:(BOOL)includeConnections includeDatabases:(BOOL)includeDatabases;
 
 #pragma mark - SPQueryControllerInitializer
 

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -33,6 +33,7 @@
 #import "SPAppController.h"
 #import "SPFunctions.h"
 #import "pthread.h"
+#import "SPCopyTable.h"
 #import <fmdb/FMDB.h>
 
 #import "sequel-ace-Swift.h"
@@ -147,64 +148,85 @@ static SPQueryController *sharedQueryController = nil;
  */
 - (void)copy:(id)sender
 {
-	NSResponder *firstResponder = [[self window] firstResponder];
+    if (([consoleTableView numberOfSelectedRows] > 0 || [consoleTableView clickedRow] > -1)) {
+        NSIndexSet *rows = [consoleTableView selectedRowIndexes];
+        if([consoleTableView clickedRow] > -1 && ![rows containsIndex:[consoleTableView clickedRow]]) {
+            rows = [NSIndexSet indexSetWithIndex:[consoleTableView clickedRow]];
+        }
 
-	if ((firstResponder == consoleTableView) && ([consoleTableView numberOfSelectedRows] > 0)) {
-		
-		NSIndexSet *rows = [consoleTableView selectedRowIndexes];
 
-		NSString *string = [self sqlStringForRowIndexes:rows];
+        BOOL includeTimestamps  = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDateColumnID] isHidden];
+        BOOL includeConnections = ![[consoleTableView tableColumnWithIdentifier:SPTableViewConnectionColumnID] isHidden];
+        BOOL includeDatabases   = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDatabaseColumnID] isHidden];
+        NSString *string = [self infoStringForRowIndexes:rows includeTimestamps:includeTimestamps includeConnections:includeConnections includeDatabases:includeDatabases];
 
-		NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
+        NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
 
-		// Copy the string to the pasteboard
-		[pasteBoard declareTypes:@[NSStringPboardType] owner:nil];
-		[pasteBoard setString:string forType:NSStringPboardType];
-	}
+        // Copy the string to the pasteboard
+        [pasteBoard declareTypes:@[NSStringPboardType] owner:self];
+        [pasteBoard setString:string forType:NSStringPboardType];
+    }
 }
 
-- (NSString *)sqlStringForRowIndexes:(NSIndexSet *)rows
+/**
+ * Copy implementation for console table view.
+ */
+- (void)copyQueryOnly:(id)sender
 {
-	if(![rows count]) return @"";
-	
-	NSMutableString *string = [[NSMutableString alloc] init];
-	
-	BOOL includeTimestamps  = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDateColumnID] isHidden];
-	BOOL includeConnections = ![[consoleTableView tableColumnWithIdentifier:SPTableViewConnectionColumnID] isHidden];
-	BOOL includeDatabases   = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDatabaseColumnID] isHidden];
-	
-	[rows enumerateIndexesUsingBlock:^(NSUInteger i, BOOL * _Nonnull stop) {
-		if (i < [messagesVisibleSet count]) {
-			SPConsoleMessage *message = [messagesVisibleSet safeObjectAtIndex:i];
-			
-			if (includeTimestamps || includeConnections || includeDatabases) [string appendString:@"/* "];
-			
-			NSDate *date = [message messageDate];
-			if (includeTimestamps && date) {
-				[string appendString:[dateFormatter stringFromDate:date]];
-				[string appendString:@" "];
-			}
-			
-			NSString *connection = [message messageConnection];
-			if (includeConnections && connection) {
-				[string appendString:connection];
-				[string appendString:@" "];
-			}
-			
-			NSString *database = [message messageDatabase];
-			if (includeDatabases && database) {
-				[string appendString:database];
-				[string appendString:@" "];
-			}
-			
-			if (includeTimestamps || includeConnections || includeDatabases) [string appendString:@"*/ "];
-			
-			[string appendString:[message message]];
-			[string appendString:@"\n"];
-		}
-	}];
-	
-	return string;
+    if (([consoleTableView numberOfSelectedRows] > 0 || [consoleTableView clickedRow] > -1)) {
+        NSIndexSet *rows = [consoleTableView selectedRowIndexes];
+        if([consoleTableView clickedRow] > -1 && ![rows containsIndex:[consoleTableView clickedRow]]) {
+            rows = [NSIndexSet indexSetWithIndex:[consoleTableView clickedRow]];
+        }
+
+        NSString *string = [self infoStringForRowIndexes:rows includeTimestamps:NO includeConnections:NO includeDatabases:NO];
+
+        NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
+
+        // Copy the string to the pasteboard
+        [pasteBoard declareTypes:@[NSStringPboardType] owner:self];
+        [pasteBoard setString:string forType:NSStringPboardType];
+    }
+}
+
+- (NSString *)infoStringForRowIndexes:(NSIndexSet *)rows includeTimestamps:(BOOL)includeTimestamps includeConnections:(BOOL)includeConnections includeDatabases:(BOOL)includeDatabases
+{
+    if(![rows count]) return @"";
+
+    NSMutableString *string = [[NSMutableString alloc] init];
+
+    [rows enumerateIndexesUsingBlock:^(NSUInteger i, BOOL * _Nonnull stop) {
+        if (i < [messagesVisibleSet count]) {
+            SPConsoleMessage *message = [messagesVisibleSet safeObjectAtIndex:i];
+
+            if (includeTimestamps || includeConnections || includeDatabases) [string appendString:@"/* "];
+
+            NSDate *date = [message messageDate];
+            if (includeTimestamps && date) {
+                [string appendString:[dateFormatter stringFromDate:date]];
+                [string appendString:@" "];
+            }
+
+            NSString *connection = [message messageConnection];
+            if (includeConnections && connection) {
+                [string appendString:connection];
+                [string appendString:@" "];
+            }
+
+            NSString *database = [message messageDatabase];
+            if (includeDatabases && database) {
+                [string appendString:database];
+                [string appendString:@" "];
+            }
+
+            if (includeTimestamps || includeConnections || includeDatabases) [string appendString:@"*/ "];
+
+            [string appendString:[message message]];
+            [string appendString:@"\n"];
+        }
+    }];
+
+    return string;
 }
 
 /**
@@ -364,9 +386,19 @@ static SPQueryController *sharedQueryController = nil;
  */
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
+    // Disable "Copy with Column Names" and "Copy as SQL INSERT"
+    // in the main menu
+    if ([menuItem tag] == SPEditMenuCopyWithColumns || [menuItem tag] == SPEditMenuCopyAsSQL || [menuItem tag] == SPEditMenuCopyAsSQLNoAutoInc) {
+        return NO;
+    }
+    
 	if ([menuItem action] == @selector(copy:)) {
-		return ([consoleTableView numberOfSelectedRows] > 0);
+		return ([consoleTableView numberOfSelectedRows] > 0 || [consoleTableView clickedRow] > -1);
 	}
+
+    if ([menuItem action] == @selector(copyQueryOnly:)) {
+        return ([consoleTableView numberOfSelectedRows] > 0 || [consoleTableView clickedRow] > -1);
+    }
 
 	// Clear console
 	if ([menuItem action] == @selector(clearConsole:)) {
@@ -743,7 +775,11 @@ static SPQueryController *sharedQueryController = nil;
 
 - (BOOL)tableView:(NSTableView *)aTableView writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	NSString *string = [self sqlStringForRowIndexes:rowIndexes];
+    BOOL includeTimestamps  = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDateColumnID] isHidden];
+    BOOL includeConnections = ![[consoleTableView tableColumnWithIdentifier:SPTableViewConnectionColumnID] isHidden];
+    BOOL includeDatabases   = ![[consoleTableView tableColumnWithIdentifier:SPTableViewDatabaseColumnID] isHidden];
+
+    NSString *string = [self infoStringForRowIndexes:rowIndexes includeTimestamps:includeTimestamps includeConnections:includeConnections includeDatabases:includeDatabases];
 	if([string length]) {
 		[pboard declareTypes:@[NSStringPboardType] owner:self];
 		return [pboard setString:string forType:NSStringPboardType];

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3114,10 +3114,9 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 	}
 	// Disable "Copy with Column Names" and "Copy as SQL INSERT"
 	// in the main menu
-	if ( [menuItem tag] == SPEditMenuCopyWithColumns
-		|| [menuItem tag] == SPEditMenuCopyAsSQL) {
-		return NO;
-	}
+    if ([menuItem tag] == SPEditMenuCopyWithColumns || [menuItem tag] == SPEditMenuCopyAsSQL || [menuItem tag] == SPEditMenuCopyAsSQLNoAutoInc) {
+        return NO;
+    }
 
 	return [super validateMenuItem:menuItem];
 }


### PR DESCRIPTION
## Changes:
- Changed title bar to be transparent (I think it looks better)
- Added a new copy option to copy just the raw query (without comment with timestamp and db connection)
- Made right click copy from console work properly in several cases it didn't before
  - When right clicking on a random row
  - When right clicking on an already-selected row
- Improved menu item validation to hide extraneous copy menu items when viewing the console
- Allow fullscreen view support from console

## Closes following issues:
- Closes 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.1 (Big Sur)
- Xcode Version: 12.3
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
 
## Screenshots:
<img width="674" alt="Screen Shot 2020-12-27 at 12 04 34" src="https://user-images.githubusercontent.com/10710367/103179266-ff1a0680-483e-11eb-868b-b0bf8a18ce27.png">


## Additional notes:
