### PR TITLE
#fixed Undo/Redo in Query Editor

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -418,7 +418,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [textView breakUndoCoalescing];
             NSString *historyString = [[[SPQueryController sharedQueryController] historyForFileURL:[tableDocumentInstance fileURL]] objectAtIndex:currentHistoryOffsetIndex];
             NSRange rangeOfInsertedString = NSMakeRange([textView selectedRange].location, [historyString length]);
-            [textView appendString:historyString];
+            [textView insertString:historyString intoRange:textView.selectedRange];
             [textView setSelectedRange:rangeOfInsertedString];
         } else {
             currentHistoryOffsetIndex--;
@@ -435,7 +435,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [textView breakUndoCoalescing];
             NSString *historyString = [[[SPQueryController sharedQueryController] historyForFileURL:[tableDocumentInstance fileURL]] objectAtIndex:currentHistoryOffsetIndex];
             NSRange rangeOfInsertedString = NSMakeRange([textView selectedRange].location, [historyString length]);
-            [textView appendString:historyString];
+            [textView insertString:historyString intoRange:textView.selectedRange];
             [textView setSelectedRange:rangeOfInsertedString];
         } else {
             currentHistoryOffsetIndex++;
@@ -1350,7 +1350,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     }
     
     // Replace current query/selection by (un)commented string
-    [textView insertText:[[NSAttributedString alloc] initWithString:n] replacementRange:workingRange];
+    [textView insertString:n intoRange:workingRange];
     [textView setSelectedRange:NSMakeRange(workingRange.location, n.length)];
 }
 
@@ -1411,7 +1411,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         // Replace current line by (un)commented string
         // The caret will be placed at the beginning of the next line if present to
         // allow a fast (un)commenting of lines
-        [textView insertText:[[NSAttributedString alloc] initWithString:n] replacementRange:lineRange];
+        [textView insertString:n intoRange:lineRange];
         [textView setSelectedRange:NSMakeRange(MAX(0, oldRange.location + offsetForPointer),0)];
     }
 }

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -171,5 +171,7 @@ typedef struct {
 
 - (void)doSyntaxHighlightingWithForce:(BOOL)forced;
 - (void)appendString:(NSString *)string;
+- (void)insertString:(NSString *)string atIndex:(NSUInteger)loc;
+- (void)insertString:(NSString *)string intoRange:(NSRange)range;
 
 @end


### PR DESCRIPTION
Attempting to address various undo/redo issues with Query Editor.
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- `SPTextView.m` - Update to use convenience methods to insert/remove text in manner visible to UndoManager.
- `SPNarrowDownCompletion.m` - Now bypasses UndoManager when adding/remove placeholder text from auto-completion.
- `SPCustomQuery.m` - Inserting from `Query Favorites`/`Query History` is now undoable. In addition  inserts now occur at cursor and properly selects the inserted text. This makes it possible to quickly cycle through history items by using `^+↑`/`^+↓`.

## Closes following issues:
- Closes: #1196
- Closes: #1117

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

Leading Whitespace
- Before:
  - Video in: #1196
- After: 
  - ![leading-whitespace-undo-fixed](https://user-images.githubusercontent.com/1121410/147730355-b45729d6-c1ec-4b5d-826d-c9436aec7ca7.gif)

Auto-Complete:
- Before: 
  - ![autocomplete-broken](https://user-images.githubusercontent.com/1121410/147730121-423e1eec-8150-47ed-b367-aa20b97240a4.gif)
  - Another example on: #1117
- After: 
  -  ![autocomplete-fixed](https://user-images.githubusercontent.com/1121410/147730164-58b60de2-2df4-42ad-bb5b-2f09c8e60b2a.gif)

- From History
  - Before:
    - ![cycle-history-broken](https://user-images.githubusercontent.com/1121410/147730236-252e0dee-ddf2-4d68-9b28-4d548dc159f7.gif)
  - After:
    - ![cycle-history-fixed](https://user-images.githubusercontent.com/1121410/147730248-e2c06c41-7338-46be-8647-9ab0df7a3d41.gif)
    - ![cycle-with-shortcuts](https://user-images.githubusercontent.com/1121410/147730644-20f1415b-3b92-4d85-a5d9-d00ba8eeb164.gif)

## Additional notes:
