### PR TITLE
Fix copy create table syntax always disabled #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -469,7 +469,7 @@
 
 - (void)focusOnTableContentFilter;
 - (void)showFilterTable;
-- (void)copyCreateTableSyntax;
+- (void)copyCreateTableSyntax:(SPDatabaseDocument *)sender;
 - (void)showCreateTableSyntax:(SPDatabaseDocument *)sender;
 - (void)checkTable;
 - (void)repairTable;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1793,7 +1793,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 /**
  * Copies the CREATE TABLE syntax of the selected table to the pasteboard.
  */
-- (void)copyCreateTableSyntax {
+- (void)copyCreateTableSyntax:(SPDatabaseDocument *)sender {
     [self showCreateTableSyntax:self];
 
     return;

--- a/Source/Controllers/SPAppController.swift
+++ b/Source/Controllers/SPAppController.swift
@@ -166,7 +166,7 @@ extension SPAppController {
     }
 
     @IBAction func copyCreateTableSyntax(_ sender: Any) {
-        tabManager.activeWindowController?.databaseDocument.copyCreateTableSyntax()
+        tabManager.activeWindowController?.databaseDocument.copyCreateTableSyntax(nil)
     }
 
     @IBAction func showCreateTableSyntax(_ sender: Any) {


### PR DESCRIPTION
## Changes:
- Fixes the Copy Create Table Syntax option always showing disabled in the table list and nav bar

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
