### PR TITLE
#changed/#fixed - Feature requests 955

### DIFF
--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -1592,20 +1592,20 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <point key="canvasLocation" x="732" y="551"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="802" userLabel="Editor">
-            <rect key="frame" x="0.0" y="0.0" width="541" height="538"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="487"/>
             <userGuides>
                 <userLayoutGuide location="146" affinity="minX"/>
                 <userLayoutGuide location="315" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1085">
-                    <rect key="frame" x="20" y="489" width="501" height="5"/>
+                    <rect key="frame" x="20" y="438" width="500" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="mJZ-MM-v9M"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
-                    <rect key="frame" x="489" y="307" width="34" height="14"/>
+                    <rect key="frame" x="488" y="256" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="4mD-hS-s3t"/>
                     </constraints>
@@ -1619,7 +1619,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="475" y="302" width="15" height="22"/>
+                    <rect key="frame" x="474" y="251" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1634,7 +1634,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
-                    <rect key="frame" x="300" y="303" width="59" height="22"/>
+                    <rect key="frame" x="299" y="252" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="J1h-3t-Frd"/>
                         <constraint firstAttribute="width" constant="55" id="wmw-DW-vkB"/>
@@ -1649,7 +1649,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
-                    <rect key="frame" x="362" y="303" width="114" height="22"/>
+                    <rect key="frame" x="361" y="252" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="7Gy-54-e6x"/>
                     </constraints>
@@ -1671,7 +1671,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="260" y="271" width="261" height="24"/>
+                    <rect key="frame" x="259" y="220" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="o8a-4g-ciG"/>
                     </constraints>
@@ -1684,7 +1684,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="260" y="366" width="261" height="24"/>
+                    <rect key="frame" x="259" y="315" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Nm1-1L-fkL"/>
                     </constraints>
@@ -1697,7 +1697,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="260" y="324" width="261" height="35"/>
+                    <rect key="frame" x="259" y="273" width="261" height="35"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="33" id="LMj-pz-5qi"/>
                     </constraints>
@@ -1710,7 +1710,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="260" y="397" width="261" height="24"/>
+                    <rect key="frame" x="259" y="346" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="okU-1B-JWL"/>
                     </constraints>
@@ -1723,7 +1723,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="260" y="459" width="261" height="24"/>
+                    <rect key="frame" x="259" y="408" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="QM4-7n-4Uf"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YuJ-Px-Th2"/>
@@ -1737,7 +1737,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1037" customClass="SPFontPreviewTextField">
-                    <rect key="frame" x="171" y="501" width="200" height="22"/>
+                    <rect key="frame" x="170" y="450" width="200" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="F5G-7E-Xu4"/>
                         <constraint firstAttribute="height" constant="22" id="Jtz-vN-iPm"/>
@@ -1749,7 +1749,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="374" y="495" width="114" height="32"/>
+                    <rect key="frame" x="373" y="444" width="114" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="Z6f-Ex-CfK"/>
                     </constraints>
@@ -1762,7 +1762,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1034">
-                    <rect key="frame" x="18" y="504" width="145" height="16"/>
+                    <rect key="frame" x="18" y="453" width="144" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="6gj-Xz-W0f"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="150" id="ltM-Zr-Qpk"/>
@@ -1812,19 +1812,19 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </popUpButtonCell>
                 </popUpButton>
                 <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1682">
-                    <rect key="frame" x="20" y="42" width="232" height="440"/>
+                    <rect key="frame" x="20" y="42" width="231" height="389"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
-                        <rect key="frame" x="1" y="1" width="230" height="438"/>
+                        <rect key="frame" x="1" y="1" width="229" height="387"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
-                                <rect key="frame" x="0.0" y="0.0" width="230" height="438"/>
+                                <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="name" width="195" minWidth="40" maxWidth="10000" id="1687">
+                                    <tableColumn identifier="name" width="194" minWidth="40" maxWidth="10000" id="1687">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1857,6 +1857,9 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         </subviews>
                         <nil key="backgroundColor"/>
                     </clipView>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Fuh-SQ-jA3"/>
+                    </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1684">
                         <rect key="frame" x="-100" y="-100" width="223" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -1878,7 +1881,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField toolTip="The name of the current set color theme" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1740">
-                    <rect key="frame" x="132" y="20" width="122" height="14"/>
+                    <rect key="frame" x="132" y="20" width="121" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="theme name" id="1741">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1896,7 +1899,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="260" y="428" width="93" height="24"/>
+                    <rect key="frame" x="259" y="377" width="93" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OaX-My-oPP"/>
                     </constraints>
@@ -1909,7 +1912,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="358" y="429" width="151" height="22"/>
+                    <rect key="frame" x="357" y="378" width="151" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -1927,7 +1930,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="508" y="428" width="15" height="22"/>
+                    <rect key="frame" x="507" y="377" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -1941,7 +1944,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="260" y="240" width="261" height="24"/>
+                    <rect key="frame" x="259" y="189" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="NJU-0g-hK3"/>
                     </constraints>
@@ -1954,7 +1957,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="260" y="209" width="261" height="24"/>
+                    <rect key="frame" x="259" y="158" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="LQ3-Eq-hy0"/>
                     </constraints>
@@ -1970,7 +1973,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
-                    <rect key="frame" x="489" y="161" width="34" height="14"/>
+                    <rect key="frame" x="488" y="110" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="Wt0-DH-0yD"/>
                     </constraints>
@@ -1984,22 +1987,22 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="475" y="156" width="15" height="22"/>
+                    <rect key="frame" x="474" y="105" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
                     </constraints>
-                    <stepperCell key="cell" controlSize="small" continuous="YES" enabled="NO" alignment="left" increment="0.10000000000000001" maxValue="5" doubleValue="2.5" id="1526">
+                    <stepperCell key="cell" controlSize="small" continuous="YES" enabled="NO" alignment="left" increment="0.10000000000000001" maxValue="5" doubleValue="1" id="1526">
                         <font key="font" metaFont="message" size="11"/>
                     </stepperCell>
                     <connections>
-                        <action selector="delayStepperChanged:" target="2144" id="0lC-yA-DTc"/>
+                        <action selector="delayStepperChanged:" target="2144" id="jTJ-rr-cCf"/>
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="1541"/>
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteDelay" id="1540"/>
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
-                    <rect key="frame" x="300" y="157" width="59" height="22"/>
+                    <rect key="frame" x="299" y="106" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6rD-Fb-Wtt"/>
                         <constraint firstAttribute="width" constant="55" id="sCD-jX-6bG"/>
@@ -2014,12 +2017,12 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
-                    <rect key="frame" x="362" y="157" width="114" height="22"/>
+                    <rect key="frame" x="361" y="106" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0.5" drawsBackground="YES" usesSingleLineMode="YES" id="1523">
-                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#.0" allowsFloats="NO" alwaysShowsDecimalSeparator="YES" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="1" groupingSeparator="" id="1524">
+                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#.0" allowsFloats="NO" alwaysShowsDecimalSeparator="YES" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="1" decimalSeparator="." groupingSeparator="" id="1524">
                             <nil key="negativeInfinitySymbol"/>
                             <nil key="positiveInfinitySymbol"/>
                             <real key="minimum" value="0.0"/>
@@ -2036,7 +2039,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="260" y="178" width="261" height="24"/>
+                    <rect key="frame" x="259" y="127" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="JL1-kC-qdF"/>
                     </constraints>
@@ -2049,7 +2052,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="260" y="85" width="261" height="24"/>
+                    <rect key="frame" x="259" y="74" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Hbi-dI-piB"/>
                     </constraints>
@@ -2062,7 +2065,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="260" y="54" width="261" height="24"/>
+                    <rect key="frame" x="259" y="43" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Vdm-3z-iY0"/>
                     </constraints>
@@ -2075,7 +2078,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
-                    <rect key="frame" x="260" y="26" width="101" height="20"/>
+                    <rect key="frame" x="259" y="15" width="101" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OHa-nn-g2y"/>
                     </constraints>
@@ -2086,7 +2089,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
-                    <rect key="frame" x="364" y="25" width="145" height="22"/>
+                    <rect key="frame" x="363" y="14" width="145" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VkS-BX-Qdr"/>
                     </constraints>
@@ -2105,7 +2108,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="508" y="24" width="15" height="22"/>
+                    <rect key="frame" x="507" y="13" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2118,25 +2121,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEditorTabStopWidth" id="1516"/>
                     </connections>
                 </stepper>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4c6-aS-Wtf">
-                    <rect key="frame" x="360" y="129" width="161" height="24"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="Isn-KM-jRA"/>
-                        <constraint firstAttribute="width" constant="159" id="rvy-aL-MDx"/>
-                    </constraints>
-                    <buttonCell key="cell" type="check" title="Use Fuzzy Matching" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2Km-2V-2OM">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                        <connections>
-                            <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="qUf-AL-cus"/>
-                            <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="2jw-zh-sM3"/>
-                        </connections>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="EjQ-jn-N3y"/>
-                        <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="bBZ-C2-GD9"/>
-                    </connections>
-                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="1040" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="07h-Be-Qb7"/>
@@ -2154,6 +2138,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1041" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="6Gc-GN-jaM"/>
                 <constraint firstItem="1499" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Gd-YR-UwY"/>
                 <constraint firstItem="1128" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Rt-Dl-nEH"/>
+                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="9" id="753-w2-5rN"/>
                 <constraint firstItem="1040" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="88v-JT-MZi"/>
                 <constraint firstItem="1044" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="8Nx-5g-ekY"/>
                 <constraint firstItem="1669" firstAttribute="top" secondItem="1682" secondAttribute="bottom" constant="3" id="8X8-bM-jcO"/>
@@ -2165,14 +2150,12 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1499" firstAttribute="top" secondItem="1542" secondAttribute="bottom" constant="9" id="I3G-h6-HEr"/>
                 <constraint firstItem="1040" firstAttribute="top" secondItem="2185" secondAttribute="bottom" constant="9" id="ISt-G5-WmP"/>
                 <constraint firstItem="1517" firstAttribute="leading" secondItem="1518" secondAttribute="trailing" constant="3" id="LrC-x9-AzB"/>
-                <constraint firstItem="4c6-aS-Wtf" firstAttribute="top" secondItem="1520" secondAttribute="bottom" constant="5" id="Mbp-dX-hbm"/>
                 <constraint firstItem="1740" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="Mxl-Bt-Lmm"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="top" secondItem="1128" secondAttribute="bottom" constant="9" id="N4F-tp-Ye3"/>
                 <constraint firstItem="1037" firstAttribute="top" secondItem="802" secondAttribute="top" constant="15" id="NUM-ia-xR0"/>
                 <constraint firstItem="1519" firstAttribute="top" secondItem="1521" secondAttribute="bottom" id="OBh-aS-TeB"/>
                 <constraint firstItem="1036" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="OcA-Yd-0DW"/>
                 <constraint firstItem="2196" firstAttribute="leading" secondItem="2188" secondAttribute="trailing" constant="1" id="Qx4-WP-Nw8"/>
-                <constraint firstItem="4c6-aS-Wtf" firstAttribute="leading" secondItem="1520" secondAttribute="leading" id="QxR-tB-Wy8"/>
                 <constraint firstItem="1037" firstAttribute="leading" secondItem="1034" secondAttribute="trailing" constant="10" id="RK9-T0-IMB"/>
                 <constraint firstItem="1041" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="RN4-RH-L81"/>
                 <constraint firstItem="2188" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="Rpe-nI-N5h"/>
@@ -2187,7 +2170,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VhL-v5-EOm"/>
                 <constraint firstItem="1037" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="ViK-Wb-m47"/>
                 <constraint firstItem="2196" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="W50-pu-PZf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="26" id="WqO-mA-gjk"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="15" id="WqO-mA-gjk"/>
                 <constraint firstItem="1034" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="Xsx-t7-c69"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="agH-Ty-N6d"/>
                 <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="bwP-pO-qGY"/>
@@ -2207,13 +2190,12 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="2188" firstAttribute="leading" secondItem="2185" secondAttribute="trailing" constant="5" id="mm3-tG-9b9"/>
                 <constraint firstItem="1083" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="oSA-hL-2he"/>
                 <constraint firstItem="1046" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="ohG-5j-dFT"/>
-                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="4c6-aS-Wtf" secondAttribute="bottom" constant="22" id="opy-MM-ahc"/>
+                <constraint firstItem="1682" firstAttribute="width" secondItem="802" secondAttribute="width" multiplier="3/7" id="oyD-c7-AK6"/>
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="top" secondItem="xIN-qP-ogl" secondAttribute="bottom" constant="9" id="qSa-Cf-Vj8"/>
                 <constraint firstItem="1045" firstAttribute="top" secondItem="1041" secondAttribute="bottom" id="rGS-R2-10k"/>
                 <constraint firstItem="1740" firstAttribute="leading" secondItem="1738" secondAttribute="trailing" constant="5" id="rkP-ab-hmB"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1036" secondAttribute="trailing" constant="10" id="sKG-JP-bV9"/>
                 <constraint firstItem="1497" firstAttribute="centerY" secondItem="1499" secondAttribute="centerY" id="sig-Tk-KWs"/>
-                <constraint firstItem="4c6-aS-Wtf" firstAttribute="trailing" secondItem="1517" secondAttribute="trailing" id="tH9-b0-r12"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vAd-Sh-CJY"/>
                 <constraint firstItem="1042" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="vgo-wx-KMP"/>
                 <constraint firstItem="1542" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vyL-HG-CgB"/>
@@ -2227,7 +2209,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="trailing" secondItem="1085" secondAttribute="trailing" constant="20" id="ydA-be-JIe"/>
                 <constraint firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" constant="20" id="yoh-2E-iOA"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="1119"/>
+            <point key="canvasLocation" x="751" y="1094"/>
         </customView>
         <menu id="1547" userLabel="Context Menu">
             <items>

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -1372,7 +1372,7 @@ Gw
                     <rect key="frame" x="180" y="40" width="340" height="160"/>
                     <clipView key="contentView" id="M9x-3Q-tiD">
                         <rect key="frame" x="1" y="1" width="338" height="158"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" id="RuH-Yq-cdH">
                                 <rect key="frame" x="0.0" y="0.0" width="338" height="158"/>
@@ -1592,20 +1592,20 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <point key="canvasLocation" x="732" y="551"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="802" userLabel="Editor">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="487"/>
+            <rect key="frame" x="0.0" y="0.0" width="541" height="538"/>
             <userGuides>
                 <userLayoutGuide location="146" affinity="minX"/>
                 <userLayoutGuide location="315" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1085">
-                    <rect key="frame" x="20" y="438" width="500" height="5"/>
+                    <rect key="frame" x="20" y="489" width="501" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="mJZ-MM-v9M"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
-                    <rect key="frame" x="488" y="256" width="34" height="14"/>
+                    <rect key="frame" x="489" y="307" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="4mD-hS-s3t"/>
                     </constraints>
@@ -1619,7 +1619,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="474" y="251" width="15" height="22"/>
+                    <rect key="frame" x="475" y="302" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1634,7 +1634,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
-                    <rect key="frame" x="299" y="252" width="59" height="22"/>
+                    <rect key="frame" x="300" y="303" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="J1h-3t-Frd"/>
                         <constraint firstAttribute="width" constant="55" id="wmw-DW-vkB"/>
@@ -1649,7 +1649,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
-                    <rect key="frame" x="361" y="252" width="114" height="22"/>
+                    <rect key="frame" x="362" y="303" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="7Gy-54-e6x"/>
                     </constraints>
@@ -1671,7 +1671,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="259" y="220" width="261" height="24"/>
+                    <rect key="frame" x="260" y="271" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="o8a-4g-ciG"/>
                     </constraints>
@@ -1684,7 +1684,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="259" y="315" width="261" height="24"/>
+                    <rect key="frame" x="260" y="366" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Nm1-1L-fkL"/>
                     </constraints>
@@ -1697,7 +1697,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="259" y="273" width="261" height="35"/>
+                    <rect key="frame" x="260" y="324" width="261" height="35"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="33" id="LMj-pz-5qi"/>
                     </constraints>
@@ -1710,7 +1710,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="259" y="346" width="261" height="24"/>
+                    <rect key="frame" x="260" y="397" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="okU-1B-JWL"/>
                     </constraints>
@@ -1723,7 +1723,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="259" y="408" width="261" height="24"/>
+                    <rect key="frame" x="260" y="459" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="QM4-7n-4Uf"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YuJ-Px-Th2"/>
@@ -1737,7 +1737,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1037" customClass="SPFontPreviewTextField">
-                    <rect key="frame" x="170" y="450" width="200" height="22"/>
+                    <rect key="frame" x="171" y="501" width="200" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="F5G-7E-Xu4"/>
                         <constraint firstAttribute="height" constant="22" id="Jtz-vN-iPm"/>
@@ -1749,7 +1749,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="373" y="444" width="114" height="32"/>
+                    <rect key="frame" x="374" y="495" width="114" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="Z6f-Ex-CfK"/>
                     </constraints>
@@ -1762,7 +1762,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1034">
-                    <rect key="frame" x="18" y="453" width="144" height="16"/>
+                    <rect key="frame" x="18" y="504" width="145" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="6gj-Xz-W0f"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="150" id="ltM-Zr-Qpk"/>
@@ -1812,19 +1812,19 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </popUpButtonCell>
                 </popUpButton>
                 <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1682">
-                    <rect key="frame" x="20" y="42" width="231" height="389"/>
+                    <rect key="frame" x="20" y="42" width="232" height="440"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
-                        <rect key="frame" x="1" y="1" width="229" height="387"/>
+                        <rect key="frame" x="1" y="1" width="230" height="438"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
-                                <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>
+                                <rect key="frame" x="0.0" y="0.0" width="230" height="438"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="name" width="194" minWidth="40" maxWidth="10000" id="1687">
+                                    <tableColumn identifier="name" width="195" minWidth="40" maxWidth="10000" id="1687">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1857,9 +1857,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         </subviews>
                         <nil key="backgroundColor"/>
                     </clipView>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Fuh-SQ-jA3"/>
-                    </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1684">
                         <rect key="frame" x="-100" y="-100" width="223" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -1881,7 +1878,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField toolTip="The name of the current set color theme" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1740">
-                    <rect key="frame" x="132" y="20" width="121" height="14"/>
+                    <rect key="frame" x="132" y="20" width="122" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="theme name" id="1741">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1899,7 +1896,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="259" y="377" width="93" height="24"/>
+                    <rect key="frame" x="260" y="428" width="93" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OaX-My-oPP"/>
                     </constraints>
@@ -1912,7 +1909,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="357" y="378" width="151" height="22"/>
+                    <rect key="frame" x="358" y="429" width="151" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -1930,7 +1927,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="507" y="377" width="15" height="22"/>
+                    <rect key="frame" x="508" y="428" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -1944,7 +1941,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="259" y="189" width="261" height="24"/>
+                    <rect key="frame" x="260" y="240" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="NJU-0g-hK3"/>
                     </constraints>
@@ -1957,7 +1954,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="259" y="158" width="261" height="24"/>
+                    <rect key="frame" x="260" y="209" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="LQ3-Eq-hy0"/>
                     </constraints>
@@ -1973,7 +1970,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
-                    <rect key="frame" x="488" y="110" width="34" height="14"/>
+                    <rect key="frame" x="489" y="161" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="Wt0-DH-0yD"/>
                     </constraints>
@@ -1987,7 +1984,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="474" y="105" width="15" height="22"/>
+                    <rect key="frame" x="475" y="156" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
@@ -2002,7 +1999,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
-                    <rect key="frame" x="299" y="106" width="59" height="22"/>
+                    <rect key="frame" x="300" y="157" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6rD-Fb-Wtt"/>
                         <constraint firstAttribute="width" constant="55" id="sCD-jX-6bG"/>
@@ -2017,7 +2014,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
-                    <rect key="frame" x="361" y="106" width="114" height="22"/>
+                    <rect key="frame" x="362" y="157" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
@@ -2039,7 +2036,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="259" y="127" width="261" height="24"/>
+                    <rect key="frame" x="260" y="178" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="JL1-kC-qdF"/>
                     </constraints>
@@ -2052,7 +2049,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="259" y="74" width="261" height="24"/>
+                    <rect key="frame" x="260" y="85" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Hbi-dI-piB"/>
                     </constraints>
@@ -2065,7 +2062,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="259" y="43" width="261" height="24"/>
+                    <rect key="frame" x="260" y="54" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Vdm-3z-iY0"/>
                     </constraints>
@@ -2078,7 +2075,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
-                    <rect key="frame" x="259" y="15" width="101" height="20"/>
+                    <rect key="frame" x="260" y="26" width="101" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OHa-nn-g2y"/>
                     </constraints>
@@ -2089,7 +2086,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
-                    <rect key="frame" x="363" y="14" width="145" height="22"/>
+                    <rect key="frame" x="364" y="25" width="145" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VkS-BX-Qdr"/>
                     </constraints>
@@ -2108,7 +2105,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="507" y="13" width="15" height="22"/>
+                    <rect key="frame" x="508" y="24" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2121,6 +2118,25 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEditorTabStopWidth" id="1516"/>
                     </connections>
                 </stepper>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4c6-aS-Wtf">
+                    <rect key="frame" x="360" y="129" width="161" height="24"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="22" id="Isn-KM-jRA"/>
+                        <constraint firstAttribute="width" constant="159" id="rvy-aL-MDx"/>
+                    </constraints>
+                    <buttonCell key="cell" type="check" title="Use Fuzzy Matching" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2Km-2V-2OM">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                        <connections>
+                            <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="qUf-AL-cus"/>
+                            <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="2jw-zh-sM3"/>
+                        </connections>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="EjQ-jn-N3y"/>
+                        <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="bBZ-C2-GD9"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="1040" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="07h-Be-Qb7"/>
@@ -2138,7 +2154,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1041" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="6Gc-GN-jaM"/>
                 <constraint firstItem="1499" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Gd-YR-UwY"/>
                 <constraint firstItem="1128" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Rt-Dl-nEH"/>
-                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="9" id="753-w2-5rN"/>
                 <constraint firstItem="1040" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="88v-JT-MZi"/>
                 <constraint firstItem="1044" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="8Nx-5g-ekY"/>
                 <constraint firstItem="1669" firstAttribute="top" secondItem="1682" secondAttribute="bottom" constant="3" id="8X8-bM-jcO"/>
@@ -2150,12 +2165,14 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1499" firstAttribute="top" secondItem="1542" secondAttribute="bottom" constant="9" id="I3G-h6-HEr"/>
                 <constraint firstItem="1040" firstAttribute="top" secondItem="2185" secondAttribute="bottom" constant="9" id="ISt-G5-WmP"/>
                 <constraint firstItem="1517" firstAttribute="leading" secondItem="1518" secondAttribute="trailing" constant="3" id="LrC-x9-AzB"/>
+                <constraint firstItem="4c6-aS-Wtf" firstAttribute="top" secondItem="1520" secondAttribute="bottom" constant="5" id="Mbp-dX-hbm"/>
                 <constraint firstItem="1740" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="Mxl-Bt-Lmm"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="top" secondItem="1128" secondAttribute="bottom" constant="9" id="N4F-tp-Ye3"/>
                 <constraint firstItem="1037" firstAttribute="top" secondItem="802" secondAttribute="top" constant="15" id="NUM-ia-xR0"/>
                 <constraint firstItem="1519" firstAttribute="top" secondItem="1521" secondAttribute="bottom" id="OBh-aS-TeB"/>
                 <constraint firstItem="1036" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="OcA-Yd-0DW"/>
                 <constraint firstItem="2196" firstAttribute="leading" secondItem="2188" secondAttribute="trailing" constant="1" id="Qx4-WP-Nw8"/>
+                <constraint firstItem="4c6-aS-Wtf" firstAttribute="leading" secondItem="1520" secondAttribute="leading" id="QxR-tB-Wy8"/>
                 <constraint firstItem="1037" firstAttribute="leading" secondItem="1034" secondAttribute="trailing" constant="10" id="RK9-T0-IMB"/>
                 <constraint firstItem="1041" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="RN4-RH-L81"/>
                 <constraint firstItem="2188" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="Rpe-nI-N5h"/>
@@ -2170,7 +2187,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VhL-v5-EOm"/>
                 <constraint firstItem="1037" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="ViK-Wb-m47"/>
                 <constraint firstItem="2196" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="W50-pu-PZf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="15" id="WqO-mA-gjk"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="26" id="WqO-mA-gjk"/>
                 <constraint firstItem="1034" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="Xsx-t7-c69"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="agH-Ty-N6d"/>
                 <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="bwP-pO-qGY"/>
@@ -2190,12 +2207,13 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="2188" firstAttribute="leading" secondItem="2185" secondAttribute="trailing" constant="5" id="mm3-tG-9b9"/>
                 <constraint firstItem="1083" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="oSA-hL-2he"/>
                 <constraint firstItem="1046" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="ohG-5j-dFT"/>
-                <constraint firstItem="1682" firstAttribute="width" secondItem="802" secondAttribute="width" multiplier="3/7" id="oyD-c7-AK6"/>
+                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="4c6-aS-Wtf" secondAttribute="bottom" constant="22" id="opy-MM-ahc"/>
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="top" secondItem="xIN-qP-ogl" secondAttribute="bottom" constant="9" id="qSa-Cf-Vj8"/>
                 <constraint firstItem="1045" firstAttribute="top" secondItem="1041" secondAttribute="bottom" id="rGS-R2-10k"/>
                 <constraint firstItem="1740" firstAttribute="leading" secondItem="1738" secondAttribute="trailing" constant="5" id="rkP-ab-hmB"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1036" secondAttribute="trailing" constant="10" id="sKG-JP-bV9"/>
                 <constraint firstItem="1497" firstAttribute="centerY" secondItem="1499" secondAttribute="centerY" id="sig-Tk-KWs"/>
+                <constraint firstItem="4c6-aS-Wtf" firstAttribute="trailing" secondItem="1517" secondAttribute="trailing" id="tH9-b0-r12"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vAd-Sh-CJY"/>
                 <constraint firstItem="1042" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="vgo-wx-KMP"/>
                 <constraint firstItem="1542" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vyL-HG-CgB"/>
@@ -2209,7 +2227,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="trailing" secondItem="1085" secondAttribute="trailing" constant="20" id="ydA-be-JIe"/>
                 <constraint firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" constant="20" id="yoh-2E-iOA"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="1094"/>
+            <point key="canvasLocation" x="751" y="1119"/>
         </customView>
         <menu id="1547" userLabel="Context Menu">
             <items>

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -1592,20 +1592,20 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <point key="canvasLocation" x="732" y="551"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="802" userLabel="Editor">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="516"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="487"/>
             <userGuides>
                 <userLayoutGuide location="146" affinity="minX"/>
                 <userLayoutGuide location="315" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1085">
-                    <rect key="frame" x="20" y="467" width="500" height="5"/>
+                    <rect key="frame" x="20" y="438" width="500" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="mJZ-MM-v9M"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
-                    <rect key="frame" x="488" y="285" width="34" height="14"/>
+                    <rect key="frame" x="488" y="256" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="4mD-hS-s3t"/>
                     </constraints>
@@ -1619,7 +1619,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="474" y="280" width="15" height="22"/>
+                    <rect key="frame" x="474" y="251" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1634,7 +1634,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
-                    <rect key="frame" x="299" y="281" width="59" height="22"/>
+                    <rect key="frame" x="299" y="252" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="J1h-3t-Frd"/>
                         <constraint firstAttribute="width" constant="55" id="wmw-DW-vkB"/>
@@ -1649,7 +1649,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
-                    <rect key="frame" x="361" y="281" width="114" height="22"/>
+                    <rect key="frame" x="361" y="252" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="7Gy-54-e6x"/>
                     </constraints>
@@ -1671,7 +1671,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="259" y="249" width="261" height="24"/>
+                    <rect key="frame" x="259" y="220" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="o8a-4g-ciG"/>
                     </constraints>
@@ -1684,7 +1684,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="259" y="344" width="261" height="24"/>
+                    <rect key="frame" x="259" y="315" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Nm1-1L-fkL"/>
                     </constraints>
@@ -1697,7 +1697,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="259" y="302" width="261" height="35"/>
+                    <rect key="frame" x="259" y="273" width="261" height="35"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="33" id="LMj-pz-5qi"/>
                     </constraints>
@@ -1710,7 +1710,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="259" y="375" width="261" height="24"/>
+                    <rect key="frame" x="259" y="346" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="okU-1B-JWL"/>
                     </constraints>
@@ -1723,7 +1723,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="259" y="437" width="261" height="24"/>
+                    <rect key="frame" x="259" y="408" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="QM4-7n-4Uf"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YuJ-Px-Th2"/>
@@ -1737,7 +1737,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1037" customClass="SPFontPreviewTextField">
-                    <rect key="frame" x="170" y="479" width="200" height="22"/>
+                    <rect key="frame" x="170" y="450" width="200" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="F5G-7E-Xu4"/>
                         <constraint firstAttribute="height" constant="22" id="Jtz-vN-iPm"/>
@@ -1749,7 +1749,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="373" y="473" width="114" height="32"/>
+                    <rect key="frame" x="373" y="444" width="114" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="Z6f-Ex-CfK"/>
                     </constraints>
@@ -1762,7 +1762,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1034">
-                    <rect key="frame" x="18" y="482" width="144" height="16"/>
+                    <rect key="frame" x="18" y="453" width="144" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="6gj-Xz-W0f"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="150" id="ltM-Zr-Qpk"/>
@@ -1812,13 +1812,13 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </popUpButtonCell>
                 </popUpButton>
                 <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1682">
-                    <rect key="frame" x="20" y="42" width="231" height="418"/>
+                    <rect key="frame" x="20" y="42" width="231" height="389"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
-                        <rect key="frame" x="1" y="1" width="229" height="416"/>
+                        <rect key="frame" x="1" y="1" width="229" height="387"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
-                                <rect key="frame" x="0.0" y="0.0" width="229" height="416"/>
+                                <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1899,7 +1899,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="259" y="406" width="93" height="24"/>
+                    <rect key="frame" x="259" y="377" width="93" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OaX-My-oPP"/>
                     </constraints>
@@ -1912,7 +1912,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="357" y="407" width="151" height="22"/>
+                    <rect key="frame" x="357" y="378" width="151" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -1930,7 +1930,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="507" y="406" width="15" height="22"/>
+                    <rect key="frame" x="507" y="377" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -1944,7 +1944,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="259" y="218" width="261" height="24"/>
+                    <rect key="frame" x="259" y="189" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="NJU-0g-hK3"/>
                     </constraints>
@@ -1957,7 +1957,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="259" y="187" width="261" height="24"/>
+                    <rect key="frame" x="259" y="158" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="LQ3-Eq-hy0"/>
                     </constraints>
@@ -1973,7 +1973,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
-                    <rect key="frame" x="488" y="139" width="34" height="14"/>
+                    <rect key="frame" x="488" y="110" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="Wt0-DH-0yD"/>
                     </constraints>
@@ -1987,7 +1987,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="474" y="134" width="15" height="22"/>
+                    <rect key="frame" x="474" y="105" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
@@ -2002,7 +2002,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
-                    <rect key="frame" x="299" y="135" width="59" height="22"/>
+                    <rect key="frame" x="299" y="106" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6rD-Fb-Wtt"/>
                         <constraint firstAttribute="width" constant="55" id="sCD-jX-6bG"/>
@@ -2017,7 +2017,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
-                    <rect key="frame" x="361" y="135" width="114" height="22"/>
+                    <rect key="frame" x="361" y="106" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
@@ -2039,7 +2039,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="259" y="156" width="261" height="24"/>
+                    <rect key="frame" x="259" y="127" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="JL1-kC-qdF"/>
                     </constraints>
@@ -2052,7 +2052,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="259" y="77" width="261" height="24"/>
+                    <rect key="frame" x="259" y="74" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Hbi-dI-piB"/>
                     </constraints>
@@ -2065,7 +2065,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="259" y="46" width="261" height="24"/>
+                    <rect key="frame" x="259" y="43" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Vdm-3z-iY0"/>
                     </constraints>
@@ -2078,7 +2078,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
-                    <rect key="frame" x="259" y="18" width="101" height="20"/>
+                    <rect key="frame" x="259" y="15" width="101" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OHa-nn-g2y"/>
                     </constraints>
@@ -2089,7 +2089,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
-                    <rect key="frame" x="363" y="17" width="145" height="22"/>
+                    <rect key="frame" x="363" y="14" width="145" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VkS-BX-Qdr"/>
                     </constraints>
@@ -2108,7 +2108,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="507" y="16" width="15" height="22"/>
+                    <rect key="frame" x="507" y="13" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2121,17 +2121,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEditorTabStopWidth" id="1516"/>
                     </connections>
                 </stepper>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mOk-t2-QBr">
-                    <rect key="frame" x="361" y="110" width="149" height="18"/>
-                    <buttonCell key="cell" type="check" title="Use Fuzzy Matching" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2ZU-gx-dPA">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="htN-xh-Kve"/>
-                        <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="wkM-53-FhK"/>
-                    </connections>
-                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="1040" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="07h-Be-Qb7"/>
@@ -2149,11 +2138,10 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1041" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="6Gc-GN-jaM"/>
                 <constraint firstItem="1499" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Gd-YR-UwY"/>
                 <constraint firstItem="1128" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Rt-Dl-nEH"/>
-                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="35" id="753-w2-5rN"/>
+                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="9" id="753-w2-5rN"/>
                 <constraint firstItem="1040" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="88v-JT-MZi"/>
                 <constraint firstItem="1044" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="8Nx-5g-ekY"/>
                 <constraint firstItem="1669" firstAttribute="top" secondItem="1682" secondAttribute="bottom" constant="3" id="8X8-bM-jcO"/>
-                <constraint firstItem="mOk-t2-QBr" firstAttribute="leading" secondItem="1505" secondAttribute="leading" id="BLY-hb-Ntp"/>
                 <constraint firstItem="1518" firstAttribute="centerY" secondItem="1519" secondAttribute="centerY" id="CM5-5a-OYN"/>
                 <constraint firstItem="1085" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="E3j-XR-Tr3"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="FMR-XC-hJi"/>
@@ -2161,8 +2149,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="bottom" secondItem="1669" secondAttribute="bottom" constant="15" id="GRk-eU-Obz"/>
                 <constraint firstItem="1499" firstAttribute="top" secondItem="1542" secondAttribute="bottom" constant="9" id="I3G-h6-HEr"/>
                 <constraint firstItem="1040" firstAttribute="top" secondItem="2185" secondAttribute="bottom" constant="9" id="ISt-G5-WmP"/>
-                <constraint firstItem="mOk-t2-QBr" firstAttribute="top" secondItem="1520" secondAttribute="bottom" constant="8" symbolic="YES" id="JUn-2s-cxG"/>
-                <constraint firstAttribute="trailing" secondItem="mOk-t2-QBr" secondAttribute="trailing" constant="30" id="LSE-0c-4w0"/>
                 <constraint firstItem="1517" firstAttribute="leading" secondItem="1518" secondAttribute="trailing" constant="3" id="LrC-x9-AzB"/>
                 <constraint firstItem="1740" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="Mxl-Bt-Lmm"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="top" secondItem="1128" secondAttribute="bottom" constant="9" id="N4F-tp-Ye3"/>
@@ -2175,7 +2161,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="2188" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="Rpe-nI-N5h"/>
                 <constraint firstItem="1518" firstAttribute="leading" secondItem="1520" secondAttribute="trailing" constant="1" id="S1I-B9-WbE"/>
                 <constraint firstItem="1682" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="Tak-ON-k22"/>
-                <constraint firstItem="mOk-t2-QBr" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="363" id="TfM-ih-DGM"/>
                 <constraint firstItem="1045" firstAttribute="leading" secondItem="1682" secondAttribute="trailing" constant="50" id="TiG-wn-eVq"/>
                 <constraint firstItem="1128" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="U1K-di-gV4"/>
                 <constraint firstItem="1740" firstAttribute="trailing" secondItem="1682" secondAttribute="trailing" id="V1T-vE-bku"/>
@@ -2185,7 +2170,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VhL-v5-EOm"/>
                 <constraint firstItem="1037" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="ViK-Wb-m47"/>
                 <constraint firstItem="2196" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="W50-pu-PZf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="18" id="WqO-mA-gjk"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="15" id="WqO-mA-gjk"/>
                 <constraint firstItem="1034" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="Xsx-t7-c69"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="agH-Ty-N6d"/>
                 <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="bwP-pO-qGY"/>
@@ -2224,7 +2209,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="trailing" secondItem="1085" secondAttribute="trailing" constant="20" id="ydA-be-JIe"/>
                 <constraint firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" constant="20" id="yoh-2E-iOA"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="1108"/>
+            <point key="canvasLocation" x="751" y="1094"/>
         </customView>
         <menu id="1547" userLabel="Context Menu">
             <items>

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -216,7 +216,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="eRr-LP-c79">
                             <rect key="frame" x="1" y="1" width="263" height="152"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" id="1774">
                                     <rect key="frame" x="0.0" y="0.0" width="263" height="152"/>
@@ -1372,7 +1372,7 @@ Gw
                     <rect key="frame" x="180" y="40" width="340" height="160"/>
                     <clipView key="contentView" id="M9x-3Q-tiD">
                         <rect key="frame" x="1" y="1" width="338" height="158"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" id="RuH-Yq-cdH">
                                 <rect key="frame" x="0.0" y="0.0" width="338" height="158"/>
@@ -1992,11 +1992,11 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
                     </constraints>
-                    <stepperCell key="cell" controlSize="small" continuous="YES" enabled="NO" alignment="left" increment="0.10000000000000001" minValue="0.5" maxValue="5" doubleValue="1" id="1526">
+                    <stepperCell key="cell" controlSize="small" continuous="YES" enabled="NO" alignment="left" increment="0.10000000000000001" maxValue="5" doubleValue="2.5" id="1526">
                         <font key="font" metaFont="message" size="11"/>
                     </stepperCell>
                     <connections>
-                        <action selector="takeFloatValueFrom:" target="1520" id="1529"/>
+                        <action selector="delayStepperChanged:" target="2144" id="0lC-yA-DTc"/>
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="1541"/>
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteDelay" id="1540"/>
                     </connections>
@@ -2021,11 +2021,11 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title=".5" drawsBackground="YES" usesSingleLineMode="YES" id="1523">
-                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#.0" alwaysShowsDecimalSeparator="YES" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="1" decimalSeparator="." groupingSeparator="" id="1524">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0.5" drawsBackground="YES" usesSingleLineMode="YES" id="1523">
+                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#.0" allowsFloats="NO" alwaysShowsDecimalSeparator="YES" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="1" groupingSeparator="" id="1524">
                             <nil key="negativeInfinitySymbol"/>
                             <nil key="positiveInfinitySymbol"/>
-                            <real key="minimum" value="0.5"/>
+                            <real key="minimum" value="0.0"/>
                             <real key="maximum" value="20"/>
                         </numberFormatter>
                         <font key="font" metaFont="message" size="11"/>
@@ -2362,7 +2362,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <rect key="frame" x="20" y="46" width="500" height="212"/>
                     <clipView key="contentView" id="u3q-XC-nUM">
                         <rect key="frame" x="1" y="1" width="498" height="210"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" id="eH2-Ed-Xh3">
                                 <rect key="frame" x="0.0" y="0.0" width="498" height="210"/>

--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -1592,20 +1592,20 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <point key="canvasLocation" x="732" y="551"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="802" userLabel="Editor">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="487"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="516"/>
             <userGuides>
                 <userLayoutGuide location="146" affinity="minX"/>
                 <userLayoutGuide location="315" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1085">
-                    <rect key="frame" x="20" y="438" width="500" height="5"/>
+                    <rect key="frame" x="20" y="467" width="500" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="mJZ-MM-v9M"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
-                    <rect key="frame" x="488" y="256" width="34" height="14"/>
+                    <rect key="frame" x="488" y="285" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="4mD-hS-s3t"/>
                     </constraints>
@@ -1619,7 +1619,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="474" y="251" width="15" height="22"/>
+                    <rect key="frame" x="474" y="280" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1634,7 +1634,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
-                    <rect key="frame" x="299" y="252" width="59" height="22"/>
+                    <rect key="frame" x="299" y="281" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="J1h-3t-Frd"/>
                         <constraint firstAttribute="width" constant="55" id="wmw-DW-vkB"/>
@@ -1649,7 +1649,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
-                    <rect key="frame" x="361" y="252" width="114" height="22"/>
+                    <rect key="frame" x="361" y="281" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="7Gy-54-e6x"/>
                     </constraints>
@@ -1671,7 +1671,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="259" y="220" width="261" height="24"/>
+                    <rect key="frame" x="259" y="249" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="o8a-4g-ciG"/>
                     </constraints>
@@ -1684,7 +1684,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="259" y="315" width="261" height="24"/>
+                    <rect key="frame" x="259" y="344" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Nm1-1L-fkL"/>
                     </constraints>
@@ -1697,7 +1697,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="259" y="273" width="261" height="35"/>
+                    <rect key="frame" x="259" y="302" width="261" height="35"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="33" id="LMj-pz-5qi"/>
                     </constraints>
@@ -1710,7 +1710,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="259" y="346" width="261" height="24"/>
+                    <rect key="frame" x="259" y="375" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="okU-1B-JWL"/>
                     </constraints>
@@ -1723,7 +1723,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="259" y="408" width="261" height="24"/>
+                    <rect key="frame" x="259" y="437" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="QM4-7n-4Uf"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YuJ-Px-Th2"/>
@@ -1737,7 +1737,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1037" customClass="SPFontPreviewTextField">
-                    <rect key="frame" x="170" y="450" width="200" height="22"/>
+                    <rect key="frame" x="170" y="479" width="200" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="F5G-7E-Xu4"/>
                         <constraint firstAttribute="height" constant="22" id="Jtz-vN-iPm"/>
@@ -1749,7 +1749,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="373" y="444" width="114" height="32"/>
+                    <rect key="frame" x="373" y="473" width="114" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="Z6f-Ex-CfK"/>
                     </constraints>
@@ -1762,7 +1762,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1034">
-                    <rect key="frame" x="18" y="453" width="144" height="16"/>
+                    <rect key="frame" x="18" y="482" width="144" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="6gj-Xz-W0f"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="150" id="ltM-Zr-Qpk"/>
@@ -1812,13 +1812,13 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </popUpButtonCell>
                 </popUpButton>
                 <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1682">
-                    <rect key="frame" x="20" y="42" width="231" height="389"/>
+                    <rect key="frame" x="20" y="42" width="231" height="418"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
-                        <rect key="frame" x="1" y="1" width="229" height="387"/>
+                        <rect key="frame" x="1" y="1" width="229" height="416"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
-                                <rect key="frame" x="0.0" y="0.0" width="229" height="387"/>
+                                <rect key="frame" x="0.0" y="0.0" width="229" height="416"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1899,7 +1899,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="259" y="377" width="93" height="24"/>
+                    <rect key="frame" x="259" y="406" width="93" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OaX-My-oPP"/>
                     </constraints>
@@ -1912,7 +1912,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="357" y="378" width="151" height="22"/>
+                    <rect key="frame" x="357" y="407" width="151" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -1930,7 +1930,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="507" y="377" width="15" height="22"/>
+                    <rect key="frame" x="507" y="406" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -1944,7 +1944,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="259" y="189" width="261" height="24"/>
+                    <rect key="frame" x="259" y="218" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="NJU-0g-hK3"/>
                     </constraints>
@@ -1957,7 +1957,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="259" y="158" width="261" height="24"/>
+                    <rect key="frame" x="259" y="187" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="LQ3-Eq-hy0"/>
                     </constraints>
@@ -1973,7 +1973,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
-                    <rect key="frame" x="488" y="110" width="34" height="14"/>
+                    <rect key="frame" x="488" y="139" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="Wt0-DH-0yD"/>
                     </constraints>
@@ -1987,7 +1987,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="474" y="105" width="15" height="22"/>
+                    <rect key="frame" x="474" y="134" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
@@ -2002,7 +2002,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
-                    <rect key="frame" x="299" y="106" width="59" height="22"/>
+                    <rect key="frame" x="299" y="135" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6rD-Fb-Wtt"/>
                         <constraint firstAttribute="width" constant="55" id="sCD-jX-6bG"/>
@@ -2017,7 +2017,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
-                    <rect key="frame" x="361" y="106" width="114" height="22"/>
+                    <rect key="frame" x="361" y="135" width="114" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
@@ -2039,7 +2039,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="259" y="127" width="261" height="24"/>
+                    <rect key="frame" x="259" y="156" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="JL1-kC-qdF"/>
                     </constraints>
@@ -2052,7 +2052,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="259" y="74" width="261" height="24"/>
+                    <rect key="frame" x="259" y="77" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Hbi-dI-piB"/>
                     </constraints>
@@ -2065,7 +2065,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="259" y="43" width="261" height="24"/>
+                    <rect key="frame" x="259" y="46" width="261" height="24"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Vdm-3z-iY0"/>
                     </constraints>
@@ -2078,7 +2078,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
-                    <rect key="frame" x="259" y="15" width="101" height="20"/>
+                    <rect key="frame" x="259" y="18" width="101" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OHa-nn-g2y"/>
                     </constraints>
@@ -2089,7 +2089,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
-                    <rect key="frame" x="363" y="14" width="145" height="22"/>
+                    <rect key="frame" x="363" y="17" width="145" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VkS-BX-Qdr"/>
                     </constraints>
@@ -2108,7 +2108,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="507" y="13" width="15" height="22"/>
+                    <rect key="frame" x="507" y="16" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2121,6 +2121,17 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEditorTabStopWidth" id="1516"/>
                     </connections>
                 </stepper>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mOk-t2-QBr">
+                    <rect key="frame" x="361" y="110" width="149" height="18"/>
+                    <buttonCell key="cell" type="check" title="Use Fuzzy Matching" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2ZU-gx-dPA">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="117" name="enabled" keyPath="values.CustomQueryAutoComplete" id="htN-xh-Kve"/>
+                        <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteFuzzy" id="wkM-53-FhK"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="1040" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="07h-Be-Qb7"/>
@@ -2138,10 +2149,11 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1041" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="6Gc-GN-jaM"/>
                 <constraint firstItem="1499" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Gd-YR-UwY"/>
                 <constraint firstItem="1128" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Rt-Dl-nEH"/>
-                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="9" id="753-w2-5rN"/>
+                <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" constant="35" id="753-w2-5rN"/>
                 <constraint firstItem="1040" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="88v-JT-MZi"/>
                 <constraint firstItem="1044" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" id="8Nx-5g-ekY"/>
                 <constraint firstItem="1669" firstAttribute="top" secondItem="1682" secondAttribute="bottom" constant="3" id="8X8-bM-jcO"/>
+                <constraint firstItem="mOk-t2-QBr" firstAttribute="leading" secondItem="1505" secondAttribute="leading" id="BLY-hb-Ntp"/>
                 <constraint firstItem="1518" firstAttribute="centerY" secondItem="1519" secondAttribute="centerY" id="CM5-5a-OYN"/>
                 <constraint firstItem="1085" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="E3j-XR-Tr3"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="FMR-XC-hJi"/>
@@ -2149,6 +2161,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="bottom" secondItem="1669" secondAttribute="bottom" constant="15" id="GRk-eU-Obz"/>
                 <constraint firstItem="1499" firstAttribute="top" secondItem="1542" secondAttribute="bottom" constant="9" id="I3G-h6-HEr"/>
                 <constraint firstItem="1040" firstAttribute="top" secondItem="2185" secondAttribute="bottom" constant="9" id="ISt-G5-WmP"/>
+                <constraint firstItem="mOk-t2-QBr" firstAttribute="top" secondItem="1520" secondAttribute="bottom" constant="8" symbolic="YES" id="JUn-2s-cxG"/>
+                <constraint firstAttribute="trailing" secondItem="mOk-t2-QBr" secondAttribute="trailing" constant="30" id="LSE-0c-4w0"/>
                 <constraint firstItem="1517" firstAttribute="leading" secondItem="1518" secondAttribute="trailing" constant="3" id="LrC-x9-AzB"/>
                 <constraint firstItem="1740" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="Mxl-Bt-Lmm"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="top" secondItem="1128" secondAttribute="bottom" constant="9" id="N4F-tp-Ye3"/>
@@ -2161,6 +2175,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="2188" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="Rpe-nI-N5h"/>
                 <constraint firstItem="1518" firstAttribute="leading" secondItem="1520" secondAttribute="trailing" constant="1" id="S1I-B9-WbE"/>
                 <constraint firstItem="1682" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="Tak-ON-k22"/>
+                <constraint firstItem="mOk-t2-QBr" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="363" id="TfM-ih-DGM"/>
                 <constraint firstItem="1045" firstAttribute="leading" secondItem="1682" secondAttribute="trailing" constant="50" id="TiG-wn-eVq"/>
                 <constraint firstItem="1128" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="U1K-di-gV4"/>
                 <constraint firstItem="1740" firstAttribute="trailing" secondItem="1682" secondAttribute="trailing" id="V1T-vE-bku"/>
@@ -2170,7 +2185,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VhL-v5-EOm"/>
                 <constraint firstItem="1037" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="ViK-Wb-m47"/>
                 <constraint firstItem="2196" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="W50-pu-PZf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="15" id="WqO-mA-gjk"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="18" id="WqO-mA-gjk"/>
                 <constraint firstItem="1034" firstAttribute="leading" secondItem="802" secondAttribute="leading" constant="20" id="Xsx-t7-c69"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="agH-Ty-N6d"/>
                 <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="bwP-pO-qGY"/>
@@ -2209,7 +2224,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="trailing" secondItem="1085" secondAttribute="trailing" constant="20" id="ydA-be-JIe"/>
                 <constraint firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" constant="20" id="yoh-2E-iOA"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="1094"/>
+            <point key="canvasLocation" x="751" y="1108"/>
         </customView>
         <menu id="1547" userLabel="Context Menu">
             <items>

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3279,6 +3279,9 @@
 /* Tool tip for the Show alert when update is available preference on the Notifications pane */
 "Only available for GitHub downloads" = "Only available for GitHub downloads";
 
+/* Tool tip warning for when the user sets auto-complete delay to zero */
+"WARNING: Setting the auto-complete delay to 0.0 can result in strange output." = "WARNING: Setting the auto-complete delay to 0.0 can result in strange output.";
+
 /* downloading new version bytes of bytes done */
 "%@ of %@" = "%@ of %@";
 

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -51,6 +51,8 @@
 	<true/>
 	<key>CustomQueryAutoCompleteDelay</key>
 	<real>1.5</real>
+	<key>CustomQueryAutoCompleteFuzzy</key>
+	<false/>
 	<key>CustomQueryAutoHelpDelay</key>
 	<real>1</real>
 	<key>CustomQueryAutoIndent</key>

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -352,6 +352,22 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	[colorSettingTableView reloadData];
 }
 
+- (IBAction)delayStepperChanged:(id)sender {
+
+    NSStepper *stepper = ((NSStepper*)sender);
+
+    if(stepper.floatValue < 0.1){
+        SPLog(@"delayStepperChanged to zero: %f", stepper.floatValue);
+        stepper.toolTip = NSLocalizedString(@"WARNING: Setting the auto-complete delay to 0.0 can result in strange output.", @"WARNING: Setting the auto-complete delay to 0.0 can result in strange output.");
+
+        // automatically display the tooltip
+        NSHelpManager *helpManager = [NSHelpManager sharedHelpManager];
+        [helpManager setContextHelp:[[NSAttributedString alloc] initWithString:stepper.toolTip] forObject:stepper];
+        [helpManager showContextHelpForObject:stepper locationHint:[NSEvent mouseLocation]];
+        [helpManager removeContextHelpForObject:stepper];
+    }
+}
+
 /**
  * Updates the colour scheme selection menu according to the available schemes.
  */

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -367,6 +367,7 @@ extern NSString *SPCustomQueryUpdateAutoHelp;
 extern NSString *SPCustomQueryAutoHelpDelay;
 extern NSString *SPCustomQueryHighlightCurrentQuery;
 extern NSString *SPCustomQueryEnableBracketHighlighting;
+extern NSString *SPCustomQueryAutoCompleteFuzzy;
 extern NSString *SPCustomQueryEditorTabStopWidth;
 extern NSString *SPCustomQueryEditorCompleteWithBackticks;
 extern NSString *SPCustomQueryAutoComplete;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -179,6 +179,7 @@ NSString *SPCustomQueryEditorTabStopWidth        = @"CustomQueryEditorTabStopWid
 NSString *SPCustomQueryEditorCompleteWithBackticks = @"SPCustomQueryEditorCompleteWithBackticks";
 NSString *SPCustomQueryAutoComplete              = @"CustomQueryAutoComplete";
 NSString *SPCustomQueryAutoCompleteDelay         = @"CustomQueryAutoCompleteDelay";
+NSString *SPCustomQueryAutoCompleteFuzzy         = @"CustomQueryAutoCompleteFuzzy";
 NSString *SPCustomQueryFunctionCompletionInsertsArguments = @"CustomQueryFunctionCompletionInsertsArguments";
 NSString *SPCustomQueryEditorThemeName           = @"CustomQueryEditorThemeName";
 NSString *SPCustomQuerySoftIndent                = @"CustomQuerySoftIndent";

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -57,7 +57,8 @@ typedef struct {
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPCustomQuery *customQueryInstance;
 
-	BOOL autoindentEnabled;
+    BOOL autoindentEnabled;
+    BOOL autocompleteEnabled;
 	BOOL autopairEnabled;
 	BOOL autoindentIgnoresEnter;
 	BOOL autouppercaseKeywordsEnabled;
@@ -89,7 +90,6 @@ typedef struct {
 	BOOL completionIsOpen;
 	BOOL completionWasReinvokedAutomatically;
 	BOOL completionWasRefreshed;
-	BOOL completionFuzzyMode;
 	NSUInteger completionParseRangeLocation;
 
 	NSColor *queryHiliteColor;
@@ -123,6 +123,7 @@ typedef struct {
 @property (assign) BOOL syntaxHighlightingApplied;
 @property (assign) BOOL completionIsOpen;
 @property (assign) BOOL completionWasReinvokedAutomatically;
+@property (assign) BOOL completionFuzzyMode;
 
 - (IBAction)showMySQLHelpForCurrentWord:(id)sender;
 
@@ -134,6 +135,7 @@ typedef struct {
 - (BOOL) shiftSelectionRight;
 - (BOOL) shiftSelectionLeft;
 - (void) setAutoindent:(BOOL)enableAutoindent;
+- (void) setAutoComplete:(BOOL)enableAutocomplete;
 - (BOOL) autoindent;
 - (void) setAutoindentIgnoresEnter:(BOOL)enableAutoindentIgnoresEnter;
 - (BOOL) autoindentIgnoresEnter;


### PR DESCRIPTION
## Changes:
- allow zero seconds for auto-completion delay (with a warning)
- ensure field editor handles SPQueryWarningEnabled and queryContainsDestructiveSQL
- all auto-completions are fuzzy for non-SQL-Keywords

## Closes following issues:
- Closes: #955 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4 (12D4e)
  
## Screenshots:

## Additional notes:
