### PR TITLE
Fix crash when adding a row locally #fixed

### DIFF
--- a/Source/Views/TableViews/SPTableView.m
+++ b/Source/Views/TableViews/SPTableView.m
@@ -317,7 +317,7 @@ pass_keyDown_to_super:
 - (void)_doubleClickAction
 {
 	if ([super clickedRow] == -1 && [super clickedColumn] == -1 && emptyDoubleClickAction) {
-		[[self delegate] performSelector:emptyDoubleClickAction];
+        [NSApp sendAction:emptyDoubleClickAction to:[self delegate] from:nil];
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Fix crash when adding a row

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
   13.0 (13A233)

## Additional notes:
The crash only occurs when the optimization level is set to `None` or `Fast`, `None` being the default for local testing. It's not exactly clear why the crash occurs but it seems to be related to ARC, although the crash still happens when making `emptyDoubleClickAction` an instance variable. Inspecting the variables with LLDB didn't appear to show anything different and this statement evaluates to true: `[[self delegate] respondsToSelector:emptyDoubleClickAction]`.

Another alternative is to use `[[self delegate] performSelector:emptyDoubleClickAction withObject:nil]`, the benefit of using the proposed solution is it fixes the "PerformSelector may cause a leak because its selector is unknown" warning.