### PR TITLE
#changed Better export error handling

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -151,7 +151,21 @@
 	} else {
 
 		// First check whether the application is in a modal state; if so, wait
-		while ([NSApp modalWindow]) usleep(100000);
+        do {
+            NSWindow __block *modalWindow = nil;
+            
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                modalWindow = [NSApp modalWindow];
+            });
+
+            if(modalWindow == nil){
+                break;
+            }
+            else{
+                usleep(100000);
+            }
+
+        } while(0);
 
 		[self performSelectorOnMainThread:@selector(_delegateDecisionForLostConnection) withObject:nil waitUntilDone:YES];
 		[delegateDecisionLock lock];

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3194,3 +3194,9 @@
 
 /* Title for Stale Secure Bookmarks help window */
 "Stale Secure Bookmarks" = "Stale Secure Bookmarks";
+
+/* Title for Export Error alert */
+"Export Error" = "Export Error";
+
+/* Message for Export Error alert */
+"Error while writing to the export file. Could not open file: %@" = "Error while writing to the export file. Could not open file: %@";

--- a/Source/Controllers/DataExport/Exporters/SPCSVExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPCSVExporter.m
@@ -33,6 +33,8 @@
 #import "SPTableData.h"
 #import "SPExportUtilities.h"
 #import "SPExportFile.h"
+#import "SPExportController.h"
+#import "SPFunctions.h"
 
 #import <SPMySQL/SPMySQL.h>
 
@@ -212,8 +214,14 @@
 	
 	while (1) 
 	{
+        if(self.exportOutputFile.fileHandleError != nil){
+            SPMainQSync(^{
+                [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+            });
+            return;
+        }
 		// Check for cancellation flag
-		if ([self isCancelled]) {
+        if ([self isCancelled] ) {
 			if (streamingResult) {
 				[connection cancelCurrentQuery];
 				[streamingResult cancelResultLoad];
@@ -249,9 +257,14 @@
 		
 		for (i = 0 ; i < csvCellCount; i++) 
 		{
+            if(self.exportOutputFile.fileHandleError != nil){
+                SPMainQSync(^{
+                    [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                });
+                return;
+            }
 			// Check for cancellation flag
 			if ([self isCancelled]) {
-
 				return;
 			}
 			

--- a/Source/Controllers/DataExport/Exporters/SPDotExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPDotExporter.m
@@ -34,6 +34,8 @@
 #import "SPTableData.h"
 #import "SPExportUtilities.h"
 #import "SPExportFile.h"
+#import "SPExportController.h"
+#import "SPFunctions.h"
 
 @implementation SPDotExporter
 
@@ -110,6 +112,13 @@
 	// Process the tables
 	for (NSUInteger i = 0; i < [[self dotExportTables] count]; i++) 
 	{
+        if(self.exportOutputFile.fileHandleError != nil){
+            SPMainQSync(^{
+                [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+            });
+            return;
+        }
+
 		// Check for cancellation flag
 		if ([self isCancelled]) {
 			
@@ -158,7 +167,13 @@
 		if ([tableConstraints count]) {
 			
 			for (NSDictionary* constraint in tableConstraints) 
-			{
+            {
+                if(self.exportOutputFile.fileHandleError != nil){
+                    SPMainQSync(^{
+                        [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                    });
+                    return;
+                }
 				// Check for cancellation flag
 				if ([self isCancelled]) {
 					

--- a/Source/Controllers/DataExport/Exporters/SPExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPExporter.m
@@ -117,12 +117,16 @@
 
 - (void)writeString:(NSString *)input
 {
-	[[self exportOutputFile] writeData:[input dataUsingEncoding:[self exportOutputEncoding]]];
+    if([self exportOutputFile].fileHandleError == nil){
+        [[self exportOutputFile] writeData:[input dataUsingEncoding:[self exportOutputEncoding]]];
+    }
 }
 
 - (void)writeUTF8String:(NSString *)input
 {
-	[[self exportOutputFile] writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
+    if([self exportOutputFile].fileHandleError == nil){
+        [[self exportOutputFile] writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
+    }
 }
 
 /**

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -35,6 +35,8 @@
 #import "SPExportFile.h"
 #import "SPTableData.h"
 #import "RegexKitLite.h"
+#import "SPExportController.h"
+#import "SPFunctions.h"
 
 #import <SPMySQL/SPMySQL.h>
 #include <stdlib.h>
@@ -260,6 +262,14 @@
 	// Loop through the selected tables
 	for (NSArray *table in tables) 
 	{
+
+        if(self.exportOutputFile.fileHandleError != nil){
+            SPMainQSync(^{
+                [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+            });
+            return;
+        }
+
 		// Check for cancellation flag
 		if ([self isCancelled]) {
 			[self endCleanup:oldSqlMode];
@@ -431,6 +441,14 @@
 				NSArray *row;
 				while ((row = [streamingResult getRowAsArray]))
 				{
+
+                    if(self.exportOutputFile.fileHandleError != nil){
+                        SPMainQSync(^{
+                            [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                        });
+                        return;
+                    }
+
 					// Check for cancellation flag
 					if ([self isCancelled]) {
 						[connection cancelCurrentQuery];
@@ -583,6 +601,14 @@
 				
 				for (NSUInteger s = 0; s < [queryResult numberOfRows]; s++)
 				{
+
+                    if(self.exportOutputFile.fileHandleError != nil){
+                        SPMainQSync(^{
+                            [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                        });
+                        return;
+                    }
+
 					// Check for cancellation flag
 					if ([self isCancelled]) {
 						[self endCleanup:oldSqlMode];
@@ -626,6 +652,14 @@
 	// Process any deferred views, adding commands to delete the placeholder tables and add the actual views
 	for (NSString *viewName in viewSyntaxes)
 	{
+
+        if(self.exportOutputFile.fileHandleError != nil){
+            SPMainQSync(^{
+                [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+            });
+            return;
+        }
+
 		// Check for cancellation flag
 		if ([self isCancelled]) {
 			[self endCleanup:oldSqlMode];
@@ -645,6 +679,13 @@
 	// Export procedures and functions
 	for (NSString *procedureType in @[@"PROCEDURE", @"FUNCTION"])
 	{
+
+        if(self.exportOutputFile.fileHandleError != nil){
+            SPMainQSync(^{
+                [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+            });
+            return;
+        }
 		// Check for cancellation flag
 		if ([self isCancelled]) {
 			[self endCleanup:oldSqlMode];
@@ -674,6 +715,14 @@
 			// Loop through the definitions, exporting if enabled
 			for (NSUInteger s = 0; s < [queryResult numberOfRows]; s++)
 			{
+                
+                if(self.exportOutputFile.fileHandleError != nil){
+                    SPMainQSync(^{
+                        [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                    });
+                    return;
+                }
+                
 				// Check for cancellation flag
 				if ([self isCancelled]) {
 					[self endCleanup:oldSqlMode];
@@ -689,6 +738,14 @@
 				BOOL sqlOutputIncludeDropSyntax = NO;
 				for (NSArray *item in items)
 				{
+
+                    if(self.exportOutputFile.fileHandleError != nil){
+                        SPMainQSync(^{
+                            [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                        });
+                        return;
+                    }
+
 					// Check for cancellation flag
 					if ([self isCancelled]) {
 						[self endCleanup:oldSqlMode];

--- a/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
@@ -32,7 +32,8 @@
 #import "SPExportFile.h"
 #import "SPFileHandle.h"
 #import "SPExportUtilities.h"
-
+#import "SPExportController.h"
+#import "SPFunctions.h"
 #import <SPMySQL/SPMySQL.h>
 
 @implementation SPXMLExporter
@@ -194,6 +195,14 @@
 		
 		while (1) 
 		{
+
+            if(self.exportOutputFile.fileHandleError != nil){
+                SPMainQSync(^{
+                    [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                });
+                return;
+            }
+            
 			// Check for cancellation flag
 			if ([self isCancelled]) {
 				if (streamingResult) {
@@ -223,6 +232,13 @@
 			
 			for (i = 0; i < xmlRowCount; i++) 
 			{
+                if(self.exportOutputFile.fileHandleError != nil){
+                    SPMainQSync(^{
+                        [(SPExportController*)self->delegate cancelExportForFile:self->exportOutputFile.exportFilePath];
+                    });
+                    return;
+                }
+                
 				// Check for cancellation flag
 				if ([self isCancelled]) {
 					if (streamingResult) {

--- a/Source/Controllers/DataExport/Model/SPExportFile.h
+++ b/Source/Controllers/DataExport/Model/SPExportFile.h
@@ -73,6 +73,12 @@
 @property (readwrite, assign) BOOL exportFileNeedsUserChosenDir;
 
 /**
+ * @property fileHandleError
+ */
+@property (readwrite, copy) NSString *fileHandleError;
+
+
+/**
  * @property exportFileNeedsXMLHeader
  */
 @property (readwrite, assign) BOOL exportFileNeedsXMLHeader;

--- a/Source/Controllers/DataExport/Model/SPExportFile.m
+++ b/Source/Controllers/DataExport/Model/SPExportFile.m
@@ -46,6 +46,7 @@
 @synthesize exportFileNeedsXMLHeader;
 @synthesize exportFileHandleStatus;
 @synthesize exportFileNeedsUserChosenDir;
+@synthesize fileHandleError;
 
 #pragma mark -
 #pragma mark Initialisation
@@ -74,8 +75,9 @@
 	if ((self = [super init])) {
 		
 		[self setExportFilePath:path];
-		
+
 		exportFileHandleStatus = -1;
+        fileHandleError = nil;
 		
 		[self setExportFileNeedsCSVHeader:NO];
 		[self setExportFileNeedsXMLHeader:NO];
@@ -129,11 +131,11 @@
 - (void)writeData:(NSData *)data
 {
 	if (![self exportFileHandle]) {
-        SPLog(@"Failed to get filehandle for: %@", [self exportFileHandle]);
-        CLS_LOG(@"Failed to get filehandle for: %@", [self exportFileHandle]);
-
-		[NSException raise:NSInternalInconsistencyException format:@"Attempting to write to an uninitialized file handle."];
-		
+        SPLog(@"Failed to get filehandle for: %@", exportFilePath);
+        CLS_LOG(@"Failed to get filehandle for: %@", exportFilePath);
+        SPLog(@"fileHandleError = YES");
+        // set the filename for error reporting
+        fileHandleError = exportFilePath;
 		return;
 	}
 			

--- a/Source/Controllers/DataExport/SPExportController.h
+++ b/Source/Controllers/DataExport/SPExportController.h
@@ -292,6 +292,8 @@
 - (IBAction)toggleSQLIncludeDropSyntax:(NSButton *)sender;
 - (IBAction)toggleNewFilePerTable:(NSButton *)sender;
 
+- (void)cancelExportForFile:(NSString*)fileName;
+
 #pragma mark - SPExportInitializer
 
 - (void)startExport;

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -604,6 +604,7 @@ extern NSString *SPBundleTaskTableMetaDataFilePath;
 extern NSString *SPQueryWarningEnabledSuppressed;
 extern NSString *SPBundleLegacyAppSchema;
 extern NSString *SPBundleAppSchema;
+extern NSString *SPExportFileHandleError;
 
 extern NSString *SPBundleShellVariableInputFilePath;
 extern NSString *SPBundleShellVariableOutputFilePath;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -211,6 +211,7 @@ NSString *SPAlphabeticalTableSorting             = @"AlphabeticalTableSorting";
 
 // Import and export
 NSString *SPCSVImportFieldEnclosedBy             = @"CSVImportFieldEnclosedBy";
+NSString *SPExportFileHandleError                = @"fileHandleError";
 NSString *SPCSVImportFieldEscapeCharacter        = @"CSVImportFieldEscapeCharacter";
 NSString *SPCSVImportFieldTerminator             = @"CSVImportFieldTerminator";
 NSString *SPCSVImportFirstLineIsHeader           = @"CSVImportFirstLineIsHeader";

--- a/Source/Other/Extensions/NSAlertExtension.swift
+++ b/Source/Other/Extensions/NSAlertExtension.swift
@@ -113,7 +113,7 @@ import AppKit
 	/// Creates an alert with primary colored OK button that triggers callback
 	/// - Parameters:
 	///   - title: String for title of the alert
-	///   - message: tring for informative message
+	///   - message: string for informative message
 	///   - callback: Optional block that's invoked when user hits OK button
 	static func createWarningAlert(title: String,
 								   message: String,


### PR DESCRIPTION
## Changes:
On export, if a file handle error was encountered, previously the app crashed. These changes try to capture the error, cancel export operations (without disconnecting from the db) and show an error, and clean up. 

## Closes following issues:
- Closes 
FB: f8226b07646265192e24c6126f697e9c

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
I've tested for CSV, SQL, XML, dot. For one table. 

For more than one table, SQL, XML, dot work fine. CSV crashes the app - present in current app store app too. Will create issue.
