### PR TITLE
Fix major memory leak with database document not being released #fixed

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -33,7 +33,7 @@
 @interface SPMySQLConnection : NSObject {
 
 	// Delegate
-	NSObject <SPMySQLConnectionDelegate> *delegate;
+    __weak NSObject <SPMySQLConnectionDelegate> *delegate;
 	BOOL delegateSupportsWillQueryString;
 	BOOL delegateSupportsConnectionLost;
 	BOOL delegateQueryLogging; // Defaults to YES if protocol implemented

--- a/Source/Controllers/DataControllers/SPTableData.h
+++ b/Source/Controllers/DataControllers/SPTableData.h
@@ -33,7 +33,7 @@
 @class SPMySQLConnection;
 
 @interface SPTableData: NSObject {
-	IBOutlet SPDatabaseDocument* tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument* tableDocumentInstance;
 	IBOutlet SPTablesList* tableListInstance;
 
 	NSMutableArray *columns;

--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -79,8 +79,10 @@
 }
 
 - (void)documentWillClose:(NSNotification *)notification {
-    [mySQLConnection disconnect];
-    mySQLConnection = nil;
+    [self setConnection:nil];
+
+    pthread_mutex_destroy(&dataProcessingLock);
+    tableDocumentInstance = nil;
 }
 
 /**
@@ -1505,7 +1507,6 @@
 	[self setConnection:nil];
 
 	pthread_mutex_destroy(&dataProcessingLock);
-
 }
 
 #pragma mark -

--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -82,6 +82,7 @@
     [self setConnection:nil];
 
     pthread_mutex_destroy(&dataProcessingLock);
+    tableDocumentInstance = nil;
 }
 
 /**

--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -82,7 +82,6 @@
     [self setConnection:nil];
 
     pthread_mutex_destroy(&dataProcessingLock);
-    tableDocumentInstance = nil;
 }
 
 /**

--- a/Source/Controllers/DataExport/SPExportController.h
+++ b/Source/Controllers/DataExport/SPExportController.h
@@ -49,7 +49,7 @@
 @interface SPExportController : NSWindowController<NSOpenSavePanelDelegate>
 {	
 	// Controllers
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTableContent *tableContentInstance;
 	IBOutlet SPCustomQuery *customQueryInstance;
 	IBOutlet SPTablesList *tablesListInstance;

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -47,7 +47,7 @@ typedef enum {
 @interface SPDataImport : NSObject <NSOpenSavePanelDelegate>
 {
 #warning Outlets belong to multiple xib files!
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;
 	IBOutlet SPTableData *tableDataInstance;

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.h
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, SPConnectionTimeZoneMode) {
 
 @interface SPConnectionController : NSViewController <SPMySQLConnectionDelegate, NSOpenSavePanelDelegate, SPFavoritesImportProtocol, SPFavoritesExportProtocol, NSSplitViewDelegate>
 {	
-	SPDatabaseDocument *dbDocument;
+	__weak SPDatabaseDocument *dbDocument;
 	SPMySQLConnection *mySQLConnection;
 
 	SPKeychain *keychain;

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1975,8 +1975,6 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	if (sshTunnel) {
 		[sshTunnel setConnectionStateChangeSelector:nil delegate:nil];
 	}
-
-
 }
 
 #pragma mark - SPConnectionHandler

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.h
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.h
@@ -53,7 +53,7 @@
 
 @interface SPCustomQuery : NSObject <NSTableViewDataSource, NSWindowDelegate, NSTableViewDelegate, SPDatabaseContentViewDelegate>
 {
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 
 	IBOutlet id queryFavoritesButton;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -482,8 +482,4 @@
 
 - (void)showMySQLHelp;
 
-#pragma mark Dealloc helpers
-
-- (void)cleanup;
-
 @end

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -6582,6 +6582,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     // #2924: The connection controller doesn't retain its delegate (us), but it may outlive us (e.g. when running a bg thread)
     [connectionController setDelegate:nil];
+    [printWebView setFrameLoadDelegate:nil];
 
     if (taskDrawTimer) {
         [taskDrawTimer invalidate];
@@ -6594,7 +6595,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 #pragma mark -
 
 - (void)dealloc {
-    NSLog(@"Dealloc called %s", __FILE__);
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 @end

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2334,9 +2334,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [connectionController initiateConnection:self];
 }
 
-- (void)closeConnection
-{
+- (void)closeConnection {
     SPLog(@"closeConnection");
+    [mySQLConnection setDelegate:nil];
     [mySQLConnection disconnect];
     _isConnected = NO;
 
@@ -6216,7 +6216,6 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                                                    object:nil];
     }
 
-    [mySQLConnection setDelegate:nil];
     if (_isConnected) {
         [self closeConnection];
     } else {
@@ -6568,7 +6567,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (void)documentWillClose {
     NSAssert([NSThread isMainThread], @"Calling %s from a background thread is not supported!", __func__);
 
-    [self closeAndDisconnect];
+    [self closeConnection];
 
     // Unregister observers
     [self _removePreferenceObservers];

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
@@ -33,10 +33,11 @@
 @class SPDatabaseData;
 @class SPTablesList;
 @class SPMySQLConnection;
+@class SPDatabaseDocument;
 
 @interface SPExtendedTableInfo : NSObject
 {
-	IBOutlet id tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableData *tableDataInstance;
 	IBOutlet SPDatabaseData *databaseDataInstance;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 
 @interface SPTableContent : NSObject <NSTableViewDelegate, NSTableViewDataSource, NSComboBoxDataSource, NSComboBoxDelegate, SPDatabaseContentViewDelegate>
 {	
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 
 	IBOutlet SPTableStructure *tableSourceInstance;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4612,6 +4612,8 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	[self clearTableLoadTimer];
 	
 	pthread_mutex_destroy(&tableValuesLock);
+    
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 @end

--- a/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.h
+++ b/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.h
@@ -36,7 +36,7 @@
 
 @interface SPTableRelations : NSObject <NSTableViewDelegate, NSTableViewDataSource>
 {	
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList       *tablesListInstance;
 	IBOutlet SPTableData        *tableDataInstance;
 	IBOutlet SPTableView        *tableList;

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.h
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.h
@@ -60,7 +60,7 @@
 {
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableData *tableDataInstance;
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTableInfo *tableInfoInstance;
 	IBOutlet SPExtendedTableInfo *extendedTableInfoInstance;
 	IBOutlet SPIndexesController *indexesController;

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -75,6 +75,8 @@
 	[self setTypeDefinition:nil];
 	[self setTypeRange:nil];
 	[self setTypeDescription:nil];
+
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 @end
@@ -2497,6 +2499,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	[prefs removeObserver:self forKeyPath:SPGlobalFontSettings];
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 + (SPFieldTypeHelp *)helpForFieldType:(NSString *)typeName

--- a/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.h
+++ b/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.h
@@ -30,10 +30,11 @@
 
 @class SPTableView;
 @class SPMySQLConnection;
+@class SPDatabaseDocument;
 
 @interface SPTableTriggers : NSObject 
 {
-	IBOutlet id tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet id tablesListInstance;
 	IBOutlet id tableDataInstance;
 	

--- a/Source/Controllers/Other/SPHistoryController.h
+++ b/Source/Controllers/Other/SPHistoryController.h
@@ -34,7 +34,7 @@
 
 @interface SPHistoryController : NSObject 
 {
-	IBOutlet SPDatabaseDocument *theDocument;
+	IBOutlet __weak SPDatabaseDocument *theDocument;
 	IBOutlet NSSegmentedControl *historyControl;
 
 	SPTableContent *tableContentInstance;

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1679,20 +1679,6 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     [[NSNotificationCenter defaultCenter] postNotificationName:SPDocumentDuplicateTabNotification object:nil userInfo:frontState];
 }
 
-#pragma mark - NSWindowDelegate
-
-- (void)windowWillClose:(NSNotification *)notification
-{
-    id window = notification.object;
-    if (!window) {
-        return;
-    }
-
-    if (window == aboutController.window) {
-        aboutController.window.delegate = nil;
-    }
-}
-
 #pragma mark -
 
 - (void)dealloc

--- a/Source/Controllers/SubviewControllers/SPIndexesController.h
+++ b/Source/Controllers/SubviewControllers/SPIndexesController.h
@@ -38,7 +38,7 @@
 @interface SPIndexesController : NSWindowController <NSTableViewDelegate, NSTableViewDataSource, NSComboBoxCellDataSource>
 {
 	// Controllers
-	IBOutlet SPDatabaseDocument *dbDocument;
+	IBOutlet __weak SPDatabaseDocument *dbDocument;
 	IBOutlet SPTableStructure *tableStructure;
 	IBOutlet SPTablesList *tablesList;
 	IBOutlet SPTableData *tableData;

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.h
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.h
@@ -38,7 +38,7 @@ NSString * const SPRuleFilterHeightChangedNotification;
 @interface SPRuleFilterController : NSObject {
 	IBOutlet NSRuleEditor *filterRuleEditor;
 	IBOutlet SPTableData *tableDataInstance;
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet NSView *tableContentViewBelow;
 	IBOutlet NSButton *filterButton;

--- a/Source/Controllers/SubviewControllers/SPTableInfo.h
+++ b/Source/Controllers/SubviewControllers/SPTableInfo.h
@@ -38,7 +38,7 @@
 	IBOutlet SPTableView *tableList;
 	IBOutlet SPTablesList *tableListInstance;
 	IBOutlet SPTableData *tableDataInstance;
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 
 	IBOutlet NSTableView *infoTable;
 	IBOutlet NSTableView *activitiesTable;

--- a/Source/Controllers/SubviewControllers/SPTablesList.h
+++ b/Source/Controllers/SubviewControllers/SPTablesList.h
@@ -47,7 +47,7 @@
 
 @interface SPTablesList : NSObject <NSTextFieldDelegate, NSTableViewDelegate>
 {
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;
 	IBOutlet SPTableContent *tableContentInstance;
 	IBOutlet SPDatabaseData *databaseDataInstance;

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -2941,6 +2941,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[prefs removeObserver:self forKeyPath:SPGlobalFontSettings];
 
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 @end

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -100,9 +100,7 @@ extension SPWindowController: NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
-        if let appController = NSApp.delegate as? SPAppController {
-            appController.windowWillClose(notification)
-        }
-        databaseDocument.cleanup()
+        // Tell listeners that this database document is being closed - fixes retain cycles and allows cleanup
+        NotificationCenter.default.post(name: NSNotification.Name.SPDocumentWillClose, object: databaseDocument)
     }
 }

--- a/Source/Views/SPSplitView.h
+++ b/Source/Views/SPSplitView.h
@@ -32,7 +32,7 @@
 
 @interface SPSplitView : NSSplitView <NSSplitViewDelegate>
 {
-	id<NSSplitViewDelegate, AllowSplitViewResizing> delegate;
+    __weak id<NSSplitViewDelegate, AllowSplitViewResizing> delegate;
 
 	IBOutlet NSButton *collapseToggleButton;
 	IBOutlet NSView *additionalDragHandleView;

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -53,7 +53,7 @@ typedef struct {
 
 @interface SPTextView : NSTextView <NSTextStorageDelegate>
 {
-	IBOutlet SPDatabaseDocument *tableDocumentInstance;
+	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPCustomQuery *customQueryInstance;
 


### PR DESCRIPTION
## Changes:
- Mark database document as weak in cross-reference holders of properties to allow ARC to properly dealloc objects

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.0.0 Beta 5
  
## Screenshots:

## Additional notes:
Many other objects are still not released but this cleans up memory on close of the tab / window nicely and helps reduce 80% of memory during app runtime.