### PR TITLE
Remove hard-coded minimum for resetting auto-increment #changed

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1764,7 +1764,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 	NSString *contextInfo = @"removerow";
 
-	if (([tableContentView numberOfSelectedRows] == [tableContentView numberOfRows]) && [tableContentView numberOfSelectedRows] > 50 && !isFiltered && !isLimited && !isInterruptedLoad && !isEditingNewRow) {
+	if (([tableContentView numberOfSelectedRows] == [tableContentView numberOfRows]) && !isFiltered && !isLimited && !isInterruptedLoad && !isEditingNewRow) {
 
 		contextInfo = @"removeallrows";
 


### PR DESCRIPTION
## Changes:
- Remove hard-coded minimum for resetting auto-increment

## Closes following issues:
- Closes #874

## Tested:
- Processors:
  - [ X] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ X] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Xcode Version:
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ X] Other (please specify) N/A
## Screenshots:
N/A

## Additional notes:
