### PR TITLE
#fixed Export directory bookmarks

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -635,13 +635,20 @@ set_input:
     [changeExportOutputPathPanel setDirectoryURL:[NSURL URLWithString:[exportPathField stringValue]]];
     [changeExportOutputPathPanel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode) {
         if (returnCode == NSFileHandlingPanelOKButton) {
-			NSString *path = [[self->changeExportOutputPathPanel directoryURL] path];
+
+            NSMutableString *path = [[NSMutableString alloc] initWithCapacity:self->changeExportOutputPathPanel.directoryURL.absoluteString.length];
+            [path setString:[[self->changeExportOutputPathPanel directoryURL] path]];
+
 			if(!path) {
 				@throw [NSException exceptionWithName:NSInternalInconsistencyException
 											   reason:[NSString stringWithFormat:@"File panel ended with OK, but returned nil for path!? directoryURL=%@,isFileURL=%d",[self->changeExportOutputPathPanel directoryURL],[[self->changeExportOutputPathPanel directoryURL] isFileURL]]
 											 userInfo:nil];
 			}
-			
+
+            path = [[path dropSuffixWithSuffix:@"/"] mutableCopy];
+
+            [path appendString:@"/"];
+
 			[self->exportPathField setStringValue:path];
 
             NSMutableString *classStr = [NSMutableString string];

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -287,7 +287,7 @@ import OSLog
 
     /// bookmarkFor a file
     ///  - Parameters:
-    ///     - filename: file URL to generate secure bookmark for
+    ///     - filename: file URL to return secure bookmark for
     /// - Returns: the resolved URL or nil
     @objc func bookmarkFor(filename: String) -> URL? {
         Log.debug("filename: \(filename)")

--- a/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
@@ -186,8 +186,8 @@
 - (void)_refreshBookmarks{
     SPLog(@"Got SPBookmarksChangedNotification, refreshing bookmarks");
 
-    [bookmarks setArray:SecureBookmarkManager.sharedInstance.bookmarks];
-    [staleBookmarks setArray:SecureBookmarkManager.sharedInstance.staleBookmarks];
+    [self loadBookmarks];
+
 }
 
 - (NSImage *)preferencePaneIcon {


### PR DESCRIPTION
## Changes:
- add trailing slash to export path to ensure lookup of bookmark works

## Closes following issues:
- Closes #870 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
