### PR TITLE
#fixed various small legibility issues across the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 I'm really glad you're reading this, because we need volunteer developers to help this project be successful long-term.
 
-We make a commitment to review *all* PRs (pull requests) that are submitted by members of the community. We will provide feedback and recommendations with the effort of incorperating contributions from the community whenever possible.
+We make a commitment to review *all* pull requests that are submitted by members of the community. We will provide feedback and recommendations with the effort of incorporating contributions from the community whenever possible.
 
 ## Testing
 
@@ -10,7 +10,7 @@ If you add a new feature or fix a bug, it's generally a good idea to write a tes
 
 ## Submitting changes
 
-Please send a [GitHub Pull Request to Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace/pull/new/dev), pointed at the *dev* branch, with a clear list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)). Please include detailed explainations of what changed (screenshots of changes are preferred). Please avoid committing changes that are unrelated to the pull request (if you accidentally edited an .xib file, it's all good, just revert changes to that unrelated file).
+Please send a [GitHub Pull Request to Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace/pull/new/dev), pointed at the *main* branch, with a clear list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)). Please include detailed explanations of what changed (screenshots of changes are preferred). Please avoid committing changes that are unrelated to the pull request (if you accidentally edited an .xib file, it's all good, just revert changes to that unrelated file).
 
 Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -66,7 +66,7 @@ If you want to insert a query favorite without using the mouse you have the chan
 -   type e.g. **sel** into the **Tab Trigger** field
 -   save
 
-After doing this type in the Custom Query Editor sel and press the tab ⇥ key. sel will be replaced by the query favorite SELECT FROM WHERE. A valid tab trigger can contain any alphanumeric character but no space or other punctuation signs for instance.
+After doing this type in the Custom Query Editor sel and press the tab `⇥` key. sel will be replaced by the query favorite SELECT FROM WHERE. A valid tab trigger can contain any alphanumeric character but no space or other punctuation signs for instance.
 
 ----------
 
@@ -93,7 +93,7 @@ A mirrored tab snippet is not allowed inside of a `${x:}` tab snippet and causes
 
 ##### Nested Tab Snippets
 
-By means of tab snippets you can generalize the query favorite SELECT FROM WHEREdue to the fact that the WHERE clause is optional. This can be achieved by using nested tab snippets. You can change the query favorite into:
+By means of tab snippets you can generalize the query favorite SELECT FROM WHERE due to the fact that the WHERE clause is optional. This can be achieved by using nested tab snippets. You can change the query favorite into:
 
 ```sql
 SELECT ${0:field} FROM ${2:${1:table} WHERE }
@@ -123,9 +123,9 @@ It could be the case that you want use the query favorite mostly for a set of fi
 SELECT ${0:} FROM ${1:¦table01¦table02¦table03¦} WHERE
 ```
 
-After insertion of that query favorite and selecting the second tab snippet a narrow-down completion list window appears thus choose your desired item or start to type to narrow-down the list (or press ⌫ to expand the list again).
+After insertion of that query favorite and selecting the second tab snippet a narrow-down completion list window appears thus choose your desired item or start to type to narrow-down the list (or press `⌫` to expand the list again).
 
-> <small><small>_Tip:_ If you use the default list template **¦¦a¦b¦¦** the narrow-down completion list switches to the fuzzy search mode which means that if you have e.g. the list items _reference_ and _ref_base_ you can type simply r_ to narrow-down the list to _ref_base_due to the fuzzy regular expression search strategy .*r.*_.* If you want to switch to the fuzzy search mode coming from the normal list template **¦a¦b¦** simply press ⌃⎋.</small></small>
+> <small><small>_Tip:_ If you use the default list template **¦¦a¦b¦¦** the narrow-down completion list switches to the fuzzy search mode which means that if you have e.g. the list items _reference_ and _ref_base_ you can type simply r_ to narrow-down the list to _ref_base_due to the fuzzy regular expression search strategy .*r.*_.* If you want to switch to the fuzzy search mode coming from the normal list template **¦a¦b¦** simply press `⌃⎋`.</small></small>
 
 ##### Dynamic Default Value Due to Current Selected Table
 
@@ -175,7 +175,7 @@ _Example_ The query favorite:
 `date_field` = '${1:$(date "+%Y-%m-%d" | perl -pe 'chomp')}'
 ```
 
-will execute the shell command **date "+%Y-%m-%d" | perl -pe 'chomp'** and insert e.g. `date_field` = '2010-03-15'. It is recommended to save the shell command as script on the hard disk and invoke it inside $() due to some escaping issues of } etc. The shell script will be executed via /bin/bash -c shell_command. This allows not only to insert the result of such shell commands like **curl** etc. but also to open other applications like **open -a Preview**, or **open sequelpro.com**, or to use an AppleScript to display a list, a dialog etc. **Each shell command** can be **terminated** by the keystroke **⌘.**
+will execute the shell command **date "+%Y-%m-%d" | perl -pe 'chomp'** and insert e.g. `date_field` = '2010-03-15'. It is recommended to save the shell command as script on the hard disk and invoke it inside $() due to some escaping issues of } etc. The shell script will be executed via /bin/bash -c shell_command. This allows not only to insert the result of such shell commands like **curl** etc. but also to open other applications like **open -a Preview**, or **open sequel-ace.com**, or to use an AppleScript to display a list, a dialog etc. **Each shell command** can be **terminated** by the keystroke **`⌘`.**
 
 In addition the following shell variables will passed:
 
@@ -207,7 +207,7 @@ The example SELECT ${0:$SP_SELECTED_TABLE.} FROM ${1:$SP_SELECTED_TABLE} WHERE t
 
 SELECT $1.${2:} FROM ${1:¦$SP_ASLIST_ALL_TABLES¦} WHERE $1.${3:} = ${4:value} AND $1.$2 =
 
-Each instance of $1 will be replaced by the current content of ${1:} which is still changeable, after choosing a table from the list you press the tab ⇥ key to move the insertion point to ${2:} where you can press ⎋ to open the completion list which will come up with all field names of the chosen table, and so on.
+Each instance of $1 will be replaced by the current content of ${1:} which is still changeable, after choosing a table from the list you press the tab `⇥` key to move the insertion point to ${2:} where you can press `⎋` to open the completion list which will come up with all field names of the chosen table, and so on.
 
 #### EXAMPLES
 

--- a/docs/get-started/connection-types.md
+++ b/docs/get-started/connection-types.md
@@ -33,7 +33,7 @@ If the MySQL server is on a different computer as Sequel Ace, it's called a _rem
 -   using a **Standard** connection
 -   using a **SSH** connection
 
-You can use a standard connection if the MySQL server is directly reachable -- eg. if it is on your local network. If you cannot directly reach your server (eg. it is behind a firewall), you will have to use a SSH connection. For more details see [Connecting to a MySQL Server on a Remote Host](remote-connection.html "Connecting to a MySQL Server on a Remote Host").
+You can use a standard connection if the MySQL server is directly reachable -- e.g. if it is on your local network. If you cannot directly reach your server (e.g. it's behind a firewall), you will have to use a SSH connection. For more details see [Connecting to a MySQL Server on a Remote Host](remote-connection.html "Connecting to a MySQL Server on a Remote Host").
 
 At the moment, **Sequel Ace does not support SSL** encryption. If possible, use a SSH connection instead.
 
@@ -59,27 +59,26 @@ Required Fields
 
 Host
 
-Enter the host name or IP address of the host.
+Enter the hostname or IP address of the host.
 
 Username
 
-The default username for a mysql install is **root**
+The default username for a MySQL install is **root**.
 
 Optional Fields
 
 Name
 
-The name you want to give the favourite.
+The name you want to give the favorite.
 
 Password
 
-The default password for a mysql install is an empty string.
+The default password for a MySQL install is an empty string.
 If that's the case, you should change the root password right away.
 
 Database
 
-If you enter a database, it will be selected when the connection to
-the server is established.
+If you enter a database, it will be selected when the connection to the server is established.
 Otherwise you can select one of the databases on the server afterwards.
 
 Port
@@ -95,25 +94,24 @@ Required Fields
 
 Username
 
-The default username for a mysql install is **root**
+The default username for a MySQL install is **root**.
 
 Password
 
-The default password for a mysql install is an empty string.
+The default password for a MySQL install is an empty string.
 If that's the case, you should change the root password right away.
 
 Optional Fields
 
 Name
 
-The name you want to give the favourite.
+The name you want to give the favorite.
 
 Database
 
-If you enter a database, it will be selected when the connection to
-the server is established.
+If you enter a database, it will be selected when the connection to the server is established.
 Otherwise you can select one of the databases on the server afterwards.
 
 Socket
 
-For non-standard mysql installs (e.g - MAMP) manually set the path. Read more about connecting via sockets to [MAMP, XAMPP and other MySQL server setups](mamp-xampp.html).
+For non-standard MySQL installs (e.g - MAMP) manually set the path. Read more about connecting via sockets to [MAMP, XAMPP and other MySQL server setups](mamp-xampp.html).

--- a/docs/get-started/local-connection.md
+++ b/docs/get-started/local-connection.md
@@ -19,7 +19,7 @@ If you are not sure if the MySQL server is running, open _Activity Viewer_ (from
 
 #### Connecting via a socket connection
 
-Unfortunately, due to sandboxing nature, Sequel Ace is not allowed to connect to the sockets which are out of the Sandbox. As a workaround, you can create a socket in `~/Library/Containers/com.sequel-ace.sequel-ace/Data` and connect to it. This can be done by putting these lines to your MySQL configuration file (usually, `my.cnf`):
+Unfortunately, due to sandboxing nature, Sequel Ace is not allowed to connect to the sockets which are out of the sandbox. As a workaround, you can create a socket in `~/Library/Containers/com.sequel-ace.sequel-ace/Data` and connect to it. This can be done by putting these lines to your MySQL configuration file (usually, `my.cnf`):
 ```
 [mysqld]
 socket=/Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/Data/mysql.sock

--- a/docs/get-started/migrating-from-sequel-pro.md
+++ b/docs/get-started/migrating-from-sequel-pro.md
@@ -27,12 +27,12 @@ to
 to
 ~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application\ Support/Sequel\ Ace/Data/Favorites.plist
 
-6. Open up the Keychain Access app ( /System/Applications/Utilities/Keychain\ Access.app )
+6. Open up the Keychain Access app (/System/Applications/Utilities/Keychain\ Access.app)
 
-7. Search for ‘sequel pro’ — this should list all your Sequel Pro connections / favorites. You may also note some SSHTunnel items if you use those in Sequel Pro
+7. Search for 'sequel pro' — this should list all your Sequel Pro connections / favorites. You may also note some SSHTunnel items if you use those in Sequel Pro
 
 *Notes:*
-- Due to the sandbox, all SSH keys must be re-nagivated to and selected in Sequel Ace after migrating connections.
+- Due to the sandbox, all SSH keys must be re-navigated to and selected in Sequel Ace after migrating connections.
 - Additionally, passwords are not migrated as well as they are stored in the Keychain. See the next section for a method to migrate passwords if you have many passwords and do not want to manually re-enter all of them in Sequel Ace.
 
 

--- a/docs/get-started/remote-connection.md
+++ b/docs/get-started/remote-connection.md
@@ -61,24 +61,23 @@ Sequel Ace now sets up an SSH Tunnel for you when you choose the SSH connection 
 
 $ ssh -L 1234:mysqlhost:3306 sshuser@sshhost
 
-Here `mysqlhost` is what you have to enter in Sequel Ace as the MySQL host, `sshuser`corresponds to the SSH user, and `sshhost` corresponds to the SSH host field, obviously. The first number, `1234`, is the local port of the SSH tunnel. Sequel Ace chooses this port automatically. The second number in the command, `3306`, is the port used by the MySQL server.
+Here `mysqlhost` is what you have to enter in Sequel Ace as the MySQL host, `sshuser` corresponds to the SSH user, and `sshhost` corresponds to the SSH host field, obviously. The first number, `1234`, is the local port of the SSH tunnel. Sequel Ace chooses this port automatically. The second number in the command, `3306`, is the port used by the MySQL server.
 
 
 #### Notes
 
 -   the MySQL server must accept network connections
 
-_Some server administrators forbid connections from other computers, by using the option --skip-networking. Then the MySQL server only accepts connection from processes running on the same server (eg. PHP scripts), but not from remote clients (such as Sequel Ace). See [MySQL Manual](https://dev.mysql.com/doc/refman/en/server-options.html#option_mysqld_skip-networking)._
+_Some server administrators forbid connections from other computers, by using the option --skip-networking. Then the MySQL server only accepts connection from processes running on the same server (e.g. PHP scripts), but not from remote clients (such as Sequel Ace). See [MySQL Manual](https://dev.mysql.com/doc/refman/en/server-options.html#option_mysqld_skip-networking)._
 
--   the MySQL server must be configured to accept connections from your adress
+-   the MySQL server must be configured to accept connections from your address
 
-Many administrators configure MySQL in a manner that it allows network connections only from specific IP addresses. If this is the case, they will probably ask you for your IP adress. See [MySQL Manual](https://dev.mysql.com/doc/refman/en/connection-access.html) for details on how MySQL decides if you are allowed to connect.
+Many administrators configure MySQL in a manner that it allows network connections only from specific IP addresses. If this is the case, they will probably ask you for your IP address. See [MySQL Manual](https://dev.mysql.com/doc/refman/en/connection-access.html) for details on how MySQL decides if you are allowed to connect.
 
-if the server is behind a firewall, the firewall must be configured to accept MySQL connections
+If the server is behind a firewall, the firewall must be configured to accept MySQL connections.
 
 The firewall must be configured to allow incoming TCP connections on the port used by MySQL. Per default, MySQL uses port 3306.
 
-You must be able to reach the MySQL server directly
+You must be able to reach the MySQL server directly.
 
 If the MySQL server is behind a NAT gateway, you may not be able to reach the server.
-

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -19,8 +19,8 @@ The Query Favourites are a powerful feature that makes it easy to rerun saved qu
 
 #### Tab Trigger
 
-A **tab trigger** is used as keyboard short-cut to insert the corresponding query favorite into the Custom Query Editor. It can contain any alphanumeric character but no spaces or punctuation signs.
+A **tab trigger** is used as keyboard shortcut to insert the corresponding query favorite into the Custom Query Editor. It can contain any alphanumeric character but no spaces or punctuation signs.
 
 #### Tab Snippet
 
-A **tab snippet** represents a insertion point of the cursor within a [query favorite](favorites.html "Query View"). To navigate through defined tab snippets use `⇥` or `⇧⇥`.
+A **tab snippet** represents an insertion point of the cursor within a [query favorite](favorites.html "Query View"). To navigate through defined tab snippets use `⇥` or `⇧⇥`.

--- a/docs/ref/bookmarks.md
+++ b/docs/ref/bookmarks.md
@@ -39,7 +39,7 @@ In plain English, to prevent Sequel Ace from having to re-request access to file
 
 __In short: with the app-scoped bookmark, Sequel Ace can obtain future access to the file/folder without bothering the user again.__
 
-Note: we provide a mechanism for a user to revoke access to a file/folder in __Preferences->Files__. You can also see all the files that have a security-scoped bookmark on the same screen:
+Note: we provide a mechanism for a user to revoke access to a file/folder in _Preferences_ » _Files_. You can also see all the files that have a security-scoped bookmark on the same screen:
 
 ![File Preferences](../images/file-prefs.png)
 
@@ -59,7 +59,7 @@ If Sequel Ace detects stale bookmarks, you will see this warning when the app st
 
 ![Stale Bookmark Warning](../images/stale-bookmarks.png)
 
-If you want to allow Sequel Ace to access the stale locations, you need to click "Yes" and double-click the red items in the __Preferences->Files__ pane:
+If you want to allow Sequel Ace to access the stale locations, you need to click "Yes" and double-click the red items in the _Preferences_ » _Files_ pane:
 
 ![Stale Bookmark Warning](../images/stale-file-prefs.png)
 

--- a/docs/ref/bookmarks.md
+++ b/docs/ref/bookmarks.md
@@ -9,7 +9,7 @@
 
 ### A Quick Introduction To App Sandbox
 
-[App Sandbox](https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/AboutAppSandbox/AboutAppSandbox.html#//apple_ref/doc/uid/TP40011183-CH1-SW1) is an access control technology provided in macOS, enforced at the kernel level. It is designed to contain damage to the system and the user’s data if an app becomes compromised. Apps distributed through the Mac App Store must adopt App Sandbox.
+[App Sandbox](https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/AboutAppSandbox/AboutAppSandbox.html#//apple_ref/doc/uid/TP40011183-CH1-SW1) is an access control technology provided in macOS, enforced at the kernel level. It is designed to contain damage to the system and the user's data if an app becomes compromised. Apps distributed through the Mac App Store must adopt App Sandbox.
 
 Sequel Ace is distributed through the Mac App Store, therefore Sequel Ace adopts App Sandbox for your safety and peace of mind.
 
@@ -68,4 +68,5 @@ If you don't Sequel Ace will not be able to read the stale files.
 ***
 
 [^fn-entitlements]: You can check these yourself by opening [Terminal](https://en.wikipedia.org/wiki/Terminal_(macOS)) and running: `codesign -d --entitlements :- /Applications/Sequel\ Ace.app/`.
+
 [^fn-stale-reasons]: There could be other reasons. Bookmarks are [complex](https://michaellynn.github.io/2015/10/24/apples-bookmarkdata-exposed/).

--- a/docs/ref/features.md
+++ b/docs/ref/features.md
@@ -27,7 +27,7 @@ To create an _enum_ field follow the same procedure as you would for any other f
 
 The connections strings are stored in the following preference file:
 
-~/Library/Preferences/com.sequelpro.SequelPro.plist
+~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Preferences/com.sequel-ace.sequel-ace.plist
 
 The passwords are stored in the Mac OSX Keychain, which is stored here:
 

--- a/docs/ref/features.md
+++ b/docs/ref/features.md
@@ -35,7 +35,7 @@ The passwords are stored in the Mac OSX Keychain, which is stored here:
 
 Find more info about the Keychain here: [http://nevali.net/post/122592107/managing-the-mac-os-x-keychain](http://nevali.net/post/122592107/managing-the-mac-os-x-keychain "http://nevali.net/post/122592107/managing-the-mac-os-x-keychain").
 
-The ~/Library folder is invisible in Lion, to open it choose "Go To Folder…" (`⌘ + ⇧ + G`) and type "~/Library/Preferences/" to open the preference folder.
+The \~/Library folder is invisible in Lion, to open it choose "Go To Folder…" (`⌘ + ⇧ + G`) and type "~/Library/Preferences/" to open the preference folder.
 
 <!--
 ## Articles

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -27,7 +27,7 @@ Get the most out of Sequel Ace by remembering the following keyboard shortcuts.
 | Keyboard shortcut | Description                                |
 | :---------------- | :----------------------------------------- |
 | `⌘ N`             | New Window (Connection File)               |
-| `⌘ T`             | New Tab(Connection File)                   |
+| `⌘ T`             | New Tab (Connection File)                  |
 | `⇧ ⌘ A`           | Add Connection To Favorites                |
 | `⌘ O`             | Open (Connection File or SQL File)         |
 | `⌥ ⌘ O`           | Open current Connection File in New Window |

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ mas install 1518036000 # Sequel Ace
 
 ### Homebrew
 
-To install an unoffical community maintained [Homebrew](https://brew.sh) [Cask](https://github.com/Homebrew/homebrew-cask) of the [GitHub Release](https://github.com/sequel-ace/sequel-ace/releases)
+To install an unofficial community maintained [Homebrew](https://brew.sh) [Cask](https://github.com/Homebrew/homebrew-cask) of the [GitHub Release](https://github.com/sequel-ace/sequel-ace/releases)
 
 ```sh
 brew install --cask sequel-ace

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ To run Sequel Ace locally from XCode, please:
 - download `.zip` archive of this repo / clone locally
 - open `sequel-ace.xcworkspace` and run `Sequel Ace Local Testing` schema
 
-If you encounter any issue, let us know by creating a new Issue.
+If you encounter any issue, let us know by [creating a new issue](https://github.com/Sequel-Ace/Sequel-Ace/issues/new/choose).
 
 ## Contributing
 


### PR DESCRIPTION
This pull request aims to fix various small typos, formatting errors and inconsistencies across the documentation that should improve legibility. Changes have been made only to markdown files.

I have not tested the documentation through the existing docs implementation, but I am fairly certain these typo fixes don't require any extensive testing to begin with and can be eyed through.