### PR TITLE
#fixed Font Not Taking Effect for Create Syntax View

### DIFF
--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -238,6 +238,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 
 	// Retrieve the table status information via the table data cache
 	NSDictionary *statusFields = [tableDataInstance statusValues];
+  NSFont *font = [tableCreateSyntaxTextView font];
 
     SPLog(@"tableTypePopUpButton numberOfItems: %li", (long)tableTypePopUpButton.numberOfItems);
     SPLog(@"tableEncodingPopUpButton numberOfItems: %li", (long)tableEncodingPopUpButton.numberOfItems);
@@ -269,6 +270,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 				[tableCreateSyntaxTextView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:createViewSyntax]];
 				[tableCreateSyntaxTextView didChangeText];
 				[tableCreateSyntaxTextView setEditable:NO];
+        [tableCreateSyntaxTextView setFont: font];
 			}
 		} 
 		else {
@@ -422,6 +424,7 @@ static NSString *SPMySQLCommentField          = @"Comment";
 	
 	if ([tableDataInstance tableCreateSyntax]) {
 		[tableCreateSyntaxTextView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:[[tableDataInstance tableCreateSyntax] stringByAppendingString:@";"]]];
+    [tableCreateSyntaxTextView setFont: font];
 	}
 	
 	[tableCreateSyntaxTextView didChangeText];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes: 
- NSAttributedString default to Helvetica 12-point so we need to restore font after textStorage is set to attributed string.


## Closes following issues:
- Closes: #976

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
