### PR TITLE
Fix German translation for "truncate" operations

### DIFF
--- a/Resources/Localization/de.lproj/Localizable.strings
+++ b/Resources/Localization/de.lproj/Localizable.strings
@@ -431,7 +431,7 @@
 "An error occurred while trying to reset AUTO_INCREMENT of table '%@'.\n\nMySQL said: %@" = "Beim Zurücksetzen von AUTO_INCREMENT der Tabelle '%1$@' trat ein Fehler auf.\n\nMySQL Ergebnis: %2$@";
 
 /* error truncating table informative message */
-"An error occurred while trying to truncate the table '%@'.\n\nMySQL said: %@" = "Beim Verkürzen der Tabelle '%1$@' trat ein Fehler auf.\n\nMySQL Ergebnis: %2$@";
+"An error occurred while trying to truncate the table '%@'.\n\nMySQL said: %@" = "Beim Leeren der Tabelle '%1$@' trat ein Fehler auf.\n\nMySQL Ergebnis: %2$@";
 
 /* mysql error occurred informative message */
 "An error occurred whilst trying to perform the operation.\n\nMySQL said: %@" = "Bei der Ausführung trat ein Fehler auf.\n\nMySQL Ergebnis: %@";
@@ -1221,7 +1221,7 @@
 "Error retrieving trigger information" = "Fehler beim Abruf der Trigger-Information";
 
 /* error truncating table message */
-"Error truncating table" = "Fehler beim Einkürzen der Tabelle";
+"Error truncating table" = "Fehler beim Leeren der Tabelle";
 
 /* error updating keychain item message */
 "Error updating Keychain item" = "Fehler bei der Aktualisierung des Schlüsselbundes";
@@ -2882,19 +2882,19 @@ Befehle werden anwendungsweit ausgeführt";
 "Triggers for table: %@" = "Auslöser für Tabelle: % @";
 
 /* truncate button */
-"Truncate" = "Webformular-Eingabetabellen kürzen.";
+"Truncate" = "Leeren";
 
 /* truncate tables message */
 "Truncate selected tables?" = "Ausgewählte Tabellen abschneiden?";
 
 /* truncate table menu title */
-"Truncate Table..." = "Tabelle wird eingekürzt …";
+"Truncate Table..." = "Tabelle leeren...";
 
 /* truncate table message */
-"Truncate table '%@'?" = "Tabelle wird eingekürzt …";
+"Truncate table '%@'?" = "Tabelle '%@' leeren?";
 
 /* truncate tables menu item */
-"Truncate Tables" = "Abgeschnittene Tabellen";
+"Truncate Tables" = "Tabellen leeren";
 
 /* type label (Navigator) */
 "Type" = "Typ";


### PR DESCRIPTION
Das englische Wort "truncate" wurde im Zusammenhang mit dem Leeren von Tabellen fälschlicherweise mit "einkürzen" übersetzt.

In anderen Stellen der Übersetzung ist das korrekt, z.B. dort, wo Strings abgeschnitten werden, jedoch meint "truncate" hier klar das leeren von Tabellen.