### PR TITLE
#fixed saving individual query history

### DIFF
--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -121,7 +121,11 @@ extension String {
 	public func hasSuffix(suffix: NSString, caseSensitive: Bool = true) -> Bool {
 		return (self as String).hasSuffix(suffix as String, caseSensitive: caseSensitive)
 	}
-	
+
+    public func separatedIntoLinesByCharsetObjC() -> [NSString] {
+        return (self as String).separatedIntoLinesByCharset() as [NSString]
+    }
+
 	public func trimWhitespacesAndNewlines() -> NSString {
 		return (self as String).trimmedString as NSString
 	}

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -53,6 +53,16 @@ extension String {
         return lines
     }
 
+    func separatedIntoLinesByCharset() -> [String] {
+
+        var semiChar = CharacterSet()
+        semiChar.insert(charactersIn: ";")
+
+        let lines = (self as NSString).components(separatedBy: semiChar as CharacterSet).filter({ x in x.isNotEmpty})
+
+        return lines
+    }
+
     func format(_ arguments: CVarArg...) -> String {
             let args = arguments.map {
                 if let arg = $0 as? Int { return String(arg) }

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -635,6 +635,18 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 }
 
+- (void)testSeparatedIntoLinesByCharsetObjC{
+
+    NSString *str = @"SELECT * FROM `HKWarningsLog`\n LIMIT 1000;\nSELECT * FROM `HKWarningsLog`\n LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000\n;";
+    NSArray *expectedArray = @[@"SELECT * FROM `HKWarningsLog`\n LIMIT 1000",@"\nSELECT * FROM `HKWarningsLog`\n LIMIT 1000", @"\nSELECT * FROM `HKWarningsLog` LIMIT 1000\n"];
+
+    NSArray *arr = [str separatedIntoLinesByCharsetObjC];
+
+    XCTAssertEqualObjects(expectedArray, arr);
+
+}
+
+
 - (void)testContains{
 
     NSString *str = @"When I say ATMOS, you say FEAR.";


### PR DESCRIPTION
## Changes:
- save individually now splits on `;`

## Closes following issues:
- Closes #913 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
