### PR TITLE
#fixed empty default value for *char field types   #1407

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -971,12 +971,16 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 				[queryString appendFormat:@"\n DEFAULT %@", defaultValue];
 			}
             // *CHAR and *TEXT must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is.
-            else if ([defaultValue length] && ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"])) {
-                // If default value is not an expresion or a string, add quotes.
-                if (!defaultValueIsExpression && !defaultValueIsString)
-                    [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];
-                else
-                    [queryString appendFormat:@"\n DEFAULT %@", defaultValue];
+            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"]) {
+                if ([defaultValue length]) {
+                    // If default value is not an expresion or a string, add quotes.
+                    if (!defaultValueIsExpression && !defaultValueIsString)
+                        [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];
+                    else
+                        [queryString appendFormat:@"\n DEFAULT %@", defaultValue];
+                } else {
+                    [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:@""]];
+                }
             }
 			// Suppress appending DEFAULT clause for any numerics, date, time fields if default is empty to avoid error messages;
 			// also don't specify a default for TEXT/BLOB, JSON or geometry fields to avoid strict mode errors


### PR DESCRIPTION
## Changes:
- Fix the default value for field type *char

## Tested:
- Processors:
  - [ ] Intel
  - [X] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [X] 12.x (Monterey)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.2.1 (13C100)
  