### PR TITLE
#changed Improved tab coloring appearance in Dark and Light modes

### DIFF
--- a/Resources/Colors.xcassets/favoriteBlue-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteBlue-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.800",
+          "green" : "0.637",
+          "red" : "0.407"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteBlue.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteBlue.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.910",
+          "green" : "0.725",
+          "red" : "0.463"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.450",
+          "green" : "0.359",
+          "red" : "0.229"
+        }
+      },
+      "idiom" : "mac"
     }
   ],
   "info" : {

--- a/Resources/Colors.xcassets/favoriteGraphite-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGraphite-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.610",
+          "green" : "0.610",
+          "red" : "0.610"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteGraphite.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGraphite.colorset/Contents.json
@@ -1,20 +1,56 @@
 {
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
   "colors" : [
     {
+      "idiom" : "mac",
       "color" : {
         "color-space" : "srgb",
         "components" : {
+          "red" : "0.714",
           "alpha" : "1.000",
           "blue" : "0.714",
-          "green" : "0.714",
-          "red" : "0.714"
+          "green" : "0.714"
         }
-      },
-      "idiom" : "mac"
+      }
+    },
+    {
+      "idiom" : "mac",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.714",
+          "alpha" : "1.000",
+          "blue" : "0.714",
+          "green" : "0.714"
+        }
+      }
+    },
+    {
+      "idiom" : "mac",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.408",
+          "alpha" : "1.000",
+          "blue" : "0.408",
+          "green" : "0.408"
+        }
+      }
     }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+  ]
 }

--- a/Resources/Colors.xcassets/favoriteGreen-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGreen-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.305",
+          "green" : "0.600",
+          "red" : "0.438"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteGreen.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.354",
+          "green" : "0.696",
+          "red" : "0.508"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.183",
+          "green" : "0.360",
+          "red" : "0.263"
+        }
+      },
+      "idiom" : "mac"
     }
   ],
   "info" : {

--- a/Resources/Colors.xcassets/favoriteOrange-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteOrange-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.292",
+          "green" : "0.608",
+          "red" : "0.860"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteOrange.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteOrange.colorset/Contents.json
@@ -5,9 +5,45 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.459",
-          "green" : "0.741",
+          "blue" : "0.327",
+          "green" : "0.683",
           "red" : "0.965"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.327",
+          "green" : "0.683",
+          "red" : "0.965"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.153",
+          "green" : "0.318",
+          "red" : "0.450"
         }
       },
       "idiom" : "mac"

--- a/Resources/Colors.xcassets/favoritePurple-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoritePurple-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.780",
+          "green" : "0.529",
+          "red" : "0.704"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoritePurple.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoritePurple.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.878",
+          "green" : "0.596",
+          "red" : "0.792"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.450",
+          "green" : "0.305",
+          "red" : "0.406"
+        }
+      },
+      "idiom" : "mac"
     }
   ],
   "info" : {

--- a/Resources/Colors.xcassets/favoriteRed-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteRed-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.353",
+          "green" : "0.402",
+          "red" : "0.790"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteRed.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteRed.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.455",
+          "red" : "0.894"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.201",
+          "green" : "0.229",
+          "red" : "0.450"
+        }
+      },
+      "idiom" : "mac"
     }
   ],
   "info" : {

--- a/Resources/Colors.xcassets/favoriteYellow-tab.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteYellow-tab.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.309",
+          "green" : "0.679",
+          "red" : "0.740"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
+++ b/Resources/Colors.xcassets/favoriteYellow.colorset/Contents.json
@@ -5,9 +5,45 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.385",
-          "green" : "0.689",
-          "red" : "0.734"
+          "blue" : "0.352",
+          "green" : "0.774",
+          "red" : "0.844"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.352",
+          "green" : "0.774",
+          "red" : "0.844"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.188",
+          "green" : "0.413",
+          "red" : "0.450"
         }
       },
       "idiom" : "mac"

--- a/Source/Views/AccessoryViews/SPWindowTabAccessory.swift
+++ b/Source/Views/AccessoryViews/SPWindowTabAccessory.swift
@@ -38,6 +38,7 @@ final class SPWindowTabAccessory: NSView {
     
     init() {
         super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+
         addSubviews(tabAccessoryColorView, tabAccessoryViewImage, tabText)
         
         tabAccessoryColorView.snp.makeConstraints {
@@ -61,6 +62,7 @@ final class SPWindowTabAccessory: NSView {
     
     private lazy var tabAccessoryColorView: NSView = {
         let colorView = NSView()
+
         colorView.wantsLayer = true
         return colorView
     }()
@@ -91,7 +93,14 @@ final class SPWindowTabAccessory: NSView {
     // MARK: Setters
     
     func update(color: NSColor?, isSSL: Bool) {
-        tabAccessoryColorView.layer?.backgroundColor = color?.cgColor
+        var tabColor = color
+        if #available(macOS 10.13, *) {
+            if(tabColor != nil && tabColor?.colorNameComponent.starts(with: "favorite") == true) {
+                tabColor = NSColor(named: tabColor!.colorNameComponent + "-tab") ?? tabColor
+            }
+        }
+
+        tabAccessoryColorView.layer?.backgroundColor = tabColor?.cgColor
         tabAccessoryViewImage.isHidden = !isSSL
     }
 

--- a/Source/Views/TableViews/SPTableView.m
+++ b/Source/Views/TableViews/SPTableView.m
@@ -136,7 +136,7 @@
 		}
 		
 		if ([[[[self delegate] class] description] isEqualToString:@"SPContentFilterManager"]) {
-			if ([[[(NSObject*)[self delegate] valueForKeyPath:@"contentFilters"] safeObjectAtIndex:row]  safeObjectForKey:@"ableFileURL"])
+			if ([[[(NSObject*)[self delegate] valueForKeyPath:@"contentFilters"] safeObjectAtIndex:row]  safeObjectForKey:@"headerOfFileURL"])
 				return nil;
 		}
 		

--- a/Source/Views/TableViews/SPTableView.m
+++ b/Source/Views/TableViews/SPTableView.m
@@ -136,7 +136,7 @@
 		}
 		
 		if ([[[[self delegate] class] description] isEqualToString:@"SPContentFilterManager"]) {
-			if ([[[(NSObject*)[self delegate] valueForKeyPath:@"contentFilters"] safeObjectAtIndex:row]  safeObjectForKey:@"headerOfFileURL"])
+			if ([[[(NSObject*)[self delegate] valueForKeyPath:@"contentFilters"] safeObjectAtIndex:row]  safeObjectForKey:@"ableFileURL"])
 				return nil;
 		}
 		


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Use a color variant that's just right for dark and light variants as the tab color
- Tweak favorite colors to be more aesthetically pleasing

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots: 13.1
<img width="1200" alt="Screen Shot 2022-01-26 at 15 41 44" src="https://user-images.githubusercontent.com/10710367/151265555-1d42708a-0fa0-4f07-837a-6304fbbbc351.png">
<img width="1200" alt="Screen Shot 2022-01-26 at 15 41 26" src="https://user-images.githubusercontent.com/10710367/151265557-f7d0b0f7-9006-4751-9626-7eaed8528567.png">


## Additional notes:
