### PR TITLE
#fixed crash starting to edit NULL value of SPTableView in DEBUG

### DIFF
--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -1291,8 +1291,9 @@ static const NSInteger kBlobAsImageFile = 4;
 	if ([cellValue isKindOfClass:[NSData class]]) {
 		cellValue = [[NSString alloc] initWithData:cellValue encoding:[mySQLConnection stringEncoding]];
 	}
-
-    SPLog(@"cellValue len = %lu", (unsigned long)[cellValue length]);
+    if (![cellValue isNSNull]) {
+        SPLog(@"cellValue len = %lu", (unsigned long)[cellValue length]);
+    }
 
 	if (![cellValue isNSNull]
 		&& [columnType isEqualToString:@"string"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Fix crash when user is start to edit NULL value of SPTableView if DEBUG flag is enabled (ex. launch from Xcode)

## Closes following issues:
- Closes: #1061

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.5
  
## Screenshots:

See #1061

## Additional notes:
