### PR TITLE
#fixed exporting database with no selected table

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -403,6 +403,12 @@ static inline void SetOnOff(NSNumber *ref,id obj);
 {
 	SPExportType selectedExportType = SPAnyExportType;
 	SPExportSource selectedExportSource = SPTableExport;
+
+    // if they are exporting and haven't selected a table
+    // loadTableValues will fail, so select the last table
+    if([tablesListInstance selectedTableItems].count == 0){
+        [tablesListInstance selectTableAtIndex:@(tablesListInstance.tables.count-1)];
+    }
 	
 	NSArray *selectedTables = [tablesListInstance selectedTableItems];
 	


### PR DESCRIPTION
## Changes:
- if they are exporting and haven't selected a table, select the last one in the list to prevent errors.

## Closes following issues:
- Closes: #931 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4 (12D4e)
  
## Screenshots:

## Additional notes:
