### PR TITLE
#fixed #979 Properly reset the sorting column

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3350,12 +3350,12 @@ static void *TableContentKVOContext = &TableContentKVOContext;
  */
 - (void) setSortColumnNameToRestore:(NSString *)theSortColumnName isAscending:(BOOL)isAscending
 {
-	
-
 	if (theSortColumnName) {
 		sortColumnToRestore = [[NSString alloc] initWithString:theSortColumnName];
 		sortColumnToRestoreIsAsc = isAscending;
-	}
+    } else {
+        sortColumnToRestore = nil;
+    }
 }
 
 /**


### PR DESCRIPTION
## Changes:
- Properly reset the sorting column

## Closes following issues:
- Closes: #979

## Tested:
- Processors:
  - [X] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [X] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1

## Additional notes:
I also ran into the sorting bug. When setSortColumnNameToRestore is called with a nil value the sortColumnToRestore didn't reset properly. I'm not sure when and how this got broken.
