### PR TITLE
faster-stringForByteSize #infra

### DIFF
--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -641,11 +641,12 @@
 			if (fileIsCompressed) {
 				[[singleProgressBar onMainThread] setDoubleValue:[sqlFileHandle realDataReadLength]];
 				[[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown"),
-					[NSString stringForByteSize:fileProcessedLength]]];
+                                                                   [NSByteCountFormatter stringWithByteSize:fileProcessedLength]]];
 			} else {
 				[[singleProgressBar onMainThread] setDoubleValue:fileProcessedLength];
 				[[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"),
-					[NSString stringForByteSize:fileProcessedLength], [NSString stringForByteSize:fileTotalLength]]];
+                                                                   [NSByteCountFormatter stringWithByteSize:fileProcessedLength],
+                                                                   [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
 			}
 		}
 
@@ -1098,10 +1099,10 @@
 						SPMainQSync(^{
 							if (fileIsCompressed) {
 								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-								[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSString stringForByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
+                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
 							} else {
 								[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:i] doubleValue]];
-								[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"CSV import progress text"), [NSString stringForByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSString stringForByteSize:fileTotalLength]]];
+                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"CSV import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
 							}
 						});
 					}
@@ -1137,10 +1138,10 @@
 						SPMainQSync(^{
 							if (fileIsCompressed) {
 								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-								[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSString stringForByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
+                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
 							} else {
 								[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:i] doubleValue]];
-								[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSString stringForByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSString stringForByteSize:fileTotalLength]]];
+                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
 							}
 						});
 					}
@@ -1150,10 +1151,10 @@
 					SPMainQSync(^{
 						if (fileIsCompressed) {
 							[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-							[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSString stringForByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]]]];
+                            [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]]]];
 						} else {
 							[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:csvRowsThisQuery-1] doubleValue]];
-							[self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSString stringForByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]], [NSString stringForByteSize:fileTotalLength]]];
+                            [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
 						}
 					});
 				}

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -667,7 +667,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 			[key isEqualToString:SPMySQLIndexLengthField] ||
 			[key isEqualToString:SPMySQLDataFreeField]) {
 
-			value = [NSString stringForByteSize:[value longLongValue]];
+            value = [NSByteCountFormatter stringWithByteSize:[value longLongValue]];
 		}
 		// Format date strings to the user's long date format
 		else if ([key isEqualToString:SPMySQLCreateTimeField] ||

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -530,7 +530,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
                 NSAlert *alert = [[NSAlert alloc] init];
                 [alert setAlertStyle:NSAlertStyleWarning];
                 [alert setMessageText:NSLocalizedString(@"Warning",@"warning")];
-                [alert setInformativeText:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to load a SQL file with %@ of data into the Query Editor?", @"message of panel asking for confirmation for loading large text into the query editor"), [NSString stringForByteSize:[filesize longLongValue]]]];
+                [alert setInformativeText:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to load a SQL file with %@ of data into the Query Editor?", @"message of panel asking for confirmation for loading large text into the query editor"), [NSByteCountFormatter stringWithByteSize:[filesize longLongValue]]]];
                 [alert setHelpAnchor:filePath];
 
 

--- a/Source/Controllers/SubviewControllers/SPTableInfo.m
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.m
@@ -216,7 +216,7 @@
 
                 SPLog(@"tableStatusDataLengthAsLong = %lld", tableStatusDataLengthAsLong);
 
-				[info safeAddObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSString stringForByteSize:tableStatusDataLengthAsLong]]];
+                [info safeAddObject:[NSString stringWithFormat:NSLocalizedString(@"size: %@", @"Table Info Section : table size on disk"), [NSByteCountFormatter stringWithByteSize:tableStatusDataLengthAsLong]]];
 			}
 
 			NSString *tableEnc = [tableDataInstance tableEncoding];

--- a/Source/Other/Extensions/ByteCountFormatterExtension.swift
+++ b/Source/Other/Extensions/ByteCountFormatterExtension.swift
@@ -1,0 +1,33 @@
+//
+//  ByteCountFormatterExtension.swift
+//  Sequel Ace
+//
+//  Created by James on 3/3/2021.
+//  Copyright © 2021 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+extension ByteCountFormatter {
+
+    @objc public static func string(byteSize: Int64) -> NSString {
+        let bcf : ByteCountFormatter = ByteCountFormatter()
+        bcf.zeroPadsFractionDigits = true
+        bcf.countStyle = .binary
+
+        let newString = bcf.string(fromByteCount:byteSize)
+
+        var tmpStr = newString
+
+        let unitMap: KeyValuePairs = ["Zero KB": "0 B","KB": "KiB", "MB": "MiB", "GB": "GiB", "bytes": "B", "TB": "TiB", "byte": "B"]
+
+        for (fromUnits, toUnits) in unitMap {
+            tmpStr = newString.replacingOccurrences(of: fromUnits, with: toUnits, options: .literal)
+            if tmpStr != newString {
+                break
+            }
+        }
+
+        return tmpStr as NSString
+    }
+}

--- a/Source/Views/TextViews/SPBundleCommandTextView.m
+++ b/Source/Views/TextViews/SPBundleCommandTextView.m
@@ -636,7 +636,7 @@
 			if (filetype == NSFileTypeRegular && filesize) {
 				// Ask for confirmation if file content is larger than 1MB
 				if([filesize unsignedLongValue] > 1000000) {
-					[NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Warning", @"warning") message:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data?", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSString stringForByteSize:[filesize longLongValue]]] primaryButtonTitle:NSLocalizedString(@"OK", @"OK button") primaryButtonHandler:^{
+                    [NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Warning", @"warning") message:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data?", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSByteCountFormatter stringWithByteSize:[filesize longLongValue]]] primaryButtonTitle:NSLocalizedString(@"OK", @"OK button") primaryButtonHandler:^{
 						[self insertFileContentOfFile:filepath];
 					} cancelButtonHandler:nil];
 				} else {

--- a/Source/Views/TextViews/SPEditSheetTextView.m
+++ b/Source/Views/TextViews/SPEditSheetTextView.m
@@ -200,7 +200,7 @@
 			if (filetype == NSFileTypeRegular && filesize) {
 				// Ask for confirmation if file content is larger than 1MB
 				if ([filesize unsignedLongValue] > 1000000) {
-					[NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Warning", @"warning") message:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data?", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSString stringForByteSize:[filesize longLongValue]]] primaryButtonTitle:NSLocalizedString(@"OK", @"OK button") primaryButtonHandler:^{
+                    [NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Warning", @"warning") message:[NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data?", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSByteCountFormatter stringWithByteSize:[filesize longLongValue]]] primaryButtonTitle:NSLocalizedString(@"OK", @"OK button") primaryButtonHandler:^{
 						[self insertFileContentOfFile:filepath];
 					} cancelButtonHandler:nil];
 				} else {

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3428,7 +3428,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			if(filetype == NSFileTypeRegular && filesize) {
 				// Ask for confirmation if file content is larger than 1MB
 				if ([filesize unsignedLongValue] > 1000000) {
-					NSString *message = [NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data? The import can freeze the app for couple of seconds.", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSString stringForByteSize:[filesize longLongValue]]];
+                    NSString *message = [NSString stringWithFormat:NSLocalizedString(@"Do you really want to proceed with %@ of data? The import can freeze the app for couple of seconds.", @"message of panel asking for confirmation for inserting large text from dragging action"), [NSByteCountFormatter stringWithByteSize:[filesize longLongValue]]];
 					[NSAlert createDefaultAlertWithTitle:NSLocalizedString(@"Warning",@"warning") message:message primaryButtonTitle:NSLocalizedString(@"OK", @"OK button") primaryButtonHandler:^{
 						[self insertFileContentOfFile:filepath];
 					} cancelButtonHandler:nil];

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -52,19 +52,80 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 @implementation SPStringAdditionsTests
 
-// non static - 0.5s
+
+- (void)teststringForByteSize{
+
+    /*
+     dbSizeHumanReadable = bcf.string(fromByteCount: Int64(1234500000000))
+     Log.debug("dbSize = \(dbSizeHumanReadable)")
+     dbSizeHumanReadable = bcf.string(fromByteCount: Int64(1234500000))
+     Log.debug("dbSize = \(dbSizeHumanReadable)")
+     dbSizeHumanReadable = bcf.string(fromByteCount: Int64(12345000))
+     Log.debug("dbSize = \(dbSizeHumanReadable)")
+     dbSizeHumanReadable = bcf.string(fromByteCount: Int64(1234500))
+     Log.debug("dbSize = \(dbSizeHumanReadable)")
+
+     */
+
+    NSString *tmp = [NSString stringForByteSize:1234500000000];
+    NSLog(@"%@", tmp);
+
+    tmp = [NSString stringForByteSize:1234500000];
+    NSLog(@"%@", tmp);
+
+    tmp = [NSString stringForByteSize:12345000];
+    NSLog(@"%@", tmp);
+
+
+    tmp = [NSString stringForByteSize:1234500];
+    NSLog(@"%@", tmp);
+
+
+    tmp = [NSString stringForByteSize:123450];
+    NSLog(@"%@", tmp);
+
+
+    tmp = [NSString stringForByteSize:12345];
+    NSLog(@"%@", tmp);
+
+
+
+}
+
+// 5.2 s 
 - (void)testPerformance_stringForByteSize {
 	// this is on main thread
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
-		int const iterations = 10000;
+		int const iterations = 100000;
 		for (int i = 0; i < iterations; i++) {
 			@autoreleasepool {
 				[NSString stringForByteSize:i];
+//                NSLog(@"%@", [NSString stringForByteSize:i]);
 			}
 		}
 	}];
 }
+
+//1.18 s - about 5x faster. It's used on every table info screen and extended info screen.
+- (void)testPerformance_stringForByteSizeSwift {
+    // this is on main thread
+
+    [self measureBlock:^{
+
+        NSString *tmp = [[NSString alloc] init];
+        // Put the code you want to measure the time of here.
+        int const iterations = 100000;
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+//                NSLog(@"%@", [NSByteCountFormatter stringWithByteSize:i]);
+
+                tmp = [NSByteCountFormatter stringWithByteSize:i];
+            }
+        }
+    }];
+}
+
 // obj c static - 0.241s
 - (void)testPerformance_stringForByteSizeObjCStatic {
 	// this is on main thread

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		1A89558725D6E15D0060CE72 /* GitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A89557825D6DE860060CE72 /* GitHub.swift */; };
 		1A8B53572584520800526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
 		1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B53562584520800526DED /* SPURLAdditions.m */; };
+		1A8B582A25EEE15900DFC54A /* ByteCountFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B582925EEE15900DFC54A /* ByteCountFormatterExtension.swift */; };
 		1A94988E25516057000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498C125517191000BC793 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94988D25516057000BC793 /* DateExtension.swift */; };
 		1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1EE9492551185D0056FECD /* DateFormatterExtension.swift */; };
@@ -794,6 +795,7 @@
 		1A8B53552584520800526DED /* SPURLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPURLAdditions.h; sourceTree = "<group>"; };
 		1A8B53562584520800526DED /* SPURLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditions.m; sourceTree = "<group>"; };
 		1A8B53672584552F00526DED /* SPURLAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPURLAdditionsTests.m; sourceTree = "<group>"; };
+		1A8B582925EEE15900DFC54A /* ByteCountFormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteCountFormatterExtension.swift; sourceTree = "<group>"; };
 		1A94988D25516057000BC793 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1A96E4B42588F34C0055F5F5 /* SecureBookmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureBookmark.swift; sourceTree = "<group>"; };
 		1A96E4B52588F34C0055F5F5 /* SecureBookmarkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureBookmarkManager.swift; sourceTree = "<group>"; };
@@ -2359,6 +2361,7 @@
 				513515D1259354BB001E4533 /* NSImageExtensions.swift */,
 				51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */,
 				1ABC770025E3895300E8EE01 /* DispatchQueueExtension.swift */,
+				1A8B582925EEE15900DFC54A /* ByteCountFormatterExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3082,6 +3085,7 @@
 				513515EB2593568B001E4533 /* NSBezierPath_AMShading.m in Sources */,
 				17E6415B0EF01EF6001BC333 /* SPDataImport.m in Sources */,
 				17E6415C0EF01EF6001BC333 /* SPTableStructure.m in Sources */,
+				1A8B582A25EEE15900DFC54A /* ByteCountFormatterExtension.swift in Sources */,
 				1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */,
 				50A9F8B119EAD4B90053E571 /* SPGotoDatabaseController.m in Sources */,
 				17E641640EF01F15001BC333 /* SPTableInfo.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		1ADEA5A324BF1C4800D2140B /* SPDateAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADEA5A224BF1C4800D2140B /* SPDateAdditionsTests.m */; };
 		1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 58DF9F3215AB26C2003B4330 /* SPDateAdditions.m */; };
 		1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AE6C1CC25B07E9500880D73 /* SPFunctionsTests.m */; };
+		1AEA768425EF05D500AC4DA6 /* ByteCountFormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8B582925EEE15900DFC54A /* ByteCountFormatterExtension.swift */; };
 		1AF0DA7F259F5D8C00961974 /* SPPointerArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF0DA7E259F5D8C00961974 /* SPPointerArrayAdditions.m */; };
 		1AF0DA84259F631000961974 /* SPPointerArrayAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF0DA83259F631000961974 /* SPPointerArrayAdditionsTests.m */; };
 		1AF0DA8B259F657200961974 /* SPPointerArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF0DA7E259F5D8C00961974 /* SPPointerArrayAdditions.m */; };
@@ -3040,6 +3041,7 @@
 				1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */,
 				1798F1C4155018E2004B0AB8 /* SPMutableArrayAdditionsTests.m in Sources */,
 				1A4CB06B25926D7C00EDF804 /* StringRegexExtension.swift in Sources */,
+				1AEA768425EF05D500AC4DA6 /* ByteCountFormatterExtension.swift in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,


### PR DESCRIPTION
## Changes:
- Use ByteCountFormatter instead of a load of `if `statements and `NSNumberFormatter`

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
about 5x faster. It's used on every table info screen and extended info screen
