### PR TITLE
Fix issue with Check for Update Failing #fixed

### DIFF
--- a/Source/Controllers/Other/GitHub.swift
+++ b/Source/Controllers/Other/GitHub.swift
@@ -33,7 +33,7 @@ final class GitHubElement: Codable, Comparable {
     let id: Int
     let author: Author
     let nodeID, tagName: String
-    let targetCommitish: TargetCommitish
+    let targetCommitish: String
     let name: String
     let draft, prerelease: Bool
     let createdAt, publishedAt: Date
@@ -59,7 +59,7 @@ final class GitHubElement: Codable, Comparable {
         case body
     }
 
-    init(url: String, assetsURL: String, uploadURL: String, htmlURL: String, id: Int, author: Author, nodeID: String, tagName: String, targetCommitish: TargetCommitish, name: String, draft: Bool, prerelease: Bool, createdAt: Date, publishedAt: Date, assets: [Asset], tarballURL: String, zipballURL: String, body: String) {
+    init(url: String, assetsURL: String, uploadURL: String, htmlURL: String, id: Int, author: Author, nodeID: String, tagName: String, targetCommitish: String, name: String, draft: Bool, prerelease: Bool, createdAt: Date, publishedAt: Date, assets: [Asset], tarballURL: String, zipballURL: String, body: String) {
         self.url = url
         self.assetsURL = assetsURL
         self.uploadURL = uploadURL
@@ -109,7 +109,7 @@ extension GitHubElement {
         author: Author? = nil,
         nodeID: String? = nil,
         tagName: String? = nil,
-        targetCommitish: TargetCommitish? = nil,
+        targetCommitish: String? = nil,
         name: String? = nil,
         draft: Bool? = nil,
         prerelease: Bool? = nil,
@@ -422,12 +422,6 @@ enum StarredURL: String, Codable {
 
 enum TypeEnum: String, Codable {
     case user = "User"
-}
-
-enum TargetCommitish: String, Codable {
-    case main = "main"
-    case release = "release"
-    case staging = "staging"
 }
 
 typealias GitHub = [GitHubElement]

--- a/Source/Controllers/Other/GitHubReleaseManager.swift
+++ b/Source/Controllers/Other/GitHubReleaseManager.swift
@@ -128,10 +128,15 @@ import OSLog
                     availableRelease = releases.first
 
                     guard
-                        let currentReleaseTmp = currentRelease,
-                        let availableReleaseTmp = availableRelease
+                        let currentReleaseTmp = currentRelease
                     else {
                         Log.debug("No current release available")
+                        return
+                    }
+
+                    guard
+                        let availableReleaseTmp = availableRelease
+                    else {
                         Log.debug("No newer release available")
                         return
                     }
@@ -151,12 +156,12 @@ import OSLog
                         }
                     }
                 } catch {
-                    Log.error("Error: \(error.localizedDescription)")
+                    Log.error("Error GitHub Exception: \(error.localizedDescription)")
                     NSAlert.createWarningAlert(title: NSLocalizedString("GitHub Request Failed", comment: "GitHub Request Failed"), message: error.localizedDescription)
                 }
 
             case let .failure(error):
-                Log.error("Error: \(error.localizedDescription)")
+                Log.error("Error GitHub Failure: \(error.localizedDescription)")
                 NSAlert.createWarningAlert(title: NSLocalizedString("GitHub Request Failed", comment: "GitHub Request Failed"), message: error.localizedDescription)
                 if (manager?.isReachable == false) {
                     Log.error("manager?.isReachable == false")


### PR DESCRIPTION
## Changes:
- Fix issue with GitHub release manager and target_commitish. It was expecting one of three well-known values, but when I messed up a previous release on GitHub and had to retroactively create it, it wasn't one of those three well-known values. It's safer to just expect a string.

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

This was what the error looked like:
<img width="256" alt="Screen Shot 2021-09-10 at 14 57 47" src="https://user-images.githubusercontent.com/10710367/132999450-9ffea8a9-01dd-4471-9401-41f79b708dad.png">


## Additional notes:
