### PR TITLE
#fixed compile errors 

### DIFF
--- a/Source/Other/DebuggingSupport/SPLogger.m
+++ b/Source/Other/DebuggingSupport/SPLogger.m
@@ -45,7 +45,7 @@ static SPLogger *logger = nil;
 - (void)_initLogFile;
 - (void)_outputTimeString;
 
-int _isSPLeaksLog(const struct direct *entry);
+int _isSPLeaksLog(const struct dirent *entry);
 
 @end
 
@@ -150,7 +150,7 @@ int _isSPLeaksLog(const struct direct *entry);
 		if ([self removeOldLeakDumpsOnTermination]) {
 			
 			int cnt, cnt2, i;
-			struct direct **files;
+			struct dirent **files;
 			
 			cnt  = scandir("/tmp", &files, _isSPLeaksLog, NULL);
 			
@@ -253,7 +253,7 @@ int _isSPLeaksLog(const struct direct *entry);
 	[logFileHandle writeData:[[NSString stringWithFormat:@"Launched at %@\n\n", [[NSDate date] description]] dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
-int _isSPLeaksLog(const struct direct *entry)
+int _isSPLeaksLog(const struct dirent *entry)
 {
 	return (strstr(entry->d_name, "sp.leaks") != NULL);
 }

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,13 @@ brew install --cask sequel-ace
 
 To run Sequel Ace locally from XCode, please:
 - download `.zip` archive of this repo/clone locally
-- open `sequel-ace.xcworkspace` and run `Sequel Ace Local Testing` schema
+- open `sequel-ace.xcworkspace` 
+- for the `sequel-ace` and `SPMySQLFramework`  (located in `Source/Frameworks/SPMySQLFramework`) projects, under `Signing & Capibilities`
+    - change the Bundle Identifier to be unique to you (e.g. add `.YOUR_USER_NAME`)
+    - select a Team that you can create signing certificates for
+- open the `sequel-ace` project and, under `Signing & Capabilities` change the Team and Bundle Identifier for the `Sequel Ace` and `SequelAceTunnelAssistant` targets
+- open the `Source/Frameworks/SPMySQLFramework` project 
+- run `Sequel Ace Local Testing` schema
 
 If you encounter any issues, let us know by [creating a new issue](https://github.com/Sequel-Ace/Sequel-Ace/issues/new/choose).
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- After cloning the repo the build fails with mismatched type errors in `SPLogger` there is a typo in the `_isSPLeaksLog` function that apparently worked before macOS 11.6 and XCode 13.1.

- I also added more explicit instructions for local development so that new developers don't have to hunt around to figure out which projects need to be touched


## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
