### PR TITLE
Fix content filtering, fix remembering last filter state #fixed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,12 +20,12 @@ Please use one of these hashtags for your PR title:
   - [ ] Intel
   - [ ] Apple Silicon
 - macOS Versions:
-  - [ ] 10.12.x (Sierra)
   - [ ] 10.13.x (High Sierra)
   - [ ] 10.14.x (Mojave)
   - [ ] 10.15.x (Catalina)
   - [ ] 11.x (Big Sur)
   - [ ] 12.x (Monterey)
+  - [ ] 13.x (Ventura)
 - Localizations:
   - [ ] English
   - [ ] Spanish

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2198,7 +2198,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (void)showFilterTable {
     [self viewContent];
 
-    [tableContentInstance performSelector:@selector(showFilterTable) withObject:nil afterDelay:0.1];
+    [tableContentInstance toggleRuleEditorVisible:nil];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3917,6 +3917,8 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		NSBeep();
 		return;
 	}
+
+    [prefs setBool:YES forKey:SPRuleFilterEditorLastVisibilityChoice];
 	
 	[self setRuleEditorVisible:YES animate:YES];
 	[toggleRuleFilterButton setState:NSOnState];

--- a/Source/Controllers/SPAppController.swift
+++ b/Source/Controllers/SPAppController.swift
@@ -165,6 +165,10 @@ extension SPAppController {
         tabManager.activeWindowController?.databaseDocument.showFilterTable()
     }
 
+    @IBAction func makeTableListFilterHaveFocus(_ sender: Any) {
+        tabManager.activeWindowController?.databaseDocument.makeTableListFilterHaveFocus(nil)
+    }
+
     @IBAction func copyCreateTableSyntax(_ sender: Any) {
         tabManager.activeWindowController?.databaseDocument.copyCreateTableSyntax(nil)
     }

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.h
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.h
@@ -43,7 +43,6 @@ NSString * const SPRuleFilterHeightChangedNotification;
 	IBOutlet NSView *tableContentViewBelow;
 	IBOutlet NSButton *filterButton;
 	IBOutlet NSButton *addFilterButton;
-	IBOutlet NSButton *resetButton;
 
 	NSMutableArray *columns;
 	NSMutableDictionary *contentFilters;

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -249,7 +249,6 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (void)_resize;
 - (void)openContentFilterManagerForFilterType:(NSString *)filterType;
 - (IBAction)filterTable:(id)sender;
-- (IBAction)resetFilter:(id)sender;
 - (IBAction)_menuItemInRuleEditorClicked:(id)sender;
 - (void)_pretendPlayRuleEditorForCriteria:(NSMutableArray *)criteria
                             displayValues:(NSMutableArray *)displayValues
@@ -321,17 +320,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	return self;
 }
 
-- (void)awakeFromNib
-{
-	// move the add filter button over the filter button (since only one of them can be visible at a time)
-	NSRect filterRect = [filterButton frame];
-	NSRect addFilterRect = [addFilterButton frame];
-	CGFloat widthContainer = [[filterButton superview] frame].size.width;
-	CGFloat deltaR = widthContainer - (filterRect.origin.x + filterRect.size.width);
-	addFilterRect.origin.x = widthContainer - deltaR - addFilterRect.size.width;
-	addFilterRect.origin.y = filterRect.origin.y;
-	addFilterRect.size.height = filterRect.size.height;
-	[addFilterButton setFrame:addFilterRect];
+- (void)awakeFromNib {
 
 	[self _doChangeToRuleEditorData:^{
 		[self->filterRuleEditor bind:@"rows" toObject:self->_modelContainer withKeyPath:@"model" options:nil];
@@ -639,7 +628,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 			SPMainLoopAsync(^{
 				// if we are about to remove the only row in existance, treat it as a reset instead
 				if([[self->_modelContainer model] count] == 1) {
-					[self resetFilter:nil];
+					[self resetFilter];
 				}
 				else {
 					[self _doChangeToRuleEditorData:^{
@@ -981,8 +970,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	if(target && action) [target performSelector:action withObject:self];
 }
 
-- (IBAction)resetFilter:(id)sender
-{
+- (void)resetFilter {
     SPTableContent *con = tableDocumentInstance.tableContentInstance;
 
     con->toggleRuleFilterButton.state = !con->toggleRuleFilterButton.state;
@@ -1052,7 +1040,6 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	[addFilterButton setHidden:!empty];
 	[filterButton setHidden:empty];
 
-	[resetButton setEnabled:(enabled && !empty)];
 	[filterButton setEnabled:(enabled && !empty)];
 	[filterRuleEditor setEnabled:enabled];
 	[addFilterButton setEnabled:(enabled && empty)];

--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -212,7 +212,7 @@
                                                                 <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                 <tableColumns>
-                                                                    <tableColumn identifier="info" width="181.8690185546875" minWidth="42.868999481201172" maxWidth="1000" id="4485">
+                                                                    <tableColumn identifier="info" width="182" minWidth="42.868999481201172" maxWidth="1000" id="4485">
                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Information">
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -888,7 +888,7 @@
                                                                                             </textFieldCell>
                                                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                                         </tableColumn>
-                                                                                        <tableColumn identifier="Comment" editable="NO" width="105.97599792480469" minWidth="55.976001739501953" maxWidth="1000" id="297">
+                                                                                        <tableColumn identifier="Comment" editable="NO" width="106" minWidth="55.976001739501953" maxWidth="1000" id="297">
                                                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Comment">
                                                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1012,7 +1012,7 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" id="lwO-LP-RWZ">
                                                                             <rect key="frame" x="1" y="1" width="693" height="431"/>
-                                                                            <autoresizingMask key="autoresizingMask"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             <subviews>
                                                                                 <tableView identifier="TableContentTableView" focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowHeight="16" headerView="3920" id="36" customClass="SPCopyTable">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="693" height="414"/>
@@ -1200,7 +1200,7 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="kdv-Wp-s5h">
                                                                             <rect key="frame" x="0.0" y="0.0" width="694" height="40"/>
-                                                                            <autoresizingMask key="autoresizingMask"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             <subviews>
                                                                                 <ruleEditor nestingMode="compound" canRemoveAllRows="YES" rowHeight="29" id="FF9-z2-9od">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="694" height="40"/>
@@ -1221,20 +1221,8 @@
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                         </scroller>
                                                                     </scrollView>
-                                                                    <button toolTip="Clear filters" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4rb-LV-wk6" userLabel="Clear Filters">
-                                                                        <rect key="frame" x="0.0" y="3" width="25" height="25"/>
-                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
-                                                                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" alternateImage="NSRemoveTemplate" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="xch-cX-dFF">
-                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                            <font key="font" metaFont="system"/>
-                                                                        </buttonCell>
-                                                                        <color key="contentTintColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <connections>
-                                                                            <action selector="resetFilter:" target="ki9-Po-bdr" id="1w5-ri-92x"/>
-                                                                        </connections>
-                                                                    </button>
                                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4676">
-                                                                        <rect key="frame" x="622" y="6" width="54" height="19"/>
+                                                                        <rect key="frame" x="586" y="6" width="54" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                                         <buttonCell key="cell" type="roundRect" title="Filter" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4677">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1245,7 +1233,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xVl-jD-jgc">
-                                                                        <rect key="frame" x="548" y="6" width="66" height="19"/>
+                                                                        <rect key="frame" x="512" y="6" width="66" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                                         <buttonCell key="cell" type="roundRect" title="Add Filter" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MCE-yX-CGu">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -3286,11 +3274,11 @@ Gw
                         <rect key="frame" x="17" y="266" width="345" height="56"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <view key="contentView" id="TYl-WM-nc0">
-                            <rect key="frame" x="3" y="3" width="339" height="38"/>
+                            <rect key="frame" x="4" y="5" width="337" height="36"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5653">
-                                    <rect key="frame" x="115" y="8" width="171" height="22"/>
+                                    <rect key="frame" x="115" y="6" width="171" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="5654">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3302,7 +3290,7 @@ Gw
                                     </connections>
                                 </popUpButton>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5606">
-                                    <rect key="frame" x="15" y="13" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="11" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Column:" id="5607">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3317,11 +3305,11 @@ Gw
                         <rect key="frame" x="17" y="326" width="345" height="58"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <view key="contentView" id="zsK-y0-uf4">
-                            <rect key="frame" x="3" y="3" width="339" height="40"/>
+                            <rect key="frame" x="4" y="5" width="337" height="38"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7800">
-                                    <rect key="frame" x="15" y="15" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="13" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Name:" id="7801">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3330,7 +3318,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7808">
-                                    <rect key="frame" x="118" y="12" width="165" height="19"/>
+                                    <rect key="frame" x="118" y="10" width="165" height="19"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Generate one" drawsBackground="YES" usesSingleLineMode="YES" id="7809">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3348,11 +3336,11 @@ Gw
                         <rect key="frame" x="17" y="54" width="345" height="87"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <view key="contentView" id="cfU-Jg-Yhk">
-                            <rect key="frame" x="3" y="3" width="339" height="69"/>
+                            <rect key="frame" x="4" y="5" width="337" height="67"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5614">
-                                    <rect key="frame" x="116" y="38" width="170" height="22"/>
+                                    <rect key="frame" x="116" y="36" width="170" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="-1" imageScaling="proportionallyDown" inset="2" selectedItem="5617" id="5615">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3373,7 +3361,7 @@ Gw
                                     </popUpButtonCell>
                                 </popUpButton>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5622">
-                                    <rect key="frame" x="116" y="8" width="170" height="22"/>
+                                    <rect key="frame" x="116" y="6" width="170" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="-1" imageScaling="proportionallyDown" inset="2" selectedItem="5629" id="5623">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3394,7 +3382,7 @@ Gw
                                     </popUpButtonCell>
                                 </popUpButton>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5610">
-                                    <rect key="frame" x="15" y="43" width="99" height="14"/>
+                                    <rect key="frame" x="15" y="41" width="99" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="On update:" id="5611">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3403,7 +3391,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5612">
-                                    <rect key="frame" x="15" y="13" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="11" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="On delete:" id="5613">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3418,11 +3406,11 @@ Gw
                         <rect key="frame" x="17" y="145" width="345" height="117"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <view key="contentView" id="C4K-cX-m70">
-                            <rect key="frame" x="3" y="3" width="339" height="99"/>
+                            <rect key="frame" x="4" y="5" width="337" height="97"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wQQ-It-oAb">
-                                    <rect key="frame" x="115" y="68" width="171" height="22"/>
+                                    <rect key="frame" x="115" y="66" width="171" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="d5b-XR-bub">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3434,7 +3422,7 @@ Gw
                                     </connections>
                                 </popUpButton>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5630">
-                                    <rect key="frame" x="115" y="38" width="171" height="22"/>
+                                    <rect key="frame" x="115" y="36" width="171" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="5631">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3446,7 +3434,7 @@ Gw
                                     </connections>
                                 </popUpButton>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5636">
-                                    <rect key="frame" x="115" y="8" width="171" height="22"/>
+                                    <rect key="frame" x="115" y="6" width="171" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="5637">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3455,7 +3443,7 @@ Gw
                                     </popUpButtonCell>
                                 </popUpButton>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5608">
-                                    <rect key="frame" x="15" y="43" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="41" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Table:" id="5609">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3464,7 +3452,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5642">
-                                    <rect key="frame" x="15" y="13" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="11" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Column:" id="5643">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3473,7 +3461,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wT2-TL-vY9">
-                                    <rect key="frame" x="15" y="73" width="98" height="14"/>
+                                    <rect key="frame" x="15" y="71" width="98" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Database:" id="Bcl-mh-TYx">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3547,11 +3535,11 @@ Gw
                         <rect key="frame" x="17" y="219" width="326" height="109"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <view key="contentView" id="83r-U8-ZHm">
-                            <rect key="frame" x="3" y="3" width="320" height="91"/>
+                            <rect key="frame" x="4" y="5" width="318" height="89"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6776">
-                                    <rect key="frame" x="1" y="64" width="116" height="14"/>
+                                    <rect key="frame" x="1" y="62" width="116" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Name:" id="6777">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3560,7 +3548,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6775">
-                                    <rect key="frame" x="125" y="62" width="177" height="19"/>
+                                    <rect key="frame" x="125" y="60" width="175" height="19"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="6778">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3572,7 +3560,7 @@ Gw
                                     </connections>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6774">
-                                    <rect key="frame" x="121" y="33" width="187" height="22"/>
+                                    <rect key="frame" x="121" y="31" width="187" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" title="Before" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="6781" id="6779">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3586,7 +3574,7 @@ Gw
                                     </popUpButtonCell>
                                 </popUpButton>
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6773">
-                                    <rect key="frame" x="121" y="8" width="187" height="22"/>
+                                    <rect key="frame" x="121" y="6" width="187" height="22"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <popUpButtonCell key="cell" type="push" title="Insert" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="6785" id="6783">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3601,7 +3589,7 @@ Gw
                                     </popUpButtonCell>
                                 </popUpButton>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6772">
-                                    <rect key="frame" x="1" y="38" width="116" height="14"/>
+                                    <rect key="frame" x="1" y="36" width="116" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Action Time:" id="6788">
                                         <font key="font" metaFont="message" size="11"/>
@@ -3610,7 +3598,7 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6771">
-                                    <rect key="frame" x="1" y="13" width="116" height="14"/>
+                                    <rect key="frame" x="1" y="11" width="116" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Event:" id="6789">
                                         <font key="font" metaFont="message" size="11"/>
@@ -4399,7 +4387,6 @@ Gw
                 <outlet property="addFilterButton" destination="xVl-jD-jgc" id="hoX-nP-wFM"/>
                 <outlet property="filterButton" destination="4676" id="9tZ-dW-BR3"/>
                 <outlet property="filterRuleEditor" destination="FF9-z2-9od" id="RW4-XM-XQS"/>
-                <outlet property="resetButton" destination="4rb-LV-wk6" id="cH9-7g-geZ"/>
                 <outlet property="tableContentViewBelow" destination="36" id="ZGh-dM-J6C"/>
                 <outlet property="tableDataInstance" destination="4702" id="e69-W6-UwN"/>
                 <outlet property="tableDocumentInstance" destination="-2" id="2Xe-WU-zRw"/>
@@ -4991,17 +4978,17 @@ Gw
         </customView>
     </objects>
     <resources>
-        <image name="NSActionTemplate" width="15" height="15"/>
-        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSActionTemplate" width="20" height="20"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
         <image name="NSAdvanced" width="32" height="32"/>
         <image name="NSApplicationIcon" width="32" height="32"/>
-        <image name="NSGoLeftTemplate" width="10" height="14"/>
-        <image name="NSGoRightTemplate" width="10" height="14"/>
-        <image name="NSLeftFacingTriangleTemplate" width="10" height="14"/>
-        <image name="NSQuickLookTemplate" width="21" height="13"/>
-        <image name="NSRefreshTemplate" width="14" height="16"/>
-        <image name="NSRemoveTemplate" width="14" height="4"/>
-        <image name="NSRightFacingTriangleTemplate" width="10" height="14"/>
+        <image name="NSGoLeftTemplate" width="12" height="17"/>
+        <image name="NSGoRightTemplate" width="12" height="17"/>
+        <image name="NSLeftFacingTriangleTemplate" width="12" height="17"/>
+        <image name="NSQuickLookTemplate" width="26" height="17"/>
+        <image name="NSRefreshTemplate" width="18" height="21"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
+        <image name="NSRightFacingTriangleTemplate" width="12" height="17"/>
         <image name="NSSmartBadgeTemplate" width="14" height="14"/>
         <image name="button_bar_handleTemplate" width="6" height="10"/>
         <image name="button_duplicateTemplate" width="15" height="10"/>

--- a/Source/Interfaces/FilterTableWindow.xib
+++ b/Source/Interfaces/FilterTableWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,7 +29,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="162" y="162" width="752" height="317"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2880" height="1595"/>
             <value key="minSize" type="size" width="600" height="317"/>
             <view key="contentView" id="mgs-0s-XcR" userLabel="Filter Table Window">
                 <rect key="frame" x="0.0" y="0.0" width="752" height="317"/>
@@ -57,7 +57,7 @@
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                     <tableColumns>
-                                                        <tableColumn width="719.921875" minWidth="40" maxWidth="1000" id="VGf-vY-BT6">
+                                                        <tableColumn width="720" minWidth="40" maxWidth="1000" id="VGf-vY-BT6">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -264,7 +264,7 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="235" y="418" width="251" height="102"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2880" height="1595"/>
             <value key="minSize" type="size" width="251" height="102"/>
             <value key="maxSize" type="size" width="251" height="102"/>
             <view key="contentView" id="nxt-IK-Ukn">


### PR DESCRIPTION
## Changes:
- Fix filtering UI
- Fix filtering shortcuts
- Fix filtering last state storing

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1590
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1596
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1540
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1517
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1508

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.1