### PR TITLE
 #fixed display json string properly in edit popup

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -529,7 +529,7 @@ typedef enum {
 		case JsonSegment:
 			[usedSheet makeFirstResponder:jsonTextView];
 			if([[jsonTextView string] isEqualToString:@""]) {
-                if([sheetEditData isKindOfClass:[NSData class]]) {
+                if([sheetEditData isKindOfClass:[NSData class]] || [sheetEditData isKindOfClass:[NSString class]]) {
                     if ([sheetEditData respondsToSelector:@selector(dataUsingEncoding:)]) {
                         NSError *error;
                         NSData *jsonData = [sheetEditData dataUsingEncoding:NSUTF8StringEncoding];
@@ -553,9 +553,11 @@ typedef enum {
                     }
                 }
                 else{
-                    SPLog(@"sheetEditData not of NSData class: %@", [sheetEditData class]);
-                    CLS_LOG(@"sheetEditData not of NSData class: %@", [sheetEditData class]);
+                    SPLog(@"sheetEditData not of NSData or NSString class: %@", [sheetEditData class]);
+                    CLS_LOG(@"sheetEditData not of NSData or NSString class: %@", [sheetEditData class]);
                 }
+
+
 			}
 			[editTextView setHidden:YES];
 			[editTextScrollView setHidden:YES];


### PR DESCRIPTION
## Changes:
https://github.com/Sequel-Ace/Sequel-Ace/issues/726#issuecomment-752989703

## Closes following issues:
- Closes #726

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
