### PR TITLE
Users icon is clickable and doesn't crash #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3589,7 +3589,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         }
         //set up the target action
         [toolbarItem setTarget:self];
-        [toolbarItem setAction:@selector(showUserManager:)];
+        [toolbarItem setAction:@selector(showUserManager)];
 
     } else {
         //itemIdentifier refered to a toolbar item that is not provided or supported by us or cocoa


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Change users action selector that doesn't accept params anymore

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1011

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4
  
## Screenshots:

## Additional notes:
