### PR TITLE
Don't show no new release available alert on startup #changed

### DIFF
--- a/Source/Controllers/Other/GitHubReleaseManager.swift
+++ b/Source/Controllers/Other/GitHubReleaseManager.swift
@@ -30,6 +30,7 @@ import OSLog
     private var releases: [GitHubElement] = []
     private let Log = OSLog(subsystem: "com.sequel-ace.sequel-ace", category: "github")
     private let manager = NetworkReachabilityManager(host: "www.google.com")
+    public var isFromMenuCheck: Bool = false
 
     struct Config {
         var user: String
@@ -139,10 +140,15 @@ import OSLog
                         availableReleaseName = availableReleaseTmp.name
                         Log.info("Found availableRelease: \(availableReleaseName)")
                         _ = self.displayNewReleaseAvailableAlert()
-                    } else {
-                        Log.debug("No newer release available")
-                        NSAlert.createInfoAlert(title: NSLocalizedString("No Newer Release Available", comment: "No newer release available"),
-                                                   message: NSLocalizedString("You are currently running the latest release.", comment: "You are currently running the latest release."))
+                    }
+                    else {
+                        if isFromMenuCheck == false {
+                            Log.debug("From startup check, not menu check, so not showing no newer release alert")
+                        }
+                        else{
+                            NSAlert.createInfoAlert(title: NSLocalizedString("No Newer Release Available", comment: "No newer release available"),
+                                                    message: NSLocalizedString("You are currently running the latest release.", comment: "You are currently running the latest release."))
+                        }
                     }
                 } catch {
                     Log.error("Error: \(error.localizedDescription)")

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -72,9 +72,10 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (void)openSQLFileAtPath:(NSString *)filePath;
 - (void)openSessionBundleAtPath:(NSString *)filePath;
 - (void)openColorThemeFileAtPath:(NSString *)filePath;
-- (void)checkForNewVersionWithDelay:(double)delay;
+- (void)checkForNewVersionWithDelay:(double)delay andIsFromMenuCheck:(BOOL)isFromMenuCheck;
 - (void)removeCheckForUpdatesMenuItem;
 - (void)addCheckForUpdatesMenuItem;
+- (void)checkForNewVersionFromMenu;
 
 @property (readwrite, strong) NSFileManager *fileManager;
 @property (readwrite, strong) SPBundleManager *sharedSPBundleManager;
@@ -279,7 +280,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         [prefs setObject:dbViewInfoPanelSplit forKey:@"NSSplitView Subview Frames DbViewInfoPanelSplit"];
     });
 
-    [self checkForNewVersionWithDelay:SPDelayBeforeCheckingForNewReleases];
+    [self checkForNewVersionWithDelay:SPDelayBeforeCheckingForNewReleases andIsFromMenuCheck:NO];
 
     // Add menu item to check for updates
     [self addCheckForUpdatesMenuItem];
@@ -309,7 +310,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (void)addCheckForUpdatesMenuItem {
     if (NSBundle.mainBundle.isMASVersion == NO && [[NSUserDefaults standardUserDefaults] boolForKey:SPShowUpdateAvailable] == YES) {
         SPLog(@"Adding menu item to check for updates");
-        NSMenuItem *updates = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Check for updates", @"menu item Check for updates") action:@selector(checkForNewVersionWithDelay:) keyEquivalent:@""];
+        NSMenuItem *updates = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Check for updates", @"menu item Check for updates") action:@selector(checkForNewVersionFromMenu) keyEquivalent:@""];
         [mainMenu insertItem:updates atIndex:1];
     }
 }
@@ -325,11 +326,17 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     }];
 }
 
-- (void)checkForNewVersionWithDelay:(double)delay {
+- (void)checkForNewVersionFromMenu{
+    [self checkForNewVersionWithDelay:0 andIsFromMenuCheck:YES];
+}
+
+- (void)checkForNewVersionWithDelay:(double)delay andIsFromMenuCheck:(BOOL)isFromMenuCheck {
+
+    SPLog(@"isFromMenuCheck %d", isFromMenuCheck);
     if ([[NSUserDefaults standardUserDefaults] boolForKey:SPShowUpdateAvailable] == YES) {
         SPLog(@"checking for updates");
         executeOnLowPrioQueueAfterADelay(^{
-            [NSBundle.mainBundle checkForNewVersion];
+            [NSBundle.mainBundle checkForNewVersionWithIsFromMenuCheck:isFromMenuCheck];
         }, delay);
     }
 }

--- a/Source/Other/Extensions/BundleExtension.swift
+++ b/Source/Other/Extensions/BundleExtension.swift
@@ -61,9 +61,15 @@ import Foundation
         return "%@ (%@)".format(version, build)
     }
 
-    public func checkForNewVersion() {
+    public func checkForNewVersion(isFromMenuCheck: Bool) {
+
         if isMASVersion == false {
-            GitHubReleaseManager.setup(GitHubReleaseManager.Config(user: "Sequel-Ace", project: "Sequel-Ace", includeDraft: false, includePrerelease: isSnapshotBuild ? true : false))
+            GitHubReleaseManager.setup(GitHubReleaseManager.Config(user: "Sequel-Ace",
+                                                                   project: "Sequel-Ace",
+                                                                   includeDraft: false,
+                                                                   includePrerelease: isSnapshotBuild ? true : false))
+
+            GitHubReleaseManager.sharedInstance.isFromMenuCheck = isFromMenuCheck
             GitHubReleaseManager.sharedInstance.checkRelease(name: versionString)
         }
     }


### PR DESCRIPTION
## Changes:
- It was getting annoying. Only shows if you specifically choose it from the menu

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4 (12D4e)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
