### PR TITLE
Move MySQL version to the end of the window title

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3409,9 +3409,6 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         // Add the path to the window title
         [windowTitle appendString:pathName];
 
-        // Add the MySQL version to the window title if enabled in prefs
-        if ([prefs boolForKey:SPDisplayServerVersionInWindowTitle]) [windowTitle appendFormat:@"(MySQL %@) ", mySQLVersion];
-
         // Add the name to the window
         [windowTitle appendString:[self name]];
 
@@ -3424,6 +3421,10 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         if ([[self table] length]) {
             [windowTitle appendFormat:@"/%@", [self table]];
         }
+        
+        // Add the MySQL version to the window title if enabled in prefs
+        if ([prefs boolForKey:SPDisplayServerVersionInWindowTitle]) [windowTitle appendFormat:@" (MySQL %@)", mySQLVersion];
+        
         [self.parentWindowController updateWindowWithTitle:windowTitle];
         [self.parentWindowController updateWindowAccessoryWithColor:[[SPFavoriteColorSupport sharedInstance] colorForIndex:[connectionController colorIndex]] isSSL:[self.connectionController isConnectedViaSSL]];
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Move MySQL version text to the end of the window title

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [x] N/A
- Xcode Version: 12.4
  
## Additional notes:
When working on medium to small window sizes, the only thing visible is the MySQL version, instead of the connection / db / table breadcrumb, that in my opinion is way more important than the MySQL version.  This PR moves the MySQL version to the end of the title so more of the important breadcrumb is visible to the user.
