### PR TITLE
apply custom font to all inserted snippets #changed 

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -349,7 +349,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         }
         
         // The actual query strings have been already stored as tooltip
-        [textView insertAsSnippet:[[queryFavoritesButton selectedItem] toolTip] atRange:NSMakeRange([textView selectedRange].location, 0) isFavourite:YES];
+        [textView insertAsSnippet:[[queryFavoritesButton selectedItem] toolTip] atRange:NSMakeRange([textView selectedRange].location, 0)];
     }
 }
 

--- a/Source/Model/SPNarrowDownCompletion.m
+++ b/Source/Model/SPNarrowDownCompletion.m
@@ -1068,7 +1068,7 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 	// If it's a function or procedure append () and if a argument list can be retieved insert them as snippets
 	else if([prefs boolForKey:SPCustomQueryFunctionCompletionInsertsArguments] && ([[[filtered objectAtIndex:[theTableView selectedRow]] objectForKey:@"image"] hasPrefix:@"func"] || [[[filtered objectAtIndex:[theTableView selectedRow]] objectForKey:@"image"] hasPrefix:@"proc"]) && ![aString hasSuffix:@")"]) {
 		NSString *functionArgumentSnippet = [NSString stringWithFormat:@"(%@)", [[SPQueryController sharedQueryController] argumentSnippetForFunction:aString]];
-		[theView insertAsSnippet:functionArgumentSnippet atRange:[theView selectedRange] isFavourite:NO];
+		[theView insertAsSnippet:functionArgumentSnippet atRange:[theView selectedRange]];
 		if([functionArgumentSnippet length] == 2) [theView performSelector:@selector(moveLeft:)];
 	}
 }

--- a/Source/Other/CategoryAdditions/SPTextViewAdditions.m
+++ b/Source/Other/CategoryAdditions/SPTextViewAdditions.m
@@ -745,8 +745,8 @@
 					}
 
 					else if([action isEqualToString:SPBundleOutputActionInsertAsSnippet]) {
-                        if([self respondsToSelector:@selector(insertAsSnippet:atRange:isFavourite:)])
-							[(SPTextView *)self insertAsSnippet:output atRange:replaceRange isFavourite:NO];
+                        if([self respondsToSelector:@selector(insertAsSnippet:atRange:)])
+							[(SPTextView *)self insertAsSnippet:output atRange:replaceRange];
 						else
 							[SPTooltip showWithObject:NSLocalizedString(@"Input Field doesn't support insertion of snippets.", @"input field  doesn't support insertion of snippets.")];
 					}

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -158,7 +158,7 @@ typedef struct {
 - (void)doSyntaxHighlightingWithForceWrapper:(NSString*)keyPath;
 
 - (BOOL)checkForCaretInsideSnippet;
-- (void)insertAsSnippet:(NSString*)theSnippet atRange:(NSRange)targetRange isFavourite:(BOOL)isFave;
+- (void)insertAsSnippet:(NSString*)theSnippet atRange:(NSRange)targetRange;
 
 - (void)showCompletionListFor:(NSString*)kind atRange:(NSRange)aRange fuzzySearch:(BOOL)fuzzySearchMode;
 

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -1699,7 +1699,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 /**
  * Inserts a chosen query favorite and initialze a snippet session if user defined any
  */
-- (void)insertAsSnippet:(NSString*)theSnippet atRange:(NSRange)targetRange isFavourite:(BOOL)isFave
+- (void)insertAsSnippet:(NSString*)theSnippet atRange:(NSRange)targetRange
 {
 
 	// Do not allow the insertion of a query favorite if snippets are active
@@ -1944,14 +1944,12 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
         NSMutableAttributedString *tmpAttStr = [[NSMutableAttributedString alloc] initWithString:snip];
 
-        // if we are inserting a favourite query,
+        // if we are inserting a query,
         // add the font
-        // FIXME: should this apply to all snippet inserts actually?
-        if(isFave == YES){
-            [tmpAttStr addAttribute:NSFontAttributeName
-                              value:self.font
-                              range:NSMakeRange(0, snip.length)];
-        }
+
+        [tmpAttStr addAttribute:NSFontAttributeName
+                          value:self.font
+                          range:NSMakeRange(0, snip.length)];
 
 		[self.textStorage appendAttributedString:tmpAttStr];
 
@@ -2202,7 +2200,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		if(snippetControlCounter < 0 && [tabTrigger length] && [tableDocumentInstance fileURL]) {
 			NSArray *snippets = [[SPQueryController sharedQueryController] queryFavoritesForFileURL:[tableDocumentInstance fileURL] andTabTrigger:tabTrigger includeGlobals:YES];
 			if([snippets count] > 0 && [(NSString*)[(NSDictionary*)[snippets objectAtIndex:0] objectForKey:@"query"] length]) {
-				[self insertAsSnippet:[(NSDictionary*)[snippets objectAtIndex:0] objectForKey:@"query"] atRange:targetRange isFavourite:NO];
+				[self insertAsSnippet:[(NSDictionary*)[snippets objectAtIndex:0] objectForKey:@"query"] atRange:targetRange];
 				return;
 			}
 		}


### PR DESCRIPTION
## Changes:
- apply custom font to all inserted snippets, not just favourites.


## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
See: https://github.com/Sequel-Ace/Sequel-Ace/pull/757#discussion_r554009891