### PR TITLE
#fixed exporting multiple tables 

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -545,6 +545,7 @@
  */
 - (void)cancelCurrentQuery
 {
+    SPLog(@"cancelCurrentQuery");
 	// If not connected, no action is required
 	if (state != SPMySQLConnected && state != SPMySQLDisconnecting) return;
 
@@ -589,10 +590,10 @@
 			lastQueryWasCancelled = YES;
 			return;
 		} else {
-            NSLog(@"SPMySQL Framework: query cancellation failed due to cancellation query error (status %d) - %lu", killQueryStatus, mySQLConnection->thread_id);
+            SPLog(@"SPMySQL Framework: query cancellation failed due to cancellation query error (status %d) - %lu", killQueryStatus, mySQLConnection->thread_id);
 		}
 	} else if (!userTriggeredDisconnect) {
-        NSLog(@"SPMySQL Framework: query cancellation failed because connection failed - %lu", mySQLConnection->thread_id);
+        SPLog(@"SPMySQL Framework: query cancellation failed because connection failed - %lu", mySQLConnection->thread_id);
 	}
 
 	// A full reconnect is required at this point to force a cancellation.  As the

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStreamingResultStore.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStreamingResultStore.m
@@ -684,9 +684,13 @@ static inline void SPMySQLStreamingResultStoreFreeRowData(SPMySQLStreamingResult
 			([parentConnection isConnected])
 				&& (theRow = mysql_fetch_row(resultSet))
 			) {
+
+            SPLog(@"[parentConnection isConnected] = %d", [parentConnection isConnected]);
+
 			// If the load has been cancelled, skip any processing - we're only interested
 			// in ensuring that mysql_fetch_row is called for all rows.
 			if (loadCancelled) {
+                SPLog(@"loadCancelled");
 				continue;
 			}
 


### PR DESCRIPTION
## Changes:
- fixed exporting multiple tables, there was a redundant content check that failed for >1 rows and called disconnect.

## Closes following issues:
- Closes #732 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
Tested TCP and SSH connections.