### PR TITLE
#fixed Duplicate Table... name not editable 

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -617,6 +617,12 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 			break;
 	}
 
+    // from docs:
+    // A window that uses NSWindowStyleMaskBorderless can’t become key or main
+    // meaning it can't take input, so switch the style here.
+    // It doesn't change how the popup looks.
+    copyTableSheet.styleMask = NSWindowStyleMaskTitled;
+
 	[copyTableMessageField setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Duplicate %@ '%@' to:", @"duplicate object message"), tableType, [self tableName]]];
 	[copyTableNameField setStringValue:[NSString stringWithFormat:@"%@_copy", [filteredTables objectAtIndex:[tablesListView selectedRow]]]];
 


### PR DESCRIPTION
## Changes:
from docs:
> A window that uses NSWindowStyleMaskBorderless can’t become key or main 

Meaning it can't take input, so we switch the style to `NSWindowStyleMaskTitled`. 

It doesn't change how the popup looks. See screenshots below.

## Closes following issues:
- #845 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [x] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:

![Screenshot 2021-02-01 at 6 39 14 PM](https://user-images.githubusercontent.com/1576190/106448494-d16b5180-64bd-11eb-803e-8b5789abb78c.png)
![Screenshot 2021-02-01 at 6 39 36 PM](https://user-images.githubusercontent.com/1576190/106448498-d3cdab80-64bd-11eb-9d61-d77e440cba40.png)

## Additional notes:
