### PR TITLE
#fixed maintain table filter state

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -361,7 +361,6 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	isDesc = NO;
 
 	// Empty and disable filter options
-	[self setRuleEditorVisible:NO animate:NO];
 	[toggleRuleFilterButton setEnabled:NO];
 	[toggleRuleFilterButton setState:NSOffState];
 	[ruleFilterController setColumns:nil];


### PR DESCRIPTION
## Changes:
- don't set setRuleEditorVisible:NO when not viewing a table

## Closes following issues:
- Closes #342

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
