### PR TITLE
#1000 - Add option to disable the warning skip-show-database #added

### DIFF
--- a/Interfaces/Preferences.xib
+++ b/Interfaces/Preferences.xib
@@ -82,7 +82,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <rect key="contentRect" x="430" y="486" width="700" height="100"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="540" height="100"/>
             <value key="maxSize" type="size" width="1500" height="700"/>
             <value key="minFullScreenContentSize" type="size" width="540" height="100"/>
@@ -100,7 +100,7 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="481" width="227" height="114"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="227" height="114"/>
             <value key="maxSize" type="size" width="247" height="124"/>
             <view key="contentView" id="1717">
@@ -140,7 +140,7 @@
                         </connections>
                     </textField>
                     <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="1718">
-                        <rect key="frame" x="112" y="13" width="100" height="28"/>
+                        <rect key="frame" x="113" y="14" width="98" height="26"/>
                         <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" borderStyle="border" tag="1" inset="2" id="1730">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="message" size="11"/>
@@ -154,7 +154,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1723">
-                        <rect key="frame" x="15" y="13" width="99" height="28"/>
+                        <rect key="frame" x="16" y="14" width="97" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="87" id="bxt-Mj-yRM"/>
                             <constraint firstAttribute="height" constant="17" id="fx7-P6-vKc"/>
@@ -204,7 +204,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="370" width="264" height="234"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="264" height="225"/>
             <value key="maxSize" type="size" width="264" height="274"/>
             <view key="contentView" id="1757">
@@ -216,7 +216,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="eRr-LP-c79">
                             <rect key="frame" x="1" y="1" width="263" height="152"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" id="1774">
                                     <rect key="frame" x="0.0" y="0.0" width="263" height="152"/>
@@ -265,7 +265,7 @@ Gw
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <button toolTip="Remove Theme" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2255">
-                                    <rect key="frame" x="30" y="0.0" width="26.5" height="25"/>
+                                    <rect key="frame" x="30" y="0.0" width="27" height="25"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" alternateImage="NSRemoveTemplate" inset="2" id="2256">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -279,7 +279,7 @@ Gw
                                     </connections>
                                 </button>
                                 <button toolTip="Duplicate Theme" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2253">
-                                    <rect key="frame" x="0.0" y="0.5" width="25.5" height="25"/>
+                                    <rect key="frame" x="0.0" y="1" width="26" height="25"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="only" alignment="center" alternateImage="NSAddTemplate" inset="2" id="2258">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -343,7 +343,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1418">
-                    <rect key="frame" x="177" y="265" width="347" height="27"/>
+                    <rect key="frame" x="178" y="266" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GTX-3c-yQF"/>
                     </constraints>
@@ -394,7 +394,7 @@ Gw
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="947">
-                    <rect key="frame" x="178" y="162" width="342" height="24"/>
+                    <rect key="frame" x="178" y="161" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="D5k-pg-HI7"/>
                     </constraints>
@@ -407,7 +407,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hMm-gH-Xw4">
-                    <rect key="frame" x="178" y="138" width="342" height="24"/>
+                    <rect key="frame" x="178" y="137" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="hzI-1g-IJw"/>
                     </constraints>
@@ -420,7 +420,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="957">
-                    <rect key="frame" x="178" y="186" width="342" height="24"/>
+                    <rect key="frame" x="178" y="185" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="GzU-Bz-1Le"/>
                     </constraints>
@@ -457,7 +457,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="569">
-                    <rect key="frame" x="177" y="337" width="347" height="27"/>
+                    <rect key="frame" x="178" y="338" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="c8F-90-8rt"/>
                         <constraint firstAttribute="height" constant="22" id="qGo-nM-5Lp"/>
@@ -484,7 +484,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="567">
-                    <rect key="frame" x="178" y="309" width="342" height="24"/>
+                    <rect key="frame" x="178" y="308" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OPe-tH-ihg"/>
                     </constraints>
@@ -497,7 +497,7 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="177" y="224" width="347" height="27"/>
+                    <rect key="frame" x="178" y="225" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="zsc-aw-Grt"/>
                     </constraints>
@@ -644,7 +644,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YpU-KB-oKj">
-                                <rect key="frame" x="177" y="5" width="222" height="27"/>
+                                <rect key="frame" x="178" y="6" width="220" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="mxo-GC-50A"/>
                                 </constraints>
@@ -725,7 +725,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zBm-kj-adR">
-                                <rect key="frame" x="393" y="-7" width="134" height="32"/>
+                                <rect key="frame" x="394" y="-7" width="132" height="31"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="I6V-7f-rdZ"/>
                                     <constraint firstAttribute="height" constant="20" id="d3f-DE-oUX"/>
@@ -815,13 +815,13 @@ Gw
             <point key="canvasLocation" x="-52" y="1050"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="512" userLabel="Tables">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="355"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="353"/>
             <userGuides>
                 <userLayoutGuide location="195" affinity="minX"/>
             </userGuides>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="950">
-                    <rect key="frame" x="178" y="183" width="342" height="24"/>
+                    <rect key="frame" x="178" y="180" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="jKC-sK-N4K"/>
                     </constraints>
@@ -834,25 +834,25 @@ Gw
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="554">
-                    <rect key="frame" x="180" y="131" width="340" height="5"/>
+                    <rect key="frame" x="180" y="129" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="9Oq-Ng-kvf"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="553">
-                    <rect key="frame" x="180" y="172" width="340" height="5"/>
+                    <rect key="frame" x="180" y="170" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="C6E-tR-dLf"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="552">
-                    <rect key="frame" x="180" y="244" width="340" height="5"/>
+                    <rect key="frame" x="180" y="242" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="XQn-Hf-WgQ"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="535">
-                    <rect key="frame" x="178" y="214" width="342" height="24"/>
+                    <rect key="frame" x="178" y="211" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="S6J-1c-jeX"/>
                         <constraint firstAttribute="height" constant="22" id="poT-TR-Yy5"/>
@@ -866,7 +866,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="532">
-                    <rect key="frame" x="180" y="102" width="340" height="22"/>
+                    <rect key="frame" x="180" y="100" width="340" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="br0-Qy-rrh"/>
                     </constraints>
@@ -880,7 +880,7 @@ Gw
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="531">
-                    <rect key="frame" x="18" y="103" width="154" height="20"/>
+                    <rect key="frame" x="18" y="101" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="qhE-Ia-yxO"/>
                     </constraints>
@@ -891,7 +891,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="520">
-                    <rect key="frame" x="295" y="143" width="175" height="22"/>
+                    <rect key="frame" x="295" y="141" width="175" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="75" id="0em-nN-sPX"/>
                         <constraint firstAttribute="height" constant="22" id="c07-Tp-IM8"/>
@@ -914,7 +914,7 @@ Gw
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="519">
-                    <rect key="frame" x="468" y="142" width="17" height="24"/>
+                    <rect key="frame" x="468" y="141" width="17" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="4O1-HE-XH8"/>
                         <constraint firstAttribute="width" constant="11" id="BgY-gn-Agc"/>
@@ -927,7 +927,7 @@ Gw
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="518">
-                    <rect key="frame" x="178" y="286" width="342" height="24"/>
+                    <rect key="frame" x="178" y="283" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="dJC-h5-h8k"/>
                     </constraints>
@@ -940,7 +940,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="517">
-                    <rect key="frame" x="178" y="142" width="112" height="24"/>
+                    <rect key="frame" x="178" y="139" width="114" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="E5b-gA-NPS"/>
                         <constraint firstAttribute="width" constant="110" id="FbY-Rf-3Kz"/>
@@ -954,7 +954,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="516">
-                    <rect key="frame" x="178" y="317" width="342" height="24"/>
+                    <rect key="frame" x="178" y="314" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="ekR-ID-Ft2"/>
                     </constraints>
@@ -967,7 +967,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="515">
-                    <rect key="frame" x="483" y="146" width="39" height="16"/>
+                    <rect key="frame" x="483" y="144" width="39" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="35" id="0fh-Y8-SkD"/>
                     </constraints>
@@ -981,7 +981,7 @@ Gw
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="514">
-                    <rect key="frame" x="18" y="319" width="154" height="20"/>
+                    <rect key="frame" x="18" y="317" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="atp-2o-EmZ"/>
                         <constraint firstAttribute="width" constant="150" id="uia-kW-GYj"/>
@@ -993,7 +993,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="513">
-                    <rect key="frame" x="178" y="255" width="342" height="24"/>
+                    <rect key="frame" x="178" y="252" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="3B8-bR-NuH"/>
                     </constraints>
@@ -1006,13 +1006,13 @@ Gw
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1467">
-                    <rect key="frame" x="180" y="90" width="340" height="5"/>
+                    <rect key="frame" x="180" y="88" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="cvo-x6-AXc"/>
                     </constraints>
                 </box>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1468">
-                    <rect key="frame" x="18" y="62" width="154" height="20"/>
+                    <rect key="frame" x="18" y="60" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="FXJ-gj-57u"/>
                     </constraints>
@@ -1023,7 +1023,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1470">
-                    <rect key="frame" x="177" y="57" width="347" height="27"/>
+                    <rect key="frame" x="178" y="56" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="8Hk-DM-XZ6"/>
                     </constraints>
@@ -1043,7 +1043,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ykf-r8-q6R">
-                    <rect key="frame" x="178" y="35" width="200" height="18"/>
+                    <rect key="frame" x="178" y="34" width="196" height="18"/>
                     <buttonCell key="cell" type="check" title="Intelligently switch at length:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="xxI-Ka-WSh">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1053,7 +1053,7 @@ Gw
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vFL-gu-iZ8">
-                    <rect key="frame" x="18" y="39" width="154" height="16"/>
+                    <rect key="frame" x="18" y="38" width="154" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Edit inline or popup:" id="59O-pr-57t">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1061,7 +1061,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="suA-e3-Xus">
-                    <rect key="frame" x="386" y="30" width="134" height="22"/>
+                    <rect key="frame" x="380" y="28" width="140" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="zNt-Ga-qF7"/>
                     </constraints>
@@ -1140,13 +1140,13 @@ Gw
             <point key="canvasLocation" x="-52" y="605.5"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="56" userLabel="Notifications">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="284"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="315"/>
             <userGuides>
-                <userLayoutGuide location="352" affinity="minX"/>
+                <userLayoutGuide location="365" affinity="minX"/>
             </userGuides>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1154">
-                    <rect key="frame" x="48" y="16" width="432" height="24"/>
+                    <rect key="frame" x="48" y="15" width="434" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="RiX-eM-1xw"/>
                     </constraints>
@@ -1160,7 +1160,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1152">
-                    <rect key="frame" x="48" y="78" width="432" height="24"/>
+                    <rect key="frame" x="48" y="77" width="434" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="lty-eG-CJ7"/>
                     </constraints>
@@ -1174,7 +1174,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1150">
-                    <rect key="frame" x="48" y="47" width="432" height="24"/>
+                    <rect key="frame" x="48" y="46" width="434" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="CuD-yl-11v"/>
                     </constraints>
@@ -1188,7 +1188,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1148">
-                    <rect key="frame" x="48" y="109" width="432" height="24"/>
+                    <rect key="frame" x="48" y="108" width="434" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="wAZ-J7-Kn8"/>
                     </constraints>
@@ -1202,7 +1202,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1143">
-                    <rect key="frame" x="18" y="137" width="462" height="24"/>
+                    <rect key="frame" x="18" y="136" width="464" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Exg-tK-o1C"/>
                     </constraints>
@@ -1215,7 +1215,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="345">
-                    <rect key="frame" x="18" y="246" width="462" height="24"/>
+                    <rect key="frame" x="18" y="276" width="464" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Lnx-83-Yt5"/>
                     </constraints>
@@ -1228,7 +1228,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="7O5-LC-aVK">
-                    <rect key="frame" x="18" y="215" width="462" height="24"/>
+                    <rect key="frame" x="18" y="245" width="464" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6fj-Ot-Cxl"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="6gV-bD-sZv"/>
@@ -1248,7 +1248,7 @@ Gw
                     </constraints>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nmG-Wb-i0O">
-                    <rect key="frame" x="18" y="184" width="462" height="24"/>
+                    <rect key="frame" x="18" y="214" width="464" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="sLt-fe-2TR"/>
                     </constraints>
@@ -1260,11 +1260,25 @@ Gw
                         <binding destination="117" name="value" keyPath="values.ShowUpdateAvailable" id="1oJ-hg-ND4"/>
                     </connections>
                 </button>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wue-rM-fp8">
+                    <rect key="frame" x="18" y="183" width="464" height="26"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="22" id="mXS-o1-Dcv"/>
+                    </constraints>
+                    <buttonCell key="cell" type="check" title="Show warning when skip-show-database is set to ON" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="ekC-Ch-sc1">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="117" name="value" keyPath="values.ShowWarningSkipShowDatabase" id="0Sk-fz-fz5"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="7O5-LC-aVK" firstAttribute="top" secondItem="345" secondAttribute="bottom" constant="9" id="4hk-QI-vYg"/>
                 <constraint firstItem="1154" firstAttribute="top" secondItem="1150" secondAttribute="bottom" constant="9" id="5xt-fT-Nra"/>
                 <constraint firstItem="7O5-LC-aVK" firstAttribute="leading" secondItem="1156" secondAttribute="leading" id="6LL-xO-Ipe"/>
+                <constraint firstItem="1156" firstAttribute="top" secondItem="wue-rM-fp8" secondAttribute="bottom" constant="12" id="8y9-U6-0ks"/>
                 <constraint firstItem="1148" firstAttribute="width" secondItem="1156" secondAttribute="width" constant="-30" id="AUV-oU-dRf"/>
                 <constraint firstItem="345" firstAttribute="top" secondItem="56" secondAttribute="top" constant="15" id="FaQ-vm-fTJ"/>
                 <constraint firstItem="nmG-Wb-i0O" firstAttribute="leading" secondItem="1156" secondAttribute="leading" id="Gtd-lM-WPR"/>
@@ -1273,6 +1287,7 @@ Gw
                 <constraint firstItem="1150" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="Lsc-pn-thj"/>
                 <constraint firstItem="1143" firstAttribute="leading" secondItem="1156" secondAttribute="leading" id="MfT-bw-sdu"/>
                 <constraint firstItem="1152" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="N41-h7-ADA"/>
+                <constraint firstItem="wue-rM-fp8" firstAttribute="leading" secondItem="1156" secondAttribute="leading" id="PW6-pm-PGb"/>
                 <constraint firstItem="1143" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="Slw-5B-F9E"/>
                 <constraint firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" constant="20" id="WYZ-zS-Rpv"/>
                 <constraint firstItem="1143" firstAttribute="top" secondItem="1156" secondAttribute="bottom" constant="12" id="Wht-jN-U7j"/>
@@ -1282,6 +1297,7 @@ Gw
                 <constraint firstItem="1150" firstAttribute="top" secondItem="1152" secondAttribute="bottom" constant="9" id="eTF-EK-Z2n"/>
                 <constraint firstItem="1154" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="gDz-zf-ZSa"/>
                 <constraint firstItem="1152" firstAttribute="top" secondItem="1148" secondAttribute="bottom" constant="9" id="pKc-k0-Baa"/>
+                <constraint firstItem="wue-rM-fp8" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="qwL-ww-iaC"/>
                 <constraint firstItem="345" firstAttribute="leading" secondItem="1156" secondAttribute="leading" id="r5i-Dc-ygG"/>
                 <constraint firstItem="nmG-Wb-i0O" firstAttribute="top" secondItem="7O5-LC-aVK" secondAttribute="bottom" constant="9" id="rZY-VQ-JlH"/>
                 <constraint firstItem="1148" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="tEh-zH-OaF"/>
@@ -1289,7 +1305,7 @@ Gw
                 <constraint firstItem="1154" firstAttribute="leading" secondItem="1148" secondAttribute="leading" id="ujG-Zl-wft"/>
                 <constraint firstItem="7O5-LC-aVK" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="vhW-dH-m4v"/>
                 <constraint firstItem="1148" firstAttribute="top" secondItem="1143" secondAttribute="bottom" constant="6" id="wbi-xL-mtz"/>
-                <constraint firstItem="1156" firstAttribute="top" secondItem="nmG-Wb-i0O" secondAttribute="bottom" constant="12" id="wcE-8E-gGf"/>
+                <constraint firstItem="wue-rM-fp8" firstAttribute="top" secondItem="nmG-Wb-i0O" secondAttribute="bottom" constant="9" id="x4k-LN-e54"/>
             </constraints>
             <point key="canvasLocation" x="751" y="153"/>
         </customView>
@@ -1341,7 +1357,7 @@ Gw
                     </connections>
                 </textField>
                 <button toolTip="Enable to send a MySQL ping to ensure the connection is kept alive if it has not been used for a while" translatesAutoresizingMaskIntoConstraints="NO" id="652">
-                    <rect key="frame" x="178" y="322" width="342" height="24"/>
+                    <rect key="frame" x="178" y="321" width="344" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="hcU-16-gmv"/>
                     </constraints>
@@ -1410,13 +1426,13 @@ Gw
                     </connections>
                 </textField>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9lg-Fd-6u7">
-                    <rect key="frame" x="180" y="40" width="340" height="160"/>
+                    <rect key="frame" x="180" y="40" width="340" height="161"/>
                     <clipView key="contentView" id="M9x-3Q-tiD">
-                        <rect key="frame" x="1" y="1" width="338" height="158"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <rect key="frame" x="1" y="1" width="338" height="159"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" id="RuH-Yq-cdH">
-                                <rect key="frame" x="0.0" y="0.0" width="338" height="158"/>
+                                <rect key="frame" x="0.0" y="0.0" width="338" height="159"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1479,7 +1495,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="3Fg-G1-BWj">
-                    <rect key="frame" x="180" y="207" width="340" height="5"/>
+                    <rect key="frame" x="180" y="208" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Woc-dz-xx3"/>
                     </constraints>
@@ -1504,7 +1520,7 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="P6m-dR-d6a">
-                    <rect key="frame" x="177" y="251" width="347" height="27"/>
+                    <rect key="frame" x="178" y="252" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="jKo-lu-g39"/>
                     </constraints>
@@ -1530,7 +1546,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Aw-q4-73u">
-                    <rect key="frame" x="18" y="180" width="154" height="20"/>
+                    <rect key="frame" x="18" y="181" width="154" height="20"/>
                     <string key="toolTip">The cipher suites are used for SSL/TLS-secured connections and specify which algorithms Sequel Ace will use to encrypt a connection, as well as their preference.
 Warning: If Sequel Ace and the server do not have at least one cipher suite in common, you will no longer be able to connect!</string>
                     <constraints>
@@ -1544,7 +1560,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5Vs-H5-Nca">
-                    <rect key="frame" x="18" y="220" width="154" height="21"/>
+                    <rect key="frame" x="18" y="221" width="154" height="20"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" title="Known Hosts:" id="dyI-8y-FNW">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1552,7 +1568,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="l1q-C8-ytL">
-                    <rect key="frame" x="177" y="216" width="347" height="27"/>
+                    <rect key="frame" x="178" y="218" width="345" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="tk9-kk-iZA"/>
                     </constraints>
@@ -1660,7 +1676,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="474" y="251" width="15" height="22"/>
+                    <rect key="frame" x="474" y="253" width="15" height="19"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1712,7 +1728,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="259" y="220" width="261" height="24"/>
+                    <rect key="frame" x="259" y="219" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="o8a-4g-ciG"/>
                     </constraints>
@@ -1725,7 +1741,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="259" y="315" width="261" height="24"/>
+                    <rect key="frame" x="259" y="314" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Nm1-1L-fkL"/>
                     </constraints>
@@ -1738,7 +1754,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="259" y="273" width="261" height="35"/>
+                    <rect key="frame" x="259" y="272" width="263" height="37"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="33" id="LMj-pz-5qi"/>
                     </constraints>
@@ -1751,7 +1767,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="259" y="346" width="261" height="24"/>
+                    <rect key="frame" x="259" y="345" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="okU-1B-JWL"/>
                     </constraints>
@@ -1764,7 +1780,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="259" y="408" width="261" height="24"/>
+                    <rect key="frame" x="259" y="407" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="QM4-7n-4Uf"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YuJ-Px-Th2"/>
@@ -1790,7 +1806,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="373" y="444" width="114" height="32"/>
+                    <rect key="frame" x="374" y="444" width="112" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="Z6f-Ex-CfK"/>
                     </constraints>
@@ -1940,7 +1956,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="259" y="377" width="93" height="24"/>
+                    <rect key="frame" x="259" y="376" width="89" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="OaX-My-oPP"/>
                     </constraints>
@@ -1953,7 +1969,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="357" y="378" width="151" height="22"/>
+                    <rect key="frame" x="351" y="378" width="157" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -1971,7 +1987,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="507" y="377" width="15" height="22"/>
+                    <rect key="frame" x="507" y="379" width="15" height="19"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -1985,7 +2001,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="259" y="189" width="261" height="24"/>
+                    <rect key="frame" x="259" y="188" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="NJU-0g-hK3"/>
                     </constraints>
@@ -1998,7 +2014,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="259" y="158" width="261" height="24"/>
+                    <rect key="frame" x="259" y="157" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="LQ3-Eq-hy0"/>
                     </constraints>
@@ -2028,7 +2044,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="474" y="105" width="15" height="22"/>
+                    <rect key="frame" x="474" y="107" width="15" height="19"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
@@ -2080,7 +2096,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="259" y="127" width="261" height="24"/>
+                    <rect key="frame" x="259" y="126" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="JL1-kC-qdF"/>
                     </constraints>
@@ -2093,7 +2109,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="259" y="74" width="261" height="24"/>
+                    <rect key="frame" x="259" y="73" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Hbi-dI-piB"/>
                     </constraints>
@@ -2106,7 +2122,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="259" y="43" width="261" height="24"/>
+                    <rect key="frame" x="259" y="42" width="263" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="Vdm-3z-iY0"/>
                     </constraints>
@@ -2149,7 +2165,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="507" y="13" width="15" height="22"/>
+                    <rect key="frame" x="507" y="15" width="15" height="19"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2297,7 +2313,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hEB-5Q-jZ8">
-                    <rect key="frame" x="276" y="16" width="134" height="32"/>
+                    <rect key="frame" x="277" y="16" width="132" height="31"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="120" id="LCk-ny-bZd"/>
                         <constraint firstAttribute="height" constant="20" id="Xvw-M5-qBT"/>
@@ -2329,7 +2345,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bAQ-gF-4V2">
-                    <rect key="frame" x="16" y="18" width="275" height="18"/>
+                    <rect key="frame" x="16" y="17" width="277" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="1gs-sa-Z6Q"/>
                     </constraints>
@@ -2365,7 +2381,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             </userGuides>
             <subviews>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YVZ-mE-SYx">
-                    <rect key="frame" x="437" y="8" width="90" height="34"/>
+                    <rect key="frame" x="430" y="8" width="96" height="33"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="sC9-8y-2jy"/>
                     </constraints>
@@ -2451,7 +2467,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jKz-jR-d80">
-                    <rect key="frame" x="271" y="8" width="166" height="34"/>
+                    <rect key="frame" x="256" y="8" width="172" height="33"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="fOZ-7m-1BD"/>
                     </constraints>
@@ -2464,7 +2480,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="C8B-BP-39F">
-                    <rect key="frame" x="18" y="14" width="254" height="23"/>
+                    <rect key="frame" x="18" y="14" width="238" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="23" id="p5V-R8-dvE"/>
                     </constraints>
@@ -2498,9 +2514,9 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
         </customView>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSAdvanced" width="32" height="32"/>
-        <image name="NSRemoveTemplate" width="14" height="4"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="resetTemplate" width="16" height="16"/>
     </resources>
 </document>

--- a/Resources/Localization/de.lproj/Localizable.strings
+++ b/Resources/Localization/de.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/de.lproj/Localizable.strings
+++ b/Resources/Localization/de.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/es-ES.lproj/Localizable.strings
+++ b/Resources/Localization/es-ES.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/es-ES.lproj/Localizable.strings
+++ b/Resources/Localization/es-ES.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/es.lproj/Localizable.strings
+++ b/Resources/Localization/es.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/es.lproj/Localizable.strings
+++ b/Resources/Localization/es.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/pt.lproj/Localizable.strings
+++ b/Resources/Localization/pt.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/pt.lproj/Localizable.strings
+++ b/Resources/Localization/pt.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "You are currently running the latest release.";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "你当前运行的已经是最新版本";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "你当前运行的已经是最新版本";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -3302,3 +3302,6 @@
 
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "目前的版本已經是最新版。";
+
+/* Alert button, disable the warnng when skip-show-database is set to on */
+"Disable the warning" = "Disable the warning";

--- a/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -3303,5 +3303,5 @@
 /* Info alert message when there are Newer Releases Available */
 "You are currently running the latest release." = "目前的版本已經是最新版。";
 
-/* Alert button, disable the warnng when skip-show-database is set to on */
-"Disable the warning" = "Disable the warning";
+/* Alert button, disable the warning when skip-show-database is set to on */
+"Never show this again" = "Never show this again";

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -209,6 +209,8 @@
 	<false/>
 	<key>ShowWarningBeforeExecuteQuery</key>
 	<false/>
+	<key>ShowWarningSkipShowDatabase</key>
+	<true/>
 	<key>ShowUpdateAvailable</key>
 	<true/>
 	<key>NSApplicationCrashOnExceptions</key>

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -446,7 +446,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                 [NSAlert createAlertWithTitle:NSLocalizedString(@"Warning",@"warning")
                                       message:NSLocalizedString(@"The skip-show-database variable of the database server is set to ON. Thus, you won't be able to list databases unless you have the SHOW DATABASES privilege.\n\nHowever, the databases are still accessible directly through SQL queries depending on your privileges.", @"Warning message during connection in case the variable skip-show-database is set to ON")
                            primaryButtonTitle:NSLocalizedString(@"OK", @"OK button")
-                         secondaryButtonTitle:NSLocalizedString(@"Disable the warning", @"Disable the warning")
+                         secondaryButtonTitle:NSLocalizedString(@"Never show this again", @"Never show this again")
                          primaryButtonHandler:^{ }
                        secondaryButtonHandler:^{ [self->prefs setBool:false forKey:SPShowWarningSkipShowDatabase]; }
                  ];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -437,12 +437,20 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [mySQLConnection setEncoding:@"utf8mb4"];
 
     // Check if skip-show-database is set to ON
-    SPMySQLResult *result = [mySQLConnection queryString:@"SHOW VARIABLES LIKE 'skip_show_database'"];
-    [result setReturnDataAsStrings:YES];
-    if(![mySQLConnection queryErrored] && [result numberOfRows] == 1) {
-        NSString *skip_show_database = [[result getRowAsDictionary] objectForKey:@"Value"];
-        if ([skip_show_database.lowercaseString isEqualToString:@"on"]) {
-            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Warning",@"warning") message:NSLocalizedString(@"The skip-show-database variable of the database server is set to ON. Thus, you won't be able to list databases unless you have the SHOW DATABASES privilege.\n\nHowever, the databases are still accessible directly through SQL queries depending on your privileges.", @"Warning message during connection in case the variable skip-show-database is set to ON") callback:nil];
+    if ( [prefs boolForKey:SPShowWarningSkipShowDatabase] ) {
+        SPMySQLResult *result = [mySQLConnection queryString:@"SHOW VARIABLES LIKE 'skip_show_database'"];
+        [result setReturnDataAsStrings:YES];
+        if(![mySQLConnection queryErrored] && [result numberOfRows] == 1) {
+            NSString *skip_show_database = [[result getRowAsDictionary] objectForKey:@"Value"];
+            if ([skip_show_database.lowercaseString isEqualToString:@"on"]) {
+                [NSAlert createAlertWithTitle:NSLocalizedString(@"Warning",@"warning")
+                                      message:NSLocalizedString(@"The skip-show-database variable of the database server is set to ON. Thus, you won't be able to list databases unless you have the SHOW DATABASES privilege.\n\nHowever, the databases are still accessible directly through SQL queries depending on your privileges.", @"Warning message during connection in case the variable skip-show-database is set to ON")
+                           primaryButtonTitle:NSLocalizedString(@"OK", @"OK button")
+                         secondaryButtonTitle:NSLocalizedString(@"Disable the warning", @"Disable the warning")
+                         primaryButtonHandler:^{ }
+                       secondaryButtonHandler:^{ [self->prefs setBool:false forKey:SPShowWarningSkipShowDatabase]; }
+                 ];
+            }
         }
     }
 

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -335,6 +335,7 @@ extern NSString *SPFavorites;
 // Notifications Prefpane
 extern NSString *SPQueryWarningEnabled;
 extern NSString *SPShowNoAffectedRowsError;
+extern NSString *SPShowWarningSkipShowDatabase;
 extern NSString *SPConsoleEnableLogging;
 extern NSString *SPConsoleEnableInterfaceLogging;
 extern NSString *SPConsoleEnableCustomQueryLogging;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -143,6 +143,7 @@ NSString *SPQueryWarningEnabled                  = @"ShowWarningBeforeExecuteQue
 NSString *SPQueryWarningEnabledSuppressed        = @"SPQueryWarningEnabledSuppressed";
 NSString *SPShowUpdateAvailable                  = @"ShowUpdateAvailable";
 NSString *SPShowNoAffectedRowsError              = @"ShowNoAffectedRowsError";
+NSString *SPShowWarningSkipShowDatabase          = @"ShowWarningSkipShowDatabase";
 NSString *SPConsoleEnableLogging                 = @"ConsoleEnableLogging";
 NSString *SPConsoleEnableInterfaceLogging        = @"ConsoleEnableInterfaceLogging";
 NSString *SPConsoleEnableCustomQueryLogging      = @"ConsoleEnableCustomQueryLogging";


### PR DESCRIPTION
## Changes:
- Add button "Disable the warning" in the NSAlert when "skip-show-database" is "on"  
- Add new entry in "Preferences" --> "Alerts & Logs" to enable/disable the warning 

## Closes:
Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/1000

## Tested:
- Processors:
  - [X] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [X] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.4 (12D4e)
  
## Screenshots:

## Additional notes:
