### PR TITLE
Disable dark mode variants of colors for tab bar #fixed

### DIFF
--- a/Resources/Colors.xcassets/favoriteBlue.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteBlue.colorset/Contents.json
@@ -1,56 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.463",
           "alpha" : "1.000",
           "blue" : "0.910",
-          "green" : "0.725"
+          "green" : "0.725",
+          "red" : "0.463"
         }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.463",
-          "alpha" : "1.000",
-          "blue" : "0.910",
-          "green" : "0.725"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.278",
-          "alpha" : "1.000",
-          "blue" : "0.533",
-          "green" : "0.388"
-        }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoriteGraphite.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGraphite.colorset/Contents.json
@@ -1,56 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.714",
           "alpha" : "1.000",
           "blue" : "0.714",
-          "green" : "0.714"
+          "green" : "0.714",
+          "red" : "0.714"
         }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.714",
-          "alpha" : "1.000",
-          "blue" : "0.714",
-          "green" : "0.714"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.408",
-          "alpha" : "1.000",
-          "blue" : "0.408",
-          "green" : "0.408"
-        }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
@@ -11,42 +11,6 @@
         }
       },
       "idiom" : "mac"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.354",
-          "green" : "0.696",
-          "red" : "0.508"
-        }
-      },
-      "idiom" : "mac"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.337",
-          "green" : "0.459",
-          "red" : "0.380"
-        }
-      },
-      "idiom" : "mac"
     }
   ],
   "info" : {

--- a/Resources/Colors.xcassets/favoriteOrange.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteOrange.colorset/Contents.json
@@ -1,56 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.965",
           "alpha" : "1.000",
           "blue" : "0.459",
-          "green" : "0.741"
+          "green" : "0.741",
+          "red" : "0.965"
         }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.965",
-          "alpha" : "1.000",
-          "blue" : "0.459",
-          "green" : "0.741"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.514",
-          "alpha" : "1.000",
-          "blue" : "0.294",
-          "green" : "0.400"
-        }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoritePurple.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoritePurple.colorset/Contents.json
@@ -1,56 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.792",
           "alpha" : "1.000",
           "blue" : "0.878",
-          "green" : "0.596"
+          "green" : "0.596",
+          "red" : "0.792"
         }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.792",
-          "alpha" : "1.000",
-          "blue" : "0.878",
-          "green" : "0.596"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.424",
-          "alpha" : "1.000",
-          "blue" : "0.431",
-          "green" : "0.341"
-        }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoriteRed.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteRed.colorset/Contents.json
@@ -1,56 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.894",
           "alpha" : "1.000",
           "blue" : "0.400",
-          "green" : "0.455"
+          "green" : "0.455",
+          "red" : "0.894"
         }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.894",
-          "alpha" : "1.000",
-          "blue" : "0.400",
-          "green" : "0.455"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.518",
-          "alpha" : "1.000",
-          "blue" : "0.349",
-          "green" : "0.349"
-        }
-      }
+      },
+      "idiom" : "mac"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
@@ -11,42 +11,6 @@
         }
       },
       "idiom" : "mac"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.385",
-          "green" : "0.689",
-          "red" : "0.734"
-        }
-      },
-      "idiom" : "mac"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.314",
-          "green" : "0.459",
-          "red" : "0.529"
-        }
-      },
-      "idiom" : "mac"
     }
   ],
   "info" : {


### PR DESCRIPTION
## Changes:
- Disable dark mode variants of colors that might be set in a wrong way

## Closes following issues:
- Closes: Possibly fixes https://github.com/Sequel-Ace/Sequel-Ace/issues/1359

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.2