### PR TITLE
#fixed a few new crashes

### DIFF
--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -529,7 +529,7 @@
 
 						// Otherwise add a quoted string with special characters escaped
 						else {
-							[sqlString appendString:[connection escapeAndQuoteString:object]];
+							[sqlString appendStringOrNil:[connection escapeAndQuoteString:object]];
 						}
 						
 						// Add the field separator if this isn't the last cell in the row

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2291,7 +2291,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
     if ((isTestingConnection || !connectionSSHKeychainItemName || (connectionSSHKeychainItemName && ![[self sshPassword] isEqualToString:@"SequelAceSecretPassword"])) && [self sshPassword]) {
         [sshTunnel setPassword:[self sshPassword]];
     } else if (connectionSSHKeychainItemName) {
-		[sshTunnel setPasswordKeychainName:connectionSSHKeychainItemName account:connectionSSHKeychainItemAccount];
+		[sshTunnel setPasswordKeychainName:connectionSSHKeychainItemName account:connectionSSHKeychainItemAccount]; // FIXME: not error checked?
 	}
 
 	// Set the public key path if appropriate

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -105,6 +105,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 // Privately redeclare as read/write to get the synthesized setter
 @property (readwrite, assign) BOOL allowSplitViewResizing;
 
+// images
+@property (nonatomic, strong) NSImage *hideConsoleImage;
+@property (nonatomic, strong) NSImage *showConsoleImage;
+@property (nonatomic, strong) NSImage *textAndCommandMacwindowImage API_AVAILABLE(macos(11.0));
+
 - (void)_addDatabase;
 - (void)_alterDatabase;
 - (void)_copyDatabase;
@@ -146,6 +151,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 @synthesize tableContentInstance;
 @synthesize customQueryInstance;
 @synthesize allowSplitViewResizing;
+@synthesize hideConsoleImage;
+@synthesize showConsoleImage;
+@synthesize textAndCommandMacwindowImage;
 
 #pragma mark -
 
@@ -180,6 +188,12 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 		statusLoaded = NO;
 		triggersLoaded = NO;
 		relationsLoaded = NO;
+
+        hideConsoleImage = [NSImage imageNamed:@"hideconsole"];
+        showConsoleImage = [NSImage imageNamed:@"showconsole"];
+        if (@available(macOS 11.0, *)) {
+            textAndCommandMacwindowImage = [NSImage imageWithSystemSymbolName:@"text.and.command.macwindow" accessibilityDescription:nil];
+        }
 
 		selectedDatabase = nil;
 		selectedDatabaseEncoding = @"latin1";
@@ -3690,9 +3704,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 		[toolbarItem setLabel:NSLocalizedString(@"Console", @"Console")];
 		if (@available(macOS 11.0, *)) {
-			[toolbarItem setImage:[NSImage imageWithSystemSymbolName:@"text.and.command.macwindow" accessibilityDescription:nil]];
+			[toolbarItem setImage:textAndCommandMacwindowImage];
 		} else {
-			[toolbarItem setImage:[NSImage imageNamed:@"hideconsole"]];
+			[toolbarItem setImage:hideConsoleImage];
 		}
 
 		//set up the target action
@@ -3706,7 +3720,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 		//set up tooltip and image
 		[toolbarItem setToolTip:NSLocalizedString(@"Clear the console which shows all MySQL commands performed by Sequel Ace", @"tooltip for toolbar item for clear console")];
 		if (@available(macOS 11.0, *)) {
-			[toolbarItem setImage:[NSImage imageWithSystemSymbolName:@"text.and.command.macwindow" accessibilityDescription:nil]];
+			[toolbarItem setImage:textAndCommandMacwindowImage];
 		} else {
 			[toolbarItem setImage:[NSImage imageNamed:@"clearconsole"]];
 		}
@@ -3913,16 +3927,17 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 	if ([identifier isEqualToString:SPMainToolbarShowConsole]) {
 		NSWindow *queryWindow = [[SPQueryController sharedQueryController] window];
 
-		if (@available(macOS 11.0, *)) {
-			[toolbarItem setImage:[NSImage imageWithSystemSymbolName:@"text.and.command.macwindow" accessibilityDescription:nil]];
-		} else {
-			if ([queryWindow isVisible]) {
-				[toolbarItem setImage:[NSImage imageNamed:@"showconsole"]];
-			} else {
-                CLS_LOG(@"macOS < 11 and queryWindow is NOT Visible");
-				[toolbarItem setImage:[NSImage imageNamed:@"hideconsole"]];
-			}
-		}
+        if (@available(macOS 11.0, *)) {
+            toolbarItem.image = textAndCommandMacwindowImage;
+        } else {
+            if ([queryWindow isVisible]) {
+                toolbarItem.image = showConsoleImage;
+            } else {
+                 CLS_LOG(@"macOS < 11 and queryWindow is NOT Visible");
+                toolbarItem.image = hideConsoleImage;
+            }
+        }
+
 		if ([queryWindow isKeyWindow]) {
 			return NO;
 		} else {

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -354,16 +354,19 @@ static NSString *SPMySQLCommentField          = @"Comment";
 		// Populate encoding popup button
 		for (NSDictionary *encoding in encodings)
 		{
-			NSString *menuItemTitle = (![encoding objectForKey:@"DESCRIPTION"]) ? [encoding objectForKey:@"CHARACTER_SET_NAME"] : [NSString stringWithFormat:@"%@ (%@)", [encoding objectForKey:@"DESCRIPTION"], [encoding objectForKey:@"CHARACTER_SET_NAME"]];
+            NSString *encDesc    = [encoding safeObjectForKey:@"DESCRIPTION"];
+            NSString *encCharset = [encoding safeObjectForKey:@"CHARACTER_SET_NAME"];
 
-			[tableEncodingPopUpButton addItemWithTitle:menuItemTitle];
+			NSString *menuItemTitle = (!encDesc) ? encCharset : [NSString stringWithFormat:@"%@ (%@)", encDesc, encCharset];
 
-			if ([[tableDataInstance tableEncoding] isEqualToString:[encoding objectForKey:@"CHARACTER_SET_NAME"]]) {
+			if(menuItemTitle != nil) [tableEncodingPopUpButton addItemWithTitle:menuItemTitle];
+
+			if ([[tableDataInstance tableEncoding] isEqualToString:encCharset]) {
 				selectedTitle = menuItemTitle;
 			}
 		}
 
-		[tableEncodingPopUpButton selectItemWithTitle:selectedTitle];
+        if(selectedTitle != nil) [tableEncodingPopUpButton selectItemWithTitle:selectedTitle];
 		[tableEncodingPopUpButton setEnabled:enableInteraction];
 	}
 	else {

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1634,8 +1634,12 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	isEditingRow = YES;
 	isEditingNewRow = YES;
 	currentlyEditingRow = [tableContentView selectedRow];
-	if ( [multipleLineEditingButton state] == NSOffState )
-		[tableContentView editColumn:0 row:[tableContentView numberOfRows]-1 withEvent:nil select:YES];
+    if ( [multipleLineEditingButton state] == NSOffState ){
+        NSInteger numRows = [tableContentView numberOfRows];
+        if(numRows-1 != 0){
+            [tableContentView editColumn:0 row:numRows-1 withEvent:nil select:YES];
+        }
+    }
 }
 
 /**

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -715,3 +715,28 @@ typedef NS_ENUM(NSInteger,SPErrorCode) { // error codes in SPErrorDomain
 #define START_BENCH uint64_t dispatch_benchmark(size_t count, void (^block)(void)); size_t const iterations = 10000; uint64_t tt = dispatch_benchmark(iterations, ^{ @autoreleasepool {
 
 #define END_BENCH }}); SPLog(@"Benchmark Avg. Runtime: %llu ns", tt);
+
+#ifdef DEBUG
+#import <sys/time.h>
+/**
+ Profile time cost.
+ @param block     code to benchmark
+ @param complete  code time cost (millisecond)
+
+ Usage:
+    SABenchmark(^{
+        // code
+ }, ^(double ms) {
+     SPLog(@"time cost: %.2f ms",ms);
+ });
+
+ */
+static inline void SABenchmark(void (^block)(void), void (^complete)(double ms)) {
+    struct timeval t0, t1;
+    gettimeofday(&t0, NULL);
+    block();
+    gettimeofday(&t1, NULL);
+    double ms = (double)(t1.tv_sec - t0.tv_sec) * 1e3 + (double)(t1.tv_usec - t0.tv_usec) * 1e-3;
+    complete(ms);
+}
+#endif

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -295,10 +295,10 @@
 	// Set up the attributes to modify
 	attributes[0].tag = kSecAccountItemAttr;
 	attributes[0].data = (unichar *)[newAccount UTF8String];
-	attributes[0].length = (UInt32)strlen([newAccount UTF8String]);
+    attributes[0].length = (newAccount != nil) ? (UInt32)strlen([newAccount UTF8String]) : 0;
 	attributes[1].tag = kSecServiceItemAttr;
 	attributes[1].data = (unichar *)[newName UTF8String];
-	attributes[1].length = (UInt32)strlen([newName UTF8String]);
+    attributes[1].length = (newName != nil) ? (UInt32)strlen([newName UTF8String]) : 0;
 	attList.count = 2;
 	attList.attr = attributes;
 

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -178,13 +178,30 @@ static unsigned short getRandomPort(void);
  */
 - (BOOL)setPasswordKeychainName:(NSString *)theName account:(NSString *)theAccount
 {
-	
+    BOOL error = NO;
+    passwordInKeychain = YES;
 
-	passwordInKeychain = YES;
-	keychainName = [[NSString alloc] initWithString:theName];
-	keychainAccount = [[NSString alloc] initWithString:theAccount];
+    if(theName != nil){
+        keychainName = [[NSString alloc] initWithString:theName];
+    }
+    else{
+        error = YES;
+    }
+    if(theAccount != nil){
+        keychainAccount = [[NSString alloc] initWithString:theAccount];
+    }
+    else{
+        error = YES;
+    }
 
-	return YES;
+    if(error == YES){
+        SPLog(@"keychainName or keychainAccount is nil");
+        // don't log account - contains private data
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : @"setPasswordKeychainName: keychainName or keychainAccount is nil"};
+        [FIRCrashlytics.crashlytics recordError:[NSError errorWithDomain:@"sshTunnel" code:1 userInfo:userInfo]];
+    }
+
+	return !error;
 }
 
 /*

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -563,22 +563,22 @@ static const NSInteger kBlobAsImageFile = 4;
 
 					// Convert numeric types to unquoted strings
 					case 0:
-						[rowValues addObject:[cellData description]];
+						[rowValues safeAddObject:[cellData description]];
 						break;
 
 					// Quote string, text and blob types appropriately
 					case 1:
 					case 2:
 						if ([cellData isKindOfClass:nsDataClass]) {
-							[rowValues addObject:[mySQLConnection escapeAndQuoteData:cellData]];
+							[rowValues safeAddObject:[mySQLConnection escapeAndQuoteData:cellData]];
 						} else {
-							[rowValues addObject:[mySQLConnection escapeAndQuoteString:[cellData description]]];
+							[rowValues safeAddObject:[mySQLConnection escapeAndQuoteString:[cellData description]]];
 						}
 						break;
 
 					// GEOMETRY
 					case 3:
-						[rowValues addObject:[mySQLConnection escapeAndQuoteData:[cellData data]]];
+						[rowValues safeAddObject:[mySQLConnection escapeAndQuoteData:[cellData data]]];
 						break;
 					// auto_inc
 					case 4:


### PR DESCRIPTION
## Changes:

- fixed SPSSHTunnel setPasswordKeychainName:account crash on nil
- fixed selectItemWithTitle:selectedTitle where selectedTitle == nil - SPExtendedTableInfo loadTable
- fixed SPKeychain updateItemWithName:account:toName:account:password crash where newAccount == nil
- added image properties - May fix SPDatabaseDocument validateToolbarItem crash.
- added guards when adding to the values array - May fix SPCopyTable rowsAsSqlInsertsOnlySelectedRows:skipAutoIncrementColumn crash
- fixed SPSQLExporter exportOperation crash
- fixed SPTableContent addRow crash

## Closes following issues:
FB: 563298f43bbbd1889fc2c7409bac8674
FB: 20f3ee1b542926c3160018794c2b0eda
FB: 3046dbe6d7c42b1e42ecaf0ca125bfa4
FB: 2c7b4c0e17ee92f0d050d7dafdc59d53 (maybe)
FB: 249c5c9d04bdde3f3118a555d339f374 (maybe)
FB: 3f382dde5a613dc533c31bd0b14d5a99
FB: 6799d93351e7692bed1e91e0590ec89b

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
