### PR TITLE
#fixed Tooltip crash

### DIFF
--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -162,12 +162,15 @@ static CGFloat slow_in_out (CGFloat t)
 		NSString* html = nil;
 		NSMutableString* text = [(NSString*)content mutableCopy];
 
-        // check to see if the string is a unix timestamp, within +/- oneHundredYears
-        // if it is create a date time string from the unix timestamp
-        NSString *unixTimestampAsString = text.dateStringFromUnixTimestamp;
-        if(!IsEmpty(unixTimestampAsString)){
-            SPLog(@"unixTimestampAsString: %@", unixTimestampAsString);
-            [text setString:unixTimestampAsString];
+
+        if(!IsEmpty(text)){
+            // check to see if the string is a unix timestamp, within +/- oneHundredYears
+            // if it is create a date time string from the unix timestamp
+            NSString *unixTimestampAsString = text.dateStringFromUnixTimestamp;
+            if(!IsEmpty(unixTimestampAsString)){
+                SPLog(@"unixTimestampAsString: %@", unixTimestampAsString);
+                [text setString:unixTimestampAsString];
+            }
         }
 
 		if(text)

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -53,6 +53,10 @@ extension String {
         }
         return lines
     }
+
+    var isNumeric: Bool {
+        return !(self.isEmpty) && self.allSatisfy { $0.isNumber }
+    }
     
 	
 	// stringByReplacingPercentEscapesUsingEncoding is deprecated
@@ -111,6 +115,8 @@ extension String {
         os_log("string [%@]", log: OSLog.default, type: .error, self)
 
         guard
+            !IsEmpty(self),
+            (self as String).isNumeric,
             let timeInterval = self.doubleValue as Double?,
             timeInterval != 0.0
         else{
@@ -121,17 +127,18 @@ extension String {
         let now = Int(Date().timeIntervalSince1970)
         os_log("unix timestamp for now: %i", log: OSLog.default, type: .debug, now)
 
-        let oneHundredYears: Int = 3153600000
-        let upperBound = now + oneHundredYears
-        let lowerBound = now - oneHundredYears
+        let oneYear: Int = 31_536_000
+        let numberOfYears: Int = 100
+        let upperBound = now + (oneYear * numberOfYears)
+        let lowerBound = now - (oneYear * numberOfYears)
 
         if Int(timeInterval) > lowerBound && Int(timeInterval) < upperBound {
-            os_log("unix timestamp within +/- oneHundredYears", log: OSLog.default, type: .debug)
+            os_log("unix timestamp within +/- %i years", log: OSLog.default, type: .debug, numberOfYears)
             let date = Date(timeIntervalSince1970: timeInterval)
             let formatter = DateFormatter.iso8601DateFormatter
             return formatter.string(from: date) as NSString
         }
-        os_log("unix timestamp NOT within +/- oneHundredYears", log: OSLog.default, type: .debug)
+        os_log("unix timestamp NOT within +/- %i years", log: OSLog.default, type: .debug, numberOfYears)
         return nil
     }
 

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -115,7 +115,7 @@ extension String {
         os_log("string [%@]", log: OSLog.default, type: .error, self)
 
         guard
-            !IsEmpty(self),
+            !(self as String).isEmpty,
             (self as String).isNumeric,
             let timeInterval = self.doubleValue as Double?,
             timeInterval != 0.0

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -116,7 +116,7 @@ extension String {
 
         guard
             !(self as String).isEmpty,
-            (self as String).isNumeric,
+            (self as String).dropPrefix("-").isNumeric,
             let timeInterval = self.doubleValue as Double?,
             timeInterval != 0.0
         else{

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -34,3 +34,4 @@
 #import "SPConstants.h"
 
 #import "SPFileManagerAdditions.h"
+#import "SPFunctions.h"

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -34,4 +34,3 @@
 #import "SPConstants.h"
 
 #import "SPFileManagerAdditions.h"
-#import "SPFunctions.h"


### PR DESCRIPTION
## Changes:
- Extra checks when attempting to convert a string to a unix timestamp

## Closes following issues:
- Closes #2282497646u

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
