### PR TITLE
show error if setting the time zone fails #fixed 

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -505,7 +505,7 @@ const char *SPMySQLSSLPermissibleCiphers = "DHE-RSA-AES256-SHA:AES256-SHA:DHE-RS
                 [delegate queryGaveError:lastErrorMessage connection:self];
             }
             if ([delegate respondsToSelector:@selector(showErrorWithTitle:message:)]) {
-                [lastErrorMessage appendString:@"\n\ntime_zone will be set to SYSTEM."];
+                [lastErrorMessage appendString:NSLocalizedString(@"\n\ntime_zone will be set to SYSTEM.", @"\n\ntime_zone will be set to SYSTEM.")];
                 [delegate showErrorWithTitle:NSLocalizedString(@"Error", @"error") message:lastErrorMessage];
             }
         }

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -493,7 +493,22 @@ const char *SPMySQLSSLPermissibleCiphers = "DHE-RSA-AES256-SHA:AES256-SHA:DHE-RS
         [self queryString:[NSString stringWithFormat:@"SET time_zone = @@GLOBAL.time_zone"]];
     } else {
         [self queryString:[NSString stringWithFormat:@"SET time_zone = %@", [timeZoneIdentifier mySQLTickQuotedString]]];
-        self.timeZoneIdentifier = timeZoneIdentifier;
+        if ([self lastErrorMessage] == nil) {
+            self.timeZoneIdentifier = timeZoneIdentifier;
+        }
+        else{
+            NSMutableString *lastErrorMessage = [[NSMutableString alloc] init];
+            [lastErrorMessage setString:[self lastErrorMessage]];
+            SPLog(@"Failed to set time_zone. Error: %@", lastErrorMessage);
+            self.timeZoneIdentifier = nil;
+            if (delegate && [delegate respondsToSelector:@selector(queryGaveError:connection:)]) {
+                [delegate queryGaveError:lastErrorMessage connection:self];
+            }
+            if ([delegate respondsToSelector:@selector(showErrorWithTitle:message:)]) {
+                [lastErrorMessage appendString:@"\n\ntime_zone will be set to SYSTEM."];
+                [delegate showErrorWithTitle:NSLocalizedString(@"Error", @"error") message:lastErrorMessage];
+            }
+        }
     }
 }
 

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3233,3 +3233,6 @@
 
 /* New Connection Error informative message */
 "Failed to create new database connection window. Please restart Sequel Ace and try again." = "Failed to create new database connection window. Please restart Sequel Ace and try again.";
+
+/* Time zone set failed informative message */
+"\n\ntime_zone will be set to SYSTEM." = "\n\ntime_zone will be set to SYSTEM.";

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -6585,9 +6585,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)showErrorWithTitle:(NSString *)theTitle message:(NSString *)theMessage
 {
-    if ([[self.parentWindowController window] isVisible]) {
-        [NSAlert createWarningAlertWithTitle:theTitle message:theMessage callback:nil];
-    }
+    SPMainQSync(^{
+        if ([[self.parentWindowController window] isVisible]) {
+            [NSAlert createWarningAlertWithTitle:theTitle message:theMessage callback:nil];
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
## Changes:
- show error if setting the time zone fails. Also write to the console.

## Closes following issues:
- Closes #881 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:

![Screenshot 2021-02-17 at 6 46 24 PM](https://user-images.githubusercontent.com/1576190/108195199-6de65280-7152-11eb-85dd-72d6f96ad866.png)
![Screenshot 2021-02-17 at 6 45 53 PM](https://user-images.githubusercontent.com/1576190/108195203-6fb01600-7152-11eb-8668-cae6964fad07.png)


## Additional notes:
