### PR TITLE
#fixed Loading table contents when user is restricted to a subset of columns 

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2890,15 +2890,21 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 {
     NSMutableArray *fields = [NSMutableArray arrayWithCapacity:[dataColumns count]];
     NSString *fieldName;
+    NSNumber *selectable;
 
     if ([dataColumns count]) {
-        bool lazyLoad = [prefs boolForKey:SPLoadBlobsAsNeeded];
+        BOOL lazyLoad = [prefs boolForKey:SPLoadBlobsAsNeeded];
 
         for (NSDictionary* field in dataColumns) {
             fieldName = [field objectForKey:@"name"];
-            if (lazyLoad && [tableDataInstance columnIsBlobOrText: fieldName]) {
+            selectable = [field objectForKey:@"selectable"];
+            if ([selectable isLessThan:@YES]) {
                 [fields addObject:@"NULL"];
-            } else {
+            }
+            else if (lazyLoad && [tableDataInstance columnIsBlobOrText: fieldName]) {
+                [fields addObject:@"NULL"];
+            }
+            else {
                 [fields addObject:[fieldName backtickQuotedString]];
             }
         }

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2888,26 +2888,23 @@ static void *TableContentKVOContext = &TableContentKVOContext;
  */
 - (NSString *)fieldListForQuery
 {
-	if (([prefs boolForKey:SPLoadBlobsAsNeeded]) && [dataColumns count]) {
+    NSMutableArray *fields = [NSMutableArray arrayWithCapacity:[dataColumns count]];
+    NSString *fieldName;
 
-		NSMutableArray *fields = [NSMutableArray arrayWithCapacity:[dataColumns count]];
-		BOOL tableHasBlobs = NO;
-		NSString *fieldName;
+    if ([dataColumns count]) {
+        bool lazyLoad = [prefs boolForKey:SPLoadBlobsAsNeeded];
 
-		for (NSDictionary* field in dataColumns)
-			if (![tableDataInstance columnIsBlobOrText:fieldName = [field objectForKey:@"name"]] )
-				[fields addObject:[fieldName backtickQuotedString]];
-			else {
-				// For blob/text fields, select a null placeholder so the column count is still correct
-				[fields addObject:@"NULL"];
-				tableHasBlobs = YES;
-			}
+        for (NSDictionary* field in dataColumns) {
+            fieldName = [field objectForKey:@"name"];
+            if (lazyLoad && [tableDataInstance columnIsBlobOrText: fieldName]) {
+                [fields addObject:@"NULL"];
+            } else {
+                [fields addObject:[fieldName backtickQuotedString]];
+            }
+        }
+    }
 
-		return (tableHasBlobs) ? [fields componentsJoinedByString:@", "] : @"*";
-
-	}
-		return @"*";
-
+    return [fields count] ? [fields componentsJoinedByString:@", "] : @"*";
 }
 
 /**


### PR DESCRIPTION
## Changes:
- Always use column names to select data for contents view

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: `12.5 (12E262)`


## Additional notes:
MySQL (5.6 tested not sure about newer versions) does not allow `SELECT *` if the user does not have access to all of the tables' columns, you get the following error:
`MySQL said: SELECT command denied to user 'user'@'ip' for table 'table_name'`

By supplying the known allowed columns the allowed data can be loaded in the content tab.
