### PR TITLE
#fixed Query Editor Font Inconsistencies

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -418,7 +418,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [textView breakUndoCoalescing];
             NSString *historyString = [[[SPQueryController sharedQueryController] historyForFileURL:[tableDocumentInstance fileURL]] objectAtIndex:currentHistoryOffsetIndex];
             NSRange rangeOfInsertedString = NSMakeRange([textView selectedRange].location, [historyString length]);
-            [textView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:historyString]];
+            [textView appendString:historyString];
             [textView setSelectedRange:rangeOfInsertedString];
         } else {
             currentHistoryOffsetIndex--;
@@ -435,7 +435,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [textView breakUndoCoalescing];
             NSString *historyString = [[[SPQueryController sharedQueryController] historyForFileURL:[tableDocumentInstance fileURL]] objectAtIndex:currentHistoryOffsetIndex];
             NSRange rangeOfInsertedString = NSMakeRange([textView selectedRange].location, [historyString length]);
-            [textView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:historyString]];
+            [textView appendString:historyString];
             [textView setSelectedRange:rangeOfInsertedString];
         } else {
             currentHistoryOffsetIndex++;

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -170,5 +170,6 @@ typedef struct {
 - (BOOL)isSnippetMode;
 
 - (void)doSyntaxHighlightingWithForce:(BOOL)forced;
+- (void)appendString:(NSString *)string;
 
 @end

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -1424,6 +1424,16 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		return YES;
 }
 
+- (void)appendString:(NSString *)string
+{
+    [self.textStorage appendAttributedString: [[NSAttributedString alloc] initWithString: string attributes: @{ NSFontAttributeName: self.font }]];
+}
+
+- (void)insertString:(NSString *)string atIndex:(NSUInteger)loc
+{
+    [self.textStorage insertAttributedString: [[NSAttributedString alloc] initWithString: string attributes: @{ NSFontAttributeName: self.font }] atIndex: loc];
+}
+
 #pragma mark -
 #pragma mark snippet handler
 
@@ -2563,13 +2573,15 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		// Replicate the indentation on the previous line if one was found.
 		if (indentString) {
             SPLog(@"got indentString: [%@]", indentString);
+            NSString *adjustedIndent;
 			if (lineCursorLocation < [indentString length]) {
                 SPLog(@"lineCursorLocation < [indentString length]: [%lu] < [%lu]", (unsigned long)lineCursorLocation,(unsigned long)[indentString length] );
-                [self.textStorage insertAttributedString:[[NSAttributedString alloc] initWithString:[indentString substringWithRange:NSMakeRange(0, lineCursorLocation)]] atIndex:[self selectedRange].location];
+                adjustedIndent = [indentString substringWithRange:NSMakeRange(0, lineCursorLocation)];
 			} else {
                 SPLog(@"lineCursorLocation >= [indentString length]: [%lu] >= [%lu]", (unsigned long)lineCursorLocation,(unsigned long)[indentString length] );
-                [self.textStorage insertAttributedString:[[NSAttributedString alloc] initWithString:indentString] atIndex:[self selectedRange].location];
+                adjustedIndent = indentString;
 			}
+			[self insertString: adjustedIndent atIndex: self.selectedRange.location];
 		}
 
 		// Return to avoid the original implementation, preventing double linebreaks
@@ -3461,7 +3473,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		// Check if user pressed  ⌘ while dragging for inserting only the file path
 		if([sender draggingSourceOperationMask] == 4)
 		{
-			[self.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:filepath]];
+			[self appendString: filepath];
 			return YES;
 		}
 
@@ -3519,7 +3531,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			[dragString appendString:[[aPath componentsSeparatedByString:SPUniqueSchemaDelimiter] componentsJoinedByPeriodAndBacktickQuoted]];
 		}
 		[self breakUndoCoalescing];
-		[self.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:dragString]];
+        [self appendString: dragString];
 		return YES;
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

Underlying issue addressed here is related to textStorage manipulations where the font is not set and so it defaults to the system default (Helvetica 12-point per [Apple Doc](https://developer.apple.com/documentation/foundation/nsattributedstring)). We can make the issues more obvious if we set font in preferences to size 18+ and start to make changes in the editor.

## Changes:
- Added two helper methods to `SPTextView` "insert" and "append" . These add text in a way that preserves the font already specified in the view. Methods are called from `doCommandBySelector:` & `performDragOperation:` of `SPTextView `  as well as `gearMenuItemSelected:` in `SPCustomQuery`

## Closes following issues:
- Closes:
  - #1190
    - Essentially this bug causes the editor to insert spaces in the system default font instead of the one select in user preferences.
  - #1153
    - When your query editor is hit by the bug above and you then copy and paste those lines, the font on the pasted lines is "corrected" back to the user-preferences font and the alignment of text can go all out of whack.


## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

These are the cases I was able to identify and fix:

### **Indent new lines**
When "Indent new lines" setting is ON, the new line ends up with the proper number of spaces/tabs but because the font is different we get different visual offsets.
<img width="331" alt="Indent New Lines" src="https://user-images.githubusercontent.com/1121410/147580975-16d9f944-4733-4664-81f4-8464953afa9f.png">
Here all three lines are indent by 4 spaces but the spaces for line 3 were inserted by the application in the system default font. One way users might address this is by adding a couple more spaces to line three but that causes it to have more than 4 spaces so that when you copy and paste these lines in another location in the editor, the font is correct and now line three gets indented more than the first two lines.

### **Previous/Next Query From History**
<img width="311" alt="Previous Query From History" src="https://user-images.githubusercontent.com/1121410/147582924-ac734c17-dc98-4ef5-9f6e-489e1cc17d27.png">
Here, I ran the query, then clicked on bottom left corner button and selected "Previous Query from History", this cause the query to get inserted on lines 3-4 but in the system default font. Selecting from "Query Favorites" & "Query History" pop ups seems to work fine.

### **Dragging File onto Query Editor**
<img width="278" alt="Dragging File" src="https://user-images.githubusercontent.com/1121410/147583517-b0609b9d-57f5-4988-8b2a-7a7b8f18f096.png">
Dragging .sql file onto the editor appears to work fine but if you hold the `Command` key when releasing the drag event then the file path is inserted with default font.

## Additional notes:
