### PR TITLE
Fixed field editor changes not saved if part of the content was deleted #fixed

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -1278,6 +1278,7 @@ typedef enum {
 - (BOOL)textView:(NSTextView *)textView shouldChangeTextInRange:(NSRange)r replacementString:(NSString *)replacementString
 {
     if (replacementString == nil || [replacementString characterCount] == 0) {
+        editTextViewWasChanged = YES // backspace
         return YES;
     }
     

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -1278,7 +1278,7 @@ typedef enum {
 - (BOOL)textView:(NSTextView *)textView shouldChangeTextInRange:(NSRange)r replacementString:(NSString *)replacementString
 {
     if (replacementString == nil || [replacementString characterCount] == 0) {
-        editTextViewWasChanged = YES // backspace
+        editTextViewWasChanged = YES; // Backspace
         return YES;
     }
     


### PR DESCRIPTION
#fixed Fixed a bug where changes were no saved if parts of the content were deleted

To reproduce the bug, just delete the last characters of a field and close the panel. This change will not be saved.
