### PR TITLE
Reload query history after new entries are added #fixed

### DIFF
--- a/Source/Controllers/Other/SQLiteHistoryManager.swift
+++ b/Source/Controllers/Other/SQLiteHistoryManager.swift
@@ -320,6 +320,7 @@ typealias SASchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) -> Void
         }
         getDBsize()
         queue.close()
+        reloadQueryHistory()
     }
 
     /// Deletes all query history from the db


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Causes the query history to reload after new entries are added, possibly fixing a bug in which query history could be wrong between windows

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ =x] 11.x (Big Sur)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
