### PR TITLE
#fixed Remove data type names from CSV exports

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1695,7 +1695,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     // Set field names as first line
     for (tableColumn in [customQueryView tableColumns])
     {
-        [tempRow addObject:[[tableColumn headerCell] stringValue]];
+        [tempRow addObject:[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0]];
     }
     
     NSMutableArray *currentResult = [NSMutableArray array];

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1695,7 +1695,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     // Set field names as first line
     for (tableColumn in [customQueryView tableColumns])
     {
-        [tempRow addObject:[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0]];
+        [tempRow addObject:[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSString columnHeaderSplittingSpace]][0]];
     }
     
     NSMutableArray *currentResult = [NSMutableArray array];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4107,7 +4107,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		if ([[tableValues cellDataAtRow:rowIndex column:[[tableColumn identifier] integerValue]] isSPNotLoaded]) {
 
 			// Only get the data for the selected column, not all of them
-			NSString *query = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@", [[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0] backtickQuotedString], [selectedTable backtickQuotedString], wherePart];
+			NSString *query = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@", [[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSString columnHeaderSplittingSpace]][0] backtickQuotedString], [selectedTable backtickQuotedString], wherePart];
 
 			SPMySQLResult *tempResult = [mySQLConnection queryString:query];
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4107,7 +4107,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		if ([[tableValues cellDataAtRow:rowIndex column:[[tableColumn identifier] integerValue]] isSPNotLoaded]) {
 
 			// Only get the data for the selected column, not all of them
-			NSString *query = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@", [[[tableColumn headerCell] stringValue] backtickQuotedString], [selectedTable backtickQuotedString], wherePart];
+			NSString *query = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@", [[[[tableColumn headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0] backtickQuotedString], [selectedTable backtickQuotedString], wherePart];
 
 			SPMySQLResult *tempResult = [mySQLConnection queryString:query];
 

--- a/Source/Other/Extensions/NSDictionaryExtension.swift
+++ b/Source/Other/Extensions/NSDictionaryExtension.swift
@@ -16,13 +16,9 @@ import Foundation
         let font = UserDefaults.getFont()
         let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: font])
         if let columnType: String = value(forKey: "type") as? String {
-            attributedString.append(NSAttributedString(string: NSDictionary.tableContentColumnHeaderSplittingSpaceCharacter as String))
+            attributedString.append(NSAttributedString(string: NSString.columnHeaderSplittingSpace as String))
             attributedString.append(NSAttributedString(string: columnType, attributes: [.font: NSFontManager.shared.convert(font, toSize: 8), .foregroundColor: NSColor.gray]))
         }
         return attributedString
-    }
-    static var tableContentColumnHeaderSplittingSpaceCharacter: NSString {
-        //Magic special space character
-        return " ";
     }
 }

--- a/Source/Other/Extensions/NSDictionaryExtension.swift
+++ b/Source/Other/Extensions/NSDictionaryExtension.swift
@@ -16,9 +16,13 @@ import Foundation
         let font = UserDefaults.getFont()
         let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: font])
         if let columnType: String = value(forKey: "type") as? String {
-            attributedString.append(NSAttributedString(string: " "))
+            attributedString.append(NSAttributedString(string: NSDictionary.tableContentColumnHeaderSplittingSpaceCharacter as String))
             attributedString.append(NSAttributedString(string: columnType, attributes: [.font: NSFontManager.shared.convert(font, toSize: 8), .foregroundColor: NSColor.gray]))
         }
         return attributedString
+    }
+    static var tableContentColumnHeaderSplittingSpaceCharacter: NSString {
+        //Magic special space character
+        return " ";
     }
 }

--- a/Source/Other/Extensions/StringExtension.swift
+++ b/Source/Other/Extensions/StringExtension.swift
@@ -201,6 +201,9 @@ extension String {
 }
 
 @objc extension NSString {
+    //Special space-character used to separate the column name and column type
+    @objc static let columnHeaderSplittingSpace: String = " "
+
     static func rawByteString(data: NSData) -> NSString {
         return String.rawByteString(data as Data) as NSString
     }

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -293,7 +293,7 @@ NSString *kHeader     = @"HEADER";
 		for( i = 0; i < numColumns; i++ ){
 			if([result length])
 				[result appendString:@","];
-			[result appendFormat:@"\"%@\"", [[[[columns safeObjectAtIndex:i] headerCell] stringValue] stringByReplacingOccurrencesOfString:@"\"" withString:@"\"\""]];
+			[result appendFormat:@"\"%@\"", [[[[[columns safeObjectAtIndex:i] headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0] stringByReplacingOccurrencesOfString:@"\"" withString:@"\"\""]];
 		}
 		[result appendString:@"\n"];
 	}

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -293,7 +293,7 @@ NSString *kHeader     = @"HEADER";
 		for( i = 0; i < numColumns; i++ ){
 			if([result length])
 				[result appendString:@","];
-			[result appendFormat:@"\"%@\"", [[[[[columns safeObjectAtIndex:i] headerCell] stringValue] componentsSeparatedByString:[NSDictionary tableContentColumnHeaderSplittingSpaceCharacter]][0] stringByReplacingOccurrencesOfString:@"\"" withString:@"\"\""]];
+			[result appendFormat:@"\"%@\"", [[[[[columns safeObjectAtIndex:i] headerCell] stringValue] componentsSeparatedByString:[NSString columnHeaderSplittingSpace]][0] stringByReplacingOccurrencesOfString:@"\"" withString:@"\"\""]];
 		}
 		[result appendString:@"\n"];
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Fixes a regression introduced in https://github.com/Sequel-Ace/Sequel-Ace/pull/1588 that caused the data types of the columns to be embedded in CSV exports

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:

@Kaspik If there's a cleaner way to do this, we should do that instead. Did test that this works though
