### PR TITLE
#fixed spfieldmappercontroller match header names crash

### DIFF
--- a/Source/Controllers/DataImport/SPFieldMapperController.m
+++ b/Source/Controllers/DataImport/SPFieldMapperController.m
@@ -38,7 +38,7 @@
 #import "RegexKitLite.h"
 #import "SPDatabaseData.h"
 #import "SPFunctions.h"
-
+@import Firebase;
 #import <SPMySQL/SPMySQL.h>
 
 #import "sequel-ace-Swift.h"
@@ -1364,12 +1364,12 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 				dist = -1e6f;
 			}
 
-			[distMatrix addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-				[NSNumber numberWithFloat:dist], @"dist",
-				NSStringFromRange(NSMakeRange(i,j)), @"match",
-				(NSString*)fileHeaderName, @"file",
-                [tableHeaderNames safeObjectAtIndex:i], @"table",
-				nil]];
+            [distMatrix addObject:@{
+                @"dist": @(dist),
+                @"match": NSStringFromRange(NSMakeRange(i,j)),
+                @"file": (NSString*)fileHeaderName,
+                @"table": [tableHeaderNames safeObjectAtIndex:i]
+            }];
 
 		}
 
@@ -1388,7 +1388,15 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 			NSRange match = NSRangeFromString([m objectForKey:@"match"]);
 
 			// Set best match
-			[fieldMappingArray replaceObjectAtIndex:match.location withObject:[NSNumber numberWithInteger:match.length]];
+            if(match.location >= fieldMappingArray.count){
+                SPLog(@"match.location [%lu] >= fieldMappingArray.count [%lu]",(unsigned long)match.location, (unsigned long)fieldMappingArray.count );
+                CLS_LOG(@"match.location [%lu] >= fieldMappingArray.count [%lu]",(unsigned long)match.location, (unsigned long)fieldMappingArray.count );
+                CLS_LOG(@"fieldMappingArray = %@", m);
+                SPLog(@"fieldMappingArray = %@", m);
+                continue;
+            }
+
+			[fieldMappingArray replaceObjectAtIndex:match.location withObject:@(match.length)];
 			[fieldMappingOperatorArray replaceObjectAtIndex:match.location withObject:doImportKey];
 
 			// Remember matched pair

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -2593,7 +2593,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	for (NSUInteger i = 0; i < tableCount; i++)
 	{
         if([[tmpTableTypes safeObjectAtIndex:i] integerValue] == type){
-            [returnArray addObject:[tmpTableTypes safeObjectAtIndex:i]];
+            [returnArray addObject:[[self tables] safeObjectAtIndex:i]];
         }
 	}
 


### PR DESCRIPTION
## Changes:
added guard match.location >= fieldMappingArray.count and some logging

## Closes following issues:
FB: c24715dd7c0981dd707137d642ee26ec

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
