### PR TITLE
#fixed Two custom queries with syntax errors = crash  

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -847,8 +847,9 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
                         [errors appendFormat:NSLocalizedString(@"[ERROR in query %ld] %@\n", @"error text when multiple custom query failed"), (long)(i+1), errorString];
                         [[errorTextTitle onMainThread] setStringValue:NSLocalizedString(@"Last Error Message", @"Last Error Message")];
 
-                        if(errors.length>0)[[errorText onMainThread] setText:errors];
-                        
+                        if(errors.length>0){
+                            [[errorText onMainThread] setText:errors];
+                        }
                         SPMainQSync(^{
                             // ask the user to continue after detecting an error
                             if (![self->mySQLConnection lastQueryWasCancelled]) {

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -846,7 +846,8 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
                         // Update error text for the user
                         [errors appendFormat:NSLocalizedString(@"[ERROR in query %ld] %@\n", @"error text when multiple custom query failed"), (long)(i+1), errorString];
                         [[errorTextTitle onMainThread] setStringValue:NSLocalizedString(@"Last Error Message", @"Last Error Message")];
-                        [[errorText onMainThread] setStringOrNil:errors];
+
+                        if(errors.length>0)[[errorText onMainThread] setText:errors];
                         
                         SPMainQSync(^{
                             // ask the user to continue after detecting an error


### PR DESCRIPTION
## Changes:
selector should be setText 

## Closes following issues:
- #734

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
