### PR TITLE
Display binary data as hex color in dark mode #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -172,9 +172,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		tableLoadTimer = nil;
 
-		textForegroundColor  = [NSColor controlTextColor]; // this color dynamically adapts to the rest of the UI
-		nullHighlightColor   = [NSColor lightGrayColor];
-		binhexHighlightColor = [NSColor blueColor];
+		textForegroundColor  = [NSColor controlTextColor];
+		nullHighlightColor   = [NSColor systemGrayColor];
+		binhexHighlightColor = [NSColor systemBlueColor];
 
 		kCellEditorErrorNoMatch = NSLocalizedString(@"Field is not editable. No matching record found.\nReload table, check the encoding, or try to add\na primary key field or more fields\nin the view declaration of '%@' to identify\nfield origin unambiguously.", @"Table Content result editing error - could not identify original row");
 		kCellEditorErrorNoMultiTabDb = NSLocalizedString(@"Field is not editable. Field has no or multiple table or database origin(s).",@"field is not editable due to no table/database");


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Use adaptive colors for text

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/989

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4
  
## Screenshots:

## Additional notes:
