### PR TITLE
#fixed Users screen schemas not updating

### DIFF
--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -120,6 +120,12 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
         grantedSchemaPrivs = [[NSMutableArray alloc] init];
         isSaving = NO;
         doneRecordError = NO;
+
+        // listen for new/dropped/renamed databases, to refresh the list
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(_initializeSchemaPrivs)
+                                                     name:SPDatabaseCreatedRemovedRenamedNotification
+                                                   object:nil];
 	}
 	
 	return self;
@@ -365,6 +371,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
  */
 - (void)_initializeSchemaPrivs
 {
+    SPLog(@"_initializeSchemaPrivs called.");
 	// Initialize Databases
 	[schemas removeAllObjects];
 	[schemas addObjectsFromArray:[databaseDocument allDatabaseNames]];

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -431,6 +431,7 @@ extern NSString *SPSecureBookmarksOldFormat;
 extern NSString *SPSecureBookmarksHaveBeenMigrated;
 
 // Misc
+extern NSString *SPDatabaseCreatedRemovedRenamedNotification;
 extern NSString *SPContentFilters;
 extern NSString *SPBookmarksChangedNotification;
 extern NSString *SPDocumentTaskEndNotification;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -272,6 +272,7 @@ NSString *SPQueryFavoritesHaveBeenUpdatedNotification = @"QueryFavoritesHaveBeen
 NSString *SPHistoryItemsHaveBeenUpdatedNotification   = @"HistoryItemsHaveBeenUpdatedNotification";
 NSString *SPContentFiltersHaveBeenUpdatedNotification = @"ContentFiltersHaveBeenUpdatedNotification";
 NSString *SPCopyContentOnTableCopy                    = @"CopyContentOnTableCopy";
+NSString *SPDatabaseCreatedRemovedRenamedNotification = @"DatabaseCreatedRemovedRenamedNotification";
 
 // URLs
 NSString *SPMySQLSearchURL                       = @"https://dev.mysql.com/doc/search/?d=%d&p=1&q=%@";


### PR DESCRIPTION
## Changes:
- Post notifications when a database is created/renamed/dropped 
- Listen for `SPDatabaseCreatedRemovedRenamedNotification` and reload the schema list when notified

## Closes following issues:
- Closes #723  

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
