### PR TITLE
#infra fave colour support optimisation

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -3212,7 +3212,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 		[self loadNib];
 
-		NSArray *colorList = [[SPFavoriteColorSupport sharedInstance] userColorList];
+        NSArray *colorList = SPFavoriteColorSupport.sharedInstance.userColorList;
 		[sshColorField setColorList:colorList];
 		[sshColorField      bind:@"selectedTag" toObject:self withKeyPath:@"colorIndex" options:nil];
 		[standardColorField setColorList:colorList];

--- a/Source/Other/DebuggingSupport/SPFavoriteColorSupport.h
+++ b/Source/Other/DebuggingSupport/SPFavoriteColorSupport.h
@@ -33,19 +33,16 @@
 @interface SPFavoriteColorSupport : NSObject
 {
 	NSUserDefaults *prefs;
+
+    
 }
+
+@property (strong) NSArray<NSColor *> *userColorList;
 
 /** 
  * Get the single instance of this class
  */
 + (SPFavoriteColorSupport *)sharedInstance;
-
-/** 
- * Get the default list of colors supplied by Sequel Ace.
- * 
- * @return An array with NSColor * items.
- */
-+ (NSArray *)defaultColorList;
 
 /** 
  * Get the current color for a specific index.
@@ -59,6 +56,6 @@
  * 
  * @return An array with NSColor * items.
  */
-- (NSArray *)userColorList;
+- (NSArray<NSColor *>*)populateUserColorList;
 
 @end


### PR DESCRIPTION
## Changes:
made it about 50x faster
fave colours only loaded once

## Closes following issues:
FB: 15d199ef035a2b116d41d1e41dd33624 (maybe)

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version:
- Localizations: 12.3 (12C33)
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
