### PR TITLE
#fixed Table history buttons not working

### DIFF
--- a/Interfaces/DBView.xib
+++ b/Interfaces/DBView.xib
@@ -46,6 +46,7 @@
                 <outlet property="queryProgressBar" destination="858" id="860"/>
                 <outlet property="renameDatabaseButton" destination="6997" id="7011"/>
                 <outlet property="renameDatabaseMessageField" destination="6995" id="7041"/>
+                <outlet property="spHistoryControllerInstance" destination="6297" id="6298"/>
                 <outlet property="statusTableAccessoryView" destination="6885" id="6897"/>
                 <outlet property="statusTableCopyChecksum" destination="6901" id="6903"/>
                 <outlet property="statusTableView" destination="6889" id="6898"/>
@@ -4124,6 +4125,9 @@ Gw
                             <segment toolTip="Forward" image="NSGoRightTemplate" width="27" enabled="NO" tag="1"/>
                         </segments>
                     </segmentedCell>
+                    <connections>
+                        <action selector="historyControlClicked:" target="6297" id="6300"/>
+                    </connections>
                 </segmentedControl>
                 <popUpButton toolTip="Select a database to view (⇧⌘D)" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3995">
                     <rect key="frame" x="0.0" y="3" width="200" height="25"/>
@@ -4372,6 +4376,7 @@ Gw
                 <outlet property="reloadButton" destination="5176" id="6625"/>
                 <outlet property="removeButton" destination="5177" id="5190"/>
                 <outlet property="ruleFilterController" destination="ki9-Po-bdr" id="5od-0U-9xj"/>
+                <outlet property="spHistoryControllerInstance" destination="6297" id="6316"/>
                 <outlet property="tableContentContainer" destination="vcX-Xr-0cm" id="Xak-w0-y6x"/>
                 <outlet property="tableContentView" destination="36" id="142"/>
                 <outlet property="tableDataInstance" destination="4702" id="4712"/>
@@ -4444,6 +4449,7 @@ Gw
                 <outlet property="separatorTableMenuItem3" destination="7924" id="7953"/>
                 <outlet property="showCreateSyntaxContextMenuItem" destination="6923" id="6929"/>
                 <outlet property="showCreateSyntaxMenuItem" destination="7927" id="7949"/>
+                <outlet property="spHistoryControllerInstance" destination="6297" id="6302"/>
                 <outlet property="tableCollationButton" destination="8310" id="8314"/>
                 <outlet property="tableContentInstance" destination="67" id="143"/>
                 <outlet property="tableDataInstance" destination="4702" id="4707"/>
@@ -4595,6 +4601,12 @@ Gw
             </connections>
         </customObject>
         <customObject id="5814" userLabel="SPDatabaseData" customClass="SPDatabaseData"/>
+        <customObject id="6297" userLabel="SPHistoryController" customClass="SPHistoryController">
+            <connections>
+                <outlet property="historyControl" destination="6293" id="6299"/>
+                <outlet property="theDocument" destination="-2" id="6301"/>
+            </connections>
+        </customObject>
         <customObject id="7073" userLabel="SPIndexesController" customClass="SPIndexesController">
             <connections>
                 <outlet property="addIndexButton" destination="5150" id="7076"/>

--- a/Source/Controllers/Other/SPHistoryController.m
+++ b/Source/Controllers/Other/SPHistoryController.m
@@ -243,6 +243,7 @@
 - (void) updateHistoryEntries
 {
 
+    SPLog(@"updateHistoryEntries");
 	// Don't modify anything if we're in the process of restoring an old history state
 	if (modifyingState) return;
 
@@ -282,7 +283,10 @@
 
 	// If there's any items after the current history position, remove them
 	if (historyPosition != NSNotFound && historyPosition < [history count] - 1) {
-		[history removeObjectsInRange:NSMakeRange(historyPosition + 1, [history count] - historyPosition - 1)];
+        SPLog(@"If there's any items after the current history position, remove them");
+        NSRange tmpRange = NSMakeRange(historyPosition + 1, [history count] - historyPosition - 1);
+        SPLog(@"tmpRange.location=%lu tmpRange.length=%lu", (unsigned long)tmpRange.location, (unsigned long)tmpRange.length);
+		[history removeObjectsInRange:tmpRange];
 
 	} else if (historyPosition != NSNotFound && historyPosition == [history count] - 1) {
 		NSMutableDictionary *currentHistoryEntry = [history objectAtIndex:historyPosition];
@@ -326,6 +330,7 @@
 		// but the new selection does - delete the last entry, in order to replace it.
 		// This improves history flow.
 		else if (databaseIsTheSame && ![currentHistoryEntry safeObjectForKey:@"table"]) {
+            SPLog(@"history removeLastObject");
 			[history removeLastObject];
 		}
 	}
@@ -344,12 +349,17 @@
 	if (contentSelectedRows) [newEntry setObject:contentSelectedRows forKey:@"contentSelection"];
 	if (contentFilter) [newEntry setObject:contentFilter forKey:@"contentFilterV2"];
 
+    SPLog(@"history addObject: %@", newEntry);
 	[history addObject:newEntry];
 
 	// If there are now more than fifty history entries, remove one from the start
-	if ([history count] > 50) [history removeObjectAtIndex:0];
+    if ([history count] > 50){
+        SPLog(@"[history count] > 50, removeLastObject");
+        [history removeObjectAtIndex:0];
+    }
 
 	historyPosition = [history count] - 1;
+
 	[[self onMainThread] updateToolbarItem];
 }
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -2227,7 +2227,6 @@
 				969178A324A5640D0012ED42 /* Default Bundles */,
 				969178A424A5640D0012ED42 /* Default Themes */,
 				19C28FB0FE9D524F11CA2CBB /* Products */,
-				932A5F065352D9445A8F3FA0 /* Pods */,
 			);
 			name = "sequel-pro";
 			sourceTree = "<group>";
@@ -2464,13 +2463,6 @@
 				73F70A951E4E547500636550 /* SPJSONFormatter.m */,
 			);
 			path = Parsing;
-			sourceTree = "<group>";
-		};
-		932A5F065352D9445A8F3FA0 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		96D494B8249C07940092F335 /* SSH Helpers */ = {


### PR DESCRIPTION
## Changes:
- restored `spHistoryControllerInstance` to `DBView.xib`
- added some logging

## Closes following issues:
- Closes #775  
- Closes #770 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
