### PR TITLE
Enable Help menu for connection screen #fixed

### DIFF
--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -536,6 +536,10 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         return YES;
     }
 
+    if (action == @selector(visitHelpWebsite:) || action == @selector(visitFAQWebsite:) || action == @selector(viewKeyboardShortcuts:)) {
+        return YES;
+    }
+
     if (self.tabManager.activeWindowController.databaseDocument) {
         return [self.tabManager.activeWindowController.databaseDocument validateMenuItem:menuItem];
     }


### PR DESCRIPTION
## Changes:
- Enable Help menu for connection screen

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1555

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.12.x (Sierra)
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.0