### PR TITLE
#fixed Auto pair characters changing font

### DIFF
--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -1119,6 +1119,9 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
                       value:[fontAtt objectForKey:NSFontAttributeName]
                       range:NSMakeRange(0, tmpStr.length)];
 
+    // Register the wrap for undo
+    [self shouldChangeTextInRange:currentRange replacementString:[tmpStr string]];
+
     // Replace the current selection with the selected string wrapped in prefix and suffix
     [self.textStorage deleteCharactersInRange:currentRange];
 
@@ -1133,6 +1136,8 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 	// If autopair is enabled mark last autopair character as autopair-linked
 	if([prefs boolForKey:SPCustomQueryAutoPairCharacters])
 		[[self textStorage] addAttribute:kAPlinked value:kAPval range:NSMakeRange(NSMaxRange(innerSelectionRange), 1)];
+
+    [self didChangeText];
 
 	return YES;
 }

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -1111,9 +1111,20 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 	NSString *selString = [[self string] substringWithRange:currentRange];
 
+    NSMutableAttributedString *tmpStr = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@%@%@", prefix, selString, suffix]];
+
+    NSDictionary *fontAtt = [self.textStorage fontAttributesInRange:currentRange];
+
+    [tmpStr addAttribute:NSFontAttributeName
+                      value:[fontAtt objectForKey:NSFontAttributeName]
+                      range:NSMakeRange(0, tmpStr.length)];
+
     // Replace the current selection with the selected string wrapped in prefix and suffix
     [self.textStorage deleteCharactersInRange:currentRange];
-    [self.textStorage insertAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@%@%@", prefix, selString, suffix]] atIndex:currentRange.location];
+
+    // this insert changes the font to the global default, not the query editor font
+    // hence changing the font above.
+    [self.textStorage insertAttributedString:tmpStr atIndex:currentRange.location];
 
 	// Re-select original selection
 	NSRange innerSelectionRange = NSMakeRange(currentRange.location+1, [selString length]);


### PR DESCRIPTION
## Changes:
- retain editor font when wrapping text
- register the wrap edit for undo

## Closes following issues:
- Closes: #939 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4 (12D4e)
  
## Screenshots:

## Additional notes:
