### PR TITLE
#fixed table information eye symbol crash

### DIFF
--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -254,6 +254,13 @@
         NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
         FIRCrashlytics *crashlytics = FIRCrashlytics.crashlytics;
 
+        if(is_big_sur() == YES){
+            NSMutableArray *dbViewInfoPanelSplit = [[NSMutableArray alloc] initWithCapacity:2];
+            [dbViewInfoPanelSplit addObject:@"0.000000, 0.000000, 359.500000, 577.500000, NO, NO"];
+            [dbViewInfoPanelSplit addObject:@"0.000000, 586.500000, 359.500000, 190.500000, NO, NO"];
+            [prefs setObject:dbViewInfoPanelSplit forKey:@"NSSplitView Subview Frames DbViewInfoPanelSplit"];
+        }
+
         // set some keys to help us diagnose issues
         [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryAutoComplete, prefs)) forKey:@"CustomQueryAutoComplete"];
         [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryEnableSyntaxHighlighting, prefs)) forKey:@"CustomQueryEnableSyntaxHighlighting"];

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -254,12 +254,11 @@
         NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
         FIRCrashlytics *crashlytics = FIRCrashlytics.crashlytics;
 
-        if(is_big_sur() == YES){
-            NSMutableArray *dbViewInfoPanelSplit = [[NSMutableArray alloc] initWithCapacity:2];
-            [dbViewInfoPanelSplit addObject:@"0.000000, 0.000000, 359.500000, 577.500000, NO, NO"];
-            [dbViewInfoPanelSplit addObject:@"0.000000, 586.500000, 359.500000, 190.500000, NO, NO"];
-            [prefs setObject:dbViewInfoPanelSplit forKey:@"NSSplitView Subview Frames DbViewInfoPanelSplit"];
-        }
+        // fake the dbViewInfoPanelSplit being open
+        NSMutableArray *dbViewInfoPanelSplit = [[NSMutableArray alloc] initWithCapacity:2];
+        [dbViewInfoPanelSplit addObject:@"0.000000, 0.000000, 359.500000, 577.500000, NO, NO"];
+        [dbViewInfoPanelSplit addObject:@"0.000000, 586.500000, 359.500000, 190.500000, NO, NO"];
+        [prefs setObject:dbViewInfoPanelSplit forKey:@"NSSplitView Subview Frames DbViewInfoPanelSplit"];
 
         // set some keys to help us diagnose issues
         [crashlytics setCustomValue:@(user_defaults_get_bool_ud(SPCustomQueryAutoComplete, prefs)) forKey:@"CustomQueryAutoComplete"];

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -114,15 +114,11 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	[tableListSplitView setCollapsibleSubviewIndex:1];
 
     // Collapse the pane if the last state was collapsed
+    // after a delay - to fix #719
     if(user_defaults_get_bool_ud(SPTableInformationPanelCollapsed, prefs) == YES){
-        if(is_big_sur() == YES){
-            executeOnMainThreadAfterADelay(^{
-                [self->tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
-            }, 3);
-        }
-        else{
-            [tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
-        }
+        executeOnMainThreadAfterADelay(^{
+            [self->tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
+        }, 3);
     }
 
 	// Configure the table list filter, starting it collapsed

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -113,11 +113,18 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	// Configure the table information pane
 	[tableListSplitView setCollapsibleSubviewIndex:1];
 
-	// Collapse the pane if the last state was collapsed
-	if ([[prefs objectForKey:SPTableInformationPanelCollapsed] boolValue]) {
-		[tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
-	}
-	
+    // Collapse the pane if the last state was collapsed
+    if(user_defaults_get_bool_ud(SPTableInformationPanelCollapsed, prefs) == YES){
+        if(is_big_sur() == YES){
+            executeOnMainThreadAfterADelay(^{
+                [self->tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
+            }, 3);
+        }
+        else{
+            [tableListSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
+        }
+    }
+
 	// Configure the table list filter, starting it collapsed
 	[tableListFilterSplitView setCollapsibleSubviewIndex:0];
 	[tableListFilterSplitView setCollapsibleSubviewCollapsed:YES animate:NO];

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -693,6 +693,7 @@ typedef NS_ENUM(NSInteger,SPErrorCode) { // error codes in SPErrorDomain
 #define user_defaults_get_bool(key)         [[NSUserDefaults standardUserDefaults] boolForKey:key]
 #define user_defaults_get_bool_ud(key, ud)  [ud boolForKey:key]
 #define user_defaults_set_bool(key, b, ud)  [ud setBool:b forKey:key]
+#define is_big_sur()  [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ .majorVersion = 11, .minorVersion = 0, .patchVersion = 0 }]
 
 #define SPAppDelegate ((SPAppController *)[NSApp delegate])
 

--- a/Source/Other/Utility/SPFunctions.h
+++ b/Source/Other/Utility/SPFunctions.h
@@ -28,6 +28,10 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
+typedef void(^SAVoidCompletionBlock)(void);
+
+void executeOnMainThreadAfterADelay(SAVoidCompletionBlock block, double delayInSeconds);
+
 /**
  * Synchronously execute a block on the main thread.
  * This function can be called from a background thread as well as from

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -47,6 +47,17 @@ void SPMainQSync(void (^block)(void))
 	}
 }
 
+void executeOnMainThreadAfterADelay(SAVoidCompletionBlock block, double delayInSeconds){
+
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (dispatch_time_t)(delayInSeconds * NSEC_PER_SEC));
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
+        if (block) {
+            block();
+        }
+    });
+}
+
+
 void SPMainLoopAsync(void (^block)(void))
 {
 	CFRunLoopPerformBlock(CFRunLoopGetMain(), NSDefaultRunLoopMode, block);

--- a/Source/Views/SPSplitView.m
+++ b/Source/Views/SPSplitView.m
@@ -240,13 +240,13 @@
 			animationDuration *= 10;
 		}
 
-		// Modify the duration by the proportion of any interrupted animation
-		CGFloat fullViewSize = [self _lengthOfView:[[viewToAnimate subviews] objectAtIndex:0]];
-		if (shouldCollapse) {
-			animationDuration *= animationStartSize / fullViewSize;
-		} else {
-			animationDuration *= (animationTargetSize - animationStartSize) / fullViewSize;
-		}
+        // don't divide by zero
+        CGFloat fullViewSize = [self _lengthOfView:[[viewToAnimate subviews] objectAtIndex:0]];
+        if (shouldCollapse) {
+            animationDuration *= (fullViewSize > 0) ? animationStartSize / fullViewSize : 0;
+        } else {
+            animationDuration *= (fullViewSize > 0) ? (animationTargetSize - animationStartSize) / fullViewSize : 0;
+        }
 
 		// Create an object to avoid NSTimer retain cycles
 		animationRetainCycleBypassObject = [[SPSplitViewAnimationRetainCycleBypass alloc] initWithParent:self]; // TODO: leaks


### PR DESCRIPTION
## Changes:
- fixed divide by zero error
- fake the info panel being open
- then close it after a delay if it was previously closed

## Closes following issues:
-#719 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
