### PR TITLE
Retain secure bookmark access while app is active #changed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1981,8 +1981,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	if (sshTunnel) {
 		[sshTunnel setConnectionStateChangeSelector:nil delegate:nil];
 	}
-	
-    [SecureBookmarkManager.sharedInstance stopAllSecurityScopedAccess];
+
 
 }
 
@@ -3661,7 +3660,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
     [self removeObserver:self forKeyPath:SPFavoriteSSLCACertFileLocationKey];
     [self removeObserver:self forKeyPath:SPBookmarksChangedNotification];
 
-    [SecureBookmarkManager.sharedInstance stopAllSecurityScopedAccess];
 
 	[self setConnectionKeychainID:nil];
 

--- a/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
@@ -182,7 +182,6 @@
 - (void)dealloc
 {
     SPLog(@"dealloc");
-    [SecureBookmarkManager.sharedInstance stopAllSecurityScopedAccess]; // FIXME: not sure about this... just because this pane is deallocated, we don't need to revoke access?
 }
 
 - (void)_refreshBookmarks{

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -74,7 +74,6 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 {
     SPLog(@"dealloc");
     [self removeObserver:self forKeyPath:SPBookmarksChangedNotification];
-    [SecureBookmarkManager.sharedInstance stopAllSecurityScopedAccess];
 }
 
 - (void)_refreshBookmarks{

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1691,6 +1691,9 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self removeObserver:self forKeyPath:SPShowUpdateAvailable];
+    if(SecureBookmarkManager.sharedInstance != nil) {
+        [SecureBookmarkManager.sharedInstance stopAllSecurityScopedAccess];
+    }
 
 }
 


### PR DESCRIPTION
## Changes:
- Retain secure bookmark access while app is active instead of stopping access any time we stop doing one of many things. My hunch is perhaps we are stopping access to the bookmarks when we shouldn't be, causing the export folder errors. This PR changes the process to only stop accessing when the app controller is being deallocated.

I couldn't reproduce the export writability error, but this seems like a safe attempt at addressing a potential race condition with release of bookmarks.

## Closes following issues:
- Closes: Maybe #1070

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
