### PR TITLE
GitHub version checker fixes #fixed 

### DIFF
--- a/Source/Controllers/Other/GitHub.swift
+++ b/Source/Controllers/Other/GitHub.swift
@@ -17,7 +17,10 @@ import Foundation
 final class GitHubElement: Codable, Comparable {
     static func < (lhs: GitHubElement, rhs: GitHubElement) -> Bool {
         return lhs.publishedAt < rhs.publishedAt
+    }
 
+    static func > (lhs: GitHubElement, rhs: GitHubElement) -> Bool {
+        return lhs.publishedAt > rhs.publishedAt
     }
 
     static func == (lhs: GitHubElement, rhs: GitHubElement) -> Bool {

--- a/Source/Controllers/Other/GitHubReleaseManager.swift
+++ b/Source/Controllers/Other/GitHubReleaseManager.swift
@@ -100,22 +100,13 @@ import OSLog
 
                     Log.debug("releasesArray count: \(releasesArray.count)")
 
-                    if let currentReleaseTmp = releasesArray.first(where: { $0.name == name }) {
+                    if let currentReleaseTmp = releasesArray.first(where: { $0.name.hasPrefix(name) == true}) {
                         currentRelease = currentReleaseTmp
                         guard let currentReleaseName = currentRelease?.name else {
                             return
                         }
                         self.currentReleaseName = currentReleaseName
-                        Log.debug("Found this release: \(currentReleaseName))")
-                    }
-
-                    if let i = releasesArray.firstIndex(where: { $0.name == name }) {
-                        currentRelease = releasesArray[i]
-                        guard let currentReleaseName = currentRelease?.name else {
-                            return
-                        }
-                        self.currentReleaseName = currentReleaseName
-                        Log.debug("Found this release at index:[\(i)] name: \(currentReleaseName))")
+                        Log.debug("Found this release: \(currentReleaseName)")
                     }
 
                     if includeDraft == false {

--- a/Source/Controllers/Other/GitHubReleaseManager.swift
+++ b/Source/Controllers/Other/GitHubReleaseManager.swift
@@ -125,11 +125,18 @@ import OSLog
 
                     releases = releasesArray
                     availableRelease = releases.first
-                    if availableRelease != currentRelease {
-                        guard let availableReleaseName = availableRelease?.name else {
-                            return
-                        }
-                        self.availableReleaseName = availableReleaseName
+
+                    guard
+                        let currentReleaseTmp = currentRelease,
+                        let availableReleaseTmp = availableRelease
+                    else {
+                        Log.debug("No current release available")
+                        Log.debug("No newer release available")
+                        return
+                    }
+
+                    if availableReleaseTmp > currentReleaseTmp {
+                        availableReleaseName = availableReleaseTmp.name
                         Log.info("Found availableRelease: \(availableReleaseName)")
                         _ = self.displayNewReleaseAvailableAlert()
                     } else {

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -72,7 +72,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (void)openSQLFileAtPath:(NSString *)filePath;
 - (void)openSessionBundleAtPath:(NSString *)filePath;
 - (void)openColorThemeFileAtPath:(NSString *)filePath;
-- (void)checkForNewVersion;
+- (void)checkForNewVersionWithDelay:(double)delay;
 - (void)removeCheckForUpdatesMenuItem;
 - (void)addCheckForUpdatesMenuItem;
 
@@ -278,7 +278,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         [prefs setObject:dbViewInfoPanelSplit forKey:@"NSSplitView Subview Frames DbViewInfoPanelSplit"];
     });
 
-    [self checkForNewVersion];
+    [self checkForNewVersionWithDelay:SPDelayBeforeCheckingForNewReleases];
 
     // Add menu item to check for updates
     [self addCheckForUpdatesMenuItem];
@@ -308,7 +308,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (void)addCheckForUpdatesMenuItem {
     if (NSBundle.mainBundle.isMASVersion == NO && [[NSUserDefaults standardUserDefaults] boolForKey:SPShowUpdateAvailable] == YES) {
         SPLog(@"Adding menu item to check for updates");
-        NSMenuItem *updates = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Check for updates", @"menu item Check for updates") action:@selector(checkForNewVersion) keyEquivalent:@""];
+        NSMenuItem *updates = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Check for updates", @"menu item Check for updates") action:@selector(checkForNewVersionWithDelay:) keyEquivalent:@""];
         [mainMenu insertItem:updates atIndex:1];
     }
 }
@@ -324,12 +324,12 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     }];
 }
 
-- (void)checkForNewVersion {
+- (void)checkForNewVersionWithDelay:(double)delay {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:SPShowUpdateAvailable] == YES) {
         SPLog(@"checking for updates");
         executeOnLowPrioQueueAfterADelay(^{
             [NSBundle.mainBundle checkForNewVersion];
-        }, SPDelayBeforeCheckingForNewReleases);
+        }, delay);
     }
 }
 


### PR DESCRIPTION
## Changes:
- handle release names like: "3.2.3 (3022) Beta 1"
- fixed delay on checking for new version from menu
- compare releases with > rather than != (comparison is done on publishedAt)

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
