### PR TITLE
Fix saving session more than once #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2743,14 +2743,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         contextInfo = sender == nil ? @"saveSPFfileAndClose" : @"saveSPFfile";
     }
     // Save Session or Save Session As...
-    else if (sender == nil || [sender tag] == SPMainMenuFileSaveSession || [sender tag] == SPMainMenuFileSaveSessionAs)
-    {
-        // Save As Session
-        if ([sender tag] == SPMainMenuFileSaveSession && [SPAppDelegate sessionURL]) {
-            [self saveConnectionPanelDidEnd:panel returnCode:1 contextInfo:@"saveAsSession"];
-            return;
-        }
-
+    else if (sender == nil || [sender tag] == SPMainMenuFileSaveSession || [sender tag] == SPMainMenuFileSaveSessionAs) {
         // Load accessory nib each time.
         // Note that the top-level objects aren't released automatically, but are released when the panel ends.
         if (![NSBundle.mainBundle loadNibNamed:@"SaveSPFAccessory" owner:self topLevelObjects:nil]) {
@@ -2792,7 +2785,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [panel setAccessoryView:saveConnectionAccessory];
 
         // Set file name
-        filename = ([SPAppDelegate sessionURL]) ? [[[SPAppDelegate sessionURL] absoluteString] lastPathComponent] : [NSString stringWithFormat:NSLocalizedString(@"Session",@"Initial filename for 'Save session' file")];
+        filename = [NSString stringWithFormat:NSLocalizedString(@"Session",@"Initial filename for 'Save session' file")];
 
         contextInfo = @"saveSession";
     }
@@ -4213,7 +4206,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             encryptpw = [[SPAppDelegate spfSessionDocData] objectForKey:@"e_string"];
         } else {
             [inputTextWindowHeader setStringValue:NSLocalizedString(@"Connection file is encrypted", @"Connection file is encrypted")];
-            [inputTextWindowMessage setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Please enter the password for ‘%@’:", @"Please enter the password"), ([self isSaveInBundle]) ? [[[SPAppDelegate sessionURL] absoluteString] lastPathComponent] : [path lastPathComponent]]];
+            [inputTextWindowMessage setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Please enter the password for ‘%@’:", @"Please enter the password"), [path lastPathComponent]]];
             [inputTextWindowSecureTextField setStringValue:@""];
             [inputTextWindowSecureTextField selectText:nil];
 

--- a/Source/Controllers/SPAppController.h
+++ b/Source/Controllers/SPAppController.h
@@ -47,7 +47,6 @@
 
 	id encodingPopUp;
 
-	NSURL *_sessionURL;
 	NSMutableDictionary *_spfSessionDocData;
 
 	NSMutableArray *runningActivitiesArray;
@@ -85,10 +84,8 @@
 // Getters
 - (SPPreferenceController *)preferenceController;
 - (SPDatabaseDocument *)frontDocument;
-- (NSURL *)sessionURL;
 - (NSDictionary *)spfSessionDocData;
 
-- (void)setSessionURL:(NSString *)urlString;
 - (void)setSpfSessionDocData:(NSDictionary *)data;
 
 // Others

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -99,7 +99,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (instancetype)init
 {
     if ((self = [super init])) {
-        _sessionURL = nil;
         aboutController = nil;
         lastBundleBlobFilesDirectory = nil;
         _spfSessionDocData = [[NSMutableDictionary alloc] init];
@@ -390,10 +389,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     // info.plist will contain the opened structure (windows and tabs for each window). Each connection
     // is linked to a saved spf file either in 'Contents' for unTitled ones or already saved spf files.
 
-    if ([contextInfo isEqual:@"saveAsSession"] && [self sessionURL]) {
-        fileName = [[self sessionURL] path];
-    }
-
     if(!fileName || ![fileName length]) {
         return;
     }
@@ -499,8 +494,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 
         return;
     }
-
-    [self setSessionURL:fileName];
 
     // Register spfs bundle in Recent Files
     [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:fileName]];
@@ -783,7 +776,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 
         // Set global session properties
         [self setSpfSessionDocData:spfsDocData];
-        [self setSessionURL:filePath];
 
         // Loop through each defined window in reversed order to reconstruct the last active window
         for (NSDictionary *window in [[[spfs objectForKey:@"windows"] reverseObjectEnumerator] allObjects]) {
@@ -1389,22 +1381,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
  */
 - (SPDatabaseDocument *)frontDocument {
     return [[self.tabManager activeWindowController] databaseDocument];
-}
-
-/**
- * Retrieve the session URL. Return nil if no session is opened
- */
-- (NSURL *)sessionURL {
-    return _sessionURL;
-}
-
-/**
- * Set the global session URL used for Save (As) Session.
- */
-- (void)setSessionURL:(NSString *)urlString {
-
-    if(urlString)
-        _sessionURL = [NSURL fileURLWithPath:urlString];
 }
 
 - (NSDictionary *)spfSessionDocData

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -87,8 +87,7 @@ extension SPWindowController: NSWindowDelegate {
             return false
         }
 
-        if let appDelegate = NSApp.delegate as? SPAppController, appDelegate.sessionURL() != nil {
-            appDelegate.setSessionURL(nil)
+        if let appDelegate = NSApp.delegate as? SPAppController{
             appDelegate.setSpfSessionDocData(nil)
         }
         return true


### PR DESCRIPTION
## Changes:
- Remove unused property that's being saved and not cleared up

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1513

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.4.1
  
## Screenshots:

## Additional notes:
More session saving fixes coming.