### PR TITLE
#changed Handle special characters in bookmark file names and paths

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3190,10 +3190,13 @@
 "The selected file is not a valid file.\n\nPlease try again.\n\nClass: %@" = "The selected file is not a valid file.\n\nPlease try again.\n\nClass: %@";
 
 /* known hosts not writable error message */
-"The selected known hosts file is not writable.\n\n%@\n\nPlease check and try again." = "The selected known hosts file is not writable.\n\n%@\n\nPlease check and try again.";
+"The selected known hosts file is not writable.\n\n%@\n\nPlease check and try again." = "The selected known hosts file is not writable.\n\n%@\n\nPlease re-select the file in Sequel Ace's Preferences and try again.";
 
-/* known hosts not writable error title */
-"Known Hosts Error" = "Known Hosts Error";
+/* known hosts is invalid message */
+"The selected known hosts file is invalid.\n\nPlease re-select the file in Sequel Ace's Preferences and try again.";
+
+/* known hosts contains quote message */
+"The selected known hosts file contains a quote (\") in its file path which is not supported.\n\n%@\n\nPlease select a different file in Sequel Ace's Preferences or rename the file/path to remove the quote.";
 
 /* SSH Tunnel Debugging menu and window title */
 "SSH Tunnel Debugging Info" = "SSH Tunnel Debugging Info";

--- a/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPFilePreferencePane.m
@@ -579,9 +579,9 @@ thus we get an index set with number of indexes: 3 (in 1 ranges), indexes: (3-5)
     if([cell isKindOfClass:[NSCell class]] == YES){
         // default to controlTextColor
         [cell setTextColor:[NSColor controlTextColor]];
+        NSString *title = ((NSCell*)cell).title;
 
         if(weHaveStaleBookmarks == YES){
-            NSString *title = ((NSCell*)cell).title;
 
             for(NSString* staleFile in staleBookmarks){
                 if([[staleFile dropPrefixWithPrefix:@"file://"] isEqualToString:title] == YES){
@@ -589,6 +589,7 @@ thus we get an index set with number of indexes: 3 (in 1 ranges), indexes: (3-5)
                 }
             }
         }
+        [((NSCell*)cell) setTitle:[title stringByRemovingPercentEncoding]];
     }
 }
 

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -311,7 +311,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
                 continue;
             }
             NSString *itemTitle = [key substringFromIndex:len];
-            [button safeAddItemWithTitle:itemTitle];
+            [button safeAddItemWithTitle:[itemTitle stringByRemovingPercentEncoding]];
             count++;
         }
 	}];
@@ -342,7 +342,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
                 [prefs setObject:[[NSBundle mainBundle] pathForResource:SPSSHConfigFile ofType:@""] forKey:SPSSHConfigFile];
             }
 
-            [button selectItemWithTitle:currentConfig];
+            [button selectItemWithTitle:[currentConfig stringByRemovingPercentEncoding]];
         }
     }
     // knownHostsChooser button tagged with @1 in IB
@@ -359,7 +359,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
                 currentConfig = @"Sequel Ace default";
             }
 
-            [button selectItemWithTitle:currentConfig];
+            [button selectItemWithTitle:[currentConfig stringByRemovingPercentEncoding]];
 
             if([currentConfig isEqualToString:NSLocalizedString(@"Use known hosts from ssh config (ADVANCED)", @"Use known hosts from ssh config (ADVANCED)")]){
                 BOOL ret = [self checkSSHConfigFileForUserKnownHostsFile:[prefs stringForKey:SPSSHConfigFile]];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Always handle escaped characters (notably spaces) in the file viewer and selectors
- Compare file names and paths in a escaped/not-escaped compatible way whenever possible
- Warn users when a known hosts file contains a " somewhere in the path or name (the only completely disallowed use case in this implementation - I couldn't get escaping the " in known hosts to work correctly

## Closes following issues:
- Closes: #1331 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
