### PR TITLE
#fixed Fixed cannot grant DB privileges in MariaDB 10.5+

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -437,7 +437,7 @@
 "An error occurred whilst trying to perform the operation.\n\nMySQL said: %@" = "An error occurred whilst trying to perform the operation.\n\nMySQL said: %@";
 
 /* mysql resource limits unsupported message */
-"Resource Limits are not supported for your version of MySQL. MySQL said: %@" = "Resource Limits are not supported for your version of MySQL. MySQL said: %@";
+"Resource Limits are not supported for your version of MySQL. Any Resouce Limits you specified have been discarded and not saved. MySQL said: %@" = "Resource Limits are not supported for your version of MySQL. Any Resouce Limits you specified have been discarded and not saved. MySQL said: %@";
 
 /* Export files creation error explanatory text */
 "An unhandled error occurred when attempting to create %lu of the export files.  Please check the details and try again." = "An unhandled error occurred when attempting to create %lu of the export files.  Please check the details and try again.";

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -436,6 +436,9 @@
 /* mysql error occurred informative message */
 "An error occurred whilst trying to perform the operation.\n\nMySQL said: %@" = "An error occurred whilst trying to perform the operation.\n\nMySQL said: %@";
 
+/* mysql resource limits unsupported message */
+"Resource Limits are not supported for your version of MySQL. MySQL said: %@" = "Resource Limits are not supported for your version of MySQL. MySQL said: %@";
+
 /* Export files creation error explanatory text */
 "An unhandled error occurred when attempting to create %lu of the export files.  Please check the details and try again." = "An unhandled error occurred when attempting to create %lu of the export files.  Please check the details and try again.";
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2282,7 +2282,10 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         return;
     }
 
-    [userManagerInstance beginSheetModalForWindow:[self.parentWindowController window] completionHandler:^(){ }];
+    [userManagerInstance beginSheetModalForWindow:[self.parentWindowController window] completionHandler:^(){
+        //Release the UserManager instance after completion
+        self->userManagerInstance = nil;
+    }];
 }
 
 /**

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -1251,7 +1251,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 
         //And if all else fails tell the user nope
         if ([connection queryErrored]) {
-            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"An error occurred", @"mysql error occurred message") message:[NSString stringWithFormat:NSLocalizedString(@"Resource Limits are not supported for your version of MySQL (%@)", @"mysql error occurred informative message"), [connection lastErrorMessage]] callback:nil];
+            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"An error occurred", @"mysql error occurred message") message:[NSString stringWithFormat:NSLocalizedString(@"Resource Limits are not supported for your version of MySQL. MySQL said: %@", @"mysql resource limits unsupported message"), [connection lastErrorMessage]] callback:nil];
         }
     }
 	

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -1251,7 +1251,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 
         //And if all else fails tell the user nope
         if ([connection queryErrored]) {
-            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"An error occurred", @"mysql error occurred message") message:[NSString stringWithFormat:NSLocalizedString(@"Resource Limits are not supported for your version of MySQL. MySQL said: %@", @"mysql resource limits unsupported message"), [connection lastErrorMessage]] callback:nil];
+            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"An error occurred", @"mysql error occurred message") message:[NSString stringWithFormat:NSLocalizedString(@"Resource Limits are not supported for your version of MySQL. Any Resouce Limits you specified have been discarded and not saved. MySQL said: %@", @"mysql resource limits unsupported message"), [connection lastErrorMessage]] callback:nil];
         }
     }
 	

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -816,37 +816,37 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 	}
     
 	[[self managedObjectContext] reset];
-	
+
     [grantedSchemaPrivs removeAllObjects];
 	[grantedTableView reloadData];
-	
-	[self _initializeAvailablePrivs];	
-    
+
+	[self _initializeAvailablePrivs];
+
 	[outlineView reloadData];
 	[treeController rearrangeObjects];
-    
+
     // Get all the stores on the current MOC and remove them.
     NSArray *stores = [[[self managedObjectContext] persistentStoreCoordinator] persistentStores];
-    
+
 	for (NSPersistentStore* store in stores)
     {
         [[[self managedObjectContext] persistentStoreCoordinator] removePersistentStore:store error:nil];
     }
-	
+
     // Add a new store
     [[[self managedObjectContext] persistentStoreCoordinator] addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:nil];
-    
+
     // Reinitialize the tree with values from the database.
     [self _initializeUsers];
 
 	// After the reset, ensure all original password and user values are up-to-date.
 	NSEntityDescription *entityDescription = [NSEntityDescription entityForName:@"SPUser" inManagedObjectContext:[self managedObjectContext]];
 	NSFetchRequest *request = [[NSFetchRequest alloc] init];
-	
+
 	[request setEntity:entityDescription];
-	
+
 	NSArray *userArray = [[self managedObjectContext] executeFetchRequest:request error:nil];
-	
+
 	for (SPUserMO *user in userArray)
 	{
 		if (![user parent]) {
@@ -1226,7 +1226,17 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 - (BOOL)updateResourcesForUser:(SPUserMO *)user
 {
     if ([user valueForKey:@"parent"] != nil) {
-		if([connection isNotMariadb103]){
+        //Try modern way
+        NSMutableString *alterStmt = [NSMutableString stringWithFormat:@"ALTER USER %@@%@ WITH MAX_QUERIES_PER_HOUR %@ MAX_UPDATES_PER_HOUR %@ MAX_CONNECTIONS_PER_HOUR %@",
+                                      [[[user valueForKey:@"parent"] valueForKey:@"user"] tickQuotedString],
+                                      [[user valueForKey:@"host"] tickQuotedString],
+                                      [user valueForKey:@"max_questions"],
+                                      [user valueForKey:@"max_updates"],
+                                      [user valueForKey:@"max_connections"]];
+        [connection queryString:alterStmt];
+
+        //Fallback on legacy way
+        if ([connection queryErrored]) {
 			NSString *updateResourcesStatement = [NSString stringWithFormat:
 												  @"UPDATE mysql.user SET max_questions = %@, max_updates = %@, max_connections = %@ WHERE User = %@ AND Host = %@",
 												  [user valueForKey:@"max_questions"],
@@ -1236,8 +1246,13 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 												  [[user valueForKey:@"host"] tickQuotedString]];
 			
 			[connection queryString:updateResourcesStatement];
-			return [self _checkAndDisplayMySqlError];
 		}
+
+
+        //And if all else fails tell the user nope
+        if ([connection queryErrored]) {
+            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"An error occurred", @"mysql error occurred message") message:[NSString stringWithFormat:NSLocalizedString(@"Resource Limits are not supported for your version of MySQL (%@)", @"mysql error occurred informative message"), [connection lastErrorMessage]] callback:nil];
+        }
     }
 	
 	return YES;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Attempt a modern way of setting resource limits supported by MySQL 5.7+ and equivalent first before falling back on a legacy approach and ultimately showing a custom error (legacy way is no longer supported by modern MariaDB, but the modern way isn't supported by MySQL 5.6)
- Release the user manager after it's closed so that it reloads (fixes a bug which caused a user who was just created to not be updatable)

## Closes following issues:
- Closes: #1278

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
