### PR TITLE
Windows hierarchy cleanup and typesafety, part 1 #infra

### DIFF
--- a/Frameworks/PSMTabBar/NSTabViewItemExtension.swift
+++ b/Frameworks/PSMTabBar/NSTabViewItemExtension.swift
@@ -1,0 +1,15 @@
+//
+//  SPTabViewItem.swift
+//  Sequel Ace
+//
+//  Created by Jakub Kašpar on 23.01.2021.
+//  Copyright © 2021 Sequel-Ace. All rights reserved.
+//
+
+import Cocoa
+
+extension NSTabViewItem {
+    @objc var databaseDocument: SPDatabaseDocument? {
+        return identifier as? SPDatabaseDocument
+    }
+}

--- a/Frameworks/PSMTabBar/PSMTabBarControl.h
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.h
@@ -54,11 +54,11 @@ enum {
 
 @interface PSMTabBarControl : NSControl {
 	// control basics
-	NSMutableArray			*_cells;					// the cells that draw the tabs
-	IBOutlet NSTabView		*tabView;					// the tab view being navigated
-	PSMOverflowPopUpButton	*_overflowPopUpButton;		// for too many tabs
-	PSMRolloverButton			*_addTabButton;
-	PSMTabBarController		*_controller;
+	NSMutableArray *_cells;					// the cells that draw the tabs
+	IBOutlet NSTabView *tabView;					// the tab view being navigated
+	PSMOverflowPopUpButton *_overflowPopUpButton;		// for too many tabs
+	PSMRolloverButton *_addTabButton;
+	PSMTabBarController *_controller;
 	
 	// Spring-loading.
 	NSTabViewItem			*_tabViewItemWithSpring;

--- a/Frameworks/PSMTabBar/PSMTabBarControl.m
+++ b/Frameworks/PSMTabBar/PSMTabBarControl.m
@@ -18,6 +18,9 @@
 #include <Carbon/Carbon.h> /* for GetKeys() and KeyMap */
 #include <bitstring.h>
 
+#import "SPDatabaseDocument.h"
+#import "sequel-ace-Swift.h"
+
 @interface PSMTabBarControl (Private)
 
     // constructor/destructor
@@ -613,8 +616,7 @@
 	}
 }
 
-- (void)removeTabForCell:(PSMTabBarCell *)cell
-{
+- (void)removeTabForCell:(PSMTabBarCell *)cell {
 	NSTabViewItem *item = [cell representedObject];
 	
     // unbind
@@ -627,39 +629,26 @@
 	[cell unbind:@"countColor"];
     [cell unbind:@"isEdited"];
 
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(isProcessing)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"isProcessing"];
-		}
-	}
-	
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(icon)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"icon"];
-		}
-	}
-	
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(count)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"objectCount"];
-		}
-	}
-	
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(countColor)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"countColor"];
-		}
-	}
+    SPDatabaseDocument *databaseDocument = [item databaseDocument];
 
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(largeImage)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"largeImage"];
+	if (databaseDocument) {
+		if ([databaseDocument respondsToSelector:@selector(isProcessing)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"isProcessing"];
 		}
-	}
-	
-	if ([item identifier] != nil) {
-		if ([[item identifier] respondsToSelector:@selector(isEdited)]) {
-			[[item identifier] removeObserver:cell forKeyPath:@"isEdited"];
+		if ([databaseDocument respondsToSelector:@selector(icon)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"icon"];
+		}
+		if ([databaseDocument respondsToSelector:@selector(count)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"objectCount"];
+		}
+		if ([databaseDocument respondsToSelector:@selector(countColor)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"countColor"];
+		}
+		if ([databaseDocument respondsToSelector:@selector(largeImage)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"largeImage"];
+		}
+		if ([databaseDocument respondsToSelector:@selector(isEdited)]) {
+			[databaseDocument removeObserver:cell forKeyPath:@"isEdited"];
 		}
 	}
 	
@@ -1587,65 +1576,66 @@
     [item addObserver:self forKeyPath:@"identifier" options:0 context:nil];
 }
 
-- (void)_bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item
-{
+- (void)_bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item {
+
+    SPDatabaseDocument *databaseDocument = [item databaseDocument];
     // bind the indicator to the represented object's status (if it exists)
     [[cell indicator] setHidden:YES];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(isProcessing)]) {
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(isProcessing)]) {
 			NSMutableDictionary *bindingOptions = [NSMutableDictionary dictionary];
 			[bindingOptions setObject:NSNegateBooleanTransformerName forKey:@"NSValueTransformerName"];
-			[[cell indicator] bind:@"animate" toObject:[item identifier] withKeyPath:@"isProcessing" options:nil];
-			[[cell indicator] bind:@"hidden" toObject:[item identifier] withKeyPath:@"isProcessing" options:bindingOptions];
-            [[item identifier] addObserver:cell forKeyPath:@"isProcessing" options:0 context:nil];
+			[[cell indicator] bind:@"animate" toObject:databaseDocument withKeyPath:@"isProcessing" options:nil];
+			[[cell indicator] bind:@"hidden" toObject:databaseDocument withKeyPath:@"isProcessing" options:bindingOptions];
+            [databaseDocument addObserver:cell forKeyPath:@"isProcessing" options:0 context:nil];
         }
     }
     
     // bind for the existence of an icon
     [cell setHasIcon:NO];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(icon)]) {
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(icon)]) {
 			NSMutableDictionary *bindingOptions = [NSMutableDictionary dictionary];
 			[bindingOptions setObject:NSIsNotNilTransformerName forKey:@"NSValueTransformerName"];
-			[cell bind:@"hasIcon" toObject:[item identifier] withKeyPath:@"icon" options:bindingOptions];
-			[[item identifier] addObserver:cell forKeyPath:@"icon" options:0 context:nil];
+			[cell bind:@"hasIcon" toObject:databaseDocument withKeyPath:@"icon" options:bindingOptions];
+			[databaseDocument addObserver:cell forKeyPath:@"icon" options:0 context:nil];
         }
     }
     
     // bind for the existence of a counter
     [cell setCount:0];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(count)]) {
-			[cell bind:@"count" toObject:[item identifier] withKeyPath:@"objectCount" options:nil];
-			[[item identifier] addObserver:cell forKeyPath:@"objectCount" options:0 context:nil];
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(count)]) {
+			[cell bind:@"count" toObject:databaseDocument withKeyPath:@"objectCount" options:nil];
+			[databaseDocument addObserver:cell forKeyPath:@"objectCount" options:0 context:nil];
 		}
     }
 	
     // bind for the color of a counter
     [cell setCountColor:nil];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(countColor)]) {
-			[cell bind:@"countColor" toObject:[item identifier] withKeyPath:@"countColor" options:nil];
-			[[item identifier] addObserver:cell forKeyPath:@"countColor" options:0 context:nil];
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(countColor)]) {
+			[cell bind:@"countColor" toObject:databaseDocument withKeyPath:@"countColor" options:nil];
+			[databaseDocument addObserver:cell forKeyPath:@"countColor" options:0 context:nil];
 		}
     }
 
 	// bind for a large image
 	[cell setHasLargeImage:NO];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(largeImage)]) {
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(largeImage)]) {
 			NSMutableDictionary *bindingOptions = [NSMutableDictionary dictionary];
 			[bindingOptions setObject:NSIsNotNilTransformerName forKey:@"NSValueTransformerName"];
-			[cell bind:@"hasLargeImage" toObject:[item identifier] withKeyPath:@"largeImage" options:bindingOptions];
-			[[item identifier] addObserver:cell forKeyPath:@"largeImage" options:0 context:nil];
+			[cell bind:@"hasLargeImage" toObject:databaseDocument withKeyPath:@"largeImage" options:bindingOptions];
+			[databaseDocument addObserver:cell forKeyPath:@"largeImage" options:0 context:nil];
 		}
     }
 	
     [cell setIsEdited:NO];
-    if ([item identifier] != nil) {
-		if ([[[cell representedObject] identifier] respondsToSelector:@selector(isEdited)]) {
-			[cell bind:@"isEdited" toObject:[item identifier] withKeyPath:@"isEdited" options:nil];
-			[[item identifier] addObserver:cell forKeyPath:@"isEdited" options:0 context:nil];
+    if (databaseDocument != nil) {
+		if ([databaseDocument respondsToSelector:@selector(isEdited)]) {
+			[cell bind:@"isEdited" toObject:databaseDocument withKeyPath:@"isEdited" options:nil];
+			[databaseDocument addObserver:cell forKeyPath:@"isEdited" options:0 context:nil];
 		}
     }
     

--- a/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
+++ b/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
@@ -499,7 +499,7 @@
     // icon
     if ([cell hasIcon]) {
         NSRect iconRect = [self iconRectForTabCell:cell];
-        NSImage *icon = [(id)[[cell representedObject] identifier] icon];
+        NSImage *icon = [[[cell representedObject] identifier] icon];
         
         // center in available space (in case icon image is smaller than kPSMTabBarIconWidth)
         if ([icon size].width < kPSMTabBarIconWidth) {

--- a/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
+++ b/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
@@ -160,38 +160,35 @@
 	// Create and set an unique process ID for each SPDatabaseDocument which has to passed
 	// for each sequelace:// scheme command as user to be able to identify the url scheme command.
 	// Furthermore this id is used to communicate with the called command as file name.
-	id doc = nil;
-	if([[[NSApp mainWindow] delegate] respondsToSelector:@selector(selectedTableDocument)])
-		doc = [(SPWindowController *)[[NSApp mainWindow] delegate] selectedTableDocument];
+	SPDatabaseDocument *databaseDocument = nil;
+    if ([[[NSApp mainWindow] delegate] isKindOfClass:[SPWindowController class]]) {
+        databaseDocument = [(SPWindowController *)[[NSApp mainWindow] delegate] selectedTableDocument];
+    }
 	// Check if connected
-	if([doc getConnection] == nil)
-		doc = nil;
-	else {
-		for (NSWindow *aWindow in [NSApp orderedWindows])
-		{
-			if ([[[[aWindow windowController] class] description] isEqualToString:@"SPWindowController"]) {
+    if ([databaseDocument getConnection] == nil) {
+        databaseDocument = nil;
+    } else {
+        for (NSWindow *window in [NSApp orderedWindows]) {
+			if ([[[window windowController] class] isKindOfClass:[SPWindowController class]]) {
+                NSArray <SPDatabaseDocument *> *documents = [(SPWindowController *)[window windowController] documents];
+                for (SPDatabaseDocument *document in documents) {
+                    // Check if connected
+                    if ([document getConnection]) {
+                        databaseDocument = document;
+                    } else {
+                        databaseDocument = nil;
+                    }
 
-				SPWindowController *windowController = (SPWindowController *)[aWindow windowController];
-				NSArray *documents = [windowController documents];
-
-				if ([documents count] && [[[[documents objectAtIndex:0] class] description] isEqualToString:@"SPDatabaseDocument"]) {
-					// Check if connected
-					if ([[documents objectAtIndex:0] getConnection]) {
-						doc = [documents objectAtIndex:0];
-					}
-					else {
-						doc = nil;
-					}
-				}
+                    if (databaseDocument) {
+                        break;
+                    }
+                }
 			}
-
-			if (doc) break;
 		}
 	}
 
-	if (doc != nil) {
-
-		[doc setProcessID:uuid];
+	if (databaseDocument != nil) {
+		[databaseDocument setProcessID:uuid];
 
 		[theEnv setObject:uuid forKey:SPBundleShellVariableProcessID];
 		[theEnv setObject:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryInputPathHeader stringByExpandingTildeInPath], uuid] forKey:SPBundleShellVariableQueryFile];
@@ -199,21 +196,24 @@
 		[theEnv setObject:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultStatusPathHeader stringByExpandingTildeInPath], uuid] forKey:SPBundleShellVariableQueryResultStatusFile];
 		[theEnv setObject:[NSString stringWithFormat:@"%@%@", [SPURLSchemeQueryResultMetaPathHeader stringByExpandingTildeInPath], uuid] forKey:SPBundleShellVariableQueryResultMetaFile];
 
-		if([doc shellVariables])
-			[theEnv addEntriesFromDictionary:[doc shellVariables]];
+        if ([databaseDocument shellVariables]) {
+			[theEnv addEntriesFromDictionary:[databaseDocument shellVariables]];
+        }
 
 		if([theEnv objectForKey:SPBundleShellVariableCurrentEditedColumnName] && [[theEnv objectForKey:SPBundleShellVariableDataTableSource] isEqualToString:@"content"])
 			[theEnv setObject:[theEnv objectForKey:SPBundleShellVariableSelectedTable] forKey:SPBundleShellVariableCurrentEditedTable];
 
 	}
 
-	if(theEnv != nil && [theEnv count])
+    if(theEnv != nil && [theEnv count]) {
 		[bashTask setEnvironment:theEnv];
+    }
 
-	if(path != nil)
+    if (path != nil) {
 		[bashTask setCurrentDirectoryPath:path];
-	else if([shellEnvironment objectForKey:SPBundleShellVariableBundlePath] && [fileManager fileExistsAtPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath] isDirectory:&isDir] && isDir)
+    } else if ([shellEnvironment objectForKey:SPBundleShellVariableBundlePath] && [fileManager fileExistsAtPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath] isDirectory:&isDir] && isDir) {
 		[bashTask setCurrentDirectoryPath:[shellEnvironment objectForKey:SPBundleShellVariableBundlePath]];
+    }
 
     // logging below due to "Couldn't posix_spawn: error 7"
     // FB: 5c541e5508e7cdd4a925295cabfbf398

--- a/Source/Controllers/BundleSupport/SPBundleEditorController.m
+++ b/Source/Controllers/BundleSupport/SPBundleEditorController.m
@@ -1460,7 +1460,9 @@
 		(action == @selector(displayBundleMetaInfo:))) 
 	{
 		// Allow to record short-cuts used by the Bundle Editor
-		if([[NSApp keyWindow] firstResponder] == keyEquivalentField) return NO;
+        if ([[NSApp keyWindow] firstResponder] == keyEquivalentField) {
+            return NO;
+        }
 		
 		return ([[commandBundleTreeController selectedObjects] count] == 1 && ![[[commandBundleTreeController selectedObjects] objectAtIndex:0] objectForKey:kChildrenKey]);
 	}

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -334,7 +334,7 @@ static inline void SetOnOff(NSNumber *ref,id obj);
 	[self _updateExportAdvancedOptionsLabel];
 	[self setExportInput:source];
 
-	[[tableDocumentInstance parentWindow] beginSheet:self.window completionHandler:^(NSModalResponse returnCode) {
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:self.window completionHandler:^(NSModalResponse returnCode) {
 		// Perform the export
 		if (returnCode == NSModalResponseOK) {
 
@@ -366,7 +366,7 @@ static inline void SetOnOff(NSNumber *ref,id obj);
 	[errorsTextView setString:@""];
 	[errorsTextView setString:errors];
 
-	[[tableDocumentInstance parentWindow] beginSheet:errorsWindow completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:errorsWindow completionHandler:nil];
 }
 
 /**
@@ -443,7 +443,7 @@ static inline void SetOnOff(NSNumber *ref,id obj);
 			[alert setMessageText:NSLocalizedString(@"No directory selected.", @"No directory selected.")];
 			[alert setInformativeText:NSLocalizedString(@"Please select a new export location and try again.", @"Please select a new export location and try again")];
 			
-			[alert beginSheetModalForWindow:[tableDocumentInstance parentWindow] completionHandler:^(NSInteger returnCode) {
+			[alert beginSheetModalForWindow:[tableDocumentInstance parentWindowControllerWindow] completionHandler:^(NSInteger returnCode) {
 				[self performSelector:@selector(_reopenExportSheet) withObject:nil afterDelay:0.1];
 			}];
 			
@@ -1257,7 +1257,7 @@ set_input:
 
 	// If it's not already displayed, open the progress sheet
 	if (![exportProgressWindow isVisible]) {
-		[[tableDocumentInstance parentWindow] beginSheet:exportProgressWindow completionHandler:nil];
+		[[tableDocumentInstance parentWindowControllerWindow] beginSheet:exportProgressWindow completionHandler:nil];
 	}
 
 	// cache the current connection encoding so the exporter can do what it wants.
@@ -1432,7 +1432,7 @@ set_input:
 	[exportProgressIndicator setUsesThreadedAnimation:YES];
 
 	// Open the progress sheet
-	[[tableDocumentInstance parentWindow] beginSheet:exportProgressWindow completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:exportProgressWindow completionHandler:nil];
 
 	// CSV export
 	if (exportType == SPCSVExport) {
@@ -2108,7 +2108,7 @@ set_input:
  * Re-open the export sheet without resetting the interface - for use on error.
  */
 - (void)_reopenExportSheet {
-	[[tableDocumentInstance parentWindow] beginSheet:self.window completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:self.window completionHandler:nil];
 }
 
 #pragma mark - SPExportFilenameUtilities

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -46,6 +46,7 @@
 #import "SPFunctions.h"
 #import "SPQueryController.h"
 #import "SPConstants.h"
+#import "SPWindowController.h"
 @import Firebase;
 
 #import <SPMySQL/SPMySQL.h>
@@ -205,7 +206,7 @@
 	NSRect accessoryViewRect = [importFromClipboardAccessoryView frame];
 	[importView setFrame:NSMakeRect(0, 0, accessoryViewRect.size.width, accessoryViewRect.size.height)];
 
-	[[tableDocumentInstance parentWindow] beginSheet:importFromClipboardSheet completionHandler:^(NSModalResponse returnCode) {
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:importFromClipboardSheet completionHandler:^(NSModalResponse returnCode) {
 		// Reset the interface and store prefs
 		[self->importFromClipboardTextView setString:@""];
 		[self->prefs setObject:[[self->importFormatPopup selectedItem] title] forKey:@"importFormatPopupValue"];
@@ -280,7 +281,7 @@
 		[openPanel setDirectoryURL:[NSURL URLWithString:openPath]];
 	}
 
-	[openPanel beginSheetModalForWindow:[tableDocumentInstance parentWindow] completionHandler:^(NSInteger returnCode) {
+	[openPanel beginSheetModalForWindow:[[tableDocumentInstance parentWindowController] window] completionHandler:^(NSInteger returnCode) {
 		// Ensure text inputs are completed, preventing dead character entry
 		[openPanel makeFirstResponder:nil];
 
@@ -404,7 +405,7 @@
 		[self->singleProgressBar startAnimation:self];
 		
 		// Open the progress sheet
-		[[self->tableDocumentInstance parentWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
+		[[self->tableDocumentInstance parentWindowControllerWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
 	});
 
 	[tableDocumentInstance setQueryMode:SPImportExportQueryMode];
@@ -796,7 +797,7 @@
 		[self->singleProgressBar startAnimation:self];
 		
 		// Open the progress sheet
-		[[self->tableDocumentInstance parentWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
+		[[self->tableDocumentInstance parentWindowControllerWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
 	});
 
 	[tableDocumentInstance setQueryMode:SPImportExportQueryMode];
@@ -949,7 +950,7 @@
 					[self->singleProgressBar setMaxValue:fileTotalLength];
 					[self->singleProgressBar setIndeterminate:NO];
 					[self->singleProgressBar startAnimation:self];
-					[[self->tableDocumentInstance parentWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
+					[[self->tableDocumentInstance parentWindowControllerWindow] beginSheet:self->singleProgressSheet completionHandler:nil];
 				});
 
                 // Set up index sets for use during row enumeration
@@ -1260,7 +1261,7 @@
 		[fieldMapperController setImportDataArray:self->fieldMappingImportArray hasHeader:[self->importFieldNamesSwitch state] isPreview:self->fieldMappingImportArrayIsPreview];
 		
 		// Show field mapper sheet and set the focus to it
-		[[self->tableDocumentInstance parentWindow] beginSheet:[fieldMapperController window] completionHandler:^(NSModalResponse returnCode) {
+		[[self->tableDocumentInstance parentWindowControllerWindow] beginSheet:[fieldMapperController window] completionHandler:^(NSModalResponse returnCode) {
 			self->fieldMapperSheetStatus = (returnCode) ? SPFieldMapperCompleted : SPFieldMapperCancelled;
 		}];
 	});
@@ -1650,7 +1651,7 @@
 	}
 	
 	[errorsView setString:message];
-	[[tableDocumentInstance parentWindow] beginSheet:errorsSheet completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:errorsSheet completionHandler:nil];
 }
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -462,7 +462,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		[keySelectionPanel setAccessoryViewDisclosed:YES];
 	}
 	[keySelectionPanel setDelegate:self];
-	[keySelectionPanel beginSheetModalForWindow:[dbDocument parentWindow] completionHandler:^(NSInteger returnCode){
+	[keySelectionPanel beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:^(NSInteger returnCode){
 
         NSString *selectedFilePath=[[self->keySelectionPanel URL] path];
         NSError *err=nil;
@@ -565,7 +565,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	alert.messageText = [err localizedDescription];
 	alert.informativeText = [err localizedRecoverySuggestion];
 	[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
-	[alert beginSheetModalForWindow:[dbDocument parentWindow] completionHandler:nil];
+	[alert beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:nil];
 }
 
 -(BOOL)validateKeyFile:(NSURL *)url error:(NSError **)outError{
@@ -1215,7 +1215,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 	[openPanel setAllowedFileTypes:@[@"plist"]];
 
-	[openPanel beginSheetModalForWindow:[dbDocument parentWindow] completionHandler:^(NSInteger returnCode)
+	[openPanel beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:^(NSInteger returnCode)
 	{
 		if (returnCode == NSModalResponseOK) {
 			SPFavoritesImporter *importer = [[SPFavoritesImporter alloc] init];
@@ -1245,7 +1245,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	[savePanel setAccessoryView:exportPanelAccessoryView];
 	[savePanel setNameFieldStringValue:fileName];
 
-	[savePanel beginSheetModalForWindow:[dbDocument parentWindow] completionHandler:^(NSInteger returnCode)
+	[savePanel beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:^(NSInteger returnCode)
 	{
 		if (returnCode == NSModalResponseOK) {
 			SPFavoritesExporter *exporter = [[SPFavoritesExporter alloc] init];
@@ -1700,17 +1700,17 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	{
 		case SPTCPIPConnection:
 			if (![[standardPasswordField stringValue] length]) {
-				[[dbDocument parentWindow] makeFirstResponder:standardPasswordField];
+				[[dbDocument parentWindowControllerWindow] makeFirstResponder:standardPasswordField];
 			}
 			break;
 		case SPSocketConnection:
 			if (![[socketPasswordField stringValue] length]) {
-				[[dbDocument parentWindow] makeFirstResponder:socketPasswordField];
+				[[dbDocument parentWindowControllerWindow] makeFirstResponder:socketPasswordField];
 			}
 			break;
 		case SPSSHTunnelConnection:
 			if (![[sshPasswordField stringValue] length]) {
-				[[dbDocument parentWindow] makeFirstResponder:sshPasswordField];
+				[[dbDocument parentWindowControllerWindow] makeFirstResponder:sshPasswordField];
 			}
 			break;
 	}
@@ -2241,7 +2241,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		return;
 	}
 	
-	[sshTunnel setParentWindow:[dbDocument parentWindow]];
+	[sshTunnel setParentWindow:[dbDocument parentWindowControllerWindow]];
 
     // Only set the password if there is no Keychain item set or the connection is being tested or the password is different than in Keychain.
     if ((isTestingConnection || !connectionSSHKeychainItemName || (connectionSSHKeychainItemName && ![[self sshPassword] isEqualToString:@"SequelAceSecretPassword"])) && [self sshPassword]) {
@@ -2379,7 +2379,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	[databaseConnectionView setHidden:NO];
 
 	// Restore the toolbar icons
-	NSArray *toolbarItems = [[[dbDocument parentWindow] toolbar] items];
+	NSArray *toolbarItems = [[[dbDocument parentWindowControllerWindow] toolbar] items];
 
 	for (NSUInteger i = 0; i < [toolbarItems count]; i++) [[toolbarItems objectAtIndex:i] setEnabled:YES];
 
@@ -2434,7 +2434,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	}
 
 	// Only display the connection error message if there is a window visible
-	if ([[dbDocument parentWindow] isVisible]) {
+	if ([[dbDocument parentWindowControllerWindow] isVisible]) {
         errorShowing = YES;
 		NSAlert *alert = [[NSAlert alloc] init];
 		[alert setMessageText:theTitle];
@@ -3159,7 +3159,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 		// jamesstout notes
 		// API_DEPRECATED("Use -beginSheetModalForWindow:completionHandler: instead" - - NSAlert.h L136
-		[alert beginSheetModalForWindow:[dbDocument parentWindow] completionHandler:nil];
+		[alert beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:nil];
 	}
 }
 

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -263,7 +263,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         if ([tableDocumentInstance isUntitled]) {
             [saveQueryFavoriteGlobal setState:NSOnState];
         }
-        [[tableDocumentInstance parentWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
+        [[tableDocumentInstance parentWindowControllerWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
             if (returnCode == NSModalResponseOK) {
                 
                 // Add the new query favorite directly the user's preferences here instead of asking the manager to do it
@@ -305,7 +305,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         if ([tableDocumentInstance isUntitled]) {
             [saveQueryFavoriteGlobal setState:NSOnState];
         }
-        [[tableDocumentInstance parentWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
+        [[tableDocumentInstance parentWindowControllerWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
             if (returnCode == NSModalResponseOK) {
                 
                 // Add the new query favorite directly the user's preferences here instead of asking the manager to do it
@@ -332,7 +332,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         favoritesManager = [[SPQueryFavoriteManager alloc] initWithDelegate:self];
         
         // Open query favorite manager
-        [[tableDocumentInstance parentWindow] beginSheet:[favoritesManager window] completionHandler:nil];
+        [[tableDocumentInstance parentWindowControllerWindow] beginSheet:[favoritesManager window] completionHandler:nil];
     } else if ([queryFavoritesButton indexOfSelectedItem] > 5) {
         // Choose favorite
         BOOL replaceContent = [prefs boolForKey:SPQueryFavoriteReplacesContent];
@@ -509,7 +509,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     [encodingPopUp setEnabled:YES];
     
     [panel setNameFieldStringValue:@"history"];
-    [panel beginSheetModalForWindow:[tableDocumentInstance parentWindow] completionHandler:^(NSInteger returnCode) {
+    [panel beginSheetModalForWindow:[tableDocumentInstance parentWindowControllerWindow] completionHandler:^(NSInteger returnCode) {
         if (returnCode == NSModalResponseOK) {
             NSError *error = nil;
             
@@ -568,7 +568,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     NSString *taskString;
     
     //ensure there is no pending edit, which could be messed up (#2113)
-    [[tableDocumentInstance parentWindow] endEditingFor:nil];
+    [[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
     
     if ([queries count] > 1) {
         taskString = [NSString stringWithFormat:NSLocalizedString(@"Running query %i of %lu...", @"Running multiple queries string"), 1, (unsigned long)[queries count]];
@@ -1063,8 +1063,12 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         
         dispatch_sync(dispatch_get_main_queue(), ^{
             // Restore selection indexes if appropriate
-            if (selectionIndexToRestore) [customQueryView selectRowIndexes:selectionIndexToRestore byExtendingSelection:NO];
-            if (reloadingExistingResult) [[tableDocumentInstance parentWindow] makeFirstResponder:customQueryView];
+            if (selectionIndexToRestore) {
+                [customQueryView selectRowIndexes:selectionIndexToRestore byExtendingSelection:NO];
+            }
+            if (reloadingExistingResult) {
+                [[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:customQueryView];
+            }
         });
     }
 }
@@ -2580,7 +2584,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
                           usingEncoding:[mySQLConnection stringEncoding]
                            isObjectBlob:isBlob
                              isEditable:isFieldEditable
-                             withWindow:[tableDocumentInstance parentWindow]
+                             withWindow:[tableDocumentInstance parentWindowControllerWindow]
                                  sender:self
                             contextInfo:[NSDictionary dictionaryWithObjectsAndKeys:
                                          [NSNumber numberWithInteger:rowIndex], @"rowIndex",
@@ -3202,7 +3206,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     }
     
     // Preserve focus and restore selection indexes if appropriate
-    [[tableDocumentInstance parentWindow] makeFirstResponder:customQueryView];
+    [[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:customQueryView];
     if (selectionIndexToRestore)
         [customQueryView selectRowIndexes:selectionIndexToRestore byExtendingSelection:NO];
     
@@ -3325,7 +3329,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     NSInteger numberOfPossibleUpdateRows = [[editStatus safeObjectAtIndex:0] integerValue];
     
     NSPoint customQueryViewPoint = [customQueryView convertPoint:[customQueryView frameOfCellAtColumn:column row:row].origin toView:nil];
-    NSRect screenRect = [[tableDocumentInstance parentWindow] convertRectToScreen: NSMakeRect(customQueryViewPoint.x, customQueryViewPoint.y, 0,0)];
+    NSRect screenRect = [[tableDocumentInstance parentWindowControllerWindow] convertRectToScreen:NSMakeRect(customQueryViewPoint.x, customQueryViewPoint.y, 0,0)];
     NSPoint pos = NSMakePoint(screenRect.origin.x, screenRect.origin.y);
     
     pos.y -= 20;
@@ -3399,10 +3403,11 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             
             // Send moveDown/Up to the popup menu
             NSEvent *arrowEvent;
-            if(command == @selector(moveDown:))
-                arrowEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x7D];
-            else
-                arrowEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x7E];
+            if (command == @selector(moveDown:)) {
+                arrowEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindowControllerWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x7D];
+            } else {
+                arrowEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindowControllerWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x7E];
+            }
             [NSApp postEvent:arrowEvent atStart:NO];
             return YES;
             
@@ -3422,7 +3427,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [control abortEditing];
             
             // Preserve the focus
-            [[tableDocumentInstance parentWindow] makeFirstResponder:customQueryView];
+            [[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:customQueryView];
             
             return YES;
         }

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -242,8 +242,6 @@
 	NSInteger confirmCopyDatabaseReturnCode;
 
 	// Properties
-	SPWindowController *parentWindowController;
-	NSWindow *parentWindow;
 	NSTabViewItem *parentTabViewItem;
 	BOOL isProcessing;
 	NSString *processID;
@@ -257,11 +255,11 @@
 @property (nonatomic, strong) NSTableView *dbTablesTableView;
 @property (readwrite, strong) NSURL *sqlFileURL;
 @property (readwrite) NSStringEncoding sqlFileEncoding;
-@property (readwrite, strong) SPWindowController *parentWindowController;
 @property (readwrite, strong) NSTabViewItem *parentTabViewItem;
 @property (readwrite) BOOL isProcessing;
 @property (readwrite, copy) NSString *processID;
 
+@property (nonatomic, strong, readonly) SPWindowController *parentWindowController;
 @property (readonly, strong) SPServerSupport *serverSupport;
 @property (readonly, strong) SPDatabaseStructure *databaseStructureRetrieval;
 @property (readonly, strong) SPDataImport *tableDumpInstance;
@@ -270,6 +268,8 @@
 @property (readonly, strong) SPTableContent <SPDatabaseContentViewDelegate> *tableContentInstance;
 
 @property (readonly) int64_t instanceId;
+
+- (instancetype)initWithWindowController:(SPWindowController *)windowController;
 
 - (SPHelpViewerClient *)helpViewerClient;
 
@@ -426,8 +426,9 @@
 
 - (void)setIsProcessing:(BOOL)value;
 - (BOOL)isProcessing;
-- (void)setParentWindow:(NSWindow *)aWindow;
-- (NSWindow *)parentWindow;
+
+- (void)updateParentWindowController:(SPWindowController *)windowController;
+- (NSWindow *)parentWindowControllerWindow;
 
 // Scripting
 - (void)handleSchemeCommand:(NSDictionary*)commandDict;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2958,7 +2958,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [info setObject:@"connection bundle" forKey:SPFFormatKey];
 
             // Loop through all windows
-            for(NSWindow *window in [SPAppDelegate orderedDatabaseConnectionWindows]) {
+            for (SPWindowController *windowController in [SPAppDelegate windowControllers]) {
 
                 // First window is always the currently key window
 
@@ -2968,7 +2968,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                 // Loop through all tabs of a given window
                 NSInteger tabCount = 0;
                 NSInteger selectedTabItem = 0;
-                for(SPDatabaseDocument *doc in [[window windowController] documents]) {
+                for (SPDatabaseDocument *doc in [windowController documents]) {
 
                     // Skip not connected docs eg if connection controller is displayed (TODO maybe to be improved)
                     if(![doc mySQLVersion]) continue;
@@ -2991,13 +2991,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                         [tabData setObject:[[doc fileURL] path] forKey:@"path"];
                     }
                     [tabs addObject:tabData];
-                    if([[window windowController] selectedTableDocument] == doc) selectedTabItem = tabCount;
+                    if ([windowController selectedTableDocument] == doc) selectedTabItem = tabCount;
                     tabCount++;
                 }
-                if(![tabs count]) continue;
+                if (![tabs count]) continue;
                 [win setObject:tabs forKey:@"tabs"];
                 [win setObject:[NSNumber numberWithInteger:selectedTabItem] forKey:@"selectedTabIndex"];
-                [win setObject:NSStringFromRect([window frame]) forKey:@"frame"];
+                [win setObject:NSStringFromRect([[windowController window] frame]) forKey:@"frame"];
                 [windows addObject:win];
             }
             [info setObject:windows forKey:@"windows"];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -109,6 +109,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 @property (nonatomic, strong) NSImage *hideConsoleImage;
 @property (nonatomic, strong) NSImage *showConsoleImage;
 @property (nonatomic, strong) NSImage *textAndCommandMacwindowImage API_AVAILABLE(macos(11.0));
+@property (nonatomic, strong, readwrite) SPWindowController *parentWindowController;
 @property (assign) BOOL appIsTerminating;
 
 
@@ -140,7 +141,6 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 @synthesize sqlFileURL;
 @synthesize sqlFileEncoding;
-@synthesize parentWindowController;
 @synthesize parentTabViewItem;
 @synthesize isProcessing;
 @synthesize serverSupport;
@@ -163,9 +163,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 + (void)initialize {
 }
 
-- (instancetype)init
-{
-    if ((self = [super init])) {
+- (instancetype)initWithWindowController:(SPWindowController *)windowController {
+    if (self = [super init]) {
         instanceId = atomic_fetch_add(&SPDatabaseDocumentInstanceCounter, 1);
 
         _mainNibLoaded = NO;
@@ -208,7 +207,6 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         gotoDatabaseController = nil;
 
         mainToolbar = nil;
-        parentWindow = nil;
         isProcessing = NO;
 
         printWebView = [[WebView alloc] init];
@@ -252,6 +250,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
         databaseStructureRetrieval = [[SPDatabaseStructure alloc] initWithDelegate:self];
     }
+
+    _parentWindowController = windowController;
 
     return self;
 }
@@ -400,7 +400,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [self setFileURL:newURL];
 
     // ...but hide the icon while the document is temporary
-    if ([self isUntitled]) [[parentWindow standardWindowButton:NSWindowDocumentIconButton] setImage:nil];
+    if ([self isUntitled]) {
+        [[[self.parentWindowController window] standardWindowButton:NSWindowDocumentIconButton] setImage:nil];
+    }
 
     // Get the mysql version
     mySQLVersion = [mySQLConnection serverVersionString] ;
@@ -487,8 +489,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [self updateWindowTitle:self];
 
     NSString *serverDisplayName = nil;
-    if ([parentWindowController selectedTableDocument] == self) {
-        serverDisplayName = [parentWindow title];
+    if ([self.parentWindowController selectedTableDocument] == self) {
+        serverDisplayName = [[self.parentWindowController window] title];
     } else {
         serverDisplayName = [parentTabViewItem label];
     }
@@ -727,7 +729,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [addDatabaseCharsetHelper setDefaultCollation:defaultCollation];
     [addDatabaseCharsetHelper setEnabled:YES];
 
-    [parentWindow beginSheet:databaseSheet completionHandler:^(NSModalResponse returnCode) {
+    [[self.parentWindowController window] beginSheet:databaseSheet completionHandler:^(NSModalResponse returnCode) {
         [self->addDatabaseCharsetHelper setEnabled:NO];
 
         if (returnCode == NSModalResponseOK) {
@@ -766,7 +768,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [alterDatabaseCharsetHelper setSelectedCollation:currentCollation];
     [alterDatabaseCharsetHelper setEnabled:YES];
 
-    [parentWindow beginSheet:databaseAlterSheet completionHandler:^(NSModalResponse returnCode) {
+    [[self.parentWindowController window] beginSheet:databaseAlterSheet completionHandler:^(NSModalResponse returnCode) {
 
         [self->alterDatabaseCharsetHelper setEnabled:NO];
         if (returnCode == NSModalResponseOK) {
@@ -865,7 +867,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [databaseCopyNameField setStringValue:selectedDatabase];
     [copyDatabaseMessageField setStringValue:selectedDatabase];
 
-    [parentWindow beginSheet:databaseCopySheet completionHandler:^(NSModalResponse returnCode) {
+    [[self.parentWindowController window] beginSheet:databaseCopySheet completionHandler:^(NSModalResponse returnCode) {
         if (returnCode == NSModalResponseOK) {
             [self _copyDatabase];
         }
@@ -889,7 +891,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [databaseRenameNameField setStringValue:selectedDatabase];
     [renameDatabaseMessageField setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Rename database '%@' to:", @"rename database message"), selectedDatabase]];
 
-    [parentWindow beginSheet:databaseRenameSheet completionHandler:^(NSModalResponse returnCode) {
+    [[self.parentWindowController window] beginSheet:databaseRenameSheet completionHandler:^(NSModalResponse returnCode) {
         if (returnCode == NSModalResponseOK) {
             [self _renameDatabase];
         }
@@ -932,7 +934,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [serverVariablesController setConnection:mySQLConnection];
     }
 
-    [serverVariablesController displayServerVariablesSheetAttachedToWindow:parentWindow];
+    [serverVariablesController displayServerVariablesSheetAttachedToWindow:[self.parentWindowController window]];
 }
 
 /**
@@ -1481,7 +1483,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (void)centerTaskWindow
 {
     NSPoint newBottomLeftPoint;
-    NSRect mainWindowRect = [parentWindow frame];
+    NSRect mainWindowRect = [[self.parentWindowController window] frame];
     NSRect taskWindowRect = [taskProgressWindow frame];
 
     newBottomLeftPoint.x = roundf(mainWindowRect.origin.x + mainWindowRect.size.width/2 - taskWindowRect.size.width/2);
@@ -1796,8 +1798,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [createTableSyntaxWindow makeFirstResponder:createTableSyntaxTextField];
 
     // Show variables sheet
-    [parentWindow beginSheet:createTableSyntaxWindow completionHandler:nil];
-
+    [[self.parentWindowController window] beginSheet:createTableSyntaxWindow completionHandler:nil];
 }
 
 /**
@@ -2298,7 +2299,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         return;
     }
 
-    [userManagerInstance beginSheetModalForWindow:parentWindow completionHandler:^(){ }];
+    [userManagerInstance beginSheetModalForWindow:[self.parentWindowController window] completionHandler:^(){ }];
 }
 
 /**
@@ -2306,7 +2307,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)doPerformQueryService:(NSString *)query
 {
-    [parentWindow makeKeyAndOrderFront:self];
+    [[self.parentWindowController window] makeKeyAndOrderFront:self];
     [self viewQuery:nil];
     [customQueryInstance doPerformQueryService:query];
 }
@@ -2402,7 +2403,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (BOOL)couldCommitCurrentViewActions
 {
-    [parentWindow endEditingFor:nil];
+    [[self.parentWindowController window] endEditingFor:nil];
     switch ([self currentlySelectedView]) {
 
         case SPTableViewStructure:
@@ -2826,7 +2827,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     [panel setNameFieldStringValue:filename];
 
-    [panel beginSheetModalForWindow:parentWindow completionHandler:^(NSInteger returnCode) {
+    [panel beginSheetModalForWindow:[self.parentWindowController window] completionHandler:^(NSInteger returnCode) {
         [self saveConnectionPanelDidEnd:panel returnCode:returnCode contextInfo:(__bridge void *)(contextInfo)];
     }];
 }
@@ -3255,7 +3256,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (IBAction)openDatabaseInNewTab:(id)sender
 {
     // Add a new tab to the window
-    [[parentWindow windowController] addNewConnection:self];
+    [self.parentWindowController addNewConnection:self];
 
     // Get the current state
     NSDictionary *allStateDetails = @{
@@ -3544,7 +3545,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     NSMutableString *tabTitle;
     NSMutableString *windowTitle;
-    SPDatabaseDocument *frontTableDocument = [parentWindowController selectedTableDocument];
+    SPDatabaseDocument *frontTableDocument = [self.parentWindowController selectedTableDocument];
 
     NSColor *tabColor = nil;
 
@@ -3607,15 +3608,17 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Set the titles
     [parentTabViewItem setLabel:tabTitle];
     [parentTabViewItem setColor:tabColor];
-    [parentWindowController updateTabBar];
+    [self.parentWindowController updateTabBar];
 
-    if ([parentWindowController selectedTableDocument] == self) {
-        [parentWindow setTitle:windowTitle];
+    if ([self.parentWindowController selectedTableDocument] == self) {
+        [[self.parentWindowController window] setTitle:windowTitle];
     }
 
     // If the sender wasn't the window controller, update other tabs in this window
     // for shared pathname updates
-    if ([sender class] != [SPWindowController class]) [parentWindowController updateAllTabTitles:self];
+    if ([sender class] != [SPWindowController class]) {
+        [self.parentWindowController updateAllTabTitles:self];
+    }
 }
 
 /**
@@ -3651,8 +3654,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (void)updateTitlebarStatusVisibilityForcingHide:(BOOL)forceHide
 {
     BOOL newIsVisible = !forceHide;
-    if (newIsVisible && [parentWindow styleMask] & NSWindowStyleMaskFullScreen) newIsVisible = NO;
-    if (newIsVisible && [parentWindowController selectedTableDocument] != self) newIsVisible = NO;
+    if (newIsVisible && [[self.parentWindowController window] styleMask] & NSWindowStyleMaskFullScreen) newIsVisible = NO;
+    if (newIsVisible && [self.parentWindowController selectedTableDocument] != self) newIsVisible = NO;
     if (newIsVisible == windowTitleStatusViewIsVisible) return;
 
     if (newIsVisible) {
@@ -3663,9 +3666,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             NSTitlebarAccessoryViewController *accessoryViewController = [[controllerClass alloc] init];
             accessoryViewController.view = titleAccessoryView;
             accessoryViewController.layoutAttribute = NSLayoutAttributeRight;
-            [parentWindow addTitlebarAccessoryViewController:accessoryViewController];
+            [[self.parentWindowController window] addTitlebarAccessoryViewController:accessoryViewController];
         } else {
-            NSView *windowFrame = [[parentWindow contentView] superview];
+            NSView *windowFrame = [[[self.parentWindowController window] contentView] superview];
             NSRect av = [titleAccessoryView frame];
             NSRect initialAccessoryViewFrame = NSMakeRect(
                                                           [windowFrame frame].size.width - av.size.width - 30,
@@ -3678,9 +3681,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         }
     } else {
         if (NSClassFromString(@"NSTitlebarAccessoryViewController")) { // OS X 10.11 and later
-            [parentWindow.titlebarAccessoryViewControllers enumerateObjectsUsingBlock:^(__kindof NSTitlebarAccessoryViewController * _Nonnull accessoryViewController, NSUInteger idx, BOOL * _Nonnull stop) {
+            [[self.parentWindowController window].titlebarAccessoryViewControllers enumerateObjectsUsingBlock:^(__kindof NSTitlebarAccessoryViewController * _Nonnull accessoryViewController, NSUInteger idx, BOOL * _Nonnull stop) {
                 if (accessoryViewController.view == titleAccessoryView) {
-                    [parentWindow removeTitlebarAccessoryViewControllerAtIndex:idx];
+                    [[self.parentWindowController window] removeTitlebarAccessoryViewControllerAtIndex:idx];
                 }
             }];
         } else {
@@ -4012,7 +4015,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)makeKeyDocument
 {
-    [[[self parentWindow] onMainThread] makeKeyAndOrderFront:self];
+    [[[self.parentWindowController window] onMainThread] makeKeyAndOrderFront:self];
     [[[[self parentTabViewItem] onMainThread] tabView] selectTabViewItemWithIdentifier:self];
 }
 
@@ -4094,8 +4097,6 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     if ([[[SPQueryController sharedQueryController] window] isVisible]) [self toggleConsole:self];
     [createTableSyntaxWindow orderOut:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self setParentWindow:nil];
-
 }
 
 /**
@@ -4108,7 +4109,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [self updateTitlebarStatusVisibilityForcingHide:YES];
 
     // Remove the task progress window
-    [parentWindow removeChildWindow:taskProgressWindow];
+    [[self.parentWindowController window] removeChildWindow:taskProgressWindow];
     [taskProgressWindow orderOut:self];
 }
 
@@ -4119,19 +4120,19 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (void)didBecomeActiveTabInWindow
 {
     // Update the toolbar
-    BOOL toolbarVisible = ![parentWindow toolbar] || [[parentWindow toolbar] isVisible];
-    [parentWindow setToolbar:mainToolbar];
-    [[parentWindow toolbar] setVisible:toolbarVisible];
+    BOOL toolbarVisible = ![[self.parentWindowController window] toolbar] || [[[self.parentWindowController window] toolbar] isVisible];
+    [[self.parentWindowController window] setToolbar:mainToolbar];
+    [mainToolbar setVisible:toolbarVisible];
 
     // Update the window's title and represented document
     [self updateWindowTitle:self];
-    [parentWindow setRepresentedURL:(spfFileURL && [spfFileURL isFileURL] ? spfFileURL : nil)];
+    [[self.parentWindowController window] setRepresentedURL:(spfFileURL && [spfFileURL isFileURL] ? spfFileURL : nil)];
 
     [self updateTitlebarStatusVisibilityForcingHide:NO];
 
     // Add the progress window to this window
     [self centerTaskWindow];
-    [parentWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
+    [[self.parentWindowController window] addChildWindow:taskProgressWindow ordered:NSWindowAbove];
 
     // If not connected, update the favorite selection
     if (!_isConnected) {
@@ -4172,34 +4173,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [contentViewSplitter setPosition:[[[contentViewSplitter subviews] objectAtIndex:0] bounds].size.width ofDividerAtIndex:0];
 
     // If the task interface is visible, and this tab is frontmost, re-center the task child window
-    if (_isWorkingLevel && [parentWindowController selectedTableDocument] == self) [self centerTaskWindow];
-}
-
-/**
- * Set the parent window
- */
-- (void)setParentWindow:(NSWindow *)window
-{
-    NSWindow *favoritesOutlineViewWindow = [[connectionController favoritesOutlineView] window];
-
-    // If the window is being set for the first time - connection controller is visible - update focus
-    if (!parentWindow && !mySQLConnection && window == favoritesOutlineViewWindow) {
-        [window makeFirstResponder:[connectionController favoritesOutlineView]];
-    }
-
-    parentWindow = window;
-
-    SPSSHTunnel *currentTunnel = [connectionController valueForKeyPath:@"sshTunnel"];
-
-    if (currentTunnel) [currentTunnel setParentWindow:parentWindow];
-}
-
-/**
- * Return the parent window
- */
-- (NSWindow *)parentWindow
-{
-    return parentWindow;
+    if (_isWorkingLevel && [self.parentWindowController selectedTableDocument] == self) [self centerTaskWindow];
 }
 
 #pragma mark -
@@ -4210,10 +4184,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)setFileURL:(NSURL *)theURL
 {
-    spfFileURL  = theURL;
-    if ([parentWindowController selectedTableDocument] == self) {
-        if (spfFileURL && [spfFileURL isFileURL]) [parentWindow setRepresentedURL:spfFileURL];
-        else                                      [parentWindow setRepresentedURL:nil];
+    spfFileURL = theURL;
+    if ([self.parentWindowController selectedTableDocument] == self) {
+        if (spfFileURL && [spfFileURL isFileURL]) {
+            [[self.parentWindowController window] setRepresentedURL:spfFileURL];
+        } else {
+            [[self.parentWindowController window] setRepresentedURL:nil];
+        }
     }
 }
 
@@ -4398,7 +4375,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
         [sessionState setObject:[mySQLConnection encoding] forKey:@"connectionEncoding"];
 
-        [sessionState setObject:[NSNumber numberWithBool:[[parentWindow toolbar] isVisible]] forKey:@"isToolbarVisible"];
+        [sessionState setObject:[NSNumber numberWithBool:[[[self.parentWindowController window] toolbar] isVisible]] forKey:@"isToolbarVisible"];
         [sessionState setObject:[NSNumber numberWithFloat:[tableContentInstance tablesListWidth]] forKey:@"windowVerticalDividerPosition"];
 
         if ([tableContentInstance sortColumnName]) [sessionState setObject:[tableContentInstance sortColumnName] forKey:@"contentSortCol"];
@@ -4622,7 +4599,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [inputTextWindowSecureTextField setStringValue:@""];
             [inputTextWindowSecureTextField selectText:nil];
 
-            [parentWindow beginSheet:inputTextWindow completionHandler:nil];
+            [[self.parentWindowController window] beginSheet:inputTextWindow completionHandler:nil];
             // wait for encryption password
             NSModalSession session = [NSApp beginModalSessionForWindow:inputTextWindow];
             for (;;) {
@@ -4813,8 +4790,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Update the window title to indicate that we are trying to establish a connection
     [parentTabViewItem setLabel:NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting")];
 
-    if ([parentWindowController selectedTableDocument] == self) {
-        [parentWindow setTitle:NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting")];
+    if ([self.parentWindowController selectedTableDocument] == self) {
+        [[self.parentWindowController window] setTitle:NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting")];
     }
 }
 
@@ -4935,7 +4912,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     if([command isEqualToString:@"SetSelectedTextRange"]) {
         if([params count] > 1) {
-            id firstResponder = [parentWindow firstResponder];
+            id firstResponder = [[self.parentWindowController window] firstResponder];
             if([firstResponder isKindOfClass:[NSTextView class]]) {
                 NSRange theRange = NSIntersectionRange(NSRangeFromString([params objectAtIndex:1]), NSMakeRange(0, [[firstResponder string] length]));
                 if(theRange.location != NSNotFound) {
@@ -4950,7 +4927,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     if([command isEqualToString:@"InsertText"]) {
         if([params count] > 1) {
-            id firstResponder = [parentWindow firstResponder];
+            id firstResponder = [[self.parentWindowController window] firstResponder];
             if([firstResponder isKindOfClass:[NSTextView class]]) {
                 [((NSTextView *)firstResponder).textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:[params objectAtIndex:1]]];
                 return;
@@ -4962,7 +4939,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     if([command isEqualToString:@"SetText"]) {
         if([params count] > 1) {
-            id firstResponder = [parentWindow firstResponder];
+            id firstResponder = [[self.parentWindowController window] firstResponder];
             if([firstResponder isKindOfClass:[NSTextView class]]) {
                 [(NSTextView *)firstResponder setSelectedRange:NSMakeRange(0, [[firstResponder string] length])];
                 [((NSTextView *)firstResponder).textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:[params objectAtIndex:1]]];
@@ -5483,7 +5460,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     // Otherwise position the sheet beneath the tab bar if it's visible
-    rect.origin.y -= [parentWindowController.tabBar frame].size.height - 1;
+    rect.origin.y -= [self.parentWindowController.tabBar frame].size.height - 1;
 
     return rect;
 }
@@ -6082,7 +6059,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [self->spHistoryControllerInstance updateHistoryEntries];
         
         // Set the focus on the text field
-        [self->parentWindow makeFirstResponder:self->customQueryTextView];
+        [[self.parentWindowController window] makeFirstResponder:self->customQueryTextView];
         
         [self->prefs setInteger:SPQueryEditorViewMode forKey:SPLastViewMode];
     });
@@ -6111,7 +6088,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [self->extendedTableInfoInstance loadTable:[self table]];
         }
         
-        [self->parentWindow makeFirstResponder:[self->extendedTableInfoInstance valueForKeyPath:@"tableCreateSyntaxTextView"]];
+        [[self.parentWindowController window] makeFirstResponder:[self->extendedTableInfoInstance valueForKeyPath:@"tableCreateSyntaxTextView"]];
         
         [self->prefs setInteger:SPTableInfoViewMode forKey:SPLastViewMode];
     });
@@ -6624,18 +6601,20 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     // Only display the reconnect dialog if the window is visible
     // and we are not terminating
-    if ([self parentWindow] && [[self parentWindow] isVisible] && appIsTerminating == NO) {
+    if ([self.parentWindowController window] && [[self.parentWindowController window] isVisible] && appIsTerminating == NO) {
 
         SPLog(@"not terminating, parentWindow isVisible, showing connectionErrorDialog");
         CLS_LOG(@"not terminating, parentWindow isVisible, showing connectionErrorDialog");
         // Ensure the window isn't miniaturized
-        if ([[self parentWindow] isMiniaturized]) [[self parentWindow] deminiaturize:self];
+        if ([[self.parentWindowController window] isMiniaturized]) {
+            [[self.parentWindowController window] deminiaturize:self];
+        }
 
         // Ensure the window and tab are frontmost
         [self makeKeyDocument];
 
         // Display the connection error dialog and wait for the return code
-        [self.parentWindow beginSheet:connectionErrorDialog completionHandler:nil];
+        [[self.parentWindowController window] beginSheet:connectionErrorDialog completionHandler:nil];
         connectionErrorCode = (SPMySQLConnectionLostDecision)[NSApp runModalForWindow:connectionErrorDialog];
 
         [NSApp endSheet:connectionErrorDialog];
@@ -6655,7 +6634,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)showErrorWithTitle:(NSString *)theTitle message:(NSString *)theMessage
 {
-    if ([[self parentWindow] isVisible]) {
+    if ([[self.parentWindowController window] isVisible]) {
         [NSAlert createWarningAlertWithTitle:theTitle message:theMessage callback:nil];
     }
 }
@@ -6673,7 +6652,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)closeAndDisconnect
 {
-    NSWindow *theParentWindow = [self parentWindow];
+    NSWindow *theParentWindow = [self.parentWindowController window];
 
     _isConnected = NO;
 
@@ -6688,6 +6667,14 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     [self parentTabDidClose];
+}
+
+- (void)updateParentWindowController:(SPWindowController *)windowController {
+    self.parentWindowController = windowController;
+}
+
+- (NSWindow *)parentWindowControllerWindow {
+    return [self.parentWindowController window];
 }
 
 #pragma mark - SPPrintController
@@ -6712,7 +6699,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
      */
     if ([self isWorking]) [self endTask];
 
-    [op runOperationModalForWindow:[self parentWindow] delegate:self didRunSelector:nil contextInfo:nil];
+    [op runOperationModalForWindow:[self.parentWindowController window] delegate:self didRunSelector:nil contextInfo:nil];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -623,7 +623,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	}
 
 	// Store the current first responder so filter field doesn't steal focus
-	id currentFirstResponder = [[tableDocumentInstance parentWindow] firstResponder];
+	id currentFirstResponder = [[tableDocumentInstance parentWindowControllerWindow] firstResponder];
 	// For text inputs the window's fieldEditor will be the actual firstResponder, but that is useless for setting.
 	// We need the visible view object, which is the delegate of the field editor.
 	if([currentFirstResponder respondsToSelector:@selector(isFieldEditor)] && [currentFirstResponder isFieldEditor]) {
@@ -653,7 +653,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	if ([prefs boolForKey:SPLimitResults]) contentPage = pageToRestore;
 
 	// Restore first responder
-	[[tableDocumentInstance parentWindow] makeFirstResponder:currentFirstResponder];
+	[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:currentFirstResponder];
 
 	// Set the state of the table buttons
 	[addButton setEnabled:(enableInteraction && [tablesListInstance tableType] == SPTableTypeTable)];
@@ -1754,7 +1754,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
  */
 - (IBAction)removeRow:(id)sender {
 	// cancel editing (maybe this is not the ideal method -- see xcode docs for that method)
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	if (![tableContentView numberOfSelectedRows]) return;
 
@@ -2447,15 +2447,15 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		if ( isEditingNewRow ) {
 			if ( [prefs boolForKey:SPReloadAfterAddingRow] ) {
 
-				// Save any edits which have been started but not saved to the underlying table/data structures
-				// yet - but not if currently undoing/redoing, as this can cause a processing loop
-				if (![[[[tableContentView window] firstResponder] undoManager] isUndoing] && ![[[[tableContentView window] firstResponder] undoManager] isRedoing]) {
-				[[tableDocumentInstance parentWindow] endEditingFor:nil];
-				}
+                // Save any edits which have been started but not saved to the underlying table/data structures
+                // yet - but not if currently undoing/redoing, as this can cause a processing loop
+                if (![[[[tableContentView window] firstResponder] undoManager] isUndoing] && ![[[[tableContentView window] firstResponder] undoManager] isRedoing]) {
+                    [[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
+                }
 
-				previousTableRowsCount = tableRowsCount;
-				[self loadTableValues];
-			}
+                previousTableRowsCount = tableRowsCount;
+                [self loadTableValues];
+            }
 			else {
 				// Set the insertId for fields with auto_increment
 				for ( i = 0; i < [dataColumns count]; i++ ) {
@@ -2469,20 +2469,20 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		// Existing row edited successfully
 		} else {
 
-			// Reload table if set to - otherwise no action required.
-			if ([prefs boolForKey:SPReloadAfterEditingRow]) {
+            // Reload table if set to - otherwise no action required.
+            if ([prefs boolForKey:SPReloadAfterEditingRow]) {
 
-				// Save any edits which have been started but not saved to the underlying table/data structures
-				// yet - but not if currently undoing/redoing, as this can cause a processing loop
-				if (![[[[tableContentView window] firstResponder] undoManager] isUndoing] && ![[[[tableContentView window] firstResponder] undoManager] isRedoing]) {
-				[[tableDocumentInstance parentWindow] endEditingFor:nil];
-				}
+                // Save any edits which have been started but not saved to the underlying table/data structures
+                // yet - but not if currently undoing/redoing, as this can cause a processing loop
+                if (![[[[tableContentView window] firstResponder] undoManager] isUndoing] && ![[[[tableContentView window] firstResponder] undoManager] isRedoing]) {
+                    [[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
+                }
 
-				previousTableRowsCount = tableRowsCount;
-				[self loadTableValues];
-			}
-		}
-		currentlyEditingRow = -1;
+                previousTableRowsCount = tableRowsCount;
+                [self loadTableValues];
+            }
+        }
+        currentlyEditingRow = -1;
 
         isSavingRow = NO;
 		return YES;
@@ -2717,7 +2717,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// Save any edits which have been started but not saved to the underlying table/data structures
 	// yet - but not if currently undoing/redoing, as this can cause a processing loop
 	if (![[[[tableContentView window] firstResponder] undoManager] isUndoing] && ![[[[tableContentView window] firstResponder] undoManager] isRedoing]) { // -window is a UI method!
-		[[tableDocumentInstance parentWindow] endEditingFor:nil];
+		[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 	}
 
 	// If no rows are currently being edited, or a save is in progress, return success at once.
@@ -4180,7 +4180,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			              usingEncoding:[mySQLConnection stringEncoding]
 			               isObjectBlob:isBlob
 			                 isEditable:isFieldEditable
-			                 withWindow:[tableDocumentInstance parentWindow]
+			                 withWindow:[tableDocumentInstance parentWindowControllerWindow]
 			                     sender:self
 			                contextInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInteger:rowIndex], @"rowIndex", [NSNumber numberWithInteger:editedColumn], @"columnIndex", [NSNumber numberWithBool:isFieldEditable], @"isFieldEditable", nil]];
 
@@ -4480,7 +4480,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		NSInteger numberOfPossibleUpdateRows = [[editStatus objectAtIndex:0] integerValue];
 		
 		NSPoint tblContentViewPoint = [tableContentView convertPoint:[tableContentView frameOfCellAtColumn:column row:row].origin toView:nil];
-		NSRect screenRect = [[tableDocumentInstance parentWindow] convertRectToScreen: NSMakeRect(tblContentViewPoint.x, tblContentViewPoint.y, 0,0)];
+		NSRect screenRect = [[tableDocumentInstance parentWindowControllerWindow] convertRectToScreen:NSMakeRect(tblContentViewPoint.x, tblContentViewPoint.y, 0,0)];
 		NSPoint pos = NSMakePoint(screenRect.origin.x, screenRect.origin.y);
 		
 		pos.y -= 20;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4358,8 +4358,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		// Suppress tooltip if another toolip is already visible, mainly displayed by a Bundle command
 		// TODO has to be improved
-		for (id win in [NSApp orderedWindows])
-		{
+		for (id win in [NSApp orderedWindows]) {
 			if ([[[[win contentView] class] description] isEqualToString:@"WKWebView"]) return nil;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
+++ b/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
@@ -118,7 +118,7 @@ static NSString *SPRelationOnDeleteKey   = @"on_delete";
  * Opens the relation sheet, in its current state (without any reset of fields)
  */
 - (IBAction)openRelationSheet:(id)sender {
-	[[tableDocumentInstance parentWindow] beginSheet:addRelationPanel completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:addRelationPanel completionHandler:nil];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -473,7 +473,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			[resetAutoIncrementLine setHidden:NO];
 		}
 
-		[[tableDocumentInstance parentWindow] beginSheet:resetAutoIncrementSheet completionHandler:^(NSModalResponse returnCode) {
+		[[tableDocumentInstance parentWindowControllerWindow] beginSheet:resetAutoIncrementSheet completionHandler:^(NSModalResponse returnCode) {
 			if (returnCode == NSAlertFirstButtonReturn) {
 				[self takeAutoIncrementFrom:self->resetAutoIncrementValue];
 			}
@@ -521,7 +521,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	
 	currentlyEditingRow = -1;
 	
-	[[tableDocumentInstance parentWindow] makeFirstResponder:tableSourceView];
+	[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:tableSourceView];
 	
 	return YES;
 }
@@ -636,9 +636,9 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 	// Save any edits which have been made but not saved to the table yet;
 	// but not for any NSSearchFields which could cause a crash for undo, redo.
-	id currentFirstResponder = [[tableDocumentInstance parentWindow] firstResponder];
+	id currentFirstResponder = [[tableDocumentInstance parentWindowControllerWindow] firstResponder];
 	if (currentFirstResponder && [currentFirstResponder isKindOfClass:[NSView class]] && [(NSView *)currentFirstResponder isDescendantOf:tableSourceView]) {
-		[[tableDocumentInstance parentWindow] endEditingFor:nil];
+		[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 	}
 
 	// If no rows are currently being edited, or a save is already in progress, return success at once.
@@ -1009,7 +1009,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 	// Problem: reentering edit mode for first cell doesn't function
 	[tableSourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:currentlyEditingRow] byExtendingSelection:NO];
-	[tableSourceView performSelector:@selector(keyDown:) withObject:[NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x24] afterDelay:0.0];
+	[tableSourceView performSelector:@selector(keyDown:) withObject:[NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0,0) modifierFlags:0 timestamp:0 windowNumber:[[tableDocumentInstance parentWindowControllerWindow] windowNumber] context:[NSGraphicsContext currentContext] characters:@"" charactersIgnoringModifiers:@"" isARepeat:NO keyCode:0x24] afterDelay:0.0];
 
 	[tableSourceView reloadData];
 }
@@ -1288,7 +1288,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			[self->tableDocumentInstance endTask];
 
 			// Preserve focus on table for keyboard navigation
-			[[self->tableDocumentInstance parentWindow] makeFirstResponder:self->tableSourceView];
+			[[self->tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:self->tableSourceView];
 		}
 	});
 }
@@ -1771,7 +1771,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 				// Asks the user to add an index to query if AUTO_INCREMENT is set and field isn't indexed
 				if ((![currentRow objectForKey:@"Key"] || [[currentRow objectForKey:@"Key"] isEqualToString:@""])) {
 					[chooseKeyButton selectItemWithTag:SPPrimaryKeyMenuTag];
-					[[tableDocumentInstance parentWindow] beginSheet:keySheet completionHandler:^(NSModalResponse returnCode) {
+					[[tableDocumentInstance parentWindowControllerWindow] beginSheet:keySheet completionHandler:^(NSModalResponse returnCode) {
 						if (returnCode) {
 							switch ([[self->chooseKeyButton selectedItem] tag]) {
 								case SPPrimaryKeyMenuTag:
@@ -2060,7 +2060,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 		[tableSourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
 
-		[[tableDocumentInstance parentWindow] makeFirstResponder:tableSourceView];
+		[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:tableSourceView];
 
 		return YES;
 	}

--- a/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
+++ b/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
@@ -565,7 +565,7 @@ static SPTriggerEventTag TagForEvent(NSString *mysql);
  * Open the add or edit trigger sheet.
  */
 - (void)_openTriggerSheet {
-	[[tableDocumentInstance parentWindow] beginSheet:addTriggerPanel completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:addTriggerPanel completionHandler:nil];
 }
 
 /**

--- a/Source/Controllers/SPAppController.h
+++ b/Source/Controllers/SPAppController.h
@@ -54,6 +54,8 @@
 
 @property (readwrite, copy) NSString *lastBundleBlobFilesDirectory;
 
+@property (nonatomic, strong, readonly) SPWindowController *rootWindowController;
+
 @property (weak) IBOutlet NSView *staleBookmarkHelpView;
 
 // IBAction methods
@@ -114,9 +116,7 @@
 
 - (SPWindowController *)newWindow;
 - (SPDatabaseDocument *)makeNewConnectionTabOrWindow;
-- (SPWindowController *)frontController;
 
-- (NSWindow *)frontDocumentWindow;
 - (void)tabDragStarted:(id)sender;
 
 @end

--- a/Source/Controllers/SPAppController.h
+++ b/Source/Controllers/SPAppController.h
@@ -115,7 +115,6 @@
 - (IBAction)duplicateTab:(id)sender;
 
 - (SPWindowController *)newWindow;
-- (SPDatabaseDocument *)makeNewConnectionTabOrWindow;
 
 - (void)tabDragStarted:(id)sender;
 

--- a/Source/Controllers/SPAppController.h
+++ b/Source/Controllers/SPAppController.h
@@ -110,8 +110,6 @@
 - (IBAction)newTab:(id)sender;
 - (IBAction)duplicateTab:(id)sender;
 
-//- (SPWindowController *)newWindow;
-
 - (void)tabDragStarted:(id)sender;
 
 @end

--- a/Source/Controllers/SPAppController.h
+++ b/Source/Controllers/SPAppController.h
@@ -53,8 +53,7 @@
 }
 
 @property (readwrite, copy) NSString *lastBundleBlobFilesDirectory;
-
-@property (nonatomic, strong, readonly) SPWindowController *rootWindowController;
+@property (nonatomic, strong, readonly) NSMutableArray <SPWindowController *> *windowControllers;
 
 @property (weak) IBOutlet NSView *staleBookmarkHelpView;
 
@@ -79,7 +78,6 @@
 
 // Getters
 - (SPPreferenceController *)preferenceController;
-- (NSArray *)orderedDatabaseConnectionWindows;
 - (SPDatabaseDocument *)frontDocument;
 - (NSURL *)sessionURL;
 - (NSDictionary *)spfSessionDocData;
@@ -99,11 +97,9 @@
 
 - (NSDictionary *)shellEnvironmentForDocument:(NSString *)docUUID;
 
-
 #pragma mark - SPAppleScriptSupport
 
-- (NSArray *)orderedDocuments;
-- (void)insertInOrderedDocuments:(SPDatabaseDocument *)doc;
+- (NSArray <SPDatabaseDocument *> *)orderedDocuments;
 - (NSArray *)orderedWindows;
 - (id)handleQuitScriptCommand:(NSScriptCommand *)command;
 - (id)handleOpenScriptCommand:(NSScriptCommand *)command;
@@ -114,7 +110,7 @@
 - (IBAction)newTab:(id)sender;
 - (IBAction)duplicateTab:(id)sender;
 
-- (SPWindowController *)newWindow;
+//- (SPWindowController *)newWindow;
 
 - (void)tabDragStarted:(id)sender;
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1183,11 +1183,13 @@
  * Provide a method to retrieve an ordered list of the database
  * connection windows currently open in the application.
  */
-- (NSArray *) orderedDatabaseConnectionWindows
+- (NSArray *)orderedDatabaseConnectionWindows
 {
     NSMutableArray *orderedDatabaseConnectionWindows = [NSMutableArray array];
-    for (NSWindow *aWindow in [NSApp orderedWindows]) {
-        if ([[aWindow windowController] isMemberOfClass:[SPWindowController class]]) [orderedDatabaseConnectionWindows addObject:aWindow];
+    for (NSWindow *window in [NSApp orderedWindows]) {
+        if ([[window windowController] isMemberOfClass:[SPWindowController class]]) {
+            [orderedDatabaseConnectionWindows addObject:window];
+        }
     }
     return orderedDatabaseConnectionWindows;
 }
@@ -1195,24 +1197,21 @@
 /**
  * Retrieve the frontmost document; returns nil if not found.
  */
-- (SPDatabaseDocument *) frontDocument
-{
+- (SPDatabaseDocument *)frontDocument {
     return [self.rootWindowController selectedTableDocument];
 }
 
 /**
  * Retrieve the session URL. Return nil if no session is opened
  */
-- (NSURL *)sessionURL
-{
+- (NSURL *)sessionURL {
     return _sessionURL;
 }
 
 /**
  * Set the global session URL used for Save (As) Session.
  */
-- (void)setSessionURL:(NSString *)urlString
-{
+- (void)setSessionURL:(NSString *)urlString {
 
     if(urlString)
         _sessionURL = [NSURL fileURLWithPath:urlString];

--- a/Source/Controllers/SubviewControllers/SPIndexesController.m
+++ b/Source/Controllers/SubviewControllers/SPIndexesController.m
@@ -223,7 +223,7 @@ static void *IndexesControllerKVOContext = &IndexesControllerKVOContext;
 	[indexKeyBlockSizeTextField setEnabled:YES];
 
 	// Begin the sheet
-	[[dbDocument parentWindow] beginSheet:self.window completionHandler:^(NSModalResponse returnCode) {
+	[[dbDocument parentWindowControllerWindow] beginSheet:self.window completionHandler:^(NSModalResponse returnCode) {
 		if (returnCode == NSModalResponseOK) {
 			[self->dbDocument startTaskWithDescription:NSLocalizedString(@"Adding index...", @"adding index task status message")];
 

--- a/Source/Controllers/SubviewControllers/SPNavigatorController.m
+++ b/Source/Controllers/SubviewControllers/SPNavigatorController.m
@@ -280,39 +280,48 @@ static NSComparisonResult compareStrings(NSString *s1, NSString *s2, void* conte
 	ignoreUpdate = flag;
 }
 
-- (void)removeConnection:(NSString*)connectionID
-{
-	if(schemaData && [schemaData objectForKey:connectionID]) {
+- (void)removeConnection:(NSString*)connectionID {
+	if (schemaData && [schemaData objectForKey:connectionID]) {
 		
 		NSInteger docCounter = 0;
 
 		// Detect if more than one connection windows with the connectionID are open.
 		// If so, don't remove it.
 		if ([SPAppDelegate frontDocument]) {
-			for(id doc in [SPAppDelegate orderedDocuments]) {
-				if([[doc connectionID] isEqualToString:connectionID])
+			for (SPDatabaseDocument *databaseDocument in [SPAppDelegate orderedDocuments]) {
+                if ([[databaseDocument connectionID] isEqualToString:connectionID]) {
 					docCounter++;
-				if(docCounter > 1) break;
+                }
+                if (docCounter > 1) {
+                    break;
+                }
 			}
 		}
 
-		if(docCounter > 1) return;
+        if (docCounter > 1) {
+            return;
+        }
 
-		if(schemaData && [schemaData objectForKey:connectionID] && [SPAppDelegate frontDocument] && [[SPAppDelegate orderedDocuments] count])
+        if (schemaData && [schemaData objectForKey:connectionID] && [SPAppDelegate frontDocument] && [[SPAppDelegate orderedDocuments] count]) {
 			[self saveSelectedItems];
+        }
 
-		if(schemaDataFiltered)
+        if (schemaDataFiltered) {
 			[schemaDataFiltered removeObjectForKey:connectionID];
-		if(schemaData)
+        }
+        if (schemaData) {
 			[schemaData removeObjectForKey:connectionID];
-		if(allSchemaKeys)
+        }
+        if (allSchemaKeys) {
 			[allSchemaKeys removeObjectForKey:connectionID];
+        }
 
-		if([[self window] isVisible]) {
+		if ([[self window] isVisible]) {
 			[outlineSchema2 reloadData];
 			[self restoreSelectedItems];
-			if(isFiltered)
+            if (isFiltered) {
 				[self filterTree:self];
+            }
 		}
 	}
 }

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -34,6 +34,7 @@
 #import "SPFunctions.h"
 #import "pthread.h"
 #import "SPCopyTable.h"
+#import "SPDatabaseDocument.h"
 
 @import FMDB;
 
@@ -883,15 +884,16 @@ static SPQueryController *sharedQueryController = nil;
 	NSArray *allDocs = [SPAppDelegate orderedDocuments];
 	NSMutableArray *allURLs = [NSMutableArray array];
 
-	for (id doc in allDocs)
+	for (SPDatabaseDocument *databaseDocument in allDocs)
 	{
-		if (![doc fileURL]) continue;
+        if (![databaseDocument fileURL]) {
+            continue;
+        }
 
-		if ([allURLs containsObject:[doc fileURL]]) {
+		if ([allURLs containsObject:[databaseDocument fileURL]]) {
 			return;
-		}
-		else {
-			[allURLs addObject:[doc fileURL]];
+		} else {
+			[allURLs addObject:[databaseDocument fileURL]];
 		}
 	}
 

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1253,7 +1253,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	contentFilterManager = [[SPContentFilterManager alloc] initWithDatabaseDocument:tableDocumentInstance forFilterType:filterType];
 
 	// Open query favorite manager
-	[[tableDocumentInstance parentWindow] beginSheet:[contentFilterManager window] completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:[contentFilterManager window] completionHandler:nil];
 }
 
 - (void)_contentFiltersHaveBeenUpdated:(NSNotification *)notification

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -384,7 +384,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 {
 	if ((![tableSourceInstance saveRowOnDeselect]) || (![tableContentInstance saveRowOnDeselect]) || (![tableDocumentInstance database])) return;
 
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	// Populate the table type (engine) popup button
 	[tableTypeButton removeAllItems];
@@ -415,7 +415,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	// Set the focus to the name field
 	[tableSheet makeFirstResponder:tableNameField];
 
-	[[tableDocumentInstance parentWindow] beginSheet:tableSheet completionHandler:^(NSModalResponse returnCode) {
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:tableSheet completionHandler:^(NSModalResponse returnCode) {
 		[self->addTableCharsetHelper setEnabled:NO];
 		if (returnCode == NSModalResponseOK) {
 			[self _addTable];
@@ -504,7 +504,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		return;
 	}
 
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	NSString *alertTitle = @"";
 	NSString *alertInformativeText = @"";
@@ -592,7 +592,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 
 	[[self onMainThread] setDatabases:nil];
 
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	NSInteger objectType = [[filteredTableTypes objectAtIndex:[tablesListView selectedRow]] integerValue];
 
@@ -623,7 +623,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 
 	[copyTableButton setEnabled:[self isTableNameValid:[copyTableNameField stringValue] forType:[self tableType]]];
 
-	[[tableDocumentInstance parentWindow] beginSheet:copyTableSheet completionHandler:^(NSModalResponse returnCode) {
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:copyTableSheet completionHandler:^(NSModalResponse returnCode) {
 		if (returnCode == NSModalResponseOK) {
 			[self _copyTable];
 		}
@@ -670,7 +670,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		return;
 	}
 
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
     if ([tablesListView numberOfSelectedRows] != 1) return;
     if (![[self tableName] length]) return;
@@ -686,7 +686,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		return;
 	}
 
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	NSString *alertTitle = @"";
 	NSString *alertInformativeText = @"";
@@ -710,7 +710,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 - (IBAction)openTableInNewTab:(id)sender
 {
 	// Add a new tab to the window
-	[[[tableDocumentInstance parentWindow] windowController] addNewConnection:self];
+	[[tableDocumentInstance parentWindowController] addNewConnection:self];
 	
 	[self _duplicateConnectionToFrontTab];
 }
@@ -1661,7 +1661,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	if (!tableListIsSelectable) return NO;
 
 	// End editing (otherwise problems when user hits reload button)
-	[[tableDocumentInstance parentWindow] endEditingFor:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
 	// We have to be sure that document views have finished editing
 	return [tableDocumentInstance couldCommitCurrentViewActions];
@@ -1936,10 +1936,10 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 - (void) makeTableListFilterHaveFocus
 {
 	if([tables count] > 20) {
-		[[tableDocumentInstance parentWindow] makeFirstResponder:listFilterField];
+		[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:listFilterField];
 	}
 	else {
-		[[tableDocumentInstance parentWindow] makeFirstResponder:tablesListView];
+		[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:tablesListView];
 	}
 }
 
@@ -1948,7 +1948,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
  */
 - (void) makeTableListHaveFocus
 {
-	[[tableDocumentInstance parentWindow] makeFirstResponder:tablesListView];
+	[[tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:tablesListView];
 }
 
 /**

--- a/Source/Controllers/Window/SPWindowController.h
+++ b/Source/Controllers/Window/SPWindowController.h
@@ -32,6 +32,7 @@
 
 @class PSMTabBarControl;
 @class SPDatabaseDocument;
+@protocol SPWindowControllerDelegate;
 
 @interface SPWindowController : NSWindowController <NSWindowDelegate>
 {
@@ -45,6 +46,7 @@
 	NSMutableArray *managedDatabaseConnections;
 }
 
+@property (nonatomic, weak) id<SPWindowControllerDelegate> delegate;
 @property (readonly, strong) IBOutlet PSMTabBarControl *tabBar;
 @property (readonly, strong) SPDatabaseDocument *selectedTableDocument;
 
@@ -62,5 +64,12 @@
 - (NSArray <SPDatabaseDocument *> *)documents;
 - (void)selectTabAtIndex:(NSInteger)index;
 - (void)updateTabBar;
+
+@end
+
+@protocol SPWindowControllerDelegate <NSObject>
+
+- (void)windowControllerDidCreateNewWindowController:(SPWindowController *)newWindowController;
+- (void)windowControllerDidClose:(SPWindowController *)windowController;
 
 @end

--- a/Source/Controllers/Window/SPWindowController.h
+++ b/Source/Controllers/Window/SPWindowController.h
@@ -59,7 +59,7 @@
 - (IBAction)closeTab:(id)sender;
 - (IBAction)selectNextDocumentTab:(id)sender;
 - (IBAction)selectPreviousDocumentTab:(id)sender;
-- (NSArray *)documents;
+- (NSArray <SPDatabaseDocument *> *)documents;
 - (void)selectTabAtIndex:(NSInteger)index;
 - (void)updateTabBar;
 

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -109,27 +109,24 @@
 - (SPDatabaseDocument *)addNewConnection
 {
 	// Create a new database connection view
-	SPDatabaseDocument *newTableDocument = [[SPDatabaseDocument alloc] init];
-	
-	[newTableDocument setParentWindowController:self];
-	[newTableDocument setParentWindow:[self window]];
+	SPDatabaseDocument *databaseDocument = [[SPDatabaseDocument alloc] initWithWindowController:self];
 
 	// Set up a new tab with the connection view as the identifier, add the view, and add it to the tab view
-    NSTabViewItem *newItem = [[NSTabViewItem alloc] initWithIdentifier:newTableDocument];
+    NSTabViewItem *newItem = [[NSTabViewItem alloc] initWithIdentifier:databaseDocument];
 	
-	[newItem setView:[newTableDocument databaseView]];
+	[newItem setView:[databaseDocument databaseView]];
     [tabView addTabViewItem:newItem];
     [tabView selectTabViewItem:newItem];
-	[newTableDocument setParentTabViewItem:newItem];
+	[databaseDocument setParentTabViewItem:newItem];
 
 	// Tell the new database connection view to set up the window and update titles
-	[newTableDocument didBecomeActiveTabInWindow];
-	[newTableDocument updateWindowTitle:self];
+	[databaseDocument didBecomeActiveTabInWindow];
+	[databaseDocument updateWindowTitle:self];
 
 	// Bind the tab bar's progress display to the document
 	[self _updateProgressIndicatorForItem:newItem];
 	
-	return newTableDocument;
+	return databaseDocument;
 }
 
 /**
@@ -236,7 +233,7 @@
 	[newWindow setDelegate:newWindowController];
 
 	// Set window title
-	[newWindow setTitle:[[[[tabView selectedTabViewItem] identifier] parentWindow] title]];
+	[newWindow setTitle:[[[[tabView selectedTabViewItem] identifier] parentWindowControllerWindow] title]];
 
 	// New window's tabBar control
 	PSMTabBarControl *control = newWindowController.tabBar;
@@ -645,7 +642,7 @@
 	SPDatabaseDocument *draggedDocument = [tabViewItem identifier];
 
 	// Grab a reference to the old window
-	NSWindow *draggedFromWindow = [draggedDocument parentWindow];
+	NSWindow *draggedFromWindow = [draggedDocument parentWindowControllerWindow];
 
 	// If the window changed, perform additional processing.
 	if (draggedFromWindow != [tabBarControl window]) {
@@ -656,8 +653,7 @@
 
 		// Update the item's document's window and controller
 		[draggedDocument willResignActiveTabInWindow];
-		[draggedDocument setParentWindowController:[[tabBarControl window] windowController]];
-		[draggedDocument setParentWindow:[tabBarControl window]];
+        [draggedDocument updateParentWindowController:[[tabBarControl window] windowController]];
 		[draggedDocument didBecomeActiveTabInWindow];
 
 		// Update window controller's active tab, and update the document's isProcessing observation
@@ -786,7 +782,7 @@
 	[newWindow setDelegate:newWindowController];
 
 	// Set window title
-	[newWindow setTitle:[[[tabViewItem identifier] parentWindow] title]];
+	[newWindow setTitle:[[[tabViewItem identifier] parentWindowControllerWindow] title]];
 
 	// Return the window's tab bar
 	return newWindowController.tabBar;

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -92,8 +92,9 @@
 	// Because we are a document-based app we automatically adopt window restoration on 10.7+.
 	// However that causes a race condition with our own window setup code.
 	// Remove this when we actually support restoration.
-	if([window respondsToSelector:@selector(setRestorable:)])
+    if ([window respondsToSelector:@selector(setRestorable:)]) {
 		[window setRestorable:NO];
+    }
 }
 
 #pragma mark -
@@ -484,7 +485,7 @@
 	}
 
 	// Remove global session data if the last window of a session will be closed
-	if ([SPAppDelegate sessionURL] && [[SPAppDelegate orderedDatabaseConnectionWindows] count] == 1) {
+	if ([SPAppDelegate sessionURL] && [[SPAppDelegate windowControllers] count] == 1) {
 		[SPAppDelegate setSessionURL:nil];
 		[SPAppDelegate setSpfSessionDocData:nil];
 	}
@@ -596,7 +597,9 @@
 	[self _switchOutSelectedTableDocument:[tabViewItem databaseDocument]];
 	[self.selectedTableDocument didBecomeActiveTabInWindow];
 
-	if ([[self window] isKeyWindow]) [self.selectedTableDocument tabDidBecomeKey];
+    if ([[self window] isKeyWindow]) {
+        [self.selectedTableDocument tabDidBecomeKey];
+    }
 
 	[self updateAllTabTitles:self];
 }
@@ -664,7 +667,9 @@
 	}
 
 	// Check the window and move it to front if it's key (eg for new window creation)
-	if ([[tabBarControl window] isKeyWindow]) [[tabBarControl window] orderFront:self];
+    if ([[tabBarControl window] isKeyWindow]) {
+        [[tabBarControl window] orderFront:self];
+    }
 
 	// workaround bug where "source list" table views are broken in the new window. See https://github.com/sequelpro/sequelpro/issues/2863
 	SPWindowController *newWindowController = tabBarControl.window.windowController;

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -38,6 +38,8 @@
 #import "PSMTabBarControl.h"
 #import "PSMTabStyle.h"
 
+#import "sequel-ace-Swift.h"
+
 @interface SPWindowController ()
 
 - (void)_setUpTabBar;
@@ -134,7 +136,7 @@
  */
 - (void)updateSelectedTableDocument
 {
-	[self _switchOutSelectedTableDocument:[[tabView selectedTabViewItem] identifier]];
+	[self _switchOutSelectedTableDocument:[[tabView selectedTabViewItem] databaseDocument]];
 	
 	[self.selectedTableDocument didBecomeActiveTabInWindow];
 }
@@ -207,8 +209,8 @@
 {
 	static NSPoint cascadeLocation = {.x = 0, .y = 0};
 
-	SPDatabaseDocument *selectedDocument = [[tabView selectedTabViewItem] identifier];
 	NSTabViewItem *selectedTabViewItem = [tabView selectedTabViewItem];
+    SPDatabaseDocument *selectedDocument = [selectedTabViewItem databaseDocument];
 	PSMTabBarCell *selectedCell = [[tabBar cells] objectAtIndex:[tabView indexOfTabViewItem:selectedTabViewItem]];
 
 	SPWindowController *newWindowController = [[SPWindowController alloc] initWithWindowNibName:@"MainWindow"];
@@ -233,7 +235,7 @@
 	[newWindow setDelegate:newWindowController];
 
 	// Set window title
-	[newWindow setTitle:[[[[tabView selectedTabViewItem] identifier] parentWindowControllerWindow] title]];
+	[newWindow setTitle:[[selectedDocument parentWindowControllerWindow] title]];
 
 	// New window's tabBar control
 	PSMTabBarControl *control = newWindowController.tabBar;

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -63,13 +63,6 @@
 #pragma mark -
 #pragma mark Initialisation
 
-- (instancetype)initWithDelegate:(id<SPWindowControllerDelegate>)delegate {
-    if (self = [super init]) {
-        _delegate = delegate;
-    }
-    return self;
-}
-
 - (void)awakeFromNib {
 	[self _switchOutSelectedTableDocument:nil];
 	

--- a/Source/Controllers/Window/SPWindowController.m
+++ b/Source/Controllers/Window/SPWindowController.m
@@ -293,8 +293,8 @@
 /**
  * Retrieve the documents associated with this window.
  */
-- (NSArray *)documents {
-	NSMutableArray *documentsArray = [NSMutableArray array];
+- (NSArray <SPDatabaseDocument *> *)documents {
+	NSMutableArray <SPDatabaseDocument *> *documentsArray = [NSMutableArray array];
 	for (NSTabViewItem *eachItem in [tabView tabViewItems]) {
 		[documentsArray safeAddObject:[eachItem databaseDocument]];
 	}
@@ -847,16 +847,14 @@
  * When tab drags start, show all the tab bars.  This allows adding tabs to windows
  * containing only one tab - where the bar is normally hidden.
  */
-- (void)tabDragStarted:(id)sender
-{
+- (void)tabDragStarted:(id)sender {
     
 }
 
 /**
  * When tab drags stop, set tab bars to automatically hide again for only one tab.
  */
-- (void)tabDragStopped:(id)sender
-{
+- (void)tabDragStopped:(id)sender {
 
 }
 

--- a/Source/Other/CategoryAdditions/SPTextViewAdditions.m
+++ b/Source/Other/CategoryAdditions/SPTextViewAdditions.m
@@ -792,7 +792,7 @@
 		[menu removeItem:bItem];
 	}
 
-	if ([[[(SPWindowController *)[[SPAppDelegate frontDocumentWindow] delegate] selectedTableDocument] connectionID] isEqualToString:@"_"]) return menu;
+	if ([[[(SPWindowController *)[[SPAppDelegate.rootWindowController window] delegate] selectedTableDocument] connectionID] isEqualToString:@"_"]) return menu;
 
 	[SPBundleManager.sharedSPBundleManager reloadBundles:self];
 

--- a/Source/Other/CategoryAdditions/SPTextViewAdditions.m
+++ b/Source/Other/CategoryAdditions/SPTextViewAdditions.m
@@ -792,7 +792,10 @@
 		[menu removeItem:bItem];
 	}
 
-	if ([[[(SPWindowController *)[[SPAppDelegate.rootWindowController window] delegate] selectedTableDocument] connectionID] isEqualToString:@"_"]) return menu;
+    id<NSWindowDelegate> windowController = [[NSApp keyWindow] delegate];
+    if ([windowController isKindOfClass:[SPWindowController class]] && [[[(SPWindowController *)windowController selectedTableDocument] connectionID] isEqualToString:@"_"]) {
+        return menu;
+    }
 
 	[SPBundleManager.sharedSPBundleManager reloadBundles:self];
 

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -282,25 +282,7 @@ static unsigned short getRandomPort(void);
  * tunnel to the remote server.
  * Sets up and tears down as appropriate for usage in a background thread.
  */
-- (void)launchTask:(id) dummy
-{
-
-    SPMainQSync(^{
-        NSArray *allDocs = [SPAppDelegate orderedDocuments];
-        for (SPDatabaseDocument *doc in allDocs)
-        {
-            SPLog(@"host= %@",doc.getConnection.host );
-            SPLog(@"lastErrorMessage = %@",doc.getConnection.lastErrorMessage );
-            SPLog(@"isConnected = %d",doc.getConnection.isConnected );
-            SPLog(@"isProxy = %d",doc.getConnection.isProxy );
-            SPLog(@"timeout = %lu",(unsigned long)doc.getConnection.timeout );
-            CLS_LOG(@"host= %@",doc.getConnection.host );
-            CLS_LOG(@"lastErrorMessage = %@",doc.getConnection.lastErrorMessage );
-            CLS_LOG(@"isConnected = %d",doc.getConnection.isConnected );
-            CLS_LOG(@"isProxy = %d",doc.getConnection.isProxy );
-            CLS_LOG(@"timeout = %lu",(unsigned long)doc.getConnection.timeout );
-        }
-    });
+- (void)launchTask:(id) dummy {
     
     SPLog(@"connection state = %i", connectionState);
     CLS_LOG(@"connection state = %i", connectionState);

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		50EA92681AB23EFC008D3C4F /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
 		50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */; };
 		50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 50F530511ABCF66B002F2C1A /* resetTemplate.pdf */; };
+		511C466A25BC768E001AA1BD /* NSTabViewItemExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511C466925BC768E001AA1BD /* NSTabViewItemExtension.swift */; };
 		513515D2259354BB001E4533 /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513515D1259354BB001E4533 /* NSImageExtensions.swift */; };
 		513515E42593568B001E4533 /* PSMProgressIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B9071D11BD9B34000826E5 /* PSMProgressIndicator.m */; };
 		513515E52593568B001E4533 /* PSMTabDragAssistant.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B9072711BD9B34000826E5 /* PSMTabDragAssistant.m */; };
@@ -884,6 +885,7 @@
 		50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseActionTest.m; sourceTree = "<group>"; };
 		50F530511ABCF66B002F2C1A /* resetTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = resetTemplate.pdf; sourceTree = "<group>"; };
 		511B309F25ABBC6500D010E3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		511C466925BC768E001AA1BD /* NSTabViewItemExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTabViewItemExtension.swift; sourceTree = "<group>"; };
 		513515D1259354BB001E4533 /* NSImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensions.swift; sourceTree = "<group>"; };
 		5174122E2573E10C00EB6935 /* SPPrintUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPPrintUtility.h; sourceTree = "<group>"; };
 		5174122F2573E10C00EB6935 /* SPPrintUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPPrintUtility.m; sourceTree = "<group>"; };
@@ -2370,6 +2372,7 @@
 				58B9072E11BD9B34000826E5 /* PSMTabStyle.h */,
 				58B9072F11BD9B34000826E5 /* Styles */,
 				58B906F911BD9B34000826E5 /* Images */,
+				511C466925BC768E001AA1BD /* NSTabViewItemExtension.swift */,
 			);
 			name = PSMTabBar;
 			path = Frameworks/PSMTabBar;
@@ -3189,6 +3192,7 @@
 				BC77C5E4129AA69E009AD832 /* SPBundleHTMLOutputController.m in Sources */,
 				BC5750D512A6233900911BA2 /* SPActivityTextFieldCell.m in Sources */,
 				BC0ED3DA12A9196C00088461 /* SPChooseMenuItemDialog.m in Sources */,
+				511C466A25BC768E001AA1BD /* NSTabViewItemExtension.swift in Sources */,
 				583CA21512EC8B2200C9E763 /* SPWindow.m in Sources */,
 				1A9EB9AE25651F5000FE60FF /* SQLiteHistoryManager.swift in Sources */,
 				582F02311370B52600B30621 /* SPExportFileNameTokenObject.m in Sources */,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Add databaseDocument to NSTabViewItem to use it instead of identifier for typeSafety
- start using parentWindowController in SPDatabaseDocument instead of window, keyWindow etc. - make it part of init as document can't exist without Window
- hold windows in SPAppController, communicate from them to SPAppController via delegate
- add type-safety to a lot of places

## Closes following issues:
- Closes: Nothing for now.

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.3
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
This is one of more steps that will follow to rewrite whole hierarchy. Currently there is huge memory leak where tabs (DB Documents) nor windows are deallocated when closed, and even connections are not closed until killing the whole app.