### PR TITLE
Fix copy as SQL insert, Fix users modal resizing #fixed

### DIFF
--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -135,7 +135,7 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 	[tabView selectTabViewItemAtIndex:0];
 
 	[splitView setMinSize:120.f ofSubviewAtIndex:0];
-	[splitView setMinSize:620.f ofSubviewAtIndex:1];
+	[splitView setMinSize:550.f ofSubviewAtIndex:1];
 
 	NSTableColumn *tableColumn = [outlineView tableColumnWithIdentifier:SPTableViewNameColumnID];
 	ImageAndTextCell *imageAndTextCell = [[ImageAndTextCell alloc] init];

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -504,7 +504,7 @@ NSString *kHeader     = @"HEADER";
             data              = [[NSMutableDictionary alloc] init];
             data[kColMapping] = @(columnMapping);
             data[kColType]    = @(1);                 // By default, set to String
-            data[kHeader]     = [[[columns safeObjectAtIndex:c] headerCell] stringValue];
+            data[kHeader]     = [[[[columns safeObjectAtIndex:c] headerCell] stringValue] componentsSeparatedByString:[NSString columnHeaderSplittingSpace]][0];
             // Numeric data
             if ([t isEqualToString:@"bit"] || [t isEqualToString:@"integer"] || [t isEqualToString:@"float"])
                 data[kColType] = @(0);
@@ -657,8 +657,9 @@ NSString *kHeader     = @"HEADER";
     for (NSDictionary *dic in array) {
         if (![dic isKindOfClass:[NSNull class]]) {
             NSString *header = [dic safeObjectForKey:kHeader];
-            if ([result length])
+            if ([result length]) {
                 [result appendString: @", "];
+            }
             [result appendString:[header backtickQuotedString]];
         }
     }


### PR DESCRIPTION
## Changes:
- Don't add types to the copy string
- Allow better resizing of users modal

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1610
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1611

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.1