### PR TITLE
Manually Granted Files should NOT be readonly

### DIFF
--- a/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
@@ -99,7 +99,7 @@
         options.canChooseDirectories = YES;
         options.isForStaleBookmark = YES;
         options.isForKnownHostsFile = NO;
-        options.bookmarkCreationOptions = (NSURLBookmarkCreationWithSecurityScope|NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess);
+        options.bookmarkCreationOptions = (NSURLBookmarkCreationWithSecurityScope);
         options.title = NSLocalizedString(@"Please re-select the file '%@' in order to restore Sequel Ace's access.", "Title for Stale Bookmark file selection dialog");
 
         BOOL __block match = NO;
@@ -381,7 +381,7 @@ thus we get an index set with number of indexes: 3 (in 1 ranges), indexes: (3-5)
     options.isForKnownHostsFile = NO;
     options.title = NSLocalizedString(@"Please choose a file or folder to grant Sequel Ace access to.", "Please choose a file or folder to grant Sequel Ace access to.");
     options.fileNames = nil;
-    options.bookmarkCreationOptions = (NSURLBookmarkCreationWithSecurityScope|NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess);
+    options.bookmarkCreationOptions = (NSURLBookmarkCreationWithSecurityScope);
 
     SPLog(@"calling chooseFileWithOptions: %@", [options jsonStringWithPrettyPrint:YES]);
     


### PR DESCRIPTION
## Changes:
- It looks like manually granted files (in the files tab) were readonly, so after the app quit we could no longer write to those dirs
- Additionally, looks like anytime a bookmark became stale, renewed access was readonly 

## Closes following issues:
- Closes: #1070, #1107
- *The only issue is there isn't a nice cleanup for old readonly bookmarks, right now they have to be manually removed and re-created. Confirmed it fixes though!

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
