### PR TITLE
Fixed buggy behavior when trying to edit a generated column #fixed

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3311,3 +3311,6 @@
 
 /* Alert button, disable the warning when skip-show-database is set to on */
 "Never show this again" = "Never show this again";
+
+/* Info alert when editing a generated column */
+"The current field is a generated column, you cannot edit it!" = "The current field is a generated column, you cannot edit it!";

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4113,7 +4113,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		}
 
         // Field is not editable if it is a generated columun.
-        if ([tableContentView shouldNotEditGeneratedFieldForColumn:[[tableColumn identifier] integerValue]]) {
+        if (![tableContentView isColumnEditable:[[tableColumn identifier] integerValue]]) {
             [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Error", @"error") message:NSLocalizedString(@"The current field is a generated column, you cannot edit it!", @"Info alert when editing a generated column") callback:nil];
             return NO;
         }

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2677,6 +2677,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 							 cancelButtonHandler:^{
 				SPLog(@"Cancel pressed");
 				self->isEditingRow = NO;
+                self->isSavingRow = NO;
 				self->currentlyEditingRow = -1;
 				// reload
 				[self loadTableValues];
@@ -2686,6 +2687,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		else{
 			SPLog(@"No query string");
 			isEditingRow = NO;
+            isSavingRow = NO;
 			currentlyEditingRow = -1;
 			// reload
 			[self loadTableValues];
@@ -2700,6 +2702,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
         } else {
             SPLog(@"No query string");
             isEditingRow = NO;
+            isSavingRow = NO;
             currentlyEditingRow = -1;
             // reload
             [self loadTableValues];
@@ -4109,8 +4112,14 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			[tableContentView reloadData];
 		}
 
-		// Retrieve the column definition
-		NSDictionary *columnDefinition = [cqColumnDefinition objectAtIndex:[[tableColumn identifier] integerValue]];
+        // Field is not editable if it is a generated columun.
+        if ([tableContentView shouldNotEditGeneratedFieldForColumn:[[tableColumn identifier] integerValue]]) {
+            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Error", @"error") message:NSLocalizedString(@"The current field is a generated column, you cannot edit it!", @"Info alert when editing a generated column") callback:nil];
+            return NO;
+        }
+
+        // Retrieve the column definition
+        NSDictionary *columnDefinition = [cqColumnDefinition objectAtIndex:[[tableColumn identifier] integerValue]];
 
 		// Open the editing sheet if required
 		if ([tableContentView shouldUseFieldEditorForRow:rowIndex column:[[tableColumn identifier] integerValue] checkWithLock:NULL]) {

--- a/Source/Views/TableViews/SPCopyTable.h
+++ b/Source/Views/TableViews/SPCopyTable.h
@@ -204,7 +204,7 @@ extern NSInteger SPEditMenuCopyAsSQLNoAutoInc;
 */
 - (BOOL)shouldUseFieldEditorForRow:(NSUInteger)rowIndex column:(NSUInteger)colIndex checkWithLock:(pthread_mutex_t *)dataLock;
 
-- (BOOL)shouldNotEditGeneratedFieldForColumn:(NSUInteger)colIndex;
+- (BOOL)isColumnEditable:(NSUInteger)colIndex;
 
 - (IBAction)executeBundleItemForDataTable:(id)sender;
 

--- a/Source/Views/TableViews/SPCopyTable.h
+++ b/Source/Views/TableViews/SPCopyTable.h
@@ -204,6 +204,8 @@ extern NSInteger SPEditMenuCopyAsSQLNoAutoInc;
 */
 - (BOOL)shouldUseFieldEditorForRow:(NSUInteger)rowIndex column:(NSUInteger)colIndex checkWithLock:(pthread_mutex_t *)dataLock;
 
+- (BOOL)shouldNotEditGeneratedFieldForColumn:(NSUInteger)colIndex;
+
 - (IBAction)executeBundleItemForDataTable:(id)sender;
 
 - (void)selectTableRows:(NSArray*)rowIndices;

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -1315,22 +1315,22 @@ static const NSInteger kBlobAsImageFile = 4;
 }
 
 /**
- * Determine whether to use the sheet for editing; do so if the multipleLineEditingButton is enabled,
- * or if the column was a blob or a text, or if it contains linebreaks.
+ * Determine whether the column can be editable or not.
  */
-- (BOOL)shouldNotEditGeneratedFieldForColumn:(NSUInteger)colIndex
+- (BOOL)isColumnEditable:(NSUInteger)colIndex
 {
     // Retrieve the column definition
     NSDictionary *columnDefinition = [[(id <SPDatabaseContentViewDelegate>)[self delegate] dataColumnDefinitions] objectAtIndex:colIndex];
-    NSString *generatedalways = [columnDefinition objectForKey:@"generatedalways"];
 
+    // Generated column is not editable
+    NSString *generatedalways = [columnDefinition objectForKey:@"generatedalways"];
     if (generatedalways) {
         SPLog(@"got a generated column");
-        return YES;
+        return NO;
     }
 
-    // Otherwise, not a generated field
-    return NO;
+    // Otherwise, it's editable
+    return YES;
 }
 
 #pragma mark -

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -1314,6 +1314,25 @@ static const NSInteger kBlobAsImageFile = 4;
 	return NO;
 }
 
+/**
+ * Determine whether to use the sheet for editing; do so if the multipleLineEditingButton is enabled,
+ * or if the column was a blob or a text, or if it contains linebreaks.
+ */
+- (BOOL)shouldNotEditGeneratedFieldForColumn:(NSUInteger)colIndex
+{
+    // Retrieve the column definition
+    NSDictionary *columnDefinition = [[(id <SPDatabaseContentViewDelegate>)[self delegate] dataColumnDefinitions] objectAtIndex:colIndex];
+    NSString *generatedalways = [columnDefinition objectForKey:@"generatedalways"];
+
+    if (generatedalways) {
+        SPLog(@"got a generated column");
+        return YES;
+    }
+
+    // Otherwise, not a generated field
+    return NO;
+}
+
 #pragma mark -
 #pragma mark Bundle Command Support
 


### PR DESCRIPTION
## fixed:
- Fix the issue #1155 
It was'nt so easy to precisely reproduce the issue and find what was wrong, but finally the fix was easy.

2 things : 
- I added an alert view when the user tries to edit a generated column. The alert occurs only  when the user modifies a first generated field.
- This issue already existed in at least one case (Solved in this PR too) : 
   - Preferences --> Alerts & Logs --> Check "Show warning before executing a query"
   - Start to edit a field value
   - Click on another table name in the left panel
   - An alert view ask you if you want to edit the row. Say Cancel
   - same issue...

Closes: #1159 

## Tested:
- Processors:
  - [X] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [X] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:12.5.1 (12E507)
  
