### PR TITLE
Query history saving pref (#changed) and replace content fixes (#fixed)

### DIFF
--- a/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
+++ b/Frameworks/PSMTabBar/Styles/PSMSequelProTabStyle.m
@@ -571,9 +571,6 @@
 	NSColor *fillColor = nil;
     NSColor *cellBackgroundColor = [[cell backgroundColor] copy]; // seems to be almost always nil, but take a copy as we've seen memory issues
 
-    if(cellBackgroundColor){
-        SPLog(@"cellBackgroundColor not nil: %@", cellBackgroundColor.description);
-    }
 	// Set up colours
 	if (([[tabBar window] isMainWindow] || [[[tabBar window] attachedSheet] isMainWindow]) && [NSApp isActive]) {
 		if ([cell state] == NSOnState) { //active window, active cell

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -317,19 +317,19 @@ Gw
             <point key="canvasLocation" x="-364" y="159"/>
         </window>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="17" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="374"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="378"/>
             <userGuides>
                 <userLayoutGuide location="44" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1420">
-                    <rect key="frame" x="180" y="294" width="340" height="5"/>
+                    <rect key="frame" x="180" y="298" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="jHx-SA-a0F"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1419">
-                    <rect key="frame" x="18" y="266" width="154" height="20"/>
+                    <rect key="frame" x="18" y="270" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="8zj-eb-GHj"/>
                         <constraint firstAttribute="height" constant="20" id="GHh-gf-gj6"/>
@@ -341,7 +341,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1418">
-                    <rect key="frame" x="178" y="262" width="345" height="26"/>
+                    <rect key="frame" x="178" y="266" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GTX-3c-yQF"/>
                     </constraints>
@@ -380,19 +380,19 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="582">
-                    <rect key="frame" x="180" y="212" width="340" height="5"/>
+                    <rect key="frame" x="180" y="216" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="epJ-gi-vWC"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="581">
-                    <rect key="frame" x="180" y="253" width="340" height="5"/>
+                    <rect key="frame" x="180" y="257" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Lfj-js-9td"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="947">
-                    <rect key="frame" x="178" y="162" width="344" height="26"/>
+                    <rect key="frame" x="178" y="161" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="D5k-pg-HI7"/>
                     </constraints>
@@ -405,7 +405,10 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hMm-gH-Xw4">
-                    <rect key="frame" x="178" y="142" width="344" height="18"/>
+                    <rect key="frame" x="178" y="137" width="344" height="26"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="22" id="hzI-1g-IJw"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Save query history individually" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="3B6-Jd-2pW">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -415,7 +418,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="957">
-                    <rect key="frame" x="178" y="186" width="344" height="26"/>
+                    <rect key="frame" x="178" y="185" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GzU-Bz-1Le"/>
                     </constraints>
@@ -428,7 +431,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="577">
-                    <rect key="frame" x="18" y="225" width="154" height="20"/>
+                    <rect key="frame" x="18" y="229" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="2fJ-uV-yWE"/>
                         <constraint firstAttribute="width" constant="150" id="H3R-fZ-7pu"/>
@@ -440,7 +443,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1465">
-                    <rect key="frame" x="18" y="189" width="154" height="20"/>
+                    <rect key="frame" x="18" y="188" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="Pth-OX-OBR"/>
                         <constraint firstAttribute="height" constant="20" id="jzh-o6-wrC"/>
@@ -452,7 +455,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="569">
-                    <rect key="frame" x="178" y="334" width="345" height="26"/>
+                    <rect key="frame" x="178" y="338" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="c8F-90-8rt"/>
                         <constraint firstAttribute="height" constant="22" id="qGo-nM-5Lp"/>
@@ -467,7 +470,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="568">
-                    <rect key="frame" x="18" y="338" width="154" height="20"/>
+                    <rect key="frame" x="18" y="342" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iwU-u3-PUC"/>
                         <constraint firstAttribute="height" constant="20" id="y3H-yc-8cM"/>
@@ -479,7 +482,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="567">
-                    <rect key="frame" x="178" y="304" width="344" height="26"/>
+                    <rect key="frame" x="178" y="308" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OPe-tH-ihg"/>
                     </constraints>
@@ -492,7 +495,7 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="178" y="221" width="345" height="26"/>
+                    <rect key="frame" x="178" y="225" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="zsc-aw-Grt"/>
                     </constraints>
@@ -555,7 +558,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="790">
-                    <rect key="frame" x="398" y="108" width="124" height="16"/>
+                    <rect key="frame" x="398" y="101" width="124" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="nGd-yZ-I7g"/>
                     </constraints>
@@ -566,7 +569,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="787">
-                    <rect key="frame" x="180" y="105" width="215" height="22"/>
+                    <rect key="frame" x="180" y="98" width="215" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="1Oz-rT-AdX"/>
                     </constraints>
@@ -586,7 +589,7 @@ Gw
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="785">
-                    <rect key="frame" x="18" y="106" width="154" height="20"/>
+                    <rect key="frame" x="18" y="99" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iNE-8S-1ug"/>
                         <constraint firstAttribute="height" constant="20" id="m9i-Kw-gLk"/>
@@ -598,13 +601,13 @@ Gw
                     </textFieldCell>
                 </textField>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="784">
-                    <rect key="frame" x="180" y="134" width="340" height="5"/>
+                    <rect key="frame" x="180" y="127" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="vus-7q-stB"/>
                     </constraints>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
-                    <rect key="frame" x="0.0" y="55" width="540" height="41"/>
+                    <rect key="frame" x="0.0" y="48" width="540" height="41"/>
                     <view key="contentView" id="8QO-1r-5jB">
                         <rect key="frame" x="0.0" y="0.0" width="540" height="41"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -685,7 +688,7 @@ Gw
                     </view>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="F3U-SQ-W2d">
-                    <rect key="frame" x="0.0" y="24" width="540" height="31"/>
+                    <rect key="frame" x="0.0" y="17" width="540" height="31"/>
                     <view key="contentView" id="typ-rs-Tmp">
                         <rect key="frame" x="0.0" y="0.0" width="540" height="31"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -773,12 +776,12 @@ Gw
                 <constraint firstItem="784" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="JVt-FZ-AWU"/>
                 <constraint firstItem="785" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="JuX-m1-yDO"/>
                 <constraint firstItem="947" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="KeG-OR-BDE"/>
-                <constraint firstItem="hMm-gH-Xw4" firstAttribute="top" secondItem="947" secondAttribute="bottom" constant="6" id="Liq-UM-y1F"/>
+                <constraint firstItem="hMm-gH-Xw4" firstAttribute="top" secondItem="947" secondAttribute="bottom" constant="2" id="Liq-UM-y1F"/>
                 <constraint firstItem="568" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="N22-K7-HF7"/>
                 <constraint firstItem="hMm-gH-Xw4" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="NDk-wb-BH3"/>
                 <constraint firstItem="581" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Ogb-QW-1uw"/>
                 <constraint firstItem="957" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="Orb-W6-T4J"/>
-                <constraint firstItem="957" firstAttribute="top" secondItem="582" secondAttribute="bottom" constant="4" id="PIX-w3-EeM"/>
+                <constraint firstItem="957" firstAttribute="top" secondItem="582" secondAttribute="bottom" constant="9" id="PIX-w3-EeM"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="F3U-SQ-W2d" secondAttribute="bottom" constant="15" id="PYb-fK-u5u"/>
                 <constraint firstItem="577" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="QFi-wi-jse"/>
                 <constraint firstItem="7J9-Yp-qMZ" firstAttribute="top" secondItem="787" secondAttribute="bottom" constant="9" id="VDV-pe-DL0"/>
@@ -804,7 +807,7 @@ Gw
                 <constraint firstItem="790" firstAttribute="centerY" secondItem="787" secondAttribute="centerY" id="wfq-CS-s72"/>
                 <constraint firstItem="24" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="x1x-TL-91g"/>
                 <constraint firstItem="582" firstAttribute="top" secondItem="24" secondAttribute="bottom" constant="9" id="x21-dW-TG6"/>
-                <constraint firstItem="784" firstAttribute="top" secondItem="hMm-gH-Xw4" secondAttribute="bottom" constant="7" id="xsB-vw-oOb"/>
+                <constraint firstItem="784" firstAttribute="top" secondItem="hMm-gH-Xw4" secondAttribute="bottom" constant="9" id="xsB-vw-oOb"/>
                 <constraint firstItem="1419" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="zZB-QF-61w"/>
             </constraints>
             <point key="canvasLocation" x="-52" y="1050"/>
@@ -1753,7 +1756,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <rect key="frame" x="20" y="42" width="231" height="389"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
                         <rect key="frame" x="1" y="1" width="229" height="387"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
                                 <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>
@@ -2300,7 +2303,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <rect key="frame" x="20" y="46" width="500" height="212"/>
                     <clipView key="contentView" id="u3q-XC-nUM">
                         <rect key="frame" x="1" y="1" width="498" height="210"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" id="eH2-Ed-Xh3">
                                 <rect key="frame" x="0.0" y="0.0" width="498" height="210"/>

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -317,19 +317,19 @@ Gw
             <point key="canvasLocation" x="-364" y="159"/>
         </window>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="17" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="359"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="374"/>
             <userGuides>
-                <userLayoutGuide location="196" affinity="minX"/>
+                <userLayoutGuide location="44" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1420">
-                    <rect key="frame" x="180" y="279" width="340" height="5"/>
+                    <rect key="frame" x="180" y="294" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="jHx-SA-a0F"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1419">
-                    <rect key="frame" x="18" y="251" width="154" height="20"/>
+                    <rect key="frame" x="18" y="266" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="8zj-eb-GHj"/>
                         <constraint firstAttribute="height" constant="20" id="GHh-gf-gj6"/>
@@ -341,7 +341,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1418">
-                    <rect key="frame" x="178" y="247" width="345" height="26"/>
+                    <rect key="frame" x="178" y="262" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GTX-3c-yQF"/>
                     </constraints>
@@ -380,19 +380,19 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="582">
-                    <rect key="frame" x="180" y="197" width="340" height="5"/>
+                    <rect key="frame" x="180" y="212" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="epJ-gi-vWC"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="581">
-                    <rect key="frame" x="180" y="238" width="340" height="5"/>
+                    <rect key="frame" x="180" y="253" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Lfj-js-9td"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="947">
-                    <rect key="frame" x="178" y="135" width="344" height="26"/>
+                    <rect key="frame" x="178" y="162" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="D5k-pg-HI7"/>
                     </constraints>
@@ -404,8 +404,18 @@ Gw
                         <binding destination="117" name="value" keyPath="values.DisplayCommentsInTablesList" id="962"/>
                     </connections>
                 </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="hMm-gH-Xw4">
+                    <rect key="frame" x="178" y="142" width="344" height="18"/>
+                    <buttonCell key="cell" type="check" title="Save query history individually" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="3B6-Jd-2pW">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="117" name="value" keyPath="values.CustomQuerySaveHistoryIndividually" id="W9v-ez-5Wj"/>
+                    </connections>
+                </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="957">
-                    <rect key="frame" x="178" y="166" width="344" height="26"/>
+                    <rect key="frame" x="178" y="186" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GzU-Bz-1Le"/>
                     </constraints>
@@ -418,7 +428,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="577">
-                    <rect key="frame" x="18" y="210" width="154" height="20"/>
+                    <rect key="frame" x="18" y="225" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="2fJ-uV-yWE"/>
                         <constraint firstAttribute="width" constant="150" id="H3R-fZ-7pu"/>
@@ -430,7 +440,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1465">
-                    <rect key="frame" x="18" y="169" width="154" height="20"/>
+                    <rect key="frame" x="18" y="189" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="Pth-OX-OBR"/>
                         <constraint firstAttribute="height" constant="20" id="jzh-o6-wrC"/>
@@ -442,7 +452,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="569">
-                    <rect key="frame" x="178" y="319" width="345" height="26"/>
+                    <rect key="frame" x="178" y="334" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="c8F-90-8rt"/>
                         <constraint firstAttribute="height" constant="22" id="qGo-nM-5Lp"/>
@@ -457,7 +467,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="568">
-                    <rect key="frame" x="18" y="323" width="154" height="20"/>
+                    <rect key="frame" x="18" y="338" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iwU-u3-PUC"/>
                         <constraint firstAttribute="height" constant="20" id="y3H-yc-8cM"/>
@@ -469,7 +479,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="567">
-                    <rect key="frame" x="178" y="289" width="344" height="26"/>
+                    <rect key="frame" x="178" y="304" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OPe-tH-ihg"/>
                     </constraints>
@@ -482,7 +492,7 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="178" y="206" width="345" height="26"/>
+                    <rect key="frame" x="178" y="221" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="zsc-aw-Grt"/>
                     </constraints>
@@ -545,7 +555,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="790">
-                    <rect key="frame" x="398" y="99" width="124" height="16"/>
+                    <rect key="frame" x="398" y="108" width="124" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="nGd-yZ-I7g"/>
                     </constraints>
@@ -556,7 +566,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="787">
-                    <rect key="frame" x="180" y="96" width="215" height="22"/>
+                    <rect key="frame" x="180" y="105" width="215" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="1Oz-rT-AdX"/>
                     </constraints>
@@ -576,7 +586,7 @@ Gw
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="785">
-                    <rect key="frame" x="18" y="97" width="154" height="20"/>
+                    <rect key="frame" x="18" y="106" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iNE-8S-1ug"/>
                         <constraint firstAttribute="height" constant="20" id="m9i-Kw-gLk"/>
@@ -588,13 +598,13 @@ Gw
                     </textFieldCell>
                 </textField>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="784">
-                    <rect key="frame" x="180" y="125" width="340" height="5"/>
+                    <rect key="frame" x="180" y="134" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="vus-7q-stB"/>
                     </constraints>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
-                    <rect key="frame" x="0.0" y="46" width="540" height="41"/>
+                    <rect key="frame" x="0.0" y="55" width="540" height="41"/>
                     <view key="contentView" id="8QO-1r-5jB">
                         <rect key="frame" x="0.0" y="0.0" width="540" height="41"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -675,7 +685,7 @@ Gw
                     </view>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="F3U-SQ-W2d">
-                    <rect key="frame" x="0.0" y="15" width="540" height="31"/>
+                    <rect key="frame" x="0.0" y="24" width="540" height="31"/>
                     <view key="contentView" id="typ-rs-Tmp">
                         <rect key="frame" x="0.0" y="0.0" width="540" height="31"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -742,6 +752,7 @@ Gw
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="569" secondAttribute="trailing" constant="20" id="07m-Wu-Wdm"/>
+                <constraint firstItem="hMm-gH-Xw4" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="0rT-dJ-Sum"/>
                 <constraint firstItem="1418" firstAttribute="top" secondItem="1420" secondAttribute="bottom" constant="9" id="6hc-io-AZE"/>
                 <constraint firstItem="582" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="8xS-ld-NA8"/>
                 <constraint firstAttribute="trailing" secondItem="F3U-SQ-W2d" secondAttribute="trailing" id="93x-P2-EBJ"/>
@@ -755,17 +766,19 @@ Gw
                 <constraint firstItem="F3U-SQ-W2d" firstAttribute="top" secondItem="7J9-Yp-qMZ" secondAttribute="bottom" id="G6O-Ql-CaV"/>
                 <constraint firstItem="567" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="GpK-3f-RXE"/>
                 <constraint firstItem="1418" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="H5T-g6-PU5"/>
-                <constraint firstItem="947" firstAttribute="top" secondItem="957" secondAttribute="bottom" constant="9" id="HC4-0f-RPy"/>
+                <constraint firstItem="947" firstAttribute="top" secondItem="957" secondAttribute="bottom" constant="2" id="HC4-0f-RPy"/>
                 <constraint firstItem="24" firstAttribute="top" secondItem="581" secondAttribute="bottom" constant="9" id="HLY-rd-SfS"/>
                 <constraint firstItem="947" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="IYp-aC-TVp"/>
                 <constraint firstItem="F3U-SQ-W2d" firstAttribute="leading" secondItem="17" secondAttribute="leading" id="Im0-9V-68O"/>
                 <constraint firstItem="784" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="JVt-FZ-AWU"/>
                 <constraint firstItem="785" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="JuX-m1-yDO"/>
                 <constraint firstItem="947" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="KeG-OR-BDE"/>
+                <constraint firstItem="hMm-gH-Xw4" firstAttribute="top" secondItem="947" secondAttribute="bottom" constant="6" id="Liq-UM-y1F"/>
                 <constraint firstItem="568" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="N22-K7-HF7"/>
+                <constraint firstItem="hMm-gH-Xw4" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="NDk-wb-BH3"/>
                 <constraint firstItem="581" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Ogb-QW-1uw"/>
                 <constraint firstItem="957" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="Orb-W6-T4J"/>
-                <constraint firstItem="957" firstAttribute="top" secondItem="582" secondAttribute="bottom" constant="9" id="PIX-w3-EeM"/>
+                <constraint firstItem="957" firstAttribute="top" secondItem="582" secondAttribute="bottom" constant="4" id="PIX-w3-EeM"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="F3U-SQ-W2d" secondAttribute="bottom" constant="15" id="PYb-fK-u5u"/>
                 <constraint firstItem="577" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="QFi-wi-jse"/>
                 <constraint firstItem="7J9-Yp-qMZ" firstAttribute="top" secondItem="787" secondAttribute="bottom" constant="9" id="VDV-pe-DL0"/>
@@ -791,7 +804,7 @@ Gw
                 <constraint firstItem="790" firstAttribute="centerY" secondItem="787" secondAttribute="centerY" id="wfq-CS-s72"/>
                 <constraint firstItem="24" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="x1x-TL-91g"/>
                 <constraint firstItem="582" firstAttribute="top" secondItem="24" secondAttribute="bottom" constant="9" id="x21-dW-TG6"/>
-                <constraint firstItem="784" firstAttribute="top" secondItem="947" secondAttribute="bottom" constant="9" id="xsB-vw-oOb"/>
+                <constraint firstItem="784" firstAttribute="top" secondItem="hMm-gH-Xw4" secondAttribute="bottom" constant="7" id="xsB-vw-oOb"/>
                 <constraint firstItem="1419" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="zZB-QF-61w"/>
             </constraints>
             <point key="canvasLocation" x="-52" y="1050"/>
@@ -1338,7 +1351,7 @@ Gw
                     <rect key="frame" x="180" y="40" width="340" height="196"/>
                     <clipView key="contentView" id="M9x-3Q-tiD">
                         <rect key="frame" x="1" y="1" width="338" height="194"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" id="RuH-Yq-cdH">
                                 <rect key="frame" x="0.0" y="0.0" width="338" height="194"/>
@@ -1740,7 +1753,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <rect key="frame" x="20" y="42" width="231" height="389"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
                         <rect key="frame" x="1" y="1" width="229" height="387"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
                                 <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>

--- a/Resources/License.rtf
+++ b/Resources/License.rtf
@@ -1,8 +1,8 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2577
+{\rtf1\ansi\ansicpg1252\cocoartf2513
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;\f2\fmodern\fcharset0 Courier;
-}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
+\f3\fmodern\fcharset0 Courier-Bold;}
+{\colortbl;\red255\green255\blue255;\red27\green31\blue34;}
+{\*\expandedcolortbl;;\cssrgb\c14118\c16078\c18039;}
 \paperw11900\paperh16840\vieww12000\viewh15840\viewkind0
 \hyphauto1\hyphfactor90
 \deftab720
@@ -36,10 +36,102 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
 \pard\pardeftab720\sa180\partightenfactor0
 
-\f0\b \cf0 THE SOFTWARE IS PROVIDED \'93AS IS\'94, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\f0\b \cf0 THE SOFTWARE IS PROVIDED \'93AS IS\'94, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
+\
+Reachability
 \f1\b0 \
 \pard\pardeftab720\sa180\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/tonymillion/Reachability"}}{\fldrslt \cf0 \ul \ulc0 https://github.com/tonymillion/Reachability}}\
 \pard\pardeftab720\sa180\partightenfactor0
 
-\f2 \cf0 Copyright (c) 2011-2013, Tony Million.\uc0\u8232 All rights reserved.\u8232 \u8232 Redistribution and use in source and binary forms, with or without\u8232 modification, are permitted provided that the following conditions are met:\u8232 \u8232 1. Redistributions of source code must retain the above copyright notice, this\u8232 list of conditions and the following disclaimer.\u8232 \u8232 2. Redistributions in binary form must reproduce the above copyright notice,\u8232 this list of conditions and the following disclaimer in the documentation\u8232 and/or other materials provided with the distribution.\u8232 \u8232 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"\u8232 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\u8232 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\u8232 ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\u8232 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\u8232 CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\u8232 SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\u8232 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\u8232 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\u8232 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\u8232 POSSIBILITY OF SUCH DAMAGE.}
+\f2 \cf0 Copyright (c) 2011-2013, Tony Million.\uc0\u8232 All rights reserved.\u8232 \u8232 Redistribution and use in source and binary forms, with or without\u8232 modification, are permitted provided that the following conditions are met:\u8232 \u8232 1. Redistributions of source code must retain the above copyright notice, this\u8232 list of conditions and the following disclaimer.\u8232 \u8232 2. Redistributions in binary form must reproduce the above copyright notice,\u8232 this list of conditions and the following disclaimer in the documentation\u8232 and/or other materials provided with the distribution.\u8232 \u8232 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"\u8232 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\u8232 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\u8232 ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\u8232 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\u8232 CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\u8232 SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\u8232 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\u8232 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\u8232 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\u8232 POSSIBILITY OF SUCH DAMAGE. \
+\
+
+\f3\b Etcetera
+\f2\b0 \
+\pard\pardeftab720\sa180\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://github.com/jaredsinclair/etcetera/"}}{\fldrslt \cf2 \expnd0\expndtw0\kerning0
+https://github.com/jaredsinclair/etcetera/}}\cf2 \expnd0\expndtw0\kerning0
+\
+\pard\pardeftab720\partightenfactor0
+\cf2 Copyright (c) 2018 Jared Sinclair\
+\
+Permission is hereby granted, free of charge, to any person obtaining a copy\
+of this software and associated documentation files (the "Software"), to deal\
+in the Software without restriction, including without limitation the rights\
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
+copies of the Software, and to permit persons to whom the Software is\
+furnished to do so, subject to the following conditions:\
+\
+The above copyright notice and this permission notice shall be included in all\
+copies or substantial portions of the Software.\
+\
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\
+SOFTWARE.\
+\
+
+\f3\b \cf0 \kerning1\expnd0\expndtw0 AppCenter
+\f2\b0 \cf2 \expnd0\expndtw0\kerning0
+\
+\
+{\field{\*\fldinst{HYPERLINK "https://github.com/microsoft/appcenter-sdk-apple"}}{\fldrslt https://github.com/microsoft/appcenter-sdk-apple}}\
+\
+Visual Studio App Center SDK for Apple platforms\
+\
+Copyright (c) Microsoft Corporation\
+\
+All rights reserved.\
+\
+MIT License\
+\
+Permission is hereby granted, free of charge, to any person obtaining a copy\
+of this software and associated documentation files (the "Software"), to deal\
+in the Software without restriction, including without limitation the rights\
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
+copies of the Software, and to permit persons to whom the Software is\
+furnished to do so, subject to the following conditions:\
+\
+The above copyright notice and this permission notice shall be included in\
+all copies or substantial portions of the Software.\
+\
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
+THE SOFTWARE.\
+\
+\
+
+\f3\b \cf0 \kerning1\expnd0\expndtw0 FMBD
+\f2\b0 \cf2 \expnd0\expndtw0\kerning0
+\
+\
+{\field{\*\fldinst{HYPERLINK "https://github.com/ccgus/fmdb"}}{\fldrslt https://github.com/ccgus/fmdb}}\
+\
+Copyright (c) 2008-2014 Flying Meat Inc.\
+\
+Permission is hereby granted, free of charge, to any person obtaining a copy\
+of this software and associated documentation files (the "Software"), to deal\
+in the Software without restriction, including without limitation the rights\
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
+copies of the Software, and to permit persons to whom the Software is\
+furnished to do so, subject to the following conditions:\
+\
+The above copyright notice and this permission notice shall be included in\
+all copies or substantial portions of the Software.\
+\
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
+THE SOFTWARE.\
+}

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -97,6 +97,8 @@
 	<true/>
 	<key>CustomQueryMaxHistoryItems</key>
 	<integer>20</integer>
+	<key>CustomQuerySaveHistoryIndividually</key>
+	<true/>
 	<key>CustomQuerySoftIndent</key>
 	<false/>
 	<key>CustomQuerySoftIndentWidth</key>

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -3253,8 +3253,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		
 		bookmarks = [NSMutableArray arrayWithArray:SecureBookmarkManager.sharedInstance.bookmarks];
 
-        SPLog(@"prefs: %@", prefs.dictionaryRepresentation);
-
         [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_refreshBookmarks) name:SPBookmarksChangedNotification object:SecureBookmarkManager.sharedInstance];
 
 		// Create a reference to the favorites controller, forcing the data to be loaded from disk

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -927,7 +927,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         }
         
         // if(!queriesSeparatedByDelimiter) // TODO: How to combine queries delimited by DELIMITER?
-        usedQuery = [NSString stringWithString:[tempQueries componentsJoinedByString:@";\n"]];
+	usedQuery = [NSString stringWithString:[tempQueries componentsJoinedByString:@";\n"]]; // MARK: JCS - this is where the queries are split, by ";\n"
         lastExecutedQuery = [tempQueries lastObject];
         
         // Perform empty query if no query is given

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -693,8 +693,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
     if (value.length){
         return value;
     } else{
-        SPLog(@"Unable to format key: %@", key);
-        SPLog(@"infoDict: %@", infoDict);
+        SPLog(@"Unable to format key: [%@], for value: [%@]", key, value);
         return NSLocalizedString(@"Not available", @"not available label");;
     }
 }

--- a/Source/Controllers/Other/SQLiteHistoryManager.swift
+++ b/Source/Controllers/Other/SQLiteHistoryManager.swift
@@ -389,26 +389,36 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
 
         additionalHistArraySize = 0;
 
-        for query in arrayToNormalise where query.isNotEmpty {
-            if query.contains("\n"){
-                Log.debug("query contains newline: [\(query)]")
-                // an array where each entry contains the value from
-                // the history query, delimited by a new line
-                let lines = query.separatedIntoLines()
+        let saveHistoryIndividually = prefs.bool(forKey: SPCustomQuerySaveHistoryIndividually)
 
-                Log.debug("lines: [\(lines)]")
 
-                for line in lines where line.isNotEmpty {
-                    normalisedQueryArray.appendIfNotContains(line.dropSuffix(";").trimmedString)
+        if saveHistoryIndividually == true {
+            Log.debug("saveHistoryIndividually: [\(saveHistoryIndividually)]")
+            for query in arrayToNormalise where query.isNotEmpty {
+                if query.contains("\n"){
+                    Log.debug("query contains newline: [\(query)]")
+                    // an array where each entry contains the value from
+                    // the history query, delimited by a new line
+                    let lines = query.separatedIntoLines()
+
+                    Log.debug("lines: [\(lines)]")
+
+                    for line in lines where line.isNotEmpty {
+                        normalisedQueryArray.appendIfNotContains(line.dropSuffix(";").trimmedString)
+                    }
+                }
+                else{
+                    normalisedQueryArray.appendIfNotContains(query.dropSuffix(";").trimmedString)
                 }
             }
-            else{
-                normalisedQueryArray.appendIfNotContains(query.dropSuffix(";").trimmedString)
-            }
+            Log.debug("arrayToNormalise: [\(arrayToNormalise)]")
+            Log.debug("normalisedQueryArray: [\(normalisedQueryArray)]")
         }
-
-        Log.debug("arrayToNormalise: [\(arrayToNormalise)]")
-        Log.debug("normalisedQueryArray: [\(normalisedQueryArray)]")
+        else{
+            Log.debug("saveHistoryIndividually: [\(saveHistoryIndividually)], setting normalisedQueryArray = arrayToNormalise")
+            normalisedQueryArray = arrayToNormalise
+            Log.debug("arrayToNormalise: [\(arrayToNormalise)]")
+        }
 
         // keep a rough track of array size by counting string len
         for arr in normalisedQueryArray {

--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -219,8 +219,6 @@
 				[info safeAddObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSString stringForByteSize:tableStatusDataLengthAsLong]]];
 			}
 
-            SPLog(@"tableStatus: %@", tableStatus);
-
 			NSString *tableEnc = [tableDataInstance tableEncoding];
 			NSString *tableColl = [tableStatus safeObjectForKey:@"Collation"];
 

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -672,6 +672,7 @@ typedef NS_ENUM(NSInteger, SPBundleRedirectAction) {
 
 extern NSString *SPMigratedQueriesFromPrefs;
 extern NSString *SPTraceSQLiteExecutions;
+extern NSString *SPCustomQuerySaveHistoryIndividually;
 
 // URL scheme
 extern NSString *SPURLSchemeQueryInputPathHeader;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -114,6 +114,7 @@ NSString *SPDefaultEncoding                      = @"DefaultEncodingTag";
 NSString *SPDisplayTableViewVerticalGridlines    = @"DisplayTableViewVerticalGridlines";
 NSString *SPDisplayCommentsInTablesList          = @"DisplayCommentsInTablesList";
 NSString *SPCustomQueryMaxHistoryItems           = @"CustomQueryMaxHistoryItems";
+NSString *SPCustomQuerySaveHistoryIndividually   = @"CustomQuerySaveHistoryIndividually";
 NSString *SPAppearance                           = @"Appearance";
 
 // Tables Prefpane

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3259,8 +3259,6 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		return;
 	}
 
-    SPLog(@"editedRange: %@", NSStringFromRange(editedRange));
-
 	// Cancel autocompletion trigger
 	if([prefs boolForKey:SPCustomQueryAutoComplete]) {
 		[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(doAutoCompletion) object:nil];


### PR DESCRIPTION
## Changes:
- Added pref to General pane called "Save query history individually". This is the default and stores each line as a history item in the db, delimited by `;\n`. If you switch it off, the entire query is stored as one item in the db.
- Fixed `History Replaces Editor Content` and `Favorites Replaces Editor Content` not working properly.

## Closes following issues:
- Closes #818 
- Closes #820  

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:

## Additional notes:

**TODO**: unions and subqueries...