### PR TITLE
#fixed Fix to fail some copy commands when multiple perl are installed

### DIFF
--- a/SharedSupport/Default Bundles/CopyAsHTML.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyAsHTML.saBundle/command.plist
@@ -7,7 +7,7 @@
 	<key>category</key>
 	<string>Copy</string>
 	<key>command</key>
-	<string>cat | perl -e '
+	<string>cat | /usr/bin/perl -e '
 
 # read first line to get the column names (header)
 $firstLine = &lt;&gt;;

--- a/SharedSupport/Default Bundles/CopyAsJSON.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyAsJSON.saBundle/command.plist
@@ -7,7 +7,7 @@
 	<key>category</key>
 	<string>Copy</string>
 	<key>command</key>
-	<string>cat | perl -e '
+	<string>cat | /usr/bin/perl -e '
 
 # read first line to get the column names (header)
 $firstLine = &lt;&gt;;

--- a/SharedSupport/Default Bundles/CopyAsWiki.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyAsWiki.saBundle/command.plist
@@ -7,7 +7,7 @@
 	<key>category</key>
 	<string>Copy</string>
 	<key>command</key>
-	<string>cat | perl -e '
+	<string>cat | /usr/bin/perl -e '
 
 # read first line to get the column names (header)
 $firstLine = &lt;&gt;;

--- a/SharedSupport/Default Bundles/CopySingleLineQuoted.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopySingleLineQuoted.saBundle/command.plist
@@ -9,7 +9,7 @@
 	<key>command</key>
 	<string># read STDIN which contains the string data coming from the Query Editor
 # and pipe it to the following perl script
-cat | perl -ne '
+cat | /usr/bin/perl -ne '
 
 # delete final line ending
 chomp;

--- a/SharedSupport/Default Bundles/CopyasCSV.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/CopyasCSV.saBundle/command.plist
@@ -7,7 +7,7 @@
 	<key>category</key>
 	<string>Copy</string>
 	<key>command</key>
-	<string>cat | perl -e '
+	<string>cat | /usr/bin/perl -e '
 
 # read first line to get the column names (header)
 $firstLine = &lt;&gt;;

--- a/SharedSupport/Default Bundles/DB Report.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/DB Report.saBundle/command.plist
@@ -60,10 +60,10 @@ else
 	# $SP_QUERY_RESULT_FILE contains the file path to the query result
 
 	# First line contains the column names - wrap them into &lt;th&gt; tags
-	cat "$SP_QUERY_RESULT_FILE" | head -n 1 |perl -pe 's!\t!&lt;/th&gt;&lt;th&gt;&lt;/th&gt;&lt;th align=right&gt;!g;s!$!&lt;/th&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;!'
+	cat "$SP_QUERY_RESULT_FILE" | head -n 1 |/usr/bin/perl -pe 's!\t!&lt;/th&gt;&lt;th&gt;&lt;/th&gt;&lt;th align=right&gt;!g;s!$!&lt;/th&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;!'
 
 	# Output all row except the first one and wrap them into &lt;tr&gt;&lt;td&gt; tags
-	cat "$SP_QUERY_RESULT_FILE" | sed '1d' | perl -pe 's!\t!&lt;/td&gt;&lt;td&gt;&amp;nbsp;&amp;nbsp;&lt;/td&gt;&lt;td align='right'&gt;!g;s!$!&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;!'
+	cat "$SP_QUERY_RESULT_FILE" | sed '1d' | /usr/bin/perl -pe 's!\t!&lt;/td&gt;&lt;td&gt;&amp;nbsp;&amp;nbsp;&lt;/td&gt;&lt;td align='right'&gt;!g;s!$!&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;!'
 
 fi
 cat &lt;&lt;HTML2
@@ -124,7 +124,7 @@ HTML3
 	export DB="$db"
 	export PID="$SP_PROCESS_ID"
 	export RES="$SP_APP_RESOURCES_DIRECTORY";
-	cat "$SP_QUERY_RESULT_FILE" | sed '1d' | perl "$SP_BUNDLE_PATH/Support/processTableData.pl"
+	cat "$SP_QUERY_RESULT_FILE" | sed '1d' | /usr/bin/perl "$SP_BUNDLE_PATH/Support/processTableData.pl"
 
 	echo "&lt;/table&gt;"
 

--- a/SharedSupport/Default Bundles/Toggle JSON Format.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/Toggle JSON Format.saBundle/command.plist
@@ -9,7 +9,7 @@
 	<key>command</key>
 	<string>DATA=$(cat)
 
-FORMAT=$(echo "$DATA" | head -n 1 | perl -e '$l=&lt;&gt;;if($l=~m/^\s*\{\s*$/) {print "1";} else {print "2";}')
+FORMAT=$(echo "$DATA" | head -n 1 | /usr/bin/perl -e '$l=&lt;&gt;;if($l=~m/^\s*\{\s*$/) {print "1";} else {print "2";}')
 
 # if FORMAT == 1 then serialize JSON data otherwise pretty print them
 if [ "$FORMAT" -eq "1" ]; then
@@ -32,7 +32,7 @@ else
 fi
 
 # if there's a need to preserve Unicode characters remove the first to characters of the following line 
-# DATA=$(echo "$DATA"  | perl -Xpe 'binmode STDIN,":utf8";binmode STDOUT,":utf8";s/\\u([0-9A-F]{4})/chr(hex($1))/ieg')
+# DATA=$(echo "$DATA"  | /usr/bin/perl -Xpe 'binmode STDIN,":utf8";binmode STDOUT,":utf8";s/\\u([0-9A-F]{4})/chr(hex($1))/ieg')
 
 printf "%b" "$DATA"</string>
 	<key>contact</key>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Hardcodes path to perl to care about installed multiple version binary.


## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [x] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - 12.5
  
## Screenshots:

![スクリーンショット 2021-12-19 11 52 37](https://user-images.githubusercontent.com/31937/146662003-f5c3bbe6-63d2-43a4-ad68-e6d8e72c8dc1.png)


## Additional notes:

- Similar https://github.com/Sequel-Ace/Sequel-Ace/pull/223