### PR TITLE
Options when Deleting All Rows from Table #added

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -978,9 +978,6 @@
 /* delete table/view message */
 "Delete %@ '%@'?" = "Delete %1$@ '%2$@'?";
 
-/* delete all rows message */
-"Delete all rows?" = "Delete all rows?";
-
 /* table structure : indexes : delete index : error 1553 : delete index and FK button */
 "Delete Both" = "Delete Both";
 
@@ -2188,7 +2185,16 @@
 "Requires 8 bytes storage space. M is the optional display width and does not affect the possible value range. Note: Arithmetic operations might fail for large numbers." = "Requires 8 bytes storage space. M is the optional display width and does not affect the possible value range. Note: Arithmetic operations might fail for large numbers.";
 
 /* reset auto_increment after deletion of all rows message */
-"Reset AUTO_INCREMENT after deletion?" = "Reset AUTO_INCREMENT after deletion?";
+"Reset AUTO_INCREMENT after deletion\n(only for Delete ALL ROWS IN TABLE)?" = "Reset AUTO_INCREMENT after deletion\n(only for Delete ALL ROWS IN TABLE)?";
+
+/* delete selected row button */
+"Delete Selected Row" = "Delete Selected Row";
+
+/* delete selected rows button */
+"Delete Selected Rows" = "Delete Selected Rows";
+
+/* delete all rows in table button */
+"Delete ALL ROWS IN TABLE" = "Delete ALL ROWS IN TABLE";
 
 /* Restoring session task description */
 "Restoring session..." = "Restoring session...";

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1829,10 +1829,10 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 	BOOL queryWarningEnabled = [prefs boolForKey:SPQueryWarningEnabled];
 	BOOL queryWarningEnabledSuppressed = [prefs boolForKey:SPQueryWarningEnabledSuppressed];
-    BOOL isDeleteRowsRequest = alertReturnCode == NSAlertFirstButtonReturn;
-    BOOL isDeleteAllRequest = allowDeletingAllRows && alertReturnCode == NSAlertSecondButtonReturn;
+    BOOL isDeleteSomeRowsRequest = alertReturnCode == NSAlertFirstButtonReturn;
+    BOOL isDeleteAllRowsRequest = allowDeletingAllRows && alertReturnCode == NSAlertSecondButtonReturn;
 
-    BOOL __block retCode = (isDeleteRowsRequest || isDeleteAllRequest);
+    BOOL __block retCode = (isDeleteSomeRowsRequest || isDeleteAllRowsRequest);
 
 	if (retCode == YES && queryWarningEnabled == YES && queryWarningEnabledSuppressed == NO) {
         [NSAlert createDefaultAlertWithSuppressionWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Double Check", @"Double Check")] message:@"Double checking as you have 'Show warning before executing a query' set in Preferences" suppressionKey:SPQueryWarningEnabledSuppressed primaryButtonTitle:NSLocalizedString(@"Proceed", @"Proceed") primaryButtonHandler:^{
@@ -1853,7 +1853,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		return;
 	}
 
-	if (isDeleteAllRequest) {
+	if (isDeleteAllRowsRequest) {
         // Check if the user is currently editing a row, and revert to ensure a somewhat
         // consistent state if deletion fails.
         if (isEditingRow) [self cancelRowEditing];
@@ -1883,7 +1883,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
                     nil]
                 afterDelay:0.3];
         }
-	} else if (isDeleteRowsRequest) {
+	} else if (isDeleteSomeRowsRequest) {
         [selectedRows addIndexes:[tableContentView selectedRowIndexes]];
 
         //check if the user is currently editing a row

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1763,9 +1763,10 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// cancel editing (maybe this is not the ideal method -- see xcode docs for that method)
 	[[tableDocumentInstance parentWindowControllerWindow] endEditingFor:nil];
 
+    if (![tableContentView numberOfSelectedRows]) return;
+
     BOOL allowDeletingAllRows = ([tableContentView numberOfSelectedRows] == [tableContentView numberOfRows]) && !isFiltered && !isLimited && !isInterruptedLoad && !isEditingNewRow;
 
-	if (![tableContentView numberOfSelectedRows]) return;
 
 	NSAlert *alert = [[NSAlert alloc] init];
     if ([tableContentView numberOfSelectedRows] == 1) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Added an option to delete only the selected rows even when all rows in a table are selected (instead of forcing you to run a delete all from table command)

## Closes following issues:
- Closes: #1054

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
<img width="260" alt="Screen Shot 2021-06-01 at 16 51 16" src="https://user-images.githubusercontent.com/10710367/120403829-d8825f00-c2f9-11eb-97d0-afb7f7ca9b26.png">


## Additional notes:
