### PR TITLE
#fixed Fix user editing crash

### DIFF
--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -458,18 +458,18 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 					key = [privColumnToGrantMap objectForKey:key];
 				}
 				
-				[dbPriv setValue:[NSNumber numberWithBool:boolValue] forKey:key];
-			} 
+				[dbPriv setValue:[NSNumber numberWithBool:boolValue] forKey:[key lowercaseString]];
+			}
 			else if ([key isEqualToString:@"Db"] || [key isEqualToString:@"DB"]) {
                 // some servers (which? - error above should tell us) return 'DB' for this key which
                 // causes crash: the entity Privileges is not key value coding-compliant for the key DB
                 // so we'll just override it here.
                 key = @"Db";
 				NSString *db = [[rowDict objectForKey:key] stringByReplacingOccurrencesOfString:@"\\_" withString:@"_"];
-                [dbPriv setValue:db forKey:key];
-            } 
+                [dbPriv setValue:db forKey:[key lowercaseString]];
+            }
 			else if (![key isEqualToString:@"Host"] && ![key isEqualToString:@"User"]) {
-				[dbPriv setValue:[rowDict objectForKey:key] forKey:key];
+				[dbPriv setValue:[rowDict objectForKey:key] forKey:[key lowercaseString]];
 			}
 		}
 		[privs addObject:dbPriv];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Not sure why this would have changed, but it appears to be an issue with the case of the key. Making everything lowercase to match the cases of the strings in the definitions appears to fix the crash

## Closes following issues:
- Closes: #1391

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
