### PR TITLE
Only append a default value if its specified #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -946,8 +946,12 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
                 }
             }
 
+            if([defaultValue length] == 0) {
+                //DON'T APPEND AN EMPTY DEFAULT VALUE CLAUSE
+            }
+
 			// If a NULL value has been specified, and NULL is allowed, specify DEFAULT NULL
-			if ([defaultValue isEqualToString:[prefs objectForKey:SPNullValue]])
+			else if ([defaultValue isEqualToString:[prefs objectForKey:SPNullValue]])
 			{
 				if ([[theRow objectForKey:@"null"] integerValue] == 1) {
 					[queryString appendString:@"\n DEFAULT NULL"];
@@ -967,22 +971,17 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 			// If the field is of type BIT, permit the use of single qoutes and also don't quote the default value.
 			// For example, use DEFAULT b'1' as opposed to DEFAULT 'b\'1\'' which results in an error.
-			else if ([defaultValue length] && [theRowType isEqualToString:@"BIT"]) {
+			else if ([theRowType isEqualToString:@"BIT"]) {
 				[queryString appendFormat:@"\n DEFAULT %@", defaultValue];
 			}
             // *CHAR and *TEXT must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is.
-            else if ([defaultValue length] && ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"])) {
+            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"]) {
                 // If default value is not an expresion or a string, add quotes.
                 if (!defaultValueIsExpression && !defaultValueIsString)
                     [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];
                 else
                     [queryString appendFormat:@"\n DEFAULT %@", defaultValue];
             }
-			// Suppress appending DEFAULT clause for any numerics, date, time fields if default is empty to avoid error messages;
-			// also don't specify a default for TEXT/BLOB, JSON or geometry fields to avoid strict mode errors
-			else if (![defaultValue length] && ([fieldValidation isFieldTypeNumeric:theRowType] || [fieldValidation isFieldTypeDate:theRowType] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"BLOB"] || [theRowType isEqualToString:@"JSON"] || [fieldValidation isFieldTypeGeometry:theRowType])) {
-				;
-			}
 			//for ENUM field type
 			else if (([defaultValue length]==0) && [theRowType isEqualToString:@"ENUM"]) {
 				[queryString appendFormat:@" "];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- If the default value isn't specified, don't specify it in our alter statement - let MySQL come up with a default if it wants to

## Closes following issues:
- Closes: #1407

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.1
  
## Screenshots:

## Additional notes:
