### PR TITLE
#fixed Add Find Next/Previous Menu Items with Shortcuts

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -392,6 +392,16 @@
                                         <menuItem title="Find..." tag="1" keyEquivalent="f" id="154">
                                             <connections>
                                                 <action selector="performFindPanelAction:" target="-1" id="922"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Next" tag="2" keyEquivalent="g" id="keD-kh-KVf">
+                                            <connections>
+                                                <action selector="performTextFinderAction:" target="-1" id="96h-iu-ZEx"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="JjG-V7-bdr">
+                                            <connections>
+                                                <action selector="performTextFinderAction:" target="-1" id="CUl-2X-EH5"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Jump to Selection" keyEquivalent="j" id="155">


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

Hi again, fixed another small bug as I try getting more familiar with the code base.

## Changes:
- Added two new Menu Items to `MainMenu.xib`: `Find Next` and `Find Previous` both items send the `performTextFinderAction:` action to the First Responder. 
- `performTextFinderAction:` is available starting with macOS `10.7`.

## Closes following issues:
- Closes: #1286

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

Menu Items:
<img width="704" alt="MenuItems" src="https://user-images.githubusercontent.com/1121410/147551632-1653d40d-bf51-4637-a2ea-e4bf13830615.png">

Shortcuts in Action:
<img width="744" alt="In Action" src="https://user-images.githubusercontent.com/1121410/147551817-43da4768-45d7-4d47-b18d-a668cecf86d5.gif">


## Additional notes:
Note while original issue only mentions the text view of the edit value pop screen, this pull request should allow finding next/previous hits wherever vanilla text search is currently supported. Places I confirmed as working are:
* "Text" & "Json" text views of the field pop up view
* Comment text view of the "Table Info" tab
* Text view in "Query" tab.