### PR TITLE
Update SPExportFavoritesFilename to SequelAceFavorites.plist

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -62,7 +62,7 @@
 
 // Constants
 static NSString *SPRemoveNode              = @"RemoveNode";
-static NSString *SPExportFavoritesFilename = @"SequelProFavorites.plist";
+static NSString *SPExportFavoritesFilename = @"SequelAceFavorites.plist";
 static NSString *SPLocalhostAddress        = @"127.0.0.1";
 
 static NSString *SPDatabaseImage           = @"database-small";


### PR DESCRIPTION


## Changes:
- Update SPExportFavoritesFilename to SequelAceFavorites.plist

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
