### PR TITLE
Disable TouchBar font panel API #fixed

### DIFF
--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -143,6 +143,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 	isProcessingMirroredSnippets = NO;
 	completionWasRefreshed = NO;
     completionFuzzyMode = NO; // not for the value from prefs
+    self.usesFontPanel = NO;
 
     // keep track of tasks we start and stop, otherwise we get an assert error
     taskCount = 0;


### PR DESCRIPTION
## Changes:
- Disable Font panel API for NSTextView

## Closes following issues:
- Might possibly close https://github.com/Sequel-Ace/Sequel-Ace/issues/1366

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
- Inspired by [this article](https://christiantietze.de/posts/2021/09/nstextview-fontpanel-slowness/)