### PR TITLE
Export directory bookmarks #fixed

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -631,10 +631,10 @@ set_input:
 	[changeExportOutputPathPanel setCanChooseFiles:NO];
 	[changeExportOutputPathPanel setCanChooseDirectories:YES];
 	[changeExportOutputPathPanel setCanCreateDirectories:YES];
-    
+
     [changeExportOutputPathPanel setDirectoryURL:[NSURL URLWithString:[exportPathField stringValue]]];
     [changeExportOutputPathPanel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode) {
-        if (returnCode == NSFileHandlingPanelOKButton) {
+        if (returnCode == NSModalResponseOK) {
 
             NSMutableString *path = [[NSMutableString alloc] initWithCapacity:self->changeExportOutputPathPanel.directoryURL.absoluteString.length];
             [path setString:[[self->changeExportOutputPathPanel directoryURL] path]];
@@ -645,11 +645,7 @@ set_input:
 											 userInfo:nil];
 			}
 
-            path = [[path dropSuffixWithSuffix:@"/"] mutableCopy];
-
-            [path appendString:@"/"];
-
-			[self->exportPathField setStringValue:path];
+            [self->exportPathField setStringValue:path];
 
             NSMutableString *classStr = [NSMutableString string];
             [classStr appendStringOrNil:NSStringFromClass(self->changeExportOutputPathPanel.URL.class)];
@@ -680,13 +676,16 @@ set_input:
             else{
                 // this needs to be read-write
                 if([SecureBookmarkManager.sharedInstance addBookmarkForUrl:self->changeExportOutputPathPanel.URL options:(NSURLBookmarkCreationWithSecurityScope) isForStaleBookmark:NO] == YES){
-                    SPLog(@"addBookmarkForUrl success");
+                    SPLog(@"addBookmarkForUrl success: %@", self->changeExportOutputPathPanel.URL.absoluteString);
                 } else{
                     SPLog(@"addBookmarkForUrl failed: %@", self->changeExportOutputPathPanel.URL);
                 }
             }
+        }// end of OK
+        else if(returnCode == NSModalResponseCancel){
+            SPLog(@"User clicked cancel, didn't change the output path");
         }
-    }];		
+    }];
 }
 
 /**

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1304,17 +1304,6 @@ set_input:
 	
 	// Restore query mode
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
-	
-	// relinquish access to userChosenDirectory
-//	[userChosenDirectory stopAccessingSecurityScopedResource];
-//
-//	[changeExportOutputPathPanel.URL stopAccessingSecurityScopedResource];
-	
-	// release to avoid leaks
-	// I think...
-	// userChosenDirectory leaks if we don't release here
-	// the panel wasn't leaking according to Leaks instrument.
-	
 
 	// Display export finished notification
 	[self displayExportFinishedNotification];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1307,9 +1307,9 @@ set_input:
 	[tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
 	
 	// relinquish access to userChosenDirectory
-	[userChosenDirectory stopAccessingSecurityScopedResource];
-	
-	[changeExportOutputPathPanel.URL stopAccessingSecurityScopedResource];
+//	[userChosenDirectory stopAccessingSecurityScopedResource];
+//
+//	[changeExportOutputPathPanel.URL stopAccessingSecurityScopedResource];
 	
 	// release to avoid leaks
 	// I think...

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -160,7 +160,7 @@ import OSLog
     // loops through current bookmarks from prefs and re-requests secure access
     // NOTE: when re-requesting access (resolvingBookmarkData) you only need to use
     // URLBookmarkResolutionWithSecurityScope, not the options it was originally created with
-    // otherwise it will be markes as stale.
+    // otherwise it will be marked as stale.
     private func reRequestSecureAccessToBookmarks() {
 
         // re-read - must do this after migration, could put it in an if, but it only happens once per app start.


### PR DESCRIPTION
## Changes:
- stoped revoking access to the dir after each export
- don't append trailing /

## Closes following issues:
- Closes #870
(hopefully)

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


https://user-images.githubusercontent.com/1576190/108665687-75ba4400-7510-11eb-9504-36cbca508ac8.mp4



## Additional notes:
