### PR TITLE
Fix tabbing, titles and window order #fixed

### DIFF
--- a/Source/Controllers/Window/TabManager.swift
+++ b/Source/Controllers/Window/TabManager.swift
@@ -138,6 +138,7 @@ import AppKit
     @objc func replaceTabServiceWithInitialWindow() -> SPWindowController {
         let windowController = createNewWindowController()
         addManagedWindow(windowController: windowController)
+        windowController.showWindow(self)
         return windowController
     }
 
@@ -152,7 +153,6 @@ private extension TabManager {
     func createNewWindowController() -> SPWindowController {
         let windowController = SPWindowController(windowNibName: "MainWindow")
         windowController.window?.delegate = appController
-        windowController.showWindow(self)
         return windowController
     }
 


### PR DESCRIPTION
## Changes:
- Don't show window cause it's being shown via makeKeyAndOrderFront

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1056

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.5
  
## Screenshots:

## Additional notes:
I feel dumb wasting hours and hours on bug like this one. 🤦🏼 