### PR TITLE
Rename SPWindowController's properties, start AutoLayout programatically without xibs #infra

### DIFF
--- a/Interfaces/MainWindow.xib
+++ b/Interfaces/MainWindow.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SPWindowController">
             <connections>
-                <outlet property="tabBar" destination="3" id="13"/>
+                <outlet property="tabBarControl" destination="3" id="YQG-Ao-f28"/>
                 <outlet property="tabView" destination="4" id="14"/>
                 <outlet property="window" destination="1" id="15"/>
             </connections>
@@ -19,7 +19,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="238" y="168" width="948" height="555"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
             <value key="minSize" type="size" width="800" height="400"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="948" height="555"/>

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -5426,7 +5426,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     // Otherwise position the sheet beneath the tab bar if it's visible
-    rect.origin.y -= [self.parentWindowController.tabBar frame].size.height - 1;
+    rect.origin.y -= [self.parentWindowController.tabBarControl frame].size.height - 1;
 
     return rect;
 }

--- a/Source/Controllers/Window/SPWindowController.h
+++ b/Source/Controllers/Window/SPWindowController.h
@@ -36,8 +36,6 @@
 
 @interface SPWindowController : NSWindowController <NSWindowDelegate>
 {
-	IBOutlet NSTabView *tabView;
-
 	NSClipView *titleBarLineHidingView;
 
 	NSMenuItem *closeWindowMenuItem;
@@ -47,7 +45,8 @@
 }
 
 @property (nonatomic, weak) id<SPWindowControllerDelegate> delegate;
-@property (readonly, strong) IBOutlet PSMTabBarControl *tabBar;
+@property (nonatomic, strong) IBOutlet NSTabView *tabView;
+@property (nonatomic, strong) IBOutlet PSMTabBarControl *tabBarControl;
 @property (readonly, strong) SPDatabaseDocument *selectedTableDocument;
 
 // Database connection management

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -1,0 +1,29 @@
+//
+//  SPWindowController.swift
+//  Sequel Ace
+//
+//  Created by Jakub Kašpar on 24.01.2021.
+//  Copyright © 2021 Sequel-Ace. All rights reserved.
+//
+
+import Cocoa
+import SnapKit
+
+extension SPWindowController {
+    @objc func setupAppearance() {
+        // Here should ahppen all UI / layout setups
+    }
+
+    @objc func setupConstraints() {
+        tabBarControl.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(25)
+        }
+        tabView.snp.makeConstraints {
+            $0.top.equalTo(tabBarControl.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}

--- a/Source/Other/Extensions/NSViewExtension.swift
+++ b/Source/Other/Extensions/NSViewExtension.swift
@@ -1,0 +1,19 @@
+//
+//  NSViewExtension.swift
+//  Sequel Ace
+//
+//  Created by Jakub Kašpar on 24.01.2021.
+//  Copyright © 2021 Sequel-Ace. All rights reserved.
+//
+
+import Cocoa
+
+extension NSView {
+    func addSubviews(_ subviews: [NSView]) {
+        subviews.forEach { self.addSubview($0) }
+    }
+
+    func addSubviews(_ subviews: NSView...) {
+        subviews.forEach { self.addSubview($0) }
+    }
+}

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -29,6 +29,7 @@
 
 #import "SPWindowController.h"
 #import "SPDatabaseDocument.h"
+#import "PSMTabBarControl.h"
 
 #import "SPConstants.h"
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -275,6 +275,10 @@
 		519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5193502E2567D2FB001272B5 /* CollectionExtension.swift */; };
 		51A709392565B99F001F1D2F /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51A709382565B99F001F1D2F /* Images.xcassets */; };
 		51BA34A625BD9F30007CA20B /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51BA34A525BD9F30007CA20B /* OCMock.framework */; };
+		51BC14F825BE135500F1CDC9 /* SPWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BC14F725BE135500F1CDC9 /* SPWindowController.swift */; };
+		51BC150125BE138700F1CDC9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51BC150025BE138700F1CDC9 /* SnapKit */; };
+		51BC150625BE13C400F1CDC9 /* NSViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */; };
+		51BC150E25BE1EB100F1CDC9 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51BC150D25BE1EB100F1CDC9 /* MainWindow.xib */; };
 		51C4626D254ED02500F63E70 /* UserDefaultsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4626C254ED02500F63E70 /* UserDefaultsExtension.swift */; };
 		51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C8597B24C8A31400A8C7C4 /* StringExtension.swift */; };
 		51C8597C24C8A31400A8C7C4 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C8597B24C8A31400A8C7C4 /* StringExtension.swift */; };
@@ -289,7 +293,6 @@
 		51CD0BE3258D06D8009E2484 /* DBView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BC5258D06D7009E2484 /* DBView.xib */; };
 		51CD0BE4258D06D8009E2484 /* HelpViewer.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BC6258D06D7009E2484 /* HelpViewer.xib */; };
 		51CD0BE5258D06D8009E2484 /* Navigator.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BC7258D06D8009E2484 /* Navigator.xib */; };
-		51CD0BE6258D06D8009E2484 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BC8258D06D8009E2484 /* MainWindow.xib */; };
 		51CD0BE7258D06D8009E2484 /* ImportAccessory.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BC9258D06D8009E2484 /* ImportAccessory.xib */; };
 		51CD0BE8258D06D8009E2484 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BCA258D06D8009E2484 /* MainMenu.xib */; };
 		51CD0BE9258D06D8009E2484 /* Console.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BCB258D06D8009E2484 /* Console.xib */; };
@@ -893,6 +896,9 @@
 		51BA34A525BD9F30007CA20B /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Frameworks/OCMock.framework; sourceTree = "<group>"; };
 		51BB3DFC25AEF020005AAE44 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		51BB3E0425AEF0D7005AAE44 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		51BC14F725BE135500F1CDC9 /* SPWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowController.swift; sourceTree = "<group>"; };
+		51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtension.swift; sourceTree = "<group>"; };
+		51BC150D25BE1EB100F1CDC9 /* MainWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		51C4626C254ED02500F63E70 /* UserDefaultsExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtension.swift; sourceTree = "<group>"; };
 		51C8597B24C8A31400A8C7C4 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		51CD0BBE258D06D7009E2484 /* PrintAccessory.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrintAccessory.xib; sourceTree = "<group>"; };
@@ -905,7 +911,6 @@
 		51CD0BC5258D06D7009E2484 /* DBView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DBView.xib; sourceTree = "<group>"; };
 		51CD0BC6258D06D7009E2484 /* HelpViewer.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HelpViewer.xib; sourceTree = "<group>"; };
 		51CD0BC7258D06D8009E2484 /* Navigator.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Navigator.xib; sourceTree = "<group>"; };
-		51CD0BC8258D06D8009E2484 /* MainWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		51CD0BC9258D06D8009E2484 /* ImportAccessory.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ImportAccessory.xib; sourceTree = "<group>"; };
 		51CD0BCA258D06D8009E2484 /* MainMenu.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
 		51CD0BCB258D06D8009E2484 /* Console.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Console.xib; sourceTree = "<group>"; };
@@ -1253,6 +1258,7 @@
 				503CDBB21ACDC204004F8A2F /* Quartz.framework in Frameworks */,
 				265446DF24A1616900376B48 /* libz.tbd in Frameworks */,
 				17AED4161888BD67008E380F /* Security.framework in Frameworks */,
+				51BC150125BE138700F1CDC9 /* SnapKit in Frameworks */,
 				296DC8BF0F9091DF002A3258 /* libicucore.dylib in Frameworks */,
 				8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */,
 				296DC89F0F8FD336002A3258 /* WebKit.framework in Frameworks */,
@@ -1633,6 +1639,7 @@
 			children = (
 				58A8A78F11A036C000B95749 /* SPWindowController.h */,
 				58A8A79011A036C000B95749 /* SPWindowController.m */,
+				51BC14F725BE135500F1CDC9 /* SPWindowController.swift */,
 			);
 			path = Window;
 			sourceTree = "<group>";
@@ -2071,7 +2078,7 @@
 				51CD0BC9258D06D8009E2484 /* ImportAccessory.xib */,
 				51CD0BC4258D06D7009E2484 /* IndexesView.xib */,
 				51CD0BCA258D06D8009E2484 /* MainMenu.xib */,
-				51CD0BC8258D06D8009E2484 /* MainWindow.xib */,
+				51BC150D25BE1EB100F1CDC9 /* MainWindow.xib */,
 				51CD0BC7258D06D8009E2484 /* Navigator.xib */,
 				51CD0BC0258D06D7009E2484 /* Preferences.xib */,
 				51CD0BBE258D06D7009E2484 /* PrintAccessory.xib */,
@@ -2312,6 +2319,7 @@
 				5193502E2567D2FB001272B5 /* CollectionExtension.swift */,
 				1A199629257A624200F5B0F1 /* BundleExtension.swift */,
 				513515D1259354BB001E4533 /* NSImageExtensions.swift */,
+				51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2606,6 +2614,7 @@
 				51D9527525AE2B5300574BEB /* FMDB */,
 				515D303E25BD7DE60021CF1E /* AppCenterCrashes */,
 				515D304025BD7DE60021CF1E /* AppCenterAnalytics */,
+				51BC150025BE138700F1CDC9 /* SnapKit */,
 			);
 			productInstallPath = "$(HOME)/Applications";
 			productName = "sequel-pro";
@@ -2646,6 +2655,7 @@
 			packageReferences = (
 				51D9527425AE2B5300574BEB /* XCRemoteSwiftPackageReference "fmdb" */,
 				515D303D25BD7DE60021CF1E /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */,
+				51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */,
 			);
 			productRefGroup = 19C28FB0FE9D524F11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -2862,7 +2872,6 @@
 				582E93A0168296F3003459FD /* link-arrow@2x.png in Resources */,
 				51CD0BDE258D06D8009E2484 /* Preferences.xib in Resources */,
 				5135161B25935699001E4533 /* AquaTabCloseDirty_Front_Pressed.png in Resources */,
-				51CD0BE6258D06D8009E2484 /* MainWindow.xib in Resources */,
 				8831EFB62240150A00D10172 /* button_add_folderTemplate.pdf in Resources */,
 				582E940E1682A2AD003459FD /* button_bar_spacer@2x.png in Resources */,
 				50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */,
@@ -2886,6 +2895,7 @@
 				5135160425935699001E4533 /* TabNewMetalRollover.png in Resources */,
 				51CD0BEA258D06D8009E2484 /* DatabaseServerVariables.xib in Resources */,
 				582E9487168380D6003459FD /* sync_arrows_05.png in Resources */,
+				51BC150E25BE1EB100F1CDC9 /* MainWindow.xib in Resources */,
 				5135161425935699001E4533 /* AquaTabCloseDirty_Front.png in Resources */,
 				582E9488168380D6003459FD /* sync_arrows_06.png in Resources */,
 				5135160225935699001E4533 /* SequelProTabDirty_Pressed@2x.png in Resources */,
@@ -3076,6 +3086,7 @@
 				BC01BCCF104024BE006BDEE7 /* SPEncodingPopupAccessory.m in Sources */,
 				513515E42593568B001E4533 /* PSMProgressIndicator.m in Sources */,
 				3876E15D1CC0BA0300D85154 /* SPTableFooterPopUpButtonCell.m in Sources */,
+				51BC14F825BE135500F1CDC9 /* SPWindowController.swift in Sources */,
 				513515E92593568B001E4533 /* PSMTabDragWindow.m in Sources */,
 				173C4366104455E0001F3A30 /* SPQueryFavoriteManager.m in Sources */,
 				173C44D81044A6B0001F3A30 /* SPOutlineView.m in Sources */,
@@ -3157,6 +3168,7 @@
 				BC5750D512A6233900911BA2 /* SPActivityTextFieldCell.m in Sources */,
 				BC0ED3DA12A9196C00088461 /* SPChooseMenuItemDialog.m in Sources */,
 				511C466A25BC768E001AA1BD /* NSTabViewItemExtension.swift in Sources */,
+				51BC150625BE13C400F1CDC9 /* NSViewExtension.swift in Sources */,
 				583CA21512EC8B2200C9E763 /* SPWindow.m in Sources */,
 				1A9EB9AE25651F5000FE60FF /* SQLiteHistoryManager.swift in Sources */,
 				582F02311370B52600B30621 /* SPExportFileNameTokenObject.m in Sources */,
@@ -4233,6 +4245,14 @@
 				minimumVersion = 4.1.0;
 			};
 		};
+		51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.1;
+			};
+		};
 		51D9527425AE2B5300574BEB /* XCRemoteSwiftPackageReference "fmdb" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ccgus/fmdb";
@@ -4253,6 +4273,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 515D303D25BD7DE60021CF1E /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
 			productName = AppCenterAnalytics;
+		};
+		51BC150025BE138700F1CDC9 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
 		};
 		51D9527525AE2B5300574BEB /* FMDB */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/sequel-ace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sequel-ace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -27,6 +27,15 @@
           "revision": "de6b8f9db4b2a0aa859a5507550a70548e4da936",
           "version": "1.8.1"
         }
+      },
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
       }
     ]
   },


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Start xib-less setup, for now with no real visible change,
- Rename controls to proper naming and property setups

## Closes following issues:
- Closes 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.3
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
In future I would like to avoid `xib` and `storyboard` files with Auto Layout and constraints. To simplify that, I'll introduce couple of convenience methods, and I'm adding SnapKit for programatically added constraints. This is a first step that will not cause any real change for anything and users shouldn't even notice this. Also I would like to move to proper property setups and usage via `self`.