### PR TITLE
#fixed rename table so that it drops the original table

### DIFF
--- a/Source/Other/DatabaseActions/SPDatabaseAction.m
+++ b/Source/Other/DatabaseActions/SPDatabaseAction.m
@@ -49,6 +49,8 @@
 
 - (BOOL)createDatabase:(NSString *)database withEncoding:(NSString *)encoding collation:(NSString *)collation
 {
+    SPLog(@"createDatabase: %@", database);
+
 	if (![database length]) {
 		SPLog(@"'database' should not be nil or empty!");
 		return NO;

--- a/Source/Other/DatabaseActions/SPTableCopy.m
+++ b/Source/Other/DatabaseActions/SPTableCopy.m
@@ -132,6 +132,9 @@
 							   [targetDatabase backtickQuotedString],
 							   [tableName backtickQuotedString]];
 
+    SPLog(@"moveTable from : %@, to: %@", sourceDatabase, targetDatabase);
+    SPLog(@"moveTable moveStatement: %@", moveStatement);
+
 	[connection queryString:moveStatement];
 	
 	return ![connection queryErrored];


### PR DESCRIPTION
## Changes:
- fixed rename table so that it drops the original table

## Closes following issues:
- #841 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
