### PR TITLE
Breaking change: Officially drop MySQL 5.6 support #removed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,10 +58,10 @@ If you would like to help with code and development, please see either our [proj
 
 - **macOS:** >= 10.13 \*
 - **Processor:** Intel & Apple Silicon
-- **MySQL:** >= 5.6
+- **MySQL:** >= 5.7
 - **MariaDB:** >= 10.0
 
-_Note: An [older version of Sequel Ace (version 3.5.2)](https://github.com/Sequel-Ace/Sequel-Ace/releases/tag/production%2F3.5.2-20033) is available to download for macOS versions 10.12._
+_Note: An [older version of Sequel Ace (version 3.5.2)](https://github.com/Sequel-Ace/Sequel-Ace/releases/tag/production%2F3.5.2-20033) is available to download for macOS versions 10.12 or for MySQL 5.6 support._
 _Note: An [older version of Sequel Ace (version 2.3.2)](https://github.com/Sequel-Ace/Sequel-Ace/releases/tag/production%2F2.3.2-2121) is available to download for macOS versions 10.10 and 10.11._
 
 \* To run Sequel Ace on Mac OS X 10.13-10.14.4, you need to install Apple's Swift Standard Libraries for the app to work as expected. You can download this support package free of charge from [here (this repository)](https://github.com/Sequel-Ace/Sequel-Ace/blob/main/Scripts/) or [here (Apple directly)](https://support.apple.com/kb/DL1998?locale=en_GB).


### PR DESCRIPTION
## Changes:
- Drop support for MySQL 5.6 as it's EOL since 2021

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 13.4.1