### PR TITLE
allow insertion of NULL into varchar fields of length < 4 #fixed 

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -655,9 +655,14 @@ typedef enum {
 		if ([[fieldType uppercaseString] isEqualToString:@"FLOAT"] && ([[[editTextView textStorage] string] rangeOfString:@"."].location != NSNotFound)) {
 			maxLength++;
 		}
-		
-		if (maxLength > 0 && [[editTextView textStorage] length] > maxLength && ![[[editTextView textStorage] string] isEqualToString:[prefs objectForKey:SPNullValue]]) {
-			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [[editTextView textStorage] length] - (NSUInteger)maxLength)];
+
+        // SPNullValue = @"NULL"
+        NSString *nullValue = [[NSUserDefaults standardUserDefaults] objectForKey:SPNullValue];
+        NSTextStorage *editTVtextStorage = [editTextView textStorage];
+        NSString *editTVString = [editTVtextStorage string];
+        
+		if (maxLength > 0 && [editTVtextStorage length] > maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
+			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [editTVtextStorage length] - (NSUInteger)maxLength)];
 			[editTextView scrollRangeToVisible:NSMakeRange([editTextView selectedRange].location,0)];
 			[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Text is too long. Maximum text length is set to %llu.", @"Text is too long. Maximum text length is set to %llu."), maxTextLength]];
 			

--- a/Source/Views/SPDataCellFormatter.m
+++ b/Source/Views/SPDataCellFormatter.m
@@ -107,18 +107,22 @@
 
 - (BOOL)isPartialStringValid:(NSString *)partialString newEditingString:(NSString **)newString errorDescription:(NSString **)error
 {
-	// No limit set or partialString is NULL value string allow editing
-	if (textLimit == 0 || [partialString isEqualToString:[[NSUserDefaults standardUserDefaults] objectForKey:SPNullValue]])
-		return YES;
+    // SPNullValue = @"NULL"
+    NSString *nullValue = [[NSUserDefaults standardUserDefaults] objectForKey:SPNullValue];
 
-	// A single character over the length of the string - likely typed.  Prevent the change.
-	if ((NSInteger)[partialString length] == textLimit + 1) {
+	// No limit set or partialString is NULL value string allow editing
+    if (textLimit == 0 || [partialString isEqualToString:nullValue]){
+		return YES;
+    }
+
+	// A single character over the length of the string - likely typed.  Prevent the change - JCS - Unless it's NULL
+	if ((NSInteger)[partialString length] == textLimit + 1 && [nullValue contains:partialString] == NO) {
 		[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %ld.", @"Maximum text length is set to %ld."), (long)textLimit]];
 		return NO;
 	}
 
-	// If the string is considerably longer than the limit, likely pasted.  Accept but truncate.
-	if ((NSInteger)[partialString length] > textLimit) {
+	// If the string is considerably longer than the limit, likely pasted.  Accept but truncate. - JCS - Unless it's NULL
+	if ((NSInteger)[partialString length] > textLimit && partialString.length > nullValue.length) {
 		[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %ld. Inserted text was truncated.", @"Maximum text length is set to %ld. Inserted text was truncated."), (long)textLimit]];
 		*newString = [NSString stringWithString:[partialString substringToIndex:textLimit]];
 		return NO;


### PR DESCRIPTION
## Changes:
- checks if the user in in the middle of typing NULL, if so, ignore length checks
- same for paste and the popup edit panel.

## Closes following issues:
- Closes #910 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
