### PR TITLE
#fixed Query history duplicates and order

### DIFF
--- a/Source/Controllers/Other/SQLiteHistoryManager.swift
+++ b/Source/Controllers/Other/SQLiteHistoryManager.swift
@@ -395,7 +395,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     /// "SELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT COUNT(*) FROM `HKWarningsLog`;"
     /// Should return this array:
     /// [( "SELECT * FROM `HKWarningsLog` LIMIT 1000", "SELECT COUNT(*) FROM `HKWarningsLog`")]
-    private func normalizeQueryHistory(arrayToNormalise: [String], doLogging: Bool = false) -> [String] {
+   @objc func normalizeQueryHistory(arrayToNormalise: [String], doLogging: Bool = false) -> [String] {
 
         var normalisedQueryArray: [String] = []
 

--- a/Source/Controllers/Other/SQLiteHistoryManager.swift
+++ b/Source/Controllers/Other/SQLiteHistoryManager.swift
@@ -29,7 +29,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     private var newSchemaVersion: Int32 = 0
 
     override private init() {
-        log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "database")
+	log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "queryDatabase")
 
         migratedPrefsToDB = prefs.bool(forKey: SPMigratedQueriesFromPrefs)
         traceExecution = prefs.bool(forKey: SPTraceSQLiteExecutions)

--- a/Source/Controllers/Other/SQLiteHistoryManager.swift
+++ b/Source/Controllers/Other/SQLiteHistoryManager.swift
@@ -199,7 +199,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     /// Loads the query history from the SQLite database.
     private func loadQueryHistory() {
         os_log("loading Query History. SPCustomQueryMaxHistoryItems: %i", log: log, type: .debug, prefs.integer(forKey: SPCustomQueryMaxHistoryItems))
-
+        Crashlytics.crashlytics().log("loading Query History. SPCustomQueryMaxHistoryItems: \(prefs.integer(forKey: SPCustomQueryMaxHistoryItems))")
         queue.inDatabase { db in
             do {
                 db.traceExecution = traceExecution
@@ -220,6 +220,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     /// Reloads the query history from the SQLite database.
     private func reloadQueryHistory() {
         os_log("reloading Query History", log: log, type: .debug)
+        Crashlytics.crashlytics().log("reloading Query History")
         queryHist.removeAll()
         loadQueryHistory()
     }
@@ -255,6 +256,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
         }
 
         os_log("migrateQueriesFromPrefs", log: log, type: .debug)
+        Crashlytics.crashlytics().log("migrateQueriesFromPrefs")
 
         let queryHistoryArray = prefs.stringArray(forKey: SPQueryHistory) ?? [String]()
 
@@ -318,6 +320,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     /// Deletes all query history from the db
     @objc func deleteQueryHistory() {
         os_log("deleteQueryHistory", log: log, type: .debug)
+        Crashlytics.crashlytics().log("deleteQueryHistory")
         queue.inDatabase { db in
             db.traceExecution = traceExecution
             do {
@@ -337,7 +340,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
     /// The VACUUM command rebuilds the database file, repacking it into a minimal amount of disk space
     @objc func execSQLiteVacuum() {
         os_log("execSQLiteVacuum", log: log, type: .debug)
-
+        Crashlytics.crashlytics().log("execSQLiteVacuum")
         queue.inDatabase { db in
             db.traceExecution = traceExecution
             do {

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1334,8 +1334,9 @@
 {
 	BOOL shouldSaveFavorites = NO;
 
-	[SQLiteHistoryManager.sharedInstance execSQLiteVacuum];
-	
+    // removing vacuum here. See: https://www.sqlite.org/lang_vacuum.html
+    // The VACUUM command may change the ROWIDs of entries in any tables that do not have an explicit INTEGER PRIMARY KEY.
+
 	if (lastBundleBlobFilesDirectory != nil) {
 		[fileManager removeItemAtPath:lastBundleBlobFilesDirectory error:nil];
 	}

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -988,8 +988,14 @@ static SPQueryController *sharedQueryController = nil;
 
         SPLog(@"uniquifier = %@\nAdding: %@", uniquifier.debugDescription, [historyContainer safeObjectForKey:fileURLStr]);
 
+        // add current history
 		[uniquifier addItemsWithTitles:[historyContainer safeObjectForKey:fileURLStr]];
-		[uniquifier insertItemWithTitle:history atIndex:0];
+
+        // add new history
+        NSArray *histArr = [_SQLiteHistoryManager normalizeQueryHistoryWithArrayToNormalise:@[history] doLogging:YES];
+        for(NSString *str in histArr){
+            [uniquifier insertItemWithTitle:str atIndex:0];
+        }
 
 		while ((NSUInteger)[uniquifier numberOfItems] > maxHistoryItems)
 		{

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -808,7 +808,7 @@ static SPQueryController *sharedQueryController = nil;
 
 				// we want the values, sorted by the reverse of the key order
 				// remember allKey specifies no order, so we need to sort.
-				NSArray *sortedKeys = [[_SQLiteHistoryManager.queryHist allKeys] sortedArrayUsingFunction:intSort context:NULL];
+				NSArray *sortedKeys = [[_SQLiteHistoryManager.queryHist allKeys] sortedArrayUsingFunction:intSortDesc context:NULL];
 
 				NSMutableArray *sortedValues = [NSMutableArray array];
 				for (NSNumber *key in sortedKeys){

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -59,7 +59,6 @@ static NSUInteger SPMessageTruncateCharacterLength = 256;
 - (BOOL)_messageMatchesCurrentFilters:(NSString *)message;
 - (NSString *)_getConsoleStringWithTimeStamps:(BOOL)timeStamps connections:(BOOL)connections databases:(BOOL)databases;
 - (void)_addMessageToConsole:(NSString *)message connection:(NSString *)connection isError:(BOOL)error database:(NSString *)database;
-NSInteger intSort(id num1, id num2, void *context);
 
 @property (readwrite, strong) SQLiteHistoryManager *_SQLiteHistoryManager ;
 
@@ -790,20 +789,6 @@ static SPQueryController *sharedQueryController = nil;
 }
 
 #pragma mark - SPQueryDocumentsController
-
-NSInteger intSort(id num1, id num2, void *context)
-{
-	// JCS not: I want descending, so I've swapped the return values
-	// from the ifs
-	int v1 = [num1 intValue];
-	int v2 = [num2 intValue];
-	if (v1 < v2)
-		return NSOrderedDescending;
-	else if (v1 > v2)
-		return NSOrderedAscending;
-	else
-		return NSOrderedSame;
-}
 
 - (NSURL *)registerDocumentWithFileURL:(NSURL *)fileURL andContextInfo:(NSMutableDictionary *)contextInfo
 {

--- a/Source/Other/CategoryAdditions/SPStringAdditions.h
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.h
@@ -57,6 +57,8 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 + (NSString *)stringForTimeInterval:(double)timeInterval;
 + (NSString *)stringWithNewUUID;
 
+- (BOOL)contains:(NSString *)needle;
+
 - (NSString *)rot13;
 - (NSString *)HTMLEscapeString;
 - (NSString *)backtickQuotedString;

--- a/Source/Other/CategoryAdditions/SPStringAdditions.m
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.m
@@ -121,6 +121,11 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 	return [[NSUUID UUID] UUIDString];
 }
 
+- (BOOL)contains:(NSString *)needle
+{
+    return ([self rangeOfString:needle].location != NSNotFound);
+}
+
 /**
  * Returns the ROT13 representation of self.
  */

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -40,6 +40,19 @@ extension String {
 				return self.lowercased().hasSuffix(suffix.lowercased())
 		}
 	}
+
+    func separatedIntoLines() -> [String] {
+        var lines: [String] = []
+        let wholeString = self.startIndex..<self.endIndex
+        self.enumerateSubstrings(in: wholeString, options: .byLines) {
+            (substring, range, enclosingRange, stopPointer) in
+            if let line = substring {
+                lines.append(line)
+            }
+        }
+        return lines
+    }
+    
 	
 	// stringByReplacingPercentEscapesUsingEncoding is deprecated
 	// Use -stringByRemovingPercentEncoding

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -101,4 +101,9 @@ extension String {
 	public func isPercentEncoded() -> Bool {
 		return (self as String).isPercentEncoded
 	}
+
+    public func separatedIntoLinesObjc() -> [NSString] {
+        return (self as String).separatedIntoLines() as [NSString]
+    }
+
 }

--- a/Source/Other/Utility/SPFunctions.h
+++ b/Source/Other/Utility/SPFunctions.h
@@ -73,6 +73,7 @@ NSUInteger SPIntS2U(NSInteger i);
  * @see -[SPObjectAdditions unboxNull]
  */
 id SPBoxNil(id object);
+NSInteger intSort(id num1, id num2, void *context);
 
 void executeOnBackgroundThread(SAVoidCompletionBlock block);
 void executeOnBackgroundThreadSync(SAVoidCompletionBlock block);

--- a/Source/Other/Utility/SPFunctions.h
+++ b/Source/Other/Utility/SPFunctions.h
@@ -73,7 +73,7 @@ NSUInteger SPIntS2U(NSInteger i);
  * @see -[SPObjectAdditions unboxNull]
  */
 id SPBoxNil(id object);
-NSInteger intSort(id num1, id num2, void *context);
+NSInteger intSortDesc(id num1, id num2, void *context);
 
 void executeOnBackgroundThread(SAVoidCompletionBlock block);
 void executeOnBackgroundThreadSync(SAVoidCompletionBlock block);

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -159,3 +159,18 @@ id DumpObjCMethods(Class clz) {
     return arr;
 }
 
+NSInteger intSort(id num1, id num2, void *context)
+{
+    // JCS not: I want descending, so I've swapped the return values
+    // from the ifs
+    int v1 = [num1 intValue];
+    int v2 = [num2 intValue];
+    if (v1 < v2)
+        return NSOrderedDescending;
+    else if (v1 > v2)
+        return NSOrderedAscending;
+    else
+        return NSOrderedSame;
+}
+
+

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -159,7 +159,7 @@ id DumpObjCMethods(Class clz) {
     return arr;
 }
 
-NSInteger intSort(id num1, id num2, void *context)
+NSInteger intSortDesc(id num1, id num2, void *context)
 {
     // JCS not: I want descending, so I've swapped the return values
     // from the ifs

--- a/UnitTests/GeneralSwiftTests.swift
+++ b/UnitTests/GeneralSwiftTests.swift
@@ -1,0 +1,90 @@
+//
+//  GeneralSwiftTests.swift
+//  Unit Tests
+//
+//  Created by James on 12/1/2021.
+//  Copyright © 2021 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+class GeneralSwiftTests: XCTestCase {
+
+    // 0.242s
+    func testPerformanceComponents() throws {
+        // This is an example of a performance test case.
+
+        let str = "My name is JIMMY"
+        self.measure {
+
+            let iterations = Array(0...100000)
+
+            for _ in iterations {
+                _ = str.components(separatedBy: " ")
+            }
+        }
+    }
+
+    // 0.131s
+    func testPerformanceSplit() throws {
+        // This is an example of a performance test case.
+
+        let str = "My name is JIMMY"
+
+        self.measure {
+            let iterations = Array(0...100000)
+
+            for _ in iterations {
+                _ = str.split(separator: " ")
+            }
+        }
+    }
+
+    // 0.103s
+    func testPerformanceEnumerateSubstrings() throws {
+        // This is an example of a performance test case.
+
+        let str = "SELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT COUNT(*) FROM `HKWarningsLog`;"
+
+        var newHistMutArray: [String] = []
+
+        let wholeString = str.startIndex..<str.endIndex
+
+        self.measure {
+            let iterations = Array(0...10000)
+
+            for _ in iterations {
+                str.enumerateSubstrings(in: wholeString, options: NSString.EnumerationOptions.byLines) { (substring, substringRange, enclosingRange, stop) -> () in
+                    if let line = substring {
+                        newHistMutArray.appendIfNotContains(line)
+                    }
+                }
+            }
+        }
+
+        print(newHistMutArray)
+    }
+
+    // 0.114 s 
+    func testPerformanceSeparatedIntoLines() throws {
+        // This is an example of a performance test case.
+
+        let str = "SELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT COUNT(*) FROM `HKWarningsLog`;"
+
+        var newHistMutArray: [String] = []
+
+        self.measure {
+            let iterations = Array(0...10000)
+
+            for _ in iterations {
+                let lines = str.separatedIntoLines()
+
+                for line in lines  {
+                    newHistMutArray.appendIfNotContains(line)
+                }
+            }
+        }
+
+        print(newHistMutArray)
+    }
+}

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -323,6 +323,61 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 }
 
 
+- (void)testSeparatedIntoLines{
+
+    NSString *str = @"SELECT * FROM `HKWarningsLog` LIMIT 1000\nSELECT * FROM `HKWarningsLog` LIMIT 1000\nSELECT * FROM `HKWarningsLog` LIMIT 1000\n";
+    NSArray *expectedArray = @[@"SELECT * FROM `HKWarningsLog` LIMIT 1000", @"SELECT * FROM `HKWarningsLog` LIMIT 1000", @"SELECT * FROM `HKWarningsLog` LIMIT 1000"];
+
+    NSArray *arr = [str separatedIntoLinesObjc];
+
+    XCTAssertEqualObjects(expectedArray, arr);
+
+    NSLog(@"arr: %@", arr);
+
+}
+
+- (void)testContains{
+
+    NSString *str = @"When I say ATMOS, you say FEAR.";
+
+    XCTAssertTrue([str contains:@"ATMOS"]);
+    XCTAssertTrue([str contains:@"."]);
+    XCTAssertFalse([str contains:@"JIMMY"]);
+    XCTAssertFalse([str contains:@"ATMOS say"]);
+    XCTAssertFalse([str contains:@"Say"]);
+
+}
+
+// 0.145 s
+- (void)testContainsPerf{
+    [self measureBlock:^{
+        int const iterations = 1000000;
+
+        NSString *str = @"When I say ATMOS, you say FEAR.";
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                BOOL __unused res = [str contains:@"ATMOS"];
+            }
+        }
+    }];
+}
+
+// 0.13 s
+- (void)testContainsStringPerf{
+    [self measureBlock:^{
+        int const iterations = 1000000;
+
+        NSString *str = @"When I say ATMOS, you say FEAR.";
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                BOOL __unused res = [str containsString:@"ATMOS"];
+            }
+        }
+    }];
+}
+
 /**
  * stringByRemovingCharactersInSet test case.
  */

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		1A2DD55125939B6400616E7E /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2DD55025939B6400616E7E /* SPArrayAdditions.m */; };
 		1A2DD55A25939BEE00616E7E /* SPTestingUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2DD55925939BEE00616E7E /* SPTestingUtils.m */; };
 		1A3FA7962495FC2D00B7291A /* SPMainThreadTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 589582141154F8F400EDCC28 /* SPMainThreadTrampoline.m */; };
+		1A4152F125AF531000B17249 /* GeneralSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4152ED25AF530F00B17249 /* GeneralSwiftTests.swift */; };
 		1A47996F2543343A00D29E6E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1A47996E2543343A00D29E6E /* GoogleService-Info.plist */; };
 		1A4CB03425923C4B00EDF804 /* StringRegexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4CB03325923C4B00EDF804 /* StringRegexExtension.swift */; };
 		1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4CB03325923C4B00EDF804 /* StringRegexExtension.swift */; };
@@ -763,6 +764,7 @@
 		1A2DD55025939B6400616E7E /* SPArrayAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
 		1A2DD55925939BEE00616E7E /* SPTestingUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPTestingUtils.m; sourceTree = "<group>"; };
 		1A2DD55F25939C1500616E7E /* SPTestingUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTestingUtils.h; sourceTree = "<group>"; };
+		1A4152ED25AF530F00B17249 /* GeneralSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralSwiftTests.swift; sourceTree = "<group>"; };
 		1A47996E2543343A00D29E6E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Plists/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		1A479B15254375BD00D29E6E /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
 		1A479B19254375D200D29E6E /* Pods-Sequel Ace-acknowledgements.markdown */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Pods-Sequel Ace-acknowledgements.markdown"; sourceTree = "<group>"; };
@@ -2274,6 +2276,7 @@
 			isa = PBXGroup;
 			children = (
 				1AB0688D24A355B500E2AAC2 /* fixtures */,
+				1A4152ED25AF530F00B17249 /* GeneralSwiftTests.swift */,
 				50D3C35B1A771C4C00B5429C /* SPParserUtilsTest.m */,
 				503B02CE1AE95C2C0060CAB1 /* SPTableFilterParserTest.m */,
 				50837F731E50DCD4004FAE8A /* SPJSONFormatterTests.m */,
@@ -2959,6 +2962,7 @@
 				1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */,
 				1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
+				1A4152F125AF531000B17249 /* GeneralSwiftTests.swift in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,
 				519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */,
 				1A3FA7962495FC2D00B7291A /* SPMainThreadTrampoline.m in Sources */,


### PR DESCRIPTION
## Changes:
- removed vacuum on close
- added a primary key
-  handle where incoming array is one line, separated by \n
- some new helpers

## Closes following issues:
- #778  (maybe - need more info from OP)

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
