### PR TITLE
#fixed Allow connecting to localhost for ssh connections

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2041,16 +2041,19 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 		else {
 			[mySQLConnection setUseSocket:NO];
 
-			if ([self type] == SPSSHTunnelConnection) {
-				[mySQLConnection setHost:@"127.0.0.1"];
+            if([[self host] length]) {
+                [mySQLConnection setHost:[self host]];
+            } else {
+                [mySQLConnection setHost:SPLocalhostAddress];
+            }
 
+            if ([[self port] length]) {
+                [mySQLConnection setPort:[[self port] integerValue]];
+            }
+
+			if ([self type] == SPSSHTunnelConnection) {
 				[mySQLConnection setPort:[sshTunnel localPort]];
 				[mySQLConnection setProxy:sshTunnel];
-			}
-			else {
-				[mySQLConnection setHost:[self host]];
-
-				if ([[self port] length]) [mySQLConnection setPort:[[self port] integerValue]];
 			}
 		}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Allow connecting to a specific host via SSH, not just 127.0.0.1
  - We made a similar change previously for TCP/IP connections. This allows the same thing for SSH connections

## Closes following issues:
- Closes: #1326

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
