### PR TITLE
Fix tab switching #fixed

### DIFF
--- a/Source/Controllers/Window/TabManager.swift
+++ b/Source/Controllers/Window/TabManager.swift
@@ -85,35 +85,11 @@ import AppKit
     // MARK: - Public API
 
     @objc func switchToPreviousTab() {
-        // Get index of current tab
-        guard var index = managedWindows.firstIndex(where: { $0.window.isMainWindow }) else {
-            return
-        }
-        // If index is 0, we are on first tab, try to get the last tab
-        if index == 0 {
-            index = managedWindows.count
-        }
-        // If index is last window (count - 1), we are on last tab, try to get the first tab
-        guard let previousWindow = managedWindows[safe: index - 1] else {
-            return
-        }
-        previousWindow.window.order(.above, relativeTo: 0)
+        activeWindowController?.window!.selectPreviousTab(nil)
     }
 
     @objc func switchToNextTab() {
-        // Get index of current tab
-        guard var index = managedWindows.firstIndex(where: { $0.window.isMainWindow }) else {
-            return
-        }
-        // If index is last window (count - 1), we are on last tab, try to get the first tab
-        if index == managedWindows.count - 1 {
-            index = -1
-        }
-        // If tab exists, switch to it
-        guard let nextWindow = managedWindows[safe: index + 1] else {
-            return
-        }
-        nextWindow.window.order(.above, relativeTo: 0)
+        activeWindowController?.window!.selectNextTab(nil)
     }
 
     @discardableResult


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- The `selectNextTab` and `selectPreviousTab` methods are used for tab switching, this fixes an issue similar to #1201 if tabs are reordered by dragging.

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 12.5.1 (12E507)