### PR TITLE
UTC time tooltips #added

### DIFF
--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -57,7 +57,8 @@
 //	See more possible syntaxa in SPTooltip to init a tooltip
 
 #import "SPTooltip.h"
-
+#import "SPFunctions.h"
+#import "sequel-ace-Swift.h"
 #include <tgmath.h>
 
 static NSInteger spTooltipCounter = 0;
@@ -160,6 +161,15 @@ static CGFloat slow_in_out (CGFloat t)
 	if([type isEqualToString:@"text"]) {
 		NSString* html = nil;
 		NSMutableString* text = [(NSString*)content mutableCopy];
+
+        // check to see if the string is a unix timestamp, within +/- one year
+        // if it is create a date time string from the unix timestamp
+        NSString *unixTimestampAsString = text.dateStringFromUnixTimestamp;
+        if(!IsEmpty(unixTimestampAsString)){
+            SPLog(@"unixTimestampAsString: %@", unixTimestampAsString);
+            [text setString:unixTimestampAsString];
+        }
+
 		if(text)
 		{
 			int fontSize = ([displayOptions objectForKey:@"fontsize"]) ? [[displayOptions objectForKey:@"fontsize"] intValue] : 10;
@@ -171,6 +181,7 @@ static CGFloat slow_in_out (CGFloat t)
 							atIndex:0];
 			[text appendString:@"</pre>"];
 			html = text;
+            SPLog(@"html: %@", html);
 		}
 		else
 		{

--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -162,7 +162,7 @@ static CGFloat slow_in_out (CGFloat t)
 		NSString* html = nil;
 		NSMutableString* text = [(NSString*)content mutableCopy];
 
-        // check to see if the string is a unix timestamp, within +/- one year
+        // check to see if the string is a unix timestamp, within +/- oneHundredYears
         // if it is create a date time string from the unix timestamp
         NSString *unixTimestampAsString = text.dateStringFromUnixTimestamp;
         if(!IsEmpty(unixTimestampAsString)){

--- a/Source/Other/Extensions/DateFormatterExtension.swift
+++ b/Source/Other/Extensions/DateFormatterExtension.swift
@@ -16,6 +16,12 @@ extension DateFormatter {
 		formatter.timeStyle = .medium
 		return formatter
 	}()
+
+    @objc public static var iso8601DateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
 	
 	@objc public static var mediumStyleNoDateFormatter: DateFormatter = {
 		let formatter = DateFormatter()

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -121,17 +121,17 @@ extension String {
         let now = Int(Date().timeIntervalSince1970)
         os_log("unix timestamp for now: %i", log: OSLog.default, type: .debug, now)
 
-        let aYear: Int = 31536000
-        let upperBound = now + aYear
-        let lowerBound = now - aYear
+        let oneHundredYears: Int = 3153600000
+        let upperBound = now + oneHundredYears
+        let lowerBound = now - oneHundredYears
 
         if Int(timeInterval) > lowerBound && Int(timeInterval) < upperBound {
-            os_log("unix timestamp within +/- one year", log: OSLog.default, type: .debug)
+            os_log("unix timestamp within +/- oneHundredYears", log: OSLog.default, type: .debug)
             let date = Date(timeIntervalSince1970: timeInterval)
             let formatter = DateFormatter.iso8601DateFormatter
             return formatter.string(from: date) as NSString
         }
-        os_log("unix timestamp NOT within +/- one year", log: OSLog.default, type: .debug)
+        os_log("unix timestamp NOT within +/- oneHundredYears", log: OSLog.default, type: .debug)
         return nil
     }
 

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os.log
 
 extension String {
 	func dropPrefix(_ prefix: String) -> String {
@@ -105,5 +106,34 @@ extension String {
     public func separatedIntoLinesObjc() -> [NSString] {
         return (self as String).separatedIntoLines() as [NSString]
     }
+
+    public func dateStringFromUnixTimestamp() -> NSString? {
+        os_log("string [%@]", log: OSLog.default, type: .error, self)
+
+        guard
+            let timeInterval = self.doubleValue as Double?,
+            timeInterval != 0.0
+        else{
+            os_log("string [%@] cannot be represented as a double", log: OSLog.default, type: .error, self)
+            return nil
+        }
+
+        let now = Int(Date().timeIntervalSince1970)
+        os_log("unix timestamp for now: %i", log: OSLog.default, type: .debug, now)
+
+        let aYear: Int = 31536000
+        let upperBound = now + aYear
+        let lowerBound = now - aYear
+
+        if Int(timeInterval) > lowerBound && Int(timeInterval) < upperBound {
+            os_log("unix timestamp within +/- one year", log: OSLog.default, type: .debug)
+            let date = Date(timeIntervalSince1970: timeInterval)
+            let formatter = DateFormatter.iso8601DateFormatter
+            return formatter.string(from: date) as NSString
+        }
+        os_log("unix timestamp NOT within +/- one year", log: OSLog.default, type: .debug)
+        return nil
+    }
+
 
 }

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -309,6 +309,97 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 }
 
+//0.133 s
+- (void)testPerformanceDateStringFromUnixTimestamp{
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+        double epoch = 1641629299;
+
+        int const iterations = 100000;
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                // exec on bg thread
+                epoch = epoch + i;
+                NSString *epochStr = [NSString stringWithFormat:@"%f", epoch];
+                NSString __unused *tmp = epochStr.dateStringFromUnixTimestamp;
+            }
+        }
+    }];
+}
+
+//0.273 s
+- (void)testPerformanceDateStringFromUnixTimestamp2{
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+        NSString *epochStr = @"1641629299";
+        int const iterations = 100000;
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                // exec on bg thread
+                NSString __unused *tmp = epochStr.dateStringFromUnixTimestamp;
+            }
+        }
+
+    }];
+}
+
+// 0.429 s
+- (void)testPerformanceIsUnixTimeStamp{
+
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+
+        double epoch = 1578470899;
+        int const iterations = 100000;
+        double twoYears = epoch + 31536000 + 31536000;
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                // exec on bg thread
+                epoch = epoch + i;
+                if(epoch > twoYears) epoch = 1578470899;
+                NSString *epochStr = [NSString stringWithFormat:@"%f", epoch];
+                NSString __unused *tmp = epochStr.dateStringFromUnixTimestamp;
+            }
+        }
+    }];
+}
+
+//0.138 s
+- (void)testPerformanceIsUnixTimeStamp2{
+
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+
+        double epoch = 1578470899;
+        int const iterations = 100000;
+
+        int count = 0;
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                // exec on bg thread
+                epoch = epoch + i;
+                uint32_t randomNum = arc4random() % 2;
+
+                NSString *epochStr = [NSString stringWithFormat:@"%f", epoch];
+
+                if(randomNum > 0){
+                    NSString __unused *tmp2 = epochStr.dateStringFromUnixTimestamp;
+                    count++;
+                }
+
+            }
+        }
+    }];
+}
+
 
 // 0.95 s
 - (void)testSHA256Perf{

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -347,6 +347,25 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
     }];
 }
 
+- (void)testIsUnixTimeStamp{
+
+    NSString *justOver100YAgo = @"-1574579624";
+    XCTAssertNil(justOver100YAgo.dateStringFromUnixTimestamp);
+
+    NSString *justUnder100YAgo = @"-1479885224";
+    XCTAssertNotNil(justUnder100YAgo.dateStringFromUnixTimestamp);
+
+    NSString *justOver100YinTheFut = @"4800012376";
+    XCTAssertNil(justOver100YinTheFut.dateStringFromUnixTimestamp);
+
+    NSString *justUnder100YinTheFut = @"4736853976";
+    XCTAssertNotNil(justUnder100YinTheFut.dateStringFromUnixTimestamp);
+
+    NSString *aboutNow = @"1612803456";
+    XCTAssertNotNil(aboutNow.dateStringFromUnixTimestamp);
+
+}
+
 // 0.429 s
 - (void)testPerformanceIsUnixTimeStamp{
 
@@ -354,7 +373,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
-        double epoch = 1578470899;
+        double epoch = 1542957224;
         int const iterations = 100000;
         double twoYears = epoch + 31536000 + 31536000;
 
@@ -377,7 +396,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
-        double epoch = 1578470899;
+        double epoch = 1542957224;
         int const iterations = 100000;
 
         int count = 0;


### PR DESCRIPTION
## Changes:
- When mousing over a string that could be a unix timestamp, we check if it's within +/- one year, if it is we display a UTC time string.

## Closes following issues:
- Closes #793

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
