### PR TITLE
Always show tab bar as native macOS apps, cleanup tab bar code #changed

### DIFF
--- a/Frameworks/PSMTabBar/PSMTabBarCell.h
+++ b/Frameworks/PSMTabBar/PSMTabBarCell.h
@@ -16,7 +16,6 @@
     // sizing
     NSRect              _frame;
     NSSize              _stringSize;
-    NSInteger                 _currentStep;
     BOOL                _isPlaceholder;
     
     // state

--- a/Frameworks/PSMTabBar/PSMTabBarCell.h
+++ b/Frameworks/PSMTabBar/PSMTabBarCell.h
@@ -16,6 +16,7 @@
     // sizing
     NSRect              _frame;
     NSSize              _stringSize;
+    NSInteger                 _currentStep;
     BOOL                _isPlaceholder;
     
     // state

--- a/Frameworks/PSMTabBar/PSMTabBarCell.m
+++ b/Frameworks/PSMTabBar/PSMTabBarCell.m
@@ -252,22 +252,6 @@
     _isPlaceholder = value;
 }
 
-- (NSInteger)currentStep
-{
-    return _currentStep;
-}
-
-- (void)setCurrentStep:(NSInteger)value
-{
-    if(value < 0)
-        value = 0;
-    
-    if(value > (kPSMTabDragAnimationSteps - 1))
-        value = (kPSMTabDragAnimationSteps - 1);
-    
-    _currentStep = value;
-}
-
 - (BOOL)isEdited
 {
     return _isEdited;
@@ -418,7 +402,6 @@
     if ([aCoder allowsKeyedCoding]) {
         [aCoder encodeRect:_frame forKey:@"frame"];
         [aCoder encodeSize:_stringSize forKey:@"stringSize"];
-        [aCoder encodeInteger:_currentStep forKey:@"currentStep"];
         [aCoder encodeBool:_isPlaceholder forKey:@"isPlaceholder"];
         [aCoder encodeInteger:_tabState forKey:@"tabState"];
         [aCoder encodeInteger:_closeButtonTrackingTag forKey:@"closeButtonTrackingTag"];
@@ -440,7 +423,6 @@
         if ([aDecoder allowsKeyedCoding]) {
             _frame = [aDecoder decodeRectForKey:@"frame"];
             _stringSize = [aDecoder decodeSizeForKey:@"stringSize"];
-            _currentStep = [aDecoder decodeIntegerForKey:@"currentStep"];
             _isPlaceholder = [aDecoder decodeBoolForKey:@"isPlaceholder"];
             _tabState = [aDecoder decodeIntegerForKey:@"tabState"];
             _closeButtonTrackingTag = [aDecoder decodeIntegerForKey:@"closeButtonTrackingTag"];

--- a/Frameworks/PSMTabBar/PSMTabBarCell.m
+++ b/Frameworks/PSMTabBar/PSMTabBarCell.m
@@ -252,6 +252,22 @@
     _isPlaceholder = value;
 }
 
+- (NSInteger)currentStep
+{
+    return _currentStep;
+}
+
+- (void)setCurrentStep:(NSInteger)value
+{
+    if(value < 0)
+        value = 0;
+    
+    if(value > (kPSMTabDragAnimationSteps - 1))
+        value = (kPSMTabDragAnimationSteps - 1);
+    
+    _currentStep = value;
+}
+
 - (BOOL)isEdited
 {
     return _isEdited;

--- a/Frameworks/PSMTabBar/PSMTabBarCell.m
+++ b/Frameworks/PSMTabBar/PSMTabBarCell.m
@@ -129,7 +129,7 @@
     _frame = rect;
 	
 	//move the status indicator along with the rest of the cell
-	if (![[self indicator] isHidden] && ![_customControlView isTabBarHidden]) {
+	if (![[self indicator] isHidden]) {
 		[[self indicator] setFrame:[self indicatorRectForFrame:rect]];
 	}
 }
@@ -210,7 +210,6 @@
 - (void)setHasIcon:(BOOL)value
 {
     _hasIcon = value;
-    //[_customControlView update:[[self customControlView] automaticallyAnimates]]; // binding notice is too fast
 }
 
 - (BOOL)hasLargeImage
@@ -231,7 +230,6 @@
 - (void)setCount:(NSInteger)value
 {
     _count = value;
-    //[_customControlView update:[[self customControlView] automaticallyAnimates]]; // binding notice is too fast
 }
 
 - (NSColor *)countColor
@@ -278,7 +276,6 @@
 - (void)setIsEdited:(BOOL)value
 {
     _isEdited = value;
-    //[_customControlView update:[[self customControlView] automaticallyAnimates]]; // binding notice is too fast
 }
 
 - (NSColor *)backgroundColor {

--- a/Frameworks/PSMTabBar/PSMTabBarControl.h
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.h
@@ -16,7 +16,6 @@
 #define PSMTabDragDidBeginNotification @"PSMTabDragDidBeginNotification"
 
 #define kPSMTabBarControlHeight 25
-#define kPSMTabBarControlDefaultHeightCollapsed 0 // can be changed with a property
 
 // internal cell border
 #define MARGIN_X        6
@@ -75,7 +74,6 @@ enum {
 	id<PSMTabStyle>			style;
 	BOOL					_canCloseOnlyTab;
 	BOOL					_disableTabClose;
-	BOOL					_hideForSingleTab;
 	BOOL					_showAddTabButton;
 	BOOL					_sizeCellsToFit;
 	BOOL					_useOverflowMenu;
@@ -84,8 +82,6 @@ enum {
 	BOOL					_useSafariStyleDragging;
 	NSInteger				_resizeAreaCompensation;
 	PSMTabBarOrientation	_orientation;
-	BOOL					_automaticallyAnimates;
-	NSTimer					*_animationTimer;
 	PSMTabBarTearOffStyle	_tearOffStyle;
 	
 	// behavior
@@ -108,11 +104,9 @@ enum {
 	
 	// animation for hide/show
 	NSInteger				_currentStep;
-	BOOL					_isHidden;
 	IBOutlet id				partnerView;				// gets resized when hide/show
 	BOOL					_awakenedFromNib;
 	NSInteger				_tabBarWidth;
-	NSTimer					*_showHideAnimationTimer;
 
 	// Tracking last window state for update draws
 	BOOL					_lastWindowIsMainCheck;
@@ -144,8 +138,6 @@ enum {
 - (void)setStyle:(id <PSMTabStyle>)newStyle;
 - (NSString *)styleName;
 - (void)setStyleNamed:(NSString *)name;
-- (BOOL)hideForSingleTab;
-- (void)setHideForSingleTab:(BOOL)value;
 - (BOOL)showAddTabButton;
 - (void)setShowAddTabButton:(BOOL)value;
 
@@ -177,8 +169,6 @@ enum {
 - (void)setSelectsTabsOnMouseDown:(BOOL)value;
 - (BOOL)createsTabOnDoubleClick;
 - (void)setCreatesTabOnDoubleClick:(BOOL)value;
-- (BOOL)automaticallyAnimates;
-- (void)setAutomaticallyAnimates:(BOOL)value;
 - (BOOL)alwaysShowActiveTab;
 - (void)setAlwaysShowActiveTab:(BOOL)value;
 - (BOOL)allowsScrubbing;
@@ -187,7 +177,6 @@ enum {
 - (void)setUsesSafariStyleDragging:(BOOL)value;
 - (PSMTabBarTearOffStyle)tearOffStyle;
 - (void)setTearOffStyle:(PSMTabBarTearOffStyle)tearOffStyle;
-@property CGFloat heightCollapsed;
 
 // accessors
 - (NSTabView *)tabView;
@@ -212,9 +201,6 @@ enum {
 
 // special effects
 - (void)hideTabBar:(BOOL)hide animate:(BOOL)animate;
-- (BOOL)isTabBarHidden;
-- (BOOL)isAnimating;
-- (void)destroyAnimations;
 
 // internal bindings methods also used by the tab drag assistant
 - (void)bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item;

--- a/Frameworks/PSMTabBar/PSMTabBarControl.h
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.h
@@ -190,16 +190,14 @@ enum {
 - (NSUInteger)numberOfVisibleTabs;
 - (PSMTabBarCell *)lastVisibleTab;
 
-// special effects
-- (void)hideTabBar:(BOOL)hide animate:(BOOL)animate;
-
 // internal bindings methods also used by the tab drag assistant
 - (void)bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item;
 - (void)removeTabForCell:(PSMTabBarCell *)cell;
 
 // External drawing accessors
 - (void)update;
-- (void)updateTabs:(BOOL)updateTabs;
+- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs;
+- (void)updateTabs;
 
 @end
 

--- a/Frameworks/PSMTabBar/PSMTabBarControl.h
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.h
@@ -190,14 +190,16 @@ enum {
 - (NSUInteger)numberOfVisibleTabs;
 - (PSMTabBarCell *)lastVisibleTab;
 
+// special effects
+- (void)hideTabBar:(BOOL)hide animate:(BOOL)animate;
+
 // internal bindings methods also used by the tab drag assistant
 - (void)bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item;
 - (void)removeTabForCell:(PSMTabBarCell *)cell;
 
 // External drawing accessors
 - (void)update;
-- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs;
-- (void)updateTabs;
+- (void)updateTabs:(BOOL)updateTabs;
 
 @end
 

--- a/Frameworks/PSMTabBar/PSMTabBarControl.h
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.h
@@ -28,13 +28,6 @@
 #define kPSMMinimumTitleWidth 30
 #define kPSMTabBarIndicatorWidth 16.0f
 #define kPSMTabBarIconWidth 16.0f
-#define kPSMHideAnimationSteps 3.0f
-
-// Value used in _currentStep to indicate that resizing operation is not in progress
-#define kPSMIsNotBeingResized -1
-
-// Value used in _currentStep when a resizing operation has just been started
-#define kPSMStartResizeAnimation 0
 
 @class PSMOverflowPopUpButton, PSMRolloverButton, PSMTabBarCell, PSMTabBarController;
 @protocol PSMTabStyle;
@@ -102,8 +95,6 @@ enum {
 	NSInteger				_cellMaxWidth;
 	NSInteger				_cellOptimumWidth;
 	
-	// animation for hide/show
-	NSInteger				_currentStep;
 	IBOutlet id				partnerView;				// gets resized when hide/show
 	BOOL					_awakenedFromNib;
 	NSInteger				_tabBarWidth;
@@ -208,7 +199,7 @@ enum {
 
 // External drawing accessors
 - (void)update;
-- (void)update:(BOOL)animate;
+- (void)updateTabs:(BOOL)updateTabs;
 
 @end
 

--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -35,7 +35,7 @@
 - (void)_setupTrackingRectsForCell:(PSMTabBarCell *)cell;
 - (void)_positionOverflowMenu;
 - (void)_checkWindowFrame;
-- (void)update:(BOOL)animate updateTabs:(BOOL)updateTabs;
+- (void)updateTabs:(BOOL)updateTabs;
 
     // actions
 - (void)closeTabClick:(id)sender;
@@ -121,7 +121,6 @@
 	_lastMouseDownEvent = nil;
 	
     // default config
-	_currentStep = kPSMIsNotBeingResized;
 	_orientation = PSMTabBarHorizontalOrientation;
     _canCloseOnlyTab = NO;
 	_disableTabClose = NO;
@@ -350,7 +349,7 @@
 		[[self style] setOrientation:_orientation];
 
         [self _positionOverflowMenu]; //move the overflow popup button to the right place
-		[self update:NO];
+		[self update];
 	}
 }
 
@@ -717,8 +716,6 @@
 	
     [[self subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
 
-    _currentStep = (NSInteger)kPSMHideAnimationSteps;
-
     [self addSubview:_overflowPopUpButton];
     [self addSubview:_addTabButton];
 
@@ -839,15 +836,10 @@
         [self setFrame:myNewFrame];
     }
     
-    // next
-    _currentStep++;
-    if (_currentStep == kPSMHideAnimationSteps + 1) {
-		_currentStep = kPSMIsNotBeingResized;
-        [self viewDidEndLiveResize];
-        [self update:NO];
-        if ([self delegate] && [[self delegate] respondsToSelector:@selector(tabView:tabBarDidUnhide:)]) {
-            [[self delegate] tabView:[self tabView] tabBarDidUnhide:self];
-        }
+    [self viewDidEndLiveResize];
+    [self update];
+    if ([self delegate] && [[self delegate] respondsToSelector:@selector(tabView:tabBarDidUnhide:)]) {
+        [[self delegate] tabView:[self tabView] tabBarDidUnhide:self];
     }
     [[self window] display];
 }
@@ -877,15 +869,10 @@
 
 - (void)update
 {
-	[self update:NO];
+	[self updateTabs:YES];
 }
 
-- (void)update:(BOOL)animate
-{
-	[self update:animate updateTabs:YES];
-}
-
-- (void)update:(BOOL)animate updateTabs:(BOOL)updateTabs
+- (void)updateTabs:(BOOL)updateTabs
 {
     // make sure all of our tabs are accounted for before updating,
 	// or only proceed if a drag is in progress (where counts may mismatch)
@@ -1332,7 +1319,7 @@
 							   afterDelay:0];
 	}
 
-	[self update:NO updateTabs:NO];
+	[self updateTabs:NO];
 }
 
 - (void)viewDidMoveToWindow
@@ -1359,7 +1346,7 @@
     }
 	
 	[self _checkWindowFrame];
-    [self update:NO];
+    [self update];
 }
 
 - (void)resetCursorRects
@@ -1533,7 +1520,6 @@
         [aCoder encodeInteger:_cellMinWidth forKey:@"PSMcellMinWidth"];
         [aCoder encodeInteger:_cellMaxWidth forKey:@"PSMcellMaxWidth"];
         [aCoder encodeInteger:_cellOptimumWidth forKey:@"PSMcellOptimumWidth"];
-        [aCoder encodeInteger:_currentStep forKey:@"PSMcurrentStep"];
         [aCoder encodeObject:partnerView forKey:@"PSMpartnerView"];
         [aCoder encodeBool:_awakenedFromNib forKey:@"PSMawakenedFromNib"];
         [aCoder encodeObject:_lastMouseDownEvent forKey:@"PSMlastMouseDownEvent"];
@@ -1569,7 +1555,6 @@
             _cellMinWidth = [aDecoder decodeIntegerForKey:@"PSMcellMinWidth"];
             _cellMaxWidth = [aDecoder decodeIntegerForKey:@"PSMcellMaxWidth"];
             _cellOptimumWidth = [aDecoder decodeIntegerForKey:@"PSMcellOptimumWidth"];
-            _currentStep = [aDecoder decodeIntegerForKey:@"PSMcurrentStep"];
             partnerView = [aDecoder decodeObjectForKey:@"PSMpartnerView"];
             _awakenedFromNib = [aDecoder decodeBoolForKey:@"PSMawakenedFromNib"];
             _lastMouseDownEvent = [aDecoder decodeObjectForKey:@"PSMlastMouseDownEvent"];
@@ -1604,7 +1589,7 @@
 {
     // this is called any time the view is resized in IB
     [self setFrame:newFrame];
-    [self update:NO];
+    [self update];
 }
 
 #pragma mark -

--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -35,7 +35,7 @@
 - (void)_setupTrackingRectsForCell:(PSMTabBarCell *)cell;
 - (void)_positionOverflowMenu;
 - (void)_checkWindowFrame;
-- (void)updateTabs:(BOOL)updateTabs;
+- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs;
 
     // actions
 - (void)closeTabClick:(id)sender;
@@ -708,8 +708,7 @@
 #pragma mark -
 #pragma mark Hide/Show
 
-- (void)hideTabBar:(BOOL)hide animate:(BOOL)animate
-{
+- (void)updateTabs {
     if (!_awakenedFromNib) {
         return;
 	}
@@ -869,10 +868,10 @@
 
 - (void)update
 {
-	[self updateTabs:YES];
+	[self updateTabBarAndUpdateTabs:YES];
 }
 
-- (void)updateTabs:(BOOL)updateTabs
+- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs
 {
     // make sure all of our tabs are accounted for before updating,
 	// or only proceed if a drag is in progress (where counts may mismatch)
@@ -881,7 +880,7 @@
     }
 
 	if (updateTabs) {
-        [self hideTabBar:NO animate:YES];
+        [self updateTabs];
 	}
 	
     [self removeAllToolTips];
@@ -1319,7 +1318,7 @@
 							   afterDelay:0];
 	}
 
-	[self updateTabs:NO];
+	[self updateTabBarAndUpdateTabs:NO];
 }
 
 - (void)viewDidMoveToWindow

--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -39,7 +39,6 @@
 
     // actions
 - (void)closeTabClick:(id)sender;
-- (void)tabNothing:(id)sender;
 
 	// notification handlers
 - (void)frameDidChange:(NSNotification *)notification;
@@ -1135,8 +1134,6 @@
 					[self performSelector:@selector(tabClick:) withObject:cell];
 				}
 
-			} else {
-				[self performSelector:@selector(tabNothing:) withObject:cell];
 			}
 		}
 		
@@ -1297,27 +1294,9 @@
     [tabView selectTabViewItem:[sender representedObject]];
 }
 
-- (void)tabNothing:(id)sender
-{
-    //[self update];  // takes care of highlighting based on state
-}
-
 - (void)frameDidChange:(NSNotification *)notification
 {
 	[self _checkWindowFrame];
-
-	// trying to address the drawing artifacts for the progress indicators - hackery follows
-	// this one fixes the "blanking" effect when the control hides and shows itself
-	NSEnumerator *e = [_cells objectEnumerator];
-	PSMTabBarCell *cell;
-	while ( (cell = [e nextObject]) ) {
-		[[cell indicator] stopAnimation:self];
-
-		[[cell indicator] performSelector:@selector(startAnimation:)
-							   withObject:nil
-							   afterDelay:0];
-	}
-
 	[self updateTabBarAndUpdateTabs:NO];
 }
 

--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -35,7 +35,7 @@
 - (void)_setupTrackingRectsForCell:(PSMTabBarCell *)cell;
 - (void)_positionOverflowMenu;
 - (void)_checkWindowFrame;
-- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs;
+- (void)updateTabs:(BOOL)updateTabs;
 
     // actions
 - (void)closeTabClick:(id)sender;
@@ -708,7 +708,8 @@
 #pragma mark -
 #pragma mark Hide/Show
 
-- (void)updateTabs {
+- (void)hideTabBar:(BOOL)hide animate:(BOOL)animate
+{
     if (!_awakenedFromNib) {
         return;
 	}
@@ -868,10 +869,10 @@
 
 - (void)update
 {
-	[self updateTabBarAndUpdateTabs:YES];
+	[self updateTabs:YES];
 }
 
-- (void)updateTabBarAndUpdateTabs:(BOOL)updateTabs
+- (void)updateTabs:(BOOL)updateTabs
 {
     // make sure all of our tabs are accounted for before updating,
 	// or only proceed if a drag is in progress (where counts may mismatch)
@@ -880,7 +881,7 @@
     }
 
 	if (updateTabs) {
-        [self updateTabs];
+        [self hideTabBar:NO animate:YES];
 	}
 	
     [self removeAllToolTips];
@@ -1318,7 +1319,7 @@
 							   afterDelay:0];
 	}
 
-	[self updateTabBarAndUpdateTabs:NO];
+	[self updateTabs:NO];
 }
 
 - (void)viewDidMoveToWindow

--- a/Frameworks/PSMTabBar/PSMTabBarController.m
+++ b/Frameworks/PSMTabBar/PSMTabBarController.m
@@ -573,7 +573,7 @@ static NSInteger potentialMinimumForArray(NSArray *array, NSInteger minimum)
             [cell setIsInOverflowMenu:NO];
             
             // indicator
-            if (![[cell indicator] isHidden] && ![_control isTabBarHidden]) {
+            if (![[cell indicator] isHidden]) {
 				if (![[_control subviews] containsObject:[cell indicator]]) {
                     [_control addSubview:[cell indicator]];
                     [[cell indicator] startAnimation:self];

--- a/Frameworks/PSMTabBar/PSMTabDragAssistant.m
+++ b/Frameworks/PSMTabBar/PSMTabDragAssistant.m
@@ -16,7 +16,7 @@
 #define PI 3.1417
 
 @interface PSMTabBarControl (Private)
-- (void)update:(BOOL)animate;
+- (void)update;
 @end
 
 @interface PSMTabDragAssistant (Private)
@@ -217,7 +217,7 @@ static PSMTabDragAssistant *sharedDragAssistant = nil;
 		// The placeholder is later removed by distributePlaceholdersInTabBar:.
 		PSMTabBarCell *pc = [[PSMTabBarCell alloc] initPlaceholderWithFrame:[[self draggedCell] frame] expanded:NO inControlView:control];
 		[[control cells] addObject:pc];
-		[control update:NO];
+		[control update];
 
 		// Deselect any currently selected tabs after the update
 		for (PSMTabBarCell *aCell in [control cells]) {
@@ -453,7 +453,7 @@ static PSMTabDragAssistant *sharedDragAssistant = nil;
 				[[[self sourceTabBar] tabView] removeTabViewItem:[[self draggedCell] representedObject]];
 				
 				[[control tabView] addTabViewItem:[[self draggedCell] representedObject]];
-				[control update:NO]; //make sure the new tab is set in the correct position
+				[control update]; //make sure the new tab is set in the correct position
 				
 				if (_currentTearOffStyle == PSMTabBarTearOffAlphaWindow) {
 				
@@ -930,7 +930,7 @@ static PSMTabDragAssistant *sharedDragAssistant = nil;
         }
     }
     // redraw
-    [control update:NO];
+    [control update];
 }
 
 #pragma mark -

--- a/Frameworks/PSMTabBar/PSMTabDragAssistant.m
+++ b/Frameworks/PSMTabBar/PSMTabDragAssistant.m
@@ -375,15 +375,6 @@ static PSMTabDragAssistant *sharedDragAssistant = nil;
         [[[self sourceTabBar] tabView] removeTabViewItem:[[self draggedCell] representedObject]];
         [[[self destinationTabBar] tabView] insertTabViewItem:[[self draggedCell] representedObject] atIndex:insertIndex];
 		
-		//calculate the position for the dragged cell
-		if ([[self destinationTabBar] automaticallyAnimates]) {
-			if (insertIndex > 0) {
-				NSRect cellRect = [[cells objectAtIndex:insertIndex - 1] frame];
-				cellRect.origin.x += cellRect.size.width;
-				[[self draggedCell] setFrame:cellRect];
-			}
-		}
-		
 		//rebind the cell to the new control
 		[[self destinationTabBar] bindPropertiesForCell:[self draggedCell] andTabViewItem:[[self draggedCell] representedObject]];
 		

--- a/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
+++ b/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
@@ -387,7 +387,7 @@
     NSEnumerator *e = [[bar cells] objectEnumerator];
     PSMTabBarCell *cell;
     while ( (cell = [e nextObject]) ) {
-        if ([bar isAnimating] || (![cell isInOverflowMenu] && NSIntersectsRect([cell frame], rect))) {
+        if ((![cell isInOverflowMenu] && NSIntersectsRect([cell frame], rect))) {
             [cell drawWithFrame:[cell frame] inView:bar];
         }
     }
@@ -449,11 +449,7 @@
 }
 
 // Step 3
-- (void)drawTabCell:(PSMTabBarCell *)cell
-{
-	// Don't draw cells when collapsed
-	if ([tabBar isTabBarHidden]) return;
-
+- (void)drawTabCell:(PSMTabBarCell *)cell {
 	NSColor *lineColor = [self _lineColorForTabCellDrawing];
 	NSColor *fillColor = [self fillColorForCell:cell];
 

--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -529,13 +529,6 @@
                 <menuItem title="View" tag="3" id="496">
                     <menu key="submenu" title="View" id="498">
                         <items>
-                            <menuItem title="Show Tab Bar" keyEquivalent="t" id="1124">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="toggleTabBarShown:" target="-1" id="1127"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1125"/>
                             <menuItem title="Table Structure" keyEquivalent="1" id="497">
                                 <connections>
                                     <action selector="viewStructure:" target="-1" id="501"/>

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -561,11 +561,6 @@
 			SPWindowController *newWindowController = [[SPWindowController alloc] initWithWindowNibName:@"MainWindow"];
 			NSWindow *newWindow = [newWindowController window];
 
-			// If window has more than 1 tab then set setHideForSingleTab to NO
-			// in order to avoid animation problems while opening tabs
-			if([[window objectForKey:@"tabs"] count] > 1)
-				[newWindowController setHideForSingleTab:NO];
-
 			// The first window should use autosaving; subsequent windows should cascade.
 			// So attempt to set the frame autosave name; this will succeed for the very
 			// first window, and fail for others.
@@ -628,14 +623,6 @@
 
 			// Select active tab
 			[newWindowController selectTabAtIndex:[[window objectForKey:@"selectedTabIndex"] intValue]];
-
-			// Reset setHideForSingleTab
-			if ([[NSUserDefaults standardUserDefaults] objectForKey:SPAlwaysShowWindowTabBar]) {
-				[newWindowController setHideForSingleTab:[[NSUserDefaults standardUserDefaults] boolForKey:SPAlwaysShowWindowTabBar]];
-			}
-			else {
-				[newWindowController setHideForSingleTab:YES];
-			}
 		}
 	}
 

--- a/Source/Controllers/Window/SPWindowController.h
+++ b/Source/Controllers/Window/SPWindowController.h
@@ -59,10 +59,8 @@
 - (IBAction)closeTab:(id)sender;
 - (IBAction)selectNextDocumentTab:(id)sender;
 - (IBAction)selectPreviousDocumentTab:(id)sender;
-- (IBAction)toggleTabBarShown:(id)sender;
 - (NSArray *)documents;
 - (void)selectTabAtIndex:(NSInteger)index;
-- (void)setHideForSingleTab:(BOOL)hide;
 - (void)updateTabBar;
 
 @end

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -274,15 +274,6 @@
 }
 
 /**
- * Toggle the tab bar's visibility.
- */
-- (IBAction)toggleTabBarShown:(id)sender
-{
-	[tabBar setHideForSingleTab:![tabBar hideForSingleTab]];
-	[[NSUserDefaults standardUserDefaults] setBool:![tabBar hideForSingleTab] forKey:SPAlwaysShowWindowTabBar];
-}
-
-/**
  * Menu item validation.
  */
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
@@ -293,13 +284,6 @@
 		[menuItem action] == @selector(moveSelectedTabInNewWindow:))
 	{
 		return ([tabView numberOfTabViewItems] != 1);
-	}
-
-	// Show/hide Tab bar
-	if ([menuItem action] == @selector(toggleTabBarShown:)) {
-		[menuItem setTitle:(![tabBar isTabBarHidden] ? NSLocalizedString(@"Hide Tab Bar", @"hide tab bar") : NSLocalizedString(@"Show Tab Bar", @"show tab bar"))];
-		
-		return [[tabBar cells] count] <= 1;
 	}
 	
 	// See if the front document blocks validation of this item
@@ -333,11 +317,6 @@
 	}
 }
 
-- (void)setHideForSingleTab:(BOOL)hide
-{
-	[tabBar setHideForSingleTab:hide];
-}
-
 /**
  * Opens the current connection in a new tab, but only if it's already connected.
  */
@@ -359,8 +338,6 @@
 			collapse = YES;
 		}
 	}
-	
-	tabBar.heightCollapsed = collapse ? 8 : 1;
 	
 	[tabBar update];
 }
@@ -423,7 +400,6 @@
 {
 	[tabBar setStyleNamed:@"SequelPro"];
 	[tabBar setCanCloseOnlyTab:NO];
-	[tabBar setHideForSingleTab:![[NSUserDefaults standardUserDefaults] boolForKey:SPAlwaysShowWindowTabBar]];
 	[tabBar setShowAddTabButton:YES];
 	[tabBar setSizeCellsToFit:NO];
 	[tabBar setCellMinWidth:100];
@@ -796,9 +772,7 @@
 	}
 
 	// Adjust the positioning as appropriate
-	point.y += toolbarHeight;
-
-	if ([[NSUserDefaults standardUserDefaults] boolForKey:SPAlwaysShowWindowTabBar]) point.y += kPSMTabBarControlHeight;
+	point.y += toolbarHeight + kPSMTabBarControlHeight;
 
 	// Set the new window position and size
 	NSRect targetWindowFrame = [[self window] frame];
@@ -880,7 +854,7 @@
  */
 - (void)tabDragStarted:(id)sender
 {
-	[tabBar setHideForSingleTab:NO];
+    
 }
 
 /**
@@ -888,9 +862,7 @@
  */
 - (void)tabDragStopped:(id)sender
 {
-	if (![[NSUserDefaults standardUserDefaults] boolForKey:SPAlwaysShowWindowTabBar]) {
-		[tabBar setHideForSingleTab:YES];
-	}
+
 }
 
 #pragma mark -
@@ -900,9 +872,6 @@
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	
 	[NSObject cancelPreviousPerformRequestsWithTarget:self];
-	
-	// Tear down the animations on the tab bar to stop redraws
-	[tabBar destroyAnimations];
 }
 
 @end

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -265,7 +265,7 @@
 	[[control tabView] addTabViewItem:selectedTabViewItem];
 
 	// Make sure the new tab is set in the correct position by forcing an update
-	[tabBar update:NO];
+	[tabBar update];
 
 	// Update tabBar of the new window
 	[newWindowController tabView:[tabBar tabView] didDropTabViewItem:[selectedCell representedObject] inTabBar:control];

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -392,7 +392,6 @@ extern NSString *SPProcessListEnableAutoRefresh;
 extern NSString *SPProcessListAutoRrefreshInterval;
 extern NSString *SPFavoritesSortedBy;
 extern NSString *SPFavoritesSortedInReverse;
-extern NSString *SPAlwaysShowWindowTabBar;
 extern NSString *SPResetAutoIncrementAfterDeletionOfAllRows;
 extern NSString *SPFavoriteColorList;
 extern NSString *SPDisplayBinaryDataAsHex;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -198,7 +198,6 @@ NSString *SPProcessListEnableAutoRefresh         = @"ProcessListEnableAutoRefres
 NSString *SPProcessListAutoRrefreshInterval      = @"ProcessListAutoRrefreshInterval";
 NSString *SPFavoritesSortedBy                    = @"FavoritesSortedBy";
 NSString *SPFavoritesSortedInReverse             = @"FavoritesSortedInReverse";
-NSString *SPAlwaysShowWindowTabBar               = @"WindowAlwaysShowTabBar";
 NSString *SPResetAutoIncrementAfterDeletionOfAllRows = @"ResetAutoIncrementAfterDeletionOfAllRows";
 NSString *SPFavoriteColorList                    = @"FavoriteColorList";
 NSString *SPDisplayBinaryDataAsHex               = @"DisplayBinaryDataAsHex";


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Remove option to show / hide tab bar - Safari and other native apps lately show tabs always with `+` button next to it
- Cleanup a lot of legacy code

## Closes following issues:
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/707

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.3
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
