### PR TITLE
Fix preferences path, keychain path, formatting #infra 

### DIFF
--- a/docs/ref/features.md
+++ b/docs/ref/features.md
@@ -27,15 +27,17 @@ To create an _enum_ field follow the same procedure as you would for any other f
 
 The connections strings are stored in the following preference file:
 
-~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Preferences/com.sequel-ace.sequel-ace.plist
+```
+~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application Support/Sequel Ace/Data/Favorites.plist
+```
 
 The passwords are stored in the Mac OSX Keychain, which is stored here:
 
-~/Library/Keychains/login.keychain
+```
+~/Library/Keychains/login.keychain-db
+```
 
-Find more info about the Keychain here: [http://nevali.net/post/122592107/managing-the-mac-os-x-keychain](http://nevali.net/post/122592107/managing-the-mac-os-x-keychain "http://nevali.net/post/122592107/managing-the-mac-os-x-keychain").
-
-The \~/Library folder is invisible in Lion, to open it choose "Go To Folder…" (`⌘ + ⇧ + G`) and type "~/Library/Preferences/" to open the preference folder.
+The `~/Library` folder is invisible in Lion, to open it choose "Go To Folder…" (`⌘ + ⇧ + G`) and type `~/Library/Preferences/` to open the preference folder.
 
 <!--
 ## Articles


### PR DESCRIPTION
This is a minor docs change to fix the preferences path, keychain path, and some minor formatting tweaks.

Happy to revert any changes if you would prefer the old formatting!
