### PR TITLE
Fix deprecations and warnings #fixed

### DIFF
--- a/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
+++ b/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
@@ -75,7 +75,6 @@
 	NSFileManager *fileManager = [NSFileManager defaultManager];
 
 	BOOL userTerminated = NO;
-	BOOL redirectForScript = NO;
 	BOOL isDir = NO;
 
 	NSMutableArray *scriptHeaderArguments = [NSMutableArray array];
@@ -111,7 +110,6 @@
 			NSError *writeError = nil;
 			[script writeToFile:scriptFilePath atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
 			if(writeError == nil) {
-				redirectForScript = YES;
 				[scriptHeaderArguments addObject:scriptFilePath];
 			} else {
 				NSBeep();
@@ -123,7 +121,6 @@
 		NSError *writeError = nil;
 		[command writeToFile:scriptFilePath atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
 		if(writeError == nil) {
-			redirectForScript = YES;
 			[scriptHeaderArguments addObject:scriptFilePath];
 		} else {
 			NSBeep();

--- a/Source/Controllers/BundleSupport/SPBundleEditorController.m
+++ b/Source/Controllers/BundleSupport/SPBundleEditorController.m
@@ -779,7 +779,7 @@
 	[panel setNameFieldStringValue:[[self _currentSelectedObject] objectForKey:kBundleNameKey]];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode) {
-		if (returnCode != NSFileHandlingPanelOKButton) return;
+		if (returnCode != NSModalResponseOK) return;
 		
 		// Panel is still on screen. Hide it first. (This is Apple's recommended way)
 		[panel orderOut:nil];

--- a/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
@@ -83,7 +83,7 @@
 
     NSUInteger xmlRowCount = 0;
     double lastProgressValue = 0;
-    NSUInteger i, totalRows, currentRowIndex, currentPoolDataLength;
+    NSUInteger i, totalRows, currentRowIndex;
 
     // Check to see if we have at least a table name or data array
     if ((![self xmlTableName] && ![self xmlDataArray]) ||
@@ -187,8 +187,6 @@
         currentRowIndex = 0;
 
         if ([self xmlDataArray]) currentRowIndex++;
-
-        currentPoolDataLength = 0;
 
         // Inform the delegate that we are about to start writing the data to disk
         [delegate performSelectorOnMainThread:@selector(xmlExportProcessWillBeginWritingData:) withObject:self waitUntilDone:NO];
@@ -296,9 +294,6 @@
             }
 
             [xmlString appendString:@"\t</row>\n\n"];
-
-            // Record the total length for use with pool flushing
-            currentPoolDataLength += [xmlString length];
 
             // Write the row to the filehandle
             [self writeString:xmlString];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2996,7 +2996,7 @@ set_input:
 	[panel setAllowsOtherFileTypes:YES];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger result) {
-		if(result != NSFileHandlingPanelOKButton) return;
+		if(result != NSModalResponseOK) return;
 
 		[panel orderOut:nil]; // Panel is still on screen. Hide it first. (This is Apple's recommended way)
 
@@ -3055,7 +3055,7 @@ set_input:
 	[panel setCanCreateDirectories:YES];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode) {
-		if(returnCode != NSFileHandlingPanelOKButton) return;
+		if(returnCode != NSModalResponseOK) return;
 
 		// Panel is still on screen. Hide it first. (This is Apple's recommended way)
 		[panel orderOut:nil];

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -399,8 +399,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
  */
 - (IBAction)chooseKeyLocation:(NSButton *)sender
 {
-	NSString *directoryPath = nil;
-	NSString *filePath = nil;
 	NSView *accessoryView = nil;
 
 	// If the button was toggled off, ensure editing is ended
@@ -419,8 +417,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 			return;
 		}
 
-		filePath = nil;
-		directoryPath = @"~/.ssh";
 		accessoryView = sshKeyLocationHelp;
 	}
 	// SSL key file location:

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2822,7 +2822,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 {
     [panel orderOut:nil]; // by default OS X hides the panel only after the current method is done
 
-    if (returnCode == NSFileHandlingPanelOKButton) {
+    if (returnCode == NSModalResponseOK) {
 
         NSString *fileName = [[panel URL] path];
         NSError *error = nil;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -686,9 +686,6 @@ static void *TableContentKVOContext = &TableContentKVOContext;
  */
 - (void) clearTableValues
 {
-	SPDataStorage *tableValuesTransition;
-
-	tableValuesTransition = tableValues;
 	pthread_mutex_lock(&tableValuesLock);
 	tableRowsCount = 0;
 	tableValues = [[SPDataStorage alloc] init];
@@ -3797,11 +3794,6 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 					return [NSString stringWithFormat:@"0x%@…", [[(NSData *)value subdataWithRange:NSMakeRange(0, 255)] dataToHexString]];
 				}
 				return [NSString stringWithFormat:@"0x%@", [(NSData *)value dataToHexString]];
-			}
-
-			pthread_mutex_t *fieldEditorCheckLock = NULL;
-			if (isWorking) {
-				fieldEditorCheckLock = &tableValuesLock;
 			}
 
 			// Unless we're editing, always retrieve the short string representation, truncating the value where necessary

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -159,7 +159,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 			   context:NULL];
 
 	[_currentFilePanel beginSheetModalForWindow:[[NSApplication sharedApplication] keyWindow] completionHandler:^(NSInteger result) {
-		if(result == NSFileHandlingPanelOKButton) [self->sshClientPath setStringValue:[[self->_currentFilePanel URL] path]];
+		if(result == NSModalResponseOK) [self->sshClientPath setStringValue:[[self->_currentFilePanel URL] path]];
 		
 		[self->prefs removeObserver:self forKeyPath:SPHiddenKeyFileVisibilityKey];
 		

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1231,9 +1231,8 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
  */
 - (NSDictionary*)shellEnvironmentForDocument:(NSString*)docUUID {
     NSMutableDictionary *env = [NSMutableDictionary dictionary];
-    SPDatabaseDocument *doc;
     if (docUUID == nil) {
-        doc = [self frontDocument];
+        [self frontDocument];
     } else {
         SPWindowController *windowController = [self.tabManager windowControllerWithDocumentWithProcessID:docUUID];
         if (windowController) {

--- a/Source/Other/CategoryAdditions/SPDataStorage.m
+++ b/Source/Other/CategoryAdditions/SPDataStorage.m
@@ -62,7 +62,6 @@ static inline NSMutableArray* SPDataStorageGetEditedRow(NSPointerArray* rowStore
 - (void) setDataStorage:(SPMySQLStreamingResultStore *)newDataStorage updatingExisting:(BOOL)updateExistingStore
 {
 	BOOL *oldUnloadedColumns;
-	NSPointerArray *oldEditedRows;
 	SPMySQLStreamingResultStore *oldDataStorage;
 	
 	@synchronized(self) {
@@ -87,7 +86,6 @@ static inline NSMutableArray* SPDataStorageGetEditedRow(NSPointerArray* rowStore
 		}
 
 		oldUnloadedColumns = unloadedColumns;
-		oldEditedRows = editedRows;
 		dataStorage = newDataStorage;
 		numberOfColumns = newNumberOfColumns;
 		unloadedColumns = newUnloadedColumns;

--- a/Source/Other/Parsing/SPJSONFormatter.m
+++ b/Source/Other/Parsing/SPJSONFormatter.m
@@ -82,7 +82,6 @@ static char GetNextANSIChar(SPJSONTokenizerState *stateInfo);
 		
 		//save ourselves the overhead of creating an NSString if we already know what it will contain
 		NSString *curTokenString;
-		id freeMe = nil;
 		switch (curToken.tok) {
 			case JSON_TOK_CURLY_BRACE_OPEN:
 				curTokenString = @"{";
@@ -121,7 +120,6 @@ static char GetNextANSIChar(SPJSONTokenizerState *stateInfo);
 					NSString *newTokenString = [curTokenString stringByTrimmingCharactersInSet:wsNlCharset];
 					curTokenString = newTokenString;
 				}
-				freeMe = curTokenString;
 		}
 		
 		[formatted appendString:curTokenString];
@@ -164,7 +162,6 @@ static char GetNextANSIChar(SPJSONTokenizerState *stateInfo);
 		
 		//save ourselves the overhead of creating an NSString from input if we already know what it will contain
 		NSString *curTokenString;
-		id freeMe = nil;
 		switch (curToken.tok) {
 			case JSON_TOK_CURLY_BRACE_OPEN:
 				curTokenString = @"{";
@@ -203,7 +200,6 @@ static char GetNextANSIChar(SPJSONTokenizerState *stateInfo);
 					NSString *newTokenString = [curTokenString stringByTrimmingCharactersInSet:wsNlCharset];
 					curTokenString = newTokenString;
 				}
-				freeMe = curTokenString;
 		}
 		
 		[unformatted appendString:curTokenString];

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -1368,7 +1368,6 @@ NSString *kHeader     = @"HEADER";
     }
 
     NSString *inputAction = @"";
-    NSString *inputFallBackAction = @"";
     NSError *err = nil;
     NSString *uuid = [NSString stringWithNewUUID];
     NSString *bundleInputFilePath = [NSString stringWithFormat:@"%@_%@", [SPBundleTaskInputFilePath stringByExpandingTildeInPath], uuid];
@@ -1378,8 +1377,6 @@ NSString *kHeader     = @"HEADER";
 
     if([cmdData objectForKey:SPBundleFileInputSourceKey])
         inputAction = [[cmdData objectForKey:SPBundleFileInputSourceKey] lowercaseString];
-    if([cmdData objectForKey:SPBundleFileInputSourceFallBackKey])
-        inputFallBackAction = [[cmdData objectForKey:SPBundleFileInputSourceFallBackKey] lowercaseString];
 
     NSMutableDictionary *env = [NSMutableDictionary dictionary];
     [env setObject:[infoPath stringByDeletingLastPathComponent] forKey:SPBundleShellVariableBundlePath];


### PR DESCRIPTION
## Changes:
- Fix unused variables
- Fix warnings based on macOS 10.12 drop

## Closes following issues:
- Closes: Nothing I'm aware of

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.4.1
  
## Screenshots:

## Additional notes:
