### PR TITLE
#fixed remove space char used to trigger syntax highlighting on paste

### DIFF
--- a/Source/Other/CategoryAdditions/SPStringAdditions.h
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.h
@@ -125,3 +125,7 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 
 - (void)safeDeleteCharactersInRange:(NSRange)aRange;
 @end
+
+@interface NSMutableAttributedString (SPStringAdditions)
+- (void)safeDeleteCharactersInRange:(NSRange)aRange;
+@end

--- a/Source/Other/CategoryAdditions/SPStringAdditions.m
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.m
@@ -646,3 +646,16 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c)
 }
 
 @end
+
+@implementation NSMutableAttributedString (SPStringAdditions)
+
+- (void)safeDeleteCharactersInRange:(NSRange)aRange
+{
+    if (aRange.location == NSNotFound || NSMaxRange(aRange) > [self length]) {
+        return;
+    }
+
+    [self deleteCharactersInRange:aRange];
+}
+
+@end

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -2388,9 +2388,16 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
         // this adds a space to the end that
         // triggers a text change notification
         // which fully formats the query
+        // then we need to remove it for issue #843
         executeOnMainThreadAfterADelay(^{
             [self.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:@" "]];
-        }, 0.5);
+        }, 0.1);
+        executeOnMainThreadAfterADelay(^{
+            SPLog(@"NSMakeRange(self.textStorage.length-1, 1) : %lu", self.textStorage.length-1);
+            [self.textStorage replaceCharactersInRange:NSMakeRange(self.textStorage.length-1, 1) withString:@""];
+        }, 0.2);
+
+
 
     }
     else{

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -2394,7 +2394,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
         }, 0.1);
         executeOnMainThreadAfterADelay(^{
             SPLog(@"NSMakeRange(self.textStorage.length-1, 1) : %lu", self.textStorage.length-1);
-            [self.textStorage replaceCharactersInRange:NSMakeRange(self.textStorage.length-1, 1) withString:@""];
+            [self.textStorage safeDeleteCharactersInRange:NSMakeRange(self.textStorage.length-1, 1)];
         }, 0.2);
 
 

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -371,6 +371,81 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 }
 
+- (void)testMutAttrStringSafeDeleteCharactersInRange{
+
+
+    NSDictionary *baseAttrs = @{NSFontAttributeName: [NSFont systemFontOfSize:11], NSParagraphStyleAttributeName: [NSParagraphStyle defaultParagraphStyle]};
+
+    NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:@"The Dude is abiding..." attributes:baseAttrs];
+    NSMutableAttributedString *expectedStr = [[NSMutableAttributedString alloc] initWithString:@"The Dude is abiding.." attributes:baseAttrs];
+
+
+    NSUInteger startLoc = [str length]-1;
+
+    NSRange tmpRange = NSMakeRange(startLoc, 1);
+
+    NSLog(@"tmpRange: %@", NSStringFromRange(tmpRange));
+    NSLog(@"str.len: %lu", (unsigned long)str.length);
+
+    [str safeDeleteCharactersInRange:tmpRange];
+
+    NSLog(@"str: %@", str);
+    NSLog(@"str.len: %lu", (unsigned long)str.length);
+
+    XCTAssertTrue(str.length == startLoc);
+
+    XCTAssertEqualObjects(str, expectedStr);
+
+    tmpRange = NSMakeRange(str.length+2, 1);
+
+    XCTAssertThrows([str deleteCharactersInRange:tmpRange]);
+    XCTAssertNoThrow([str safeDeleteCharactersInRange:tmpRange]);
+
+}
+
+// 1.39 s
+- (void)testMutAttrStringSafeDeleteCharactersInRangePerf{
+    [self measureBlock:^{
+        int const iterations = 1000000;
+
+        NSDictionary *baseAttrs = @{NSFontAttributeName: [NSFont systemFontOfSize:11], NSParagraphStyleAttributeName: [NSParagraphStyle defaultParagraphStyle]};
+
+        for (int i = 0; i < iterations; i++) {
+
+            NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:@"The tomato never really took off as a hand fruit..." attributes:baseAttrs];
+
+            NSUInteger startLoc = [str length]-1;
+
+            NSRange tmpRange = NSMakeRange(startLoc, 1);
+            @autoreleasepool {
+                [str safeDeleteCharactersInRange:tmpRange];
+            }
+        }
+    }];
+}
+
+//1.34 s
+- (void)testMutAttrStringDeleteCharactersInRangePerf{
+    [self measureBlock:^{
+        int const iterations = 1000000;
+
+        NSDictionary *baseAttrs = @{NSFontAttributeName: [NSFont systemFontOfSize:11], NSParagraphStyleAttributeName: [NSParagraphStyle defaultParagraphStyle]};
+
+        for (int i = 0; i < iterations; i++) {
+
+            NSMutableAttributedString *str = [[NSMutableAttributedString alloc] initWithString:@"The tomato never really took off as a hand fruit..." attributes:baseAttrs];
+
+            NSUInteger startLoc = [str length]-1;
+
+            NSRange tmpRange = NSMakeRange(startLoc, 1);
+            @autoreleasepool {
+                [str deleteCharactersInRange:tmpRange];
+            }
+        }
+    }];
+}
+
+
 - (void)testSafeDeleteCharactersInRange{
 
     NSMutableString *str = [[NSMutableString alloc] initWithString:@"How far will you go for 15 seconds of fame?"];


### PR DESCRIPTION
## Changes:
- remove space char used to trigger syntax highlighting on paste

## Closes following issues:
- #834

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version:12.3 (12C33)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
