### PR TITLE
#added Add keyboard shortcut for Filter Content menu item

### DIFF
--- a/Source/Interfaces/MainMenu.xib
+++ b/Source/Interfaces/MainMenu.xib
@@ -820,8 +820,7 @@
                 <menuItem title="Table" tag="5" id="757">
                     <menu key="submenu" title="Table" id="758">
                         <items>
-                            <menuItem title="Filter Content" toolTip="Move the keyboard focus to the Content Table filter table fields (⌘F is an available shortcut on the Content view)" id="1041">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Filter Content" keyEquivalent="i" toolTip="Move the keyboard focus to the Content Table filter table fields (⌘F is an available shortcut on the Content view)" id="1041">
                                 <connections>
                                     <action selector="focusOnTableContentFilter:" target="-1" id="1044"/>
                                 </connections>

--- a/Source/Interfaces/MainMenu.xib
+++ b/Source/Interfaces/MainMenu.xib
@@ -820,7 +820,8 @@
                 <menuItem title="Table" tag="5" id="757">
                     <menu key="submenu" title="Table" id="758">
                         <items>
-                            <menuItem title="Filter Content" keyEquivalent="i" toolTip="Move the keyboard focus to the Content Table filter table fields (⌘F is an available shortcut on the Content view)" id="1041">
+                            <menuItem title="Filter Content" keyEquivalent="f" toolTip="Move the keyboard focus to the Content Table filter table fields (⌘F is an available shortcut on the Content view)" id="1041">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="focusOnTableContentFilter:" target="-1" id="1044"/>
                                 </connections>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Adds Cmd+I shortcut to menu bar item "Filter Content"

## Closes following issues:
- Closes: #1547

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [x] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.1
  
## Screenshots:

## Additional notes:
I've used the letter `I` as the shortcut since it's the second letter in the word "filter".