### PR TITLE
Fix windows being created instead of populated #fixed

### DIFF
--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1332,11 +1332,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:SPLOCALIZEDURL_KEYBOARDSHORTCUTS]];
 }
 
-
-
-
-
-
 #pragma mark -
 #pragma mark Other methods
 
@@ -1354,7 +1349,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     // Return YES to the automatic opening
     return YES;
 }
-
 
 /**
  * If Sequel Ace is terminating kill all running BASH scripts and release all HTML output controller.
@@ -1624,7 +1618,9 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
             return windowController;
         }
     }
-    return nil;
+    SPWindowController *windowController = [self.windowControllers firstObject];
+    [windowController.window makeKeyAndOrderFront:nil];
+    return windowController;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- If there is no key window (for example miniaturized), get first window possible and make it key window

## Closes following issues:
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/892

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Xcode Version: 12.4
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
## Screenshots:


## Additional notes:
