### PR TITLE
Fix stats counts not updating immediately for MySQL 8 #fixed

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1188,6 +1188,16 @@ asm(".desc ___crashreporter_info__, 0x10");
 			[self queryString:@"SET wait_timeout=600"];
 		}
 	}
+
+
+    // Check the information_schema_stats_expiry timeout - if it's not zero, set it to 0
+    // Otherwise, stats page will lag behind reality
+    // https://github.com/Sequel-Ace/Sequel-Ace/issues/1206
+    if ([variables objectForKey:@"information_schema_stats_expiry"]) {
+        if ([[variables objectForKey:@"information_schema_stats_expiry"] integerValue] != 0) {
+            [self queryString:@"SET information_schema_stats_expiry=0"];
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Set information_schema_stats_expiry to 0 if it's set and non-zero
- Was unable to test the fix locally, but fairly safe given it checks if the variable exists before trying to set it and will have a user verify the fix and ensured this doesn't break other connections

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
