### PR TITLE
Fix tab title to show different string than window title #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3400,9 +3400,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     if ([connectionController isConnecting]) {
-        [self.parentWindowController updateWindowWithTitle:[NSMutableString stringWithString:NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting")]];
+        NSString *title = NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting");
+        [self.parentWindowController updateWindowWithTitle:title tabTitle:title];
     } else if (!_isConnected) {
-        [self.parentWindowController updateWindowWithTitle:[NSMutableString stringWithFormat:@"%@%@", pathName, [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey]]];
+        NSString *title = [NSString stringWithFormat:@"%@%@", pathName, [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey]];
+        [self.parentWindowController updateWindowWithTitle:title tabTitle:title];
     } else {
         NSMutableString *windowTitle = [NSMutableString string];
 
@@ -3410,21 +3412,26 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [windowTitle appendString:pathName];
 
         // Add the MySQL version to the window title if enabled in prefs
-        if ([prefs boolForKey:SPDisplayServerVersionInWindowTitle]) [windowTitle appendFormat:@"(MySQL %@) ", mySQLVersion];
+        if ([prefs boolForKey:SPDisplayServerVersionInWindowTitle]) {
+            [windowTitle appendFormat:@"(MySQL %@) ", mySQLVersion];
+        }
 
         // Add the name to the window
         [windowTitle appendString:[self name]];
 
+        NSMutableString *tabTitle = [NSMutableString string];
         // If a database is selected, add to the window - and other tabs if host is the same but db different or table is not set
         if ([self database]) {
             [windowTitle appendFormat:@"/%@", [self database]];
+            [tabTitle appendFormat:@"%@", [self database]];
         }
 
         // Add the table name if one is selected
         if ([[self table] length]) {
             [windowTitle appendFormat:@"/%@", [self table]];
+            [tabTitle appendFormat:@"/%@", [self table]];
         }
-        [self.parentWindowController updateWindowWithTitle:windowTitle];
+        [self.parentWindowController updateWindowWithTitle:windowTitle tabTitle:tabTitle];
         [self.parentWindowController updateWindowAccessoryWithColor:[[SPFavoriteColorSupport sharedInstance] colorForIndex:[connectionController colorIndex]] isSSL:[self.connectionController isConnectedViaSSL]];
     }
 }

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -113,10 +113,13 @@ private extension SPWindowController {
 // MARK: - Public API
 
 @objc extension SPWindowController {
-    func updateWindow(title: String) {
+    func updateWindow(title: String, tabTitle: String) {
         window?.title = title
+        if #available(macOS 10.13, *) {
+            window?.tab.title = tabTitle
+        }
         if tabAccessoryView.superview != nil {
-            tabText.stringValue = title
+            tabText.stringValue = tabTitle
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- use different tab title than window title

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4
  
## Screenshots:
<img width="1822" alt="Screenshot 2021-04-08 at 22 25 27" src="https://user-images.githubusercontent.com/7204168/114091967-a20c0300-98b9-11eb-8f15-cbf120455b4c.png">


## Additional notes:
