### PR TITLE
Shortcuts for switching between tabs work as expected #fixed

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -913,24 +913,6 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="985"/>
-                            <menuItem title="Select Next Tab" toolTip="Select the next tab in this window.  Can also be accessed via ⇧⌘] or ⌥⌘→" id="1103">
-                                <string key="keyEquivalent" base64-UTF8="YES">
-CQ
-</string>
-                                <modifierMask key="keyEquivalentModifierMask" control="YES"/>
-                                <connections>
-                                    <action selector="selectNextDocumentTab:" target="-1" id="1106"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Select Previous Tab" toolTip="Select the previous tab in this window.  Can also be accessed via ⇧⌘[ or ⌥⌘←" id="1104">
-                                <string key="keyEquivalent" base64-UTF8="YES">
-CQ
-</string>
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" control="YES"/>
-                                <connections>
-                                    <action selector="selectPreviousDocumentTab:" target="-1" id="1105"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Move Tab to New Window" id="1102">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -913,13 +913,6 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="985"/>
-                            <menuItem title="Move Tab to New Window" id="1102">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="moveSelectedTabInNewWindow:" target="-1" id="1115"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1101"/>
                             <menuItem title="Bring All to Front" id="5">
                                 <connections>
                                     <action selector="arrangeInFront:" target="-1" id="39"/>

--- a/Source/Controllers/Window/TabManager.swift
+++ b/Source/Controllers/Window/TabManager.swift
@@ -169,6 +169,7 @@ private extension TabManager {
         guard let newWindow = addManagedWindow(windowController: newWindowController)?.window else { preconditionFailure() }
 
         window.addChildWindow(newWindow, ordered: orderingMode)
+        newWindow.collectionBehavior = [newWindow.collectionBehavior, .participatesInCycle]
         newWindow.makeKeyAndOrderFront(nil)
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Remove old options in menu, keep only the native ones

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1031

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4
  
## Screenshots:

## Additional notes:
