### PR TITLE
#fixed hide the filter for the current session

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -69,7 +69,6 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 
 	IBOutlet SPCopyTable *tableContentView;
 
-	IBOutlet NSButton *toggleRuleFilterButton;
 	IBOutlet NSButton *addButton;
 	IBOutlet NSButton *duplicateButton;
 	IBOutlet NSButton *removeButton;
@@ -163,6 +162,7 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 
     @package
     IBOutlet SPTableData* tableDataInstance;
+    IBOutlet NSButton *toggleRuleFilterButton;
 }
 
 - (void)setFieldEditorSelectedRange:(NSRange)aRange;

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -35,6 +35,7 @@
 #import "SPContentFilterManager.h"
 #import "SPFunctions.h"
 #import "SPTableFilterParser.h"
+#import "SPTableContent.h"
 
 #import "sequel-ace-Swift.h"
 
@@ -982,6 +983,12 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 
 - (IBAction)resetFilter:(id)sender
 {
+    SPTableContent *con = tableDocumentInstance.tableContentInstance;
+
+    con->toggleRuleFilterButton.state = !con->toggleRuleFilterButton.state;
+
+    [con toggleRuleEditorVisible:nil];
+
 	[self _doChangeToRuleEditorData:^{
 		[[self->_modelContainer mutableArrayValueForKey:@"model"] removeAllObjects];
 	}];


### PR DESCRIPTION
## Changes:
- The reset filter button state is maintained across table changes

## Closes following issues:
- Closes #539 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:

<img width="787" alt="Screenshot 2021-02-25 at 5 17 49 PM" src="https://user-images.githubusercontent.com/1576190/109133142-a4921d80-778f-11eb-9ea2-78c982d63339.png">

## Additional notes:
