### PR TITLE
Fix character counts for multi-byte strings #fixed

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -661,8 +661,8 @@ typedef enum {
         NSTextStorage *editTVtextStorage = [editTextView textStorage];
         NSString *editTVString = [editTVtextStorage string];
         
-		if (maxLength > 0 && [[editTVtextStorage string] characterCount] > (NSInteger)maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
-			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [[editTVtextStorage string] characterCount] - (NSUInteger)maxLength)];
+		if (maxLength > 0 && [editTVString characterCount] > (NSInteger)maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
+			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [editTVString characterCount] - (NSUInteger)maxLength)];
 			[editTextView scrollRangeToVisible:NSMakeRange([editTextView selectedRange].location,0)];
 			[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Text is too long. Maximum text length is set to %llu.", @"Text is too long. Maximum text length is set to %llu."), maxTextLength]];
 			

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -661,8 +661,8 @@ typedef enum {
         NSTextStorage *editTVtextStorage = [editTextView textStorage];
         NSString *editTVString = [editTVtextStorage string];
         
-		if (maxLength > 0 && [editTVtextStorage length] > maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
-			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [editTVtextStorage length] - (NSUInteger)maxLength)];
+		if (maxLength > 0 && [[editTVtextStorage string] characterCount] > (NSInteger)maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
+			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [[editTVtextStorage string] characterCount] - (NSUInteger)maxLength)];
 			[editTextView scrollRangeToVisible:NSMakeRange([editTextView selectedRange].location,0)];
 			[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Text is too long. Maximum text length is set to %llu.", @"Text is too long. Maximum text length is set to %llu."), maxTextLength]];
 			
@@ -1268,8 +1268,8 @@ typedef enum {
  */
 - (BOOL)textView:(NSTextView *)textView shouldChangeTextInRange:(NSRange)r replacementString:(NSString *)replacementString
 {
-    if (replacementString == nil) {
-        return NO;
+    if (replacementString == nil || [replacementString characterCount] == 0) {
+        return YES;
     }
     
 	if (textView == editTextView && 
@@ -1294,7 +1294,7 @@ typedef enum {
 		if ([textView hasMarkedText] && (maxTextLength > 0) && (r.location < maxTextLength)) {
 
 			// User tries to insert a new char but max text length was already reached - return NO
-			if (!r.length && ([[textView textStorage] length] >= maxTextLength)) {
+			if (!r.length && ([[[textView textStorage] string] characterCount] >= (NSInteger)maxTextLength)) {
 				[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu.", @"Maximum text length is set to %llu."), maxTextLength]];
 				[textView unmarkText];
 				
@@ -1312,9 +1312,9 @@ typedef enum {
 		}
 
 		// Calculate the length of the text after the change.
-		newLength = [[[textView textStorage] string] length] + [replacementString length] - r.length;
+		newLength = [[[textView textStorage] string] characterCount] + [replacementString characterCount] - r.length;
 
-		NSUInteger textLength = [[[textView textStorage] string] length];
+		NSUInteger textLength = [[[textView textStorage] string] characterCount];
 		
 		unsigned long long originalMaxTextLength = maxTextLength;
 		
@@ -1334,7 +1334,7 @@ typedef enum {
 		// If it's too long, disallow the change but try
 		// to insert a text chunk partially to maxTextLength.
 		if ((NSUInteger)newLength > maxTextLength) {
-			if ((maxTextLength - textLength + [textView selectedRange].length) <= [replacementString length]) {	
+			if ((maxTextLength - textLength + [textView selectedRange].length) <= [replacementString characterCount]) {
 			
 				NSString *tooltip = nil;
 				

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -199,6 +199,11 @@ extension String {
 		return (self as String).dropPrefix(prefix as String) as NSString
 	}
 
+
+    public func characterCount() -> Int {
+        return (self as String).count;
+    }
+
 	public func dropSuffix(suffix: NSString) -> NSString {
 		return (self as String).dropSuffix(suffix as String) as NSString
 	}

--- a/Source/Views/SPDataCellFormatter.m
+++ b/Source/Views/SPDataCellFormatter.m
@@ -31,6 +31,8 @@
 #import "SPDataCellFormatter.h"
 #import "SPTooltip.h"
 
+#import "sequel-ace-Swift.h"
+
 @implementation SPDataCellFormatter
 
 @synthesize textLimit;
@@ -116,13 +118,13 @@
     }
 
 	// A single character over the length of the string - likely typed.  Prevent the change - JCS - Unless it's NULL
-	if ((NSInteger)[partialString length] == textLimit + 1 && [nullValue contains:partialString] == NO) {
+	if ((NSInteger)[partialString characterCount] == textLimit + 1 && [nullValue contains:partialString] == NO) {
 		[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %ld.", @"Maximum text length is set to %ld."), (long)textLimit]];
 		return NO;
 	}
 
 	// If the string is considerably longer than the limit, likely pasted.  Accept but truncate. - JCS - Unless it's NULL
-	if ((NSInteger)[partialString length] > textLimit && partialString.length > nullValue.length) {
+	if ((NSInteger)[partialString characterCount] > textLimit && partialString.length > nullValue.length) {
 		[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %ld. Inserted text was truncated.", @"Maximum text length is set to %ld. Inserted text was truncated."), (long)textLimit]];
 		*newString = [NSString stringWithString:[partialString substringToIndex:textLimit]];
 		return NO;


### PR DESCRIPTION
## Changes:
- Character counts are now counted instead of byte counts to handle multi-byte strings. This means that you can now actually insert the full contents of multi-byte fields
- This does mean, however, that for non-multi-byte fields, there won't be a warning about length until the user tries to insert (the db rejects the insert). That being said, we don't do much if anything in general with inputs of multi-byte characters into non-multi-byte fields (we should already be rejecting those in the first place) so I think it's not an issue for this PR

## Closes following issues:
- Closes: #1164

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
