### PR TITLE
#fixed - Tooltips width issue patched #1290

### DIFF
--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -404,12 +404,13 @@ static CGFloat slow_in_out (CGFloat t)
 			self->gotHeight = YES;
 			
 		}];
-		
 		[self->wkWebView evaluateJavaScript:@"document.body.offsetWidth + document.body.offsetLeft;" completionHandler:^(id _Nullable width2, NSError * _Nullable error) {
 			SPLog(@"width2: %@", width2);
 			if (error) SPLog(@"error: %@", error.localizedDescription);
-			
-			width = [width2 integerValue];
+
+            // Add 1 because sometimes document.body.offsetWidth value is not sufficient or the frame of WKWebView does not match the body. I don't know exactly where the truth is.
+            // 1 seems to be enougth in my case.
+			width = [width2 integerValue] + 1;
 			self->gotWidth = YES;
 		}];
 		


### PR DESCRIPTION
## Changes:
- Change the width to the tooltips. It seems the width return by javascript body.offsetWidth does not fit always exactly the content.

## Tested:
- Processors:
  - [X] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [X] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.0 (13A233)
  
## Screenshots:

## Additional notes:
The tooltips used by SA seem a bit complexe. I think it inherits from SP. I wonder if today there would be a better solution.