### PR TITLE
#fixed Longitude/Latitude order when inserting GIS data

### DIFF
--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLGeometryDataTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLGeometryDataTests.m
@@ -1,0 +1,125 @@
+//
+//  SPMySQLGeometryDataTests.m
+//  SPMySQLFramework
+//
+//  Created by Luis Aguiniga on 11.06.2022
+//
+
+#import <XCTest/XCTest.h>
+#import "SPMySQLGeometryData.h"
+#include <CoreFoundation/CoreFoundation.h>
+
+@interface SPMySQLGeometryDataTests : XCTestCase
+
+@end
+
+// C - Helper Functions - Declerations
+static void initialize_point(void *buffer, uint32_t srid, double x, double y);
+
+@implementation SPMySQLGeometryDataTests
+
+- (void)test_PointWithSrid4326_MySQL_5 {
+  uint8_t buffer[32] = {0};
+
+  // Simulate MySQL 5.5+ < 8 behavior for SRID 4326:
+  //
+  //     mysql> select
+  //         ->   HEX(ST_GeomFromText('POINT(10 20)', 4326)) as `Point_4326`,
+  //         ->   ST_AsText(ST_GeomFromText('POINT(10 20)', 4326)) as `AsText_4326`;
+  //     +----------------------------------------------------+--------------+
+  //     | Point_4326                                         | AsText_4326  |
+  //     +----------------------------------------------------+--------------+
+  //     | E6100000010100000000000000000024400000000000003440 | POINT(10 20) |
+  //     +----------------------------------------------------+--------------+
+  //
+  // buffer breakdown:
+  // [ SRID ]  [ByteOrder]  [WKB Type]  [      X       ]  [      Y       ]
+  // [ 4326 ]  [    1    ]  [    1   ]  [     10       ]  [     20       ]
+  // E6100000      01        01000000   0000000000002440  0000000000003440
+  initialize_point(buffer, 4326, 10.0, 20.0);
+
+  SPMySQLGeometryData *mysql5 = [SPMySQLGeometryData dataWithBytes:(const void *)buffer length: 25 version: 5];
+  NSString *result = [mysql5 wktString];
+  XCTAssertTrue([@"POINT(10 20),4326" isEqual: result]);
+}
+
+- (void)test_PointWithSrid4326_MySQL_8 {
+  uint8_t buffer[32] = {0};
+
+  // Simulate MySQL 8 behavior for SRID 4326:
+  //
+  //     mysql> select
+  //         ->   HEX(ST_GeomFromText('POINT(10 20)', 4326)) as `Point_4326`,
+  //         ->   ST_AsText(ST_GeomFromText('POINT(10 20)', 4326)) as `AsText_4326`;
+  //     +----------------------------------------------------+--------------+
+  //     | Point_4326                                         | AsText_4326  |
+  //     +----------------------------------------------------+--------------+
+  //     | E6100000010100000000000000000034400000000000002440 | POINT(10 20) |
+  //     +----------------------------------------------------+--------------+
+  //
+  // buffer breakdown:
+  // [ SRID ]  [ByteOrder]  [WKB Type]  [      Y       ]  [      X       ]
+  // [ 4326 ]  [    1    ]  [    1   ]  [     20       ]  [     10       ]
+  // E6100000      01       01000000    0000000000003440  0000000000002440
+  // Note: while we use POINT(10 20) in both examples, MySQL 8 swaps X Y values in storage so we swap them here to simulate that:
+  initialize_point(buffer, 4326, 20.0, 10.0);
+
+  // Pre-Fix (version 5 approach swaps coordinates):
+  SPMySQLGeometryData *mysql5 = [SPMySQLGeometryData dataWithBytes:(const void *)buffer length: 25 version: 5];
+  NSString *result5 = [mysql5 wktString];
+  XCTAssertTrue([@"POINT(20 10),4326" isEqual: result5]);
+
+  // Post Fix (version 8 recognizes swap and corrects for it based on SRID):
+  SPMySQLGeometryData *mysql8 = [SPMySQLGeometryData dataWithBytes:(const void *)buffer length: 25 version: 8];
+  NSString *result8 = [mysql8 wktString];
+  XCTAssertTrue([@"POINT(10 20),4326" isEqual: result8]);
+}
+
+- (void)test_PointWithSrid0_MySQL_5_and_8 {
+  uint8_t buffer[32] = {0};
+
+  // Simulate MySQL 5.5 & 8 behavior for SRID 0:
+  //
+  //     mysql> select
+  //         ->   HEX(ST_GeomFromText('POINT(10 20)')) as `Point`,
+  //         ->   ST_AsText(ST_GeomFromText('POINT(10 20)')) as `AsText`;
+  //     +----------------------------------------------------+--------------+
+  //     | Point                                              | AsText       |
+  //     +----------------------------------------------------+--------------+
+  //     | 00000000010100000000000000000024400000000000003440 | POINT(10 20) |
+  //     +----------------------------------------------------+--------------+
+  //
+  // buffer breakdown:
+  // [ SRID ]  [ByteOrder]  [WKB Type]  [      Y       ]  [      X       ]
+  // [ 4326 ]  [    1    ]  [    1   ]  [     20       ]  [     10       ]
+  // 00000000      01        01000000   0000000000002440  0000000000003440
+  initialize_point(buffer, 0, 10.0, 20.0);
+
+  // Pre-Fix (version 5 approach swaps coordinates):
+  SPMySQLGeometryData *mysql5 = [SPMySQLGeometryData dataWithBytes:(const void *)buffer length: 25 version: 5];
+  NSString *result5 = [mysql5 wktString];
+  XCTAssertTrue([@"POINT(10 20)" isEqual: result5]);
+
+  // Post Fix (version 8 recognizes swap and corrects for it based on SRID):
+  SPMySQLGeometryData *mysql8 = [SPMySQLGeometryData dataWithBytes:(const void *)buffer length: 25 version: 8];
+  NSString *result8 = [mysql8 wktString];
+  XCTAssertTrue([@"POINT(10 20)" isEqual: result8]);
+}
+
+@end
+
+// C - Helper Functions - Implementations
+static void initialize_point(void *buffer, uint32_t srid, double x, double y) {
+  static uint8_t  byteOrder = 0x01;
+  static uint32_t wkbtype   = 0x00000001; // wkb_point
+
+  // clear buffer
+  memset(buffer, 0x00, 32);
+
+  // set buffer
+  memcpy(buffer +  0,      &srid, 4);
+  memcpy(buffer +  4, &byteOrder, 1); // byte order == little endian
+  memcpy(buffer +  5,   &wkbtype, 4);
+  memcpy(buffer +  9,         &x, 8);
+  memcpy(buffer + 17,         &y, 8);
+}

--- a/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
+++ b/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		58D2A4D216EDF1C6002EB401 /* SPMySQLEmptyResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D2A4D016EDF1C6002EB401 /* SPMySQLEmptyResult.m */; };
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
+		FD4211952918779400941BFE /* SPMySQLGeometryDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,6 +224,7 @@
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Resources/Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* SPMySQL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPMySQL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
+		FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMySQLGeometryDataTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -344,6 +346,7 @@
 				507FF1D81BC0D7D300104523 /* Info.plist */,
 				507FF1811BC0C64100104523 /* DataConversion_Tests.m */,
 				507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */,
+				FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */,
 			);
 			name = "Unit Tests";
 			path = "SPMySQL Unit Tests";
@@ -704,6 +707,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				507FF23D1BC157B500104523 /* SPMySQLStringAdditions_Tests.m in Sources */,
+				FD4211952918779400941BFE /* SPMySQLGeometryDataTests.m in Sources */,
 				507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -355,7 +355,7 @@
 				// update the affected row count.
 				case SPMySQLResultAsResult:
 					mysqlResult = mysql_store_result(mySQLConnection);
-					theResult = [[SPMySQLResult alloc] initWithMySQLResult:mysqlResult stringEncoding:theEncoding];
+					theResult = [[SPMySQLResult alloc] initWithMySQLResult:mysqlResult stringEncoding:theEncoding version:self.serverMajorVersion];
 					theAffectedRowCount = mysql_affected_rows(mySQLConnection);
 					break;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Server Info.m
@@ -119,7 +119,7 @@
 	lastConnectionUsedTime = _monotonicTime();
 
 	// Convert to SPMySQLResult
-	SPMySQLResult *theResult = [[SPMySQLResult alloc] initWithMySQLResult:mysqlResult stringEncoding:stringEncoding];
+	SPMySQLResult *theResult = [[SPMySQLResult alloc] initWithMySQLResult:mysqlResult stringEncoding:stringEncoding version: self.serverMajorVersion];
 
 	// Unlock and return
 	[self _unlockConnection];

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLEmptyResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLEmptyResult.m
@@ -40,7 +40,7 @@
 /**
  * Override the standard SPMySQLResult interface
  */
-- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding
+- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding version:(NSUInteger)majorVersion
 {
 	return [super init];
 }

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLGeometryData.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLGeometryData.h
@@ -35,10 +35,11 @@
 	// Holds the buffer length
 	NSUInteger bufferLength;
 
+  NSUInteger serverMajorVersion;
 }
 
-- (instancetype)initWithBytes:(const void *)geoData length:(NSUInteger)length;
-+ (instancetype)dataWithBytes:(const void *)geoData length:(NSUInteger)length;
+- (instancetype)initWithBytes:(const void *)geoData length:(NSUInteger)length version:(NSUInteger)majorVersion;
++ (instancetype)dataWithBytes:(const void *)geoData length:(NSUInteger)length version:(NSUInteger)majorVersion;
 - (NSString *)description;
 - (NSUInteger)length;
 - (NSData *)data;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Data Conversion.m
@@ -153,7 +153,7 @@ static NSStringEncoding NSFromCFStringEncodingGBK_95;
 
 		// For Geometry types, use a special Geometry object to handle their complexity
 		case SPMySQLResultFieldAsGeometry:
-			return [SPMySQLGeometryData dataWithBytes:bytes length:length];
+			return [SPMySQLGeometryData dataWithBytes:bytes length:length version: self.serverMajorVersion];
 
 		// For bit fields, get a zero-padded representation of the data
 		case SPMySQLResultFieldAsBit:

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.h
@@ -65,7 +65,7 @@ typedef enum {
 }
 
 // Master init method
-- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding;
+- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding version:(NSUInteger)majorVersion;
 
 // Result set information
 - (NSUInteger)numberOfFields;
@@ -94,6 +94,7 @@ typedef enum {
  * necessary there.
  */
 @property (readwrite, assign) BOOL returnDataAsStrings;
+@property (readonly, assign) NSUInteger serverMajorVersion;
 
 @property (readwrite, assign) SPMySQLResultRowType defaultRowReturnType;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -41,6 +41,7 @@ static id NSNullPointer;
 
 @synthesize returnDataAsStrings;
 @synthesize defaultRowReturnType;
+@synthesize serverMajorVersion;
 
 #pragma mark -
 #pragma mark Setup and teardown
@@ -81,7 +82,7 @@ static id NSNullPointer;
  * Standard init method, constructing the SPMySQLResult around a MySQL
  * result pointer and the encoding to use when working with the data.
  */
-- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding
+- (instancetype)initWithMySQLResult:(void *)theResult stringEncoding:(NSStringEncoding)theStringEncoding version:(NSUInteger)majorVersion
 {
 	// If no result set was passed in, return nil.
 	if (!theResult) return nil;
@@ -93,6 +94,7 @@ static id NSNullPointer;
 		resultSet = theResult;
 		numberOfFields = mysql_num_fields(resultSet);
 		numberOfRows = mysql_num_rows(resultSet);
+    serverMajorVersion = majorVersion;
 
 		// Cache the field definitions and build up an array of cached field names and types
 		fieldDefinitions = mysql_fetch_fields(resultSet);

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStreamingResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStreamingResult.m
@@ -68,7 +68,7 @@
 	// If no result set was passed in, return nil.
 	if (!theResult) return nil;
 
-	if ((self = [super initWithMySQLResult:theResult stringEncoding:theStringEncoding])) {
+	if ((self = [super initWithMySQLResult:theResult stringEncoding:theStringEncoding version:theConnection.serverMajorVersion])) {
 		parentConnection = theConnection;
 		numberOfRows = NSNotFound;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Pass through major server version from `SPMySQLConnection` to `SOMySQLResult` to get it on into `SPMySQLGeometryData` where it is used to swap order of x,y coordinates when on version 8.

## Closes following issues:
- Closes: #1509 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
  - [ ] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.1
 