### PR TITLE
#changed Accurately show SSL connection status always

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -594,8 +594,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	serverVersionNumber = mysql_get_server_version(mySQLConnection);
 
 	// Update SSL state
-	connectedWithSSL = NO;
-	if (useSSL) connectedWithSSL = (mysql_get_ssl_cipher(mySQLConnection))?YES:NO;
+	connectedWithSSL = (mysql_get_ssl_cipher(mySQLConnection))?YES:NO;
 	if (useSSL && !connectedWithSSL) {
 		if ([delegate respondsToSelector:@selector(connectionFellBackToNonSSL:)]) {
 			[delegate connectionFellBackToNonSSL:self];
@@ -755,7 +754,10 @@ asm(".desc ___crashreporter_info__, 0x10");
 			}
 			return NULL;
 		}
-	}
+    } else {
+        enum mysql_ssl_mode opt_ssl_mode = SSL_MODE_PREFERRED;
+        mysql_options(theConnection, MYSQL_OPT_SSL_MODE, (void *)&opt_ssl_mode);
+    }
 
 	MYSQL *connectionStatus = mysql_real_connect(theConnection, theHost, theUsername, thePassword, NULL, (unsigned int)port, theSocket, [self clientFlags]);
 

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -2447,6 +2447,10 @@
 /* sql data access label (Navigator) */
 "SQL Data Access" = "SQL Data Access";
 
+
+/* Connection Secured via SSL information text */
+"Connection Secured via SSL" = "Connection Secured via SSL";
+
 /* SSH connected titlebar marker */
 "SSH Connected" = "SSH Connected";
 

--- a/Source/Views/AccessoryViews/SPWindowTabAccessory.swift
+++ b/Source/Views/AccessoryViews/SPWindowTabAccessory.swift
@@ -83,7 +83,7 @@ final class SPWindowTabAccessory: NSView {
             image = systemImage
         }
         let imageView = NSImageView(image: image)
-        imageView.toolTip = NSLocalizedString("SSH Connected", comment: "Tooltip information text")
+        imageView.toolTip = NSLocalizedString("Connection Secured via SSL", comment: "Connection Secured via SSL information text")
         imageView.isHidden = true
         return imageView
     }()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Always show the lock if connected via SSL even if "use ssl" wasn't specifically specified
- Change the hover text of the lock to "Connected via SSL" instead of re-using (inaccurately) the SSH Connected text
- Explicitly specify that the normal SSL behavior is to attempt SSL and fallback on non-SSL

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
https://dev.mysql.com/doc/refman/5.7/en/using-encrypted-connections.html