### PR TITLE
Improve tabs coloring #fixed

### DIFF
--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -43,18 +43,22 @@ import SnapKit
         }
 
         setupAppearance()
+        setupConstraints()
     }
 
     // MARK: - Accessory
 
-    private lazy var tabAccessoryView: NSView = {
-        let view = NSView()
-        view.wantsLayer = true
-        view.snp.makeConstraints {
-            $0.size.equalTo(20)
-        }
-        view.layer?.cornerRadius = 10
-        return view
+    private lazy var tabAccessoryView: NSView = NSView()
+    private lazy var tabAccessoryColorView: NSView = NSView()
+    private lazy var tabText: NSTextField = {
+        let text = NSTextField()
+        text.userActivity = .none
+        text.backgroundColor = .clear
+        text.isEditable = false
+        text.isHidden = false
+        text.alignment = .center
+        text.isBordered = false
+        return text
     }()
 
     private lazy var tabAccessoryViewImage: NSImageView = {
@@ -78,13 +82,28 @@ private extension SPWindowController {
         window?.contentView?.addSubview(databaseDocument.databaseView())
         databaseDocument.databaseView()?.frame = window?.contentView?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 400)
 
-        tabAccessoryView.addSubview(tabAccessoryViewImage)
-        tabAccessoryViewImage.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
+        tabAccessoryView.addSubviews(tabAccessoryColorView, tabAccessoryViewImage, tabText)
 
         if #available(macOS 10.13, *) {
             window?.tab.accessoryView = tabAccessoryView
+        }
+    }
+
+    func setupConstraints() {
+        tabAccessoryColorView.snp.makeConstraints {
+            $0.height.equalTo(5)
+            $0.bottom.leading.trailing.equalToSuperview()
+        }
+        tabText.snp.makeConstraints {
+            $0.bottom.equalTo(tabAccessoryColorView.snp.top)
+            $0.leading.top.equalToSuperview()
+            $0.trailing.equalTo(tabAccessoryViewImage.snp.leading)
+        }
+
+        tabAccessoryViewImage.snp.makeConstraints {
+            $0.size.equalTo(20)
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
         }
     }
 }
@@ -94,11 +113,20 @@ private extension SPWindowController {
 @objc extension SPWindowController {
     func updateWindow(title: String) {
         window?.title = title
+        if tabAccessoryView.superview != nil {
+            tabText.stringValue = title
+        }
     }
 
     func updateWindowAccessory(color: NSColor?, isSSL: Bool) {
-        tabAccessoryView.layer?.backgroundColor = color?.cgColor
+        tabAccessoryColorView.layer?.backgroundColor = color?.cgColor
         tabAccessoryViewImage.isHidden = !isSSL
+        tabAccessoryView.snp.remakeConstraints {
+            $0.leading.equalToSuperview().offset(35)
+            $0.trailing.equalToSuperview().offset(-35)
+            $0.top.equalToSuperview().offset(5)
+            $0.bottom.equalToSuperview()
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Improve tabs coloring but using bottom line for whole tab (with margins) instead of circle on right side.

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1013

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4
  
## Screenshots:
<img width="1828" alt="Screenshot 2021-04-07 at 16 28 29" src="https://user-images.githubusercontent.com/7204168/113885283-03e84200-97c0-11eb-8480-f616092f3bb2.png">
<img width="1840" alt="Screenshot 2021-04-07 at 16 33 54" src="https://user-images.githubusercontent.com/7204168/113885302-077bc900-97c0-11eb-8a03-59533b1c7ae9.png">

## Additional notes:
