### PR TITLE
#fixed Autocomplete weirdness

### DIFF
--- a/Source/Model/SPNarrowDownCompletion.h
+++ b/Source/Model/SPNarrowDownCompletion.h
@@ -104,5 +104,6 @@
 
 - (void)updateSyncArrowStatus;
 - (void)reInvokeCompletion;
+- (BOOL)hasStartedIntercepting;
 
 @end

--- a/Source/Model/SPNarrowDownCompletion.m
+++ b/Source/Model/SPNarrowDownCompletion.m
@@ -52,7 +52,9 @@ static NSString * const SPAutoCompletePlaceholderVal  = @"placholder";
 
 @end
 
-@interface SPNarrowDownCompletion ()
+@interface SPNarrowDownCompletion () {
+  BOOL startedIntercepting;
+}
 
 - (NSRect)rectOfMainScreen;
 - (NSString*)filterString;
@@ -124,6 +126,7 @@ static NSString * const SPAutoCompletePlaceholderVal  = @"placholder";
 		suggestions = nil;
 		autocompletePlaceholderWasInserted = NO;
 		prefs = [NSUserDefaults standardUserDefaults];
+    startedIntercepting = NO;
 
 		tableFont = [NSUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] dataForKey:SPCustomQueryEditorFont]];
 		[self setupInterface];
@@ -785,18 +788,15 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 
 	[theView setCompletionIsOpen:YES];
 
-	closeMe = NO;
 	while(!closeMe) {
 		NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
 		                                    untilDate:[NSDate distantFuture]
 		                                       inMode:NSDefaultRunLoopMode
 		                                      dequeue:YES];
+    startedIntercepting = YES;
 
 		if(!event) continue;
 
-		// Exit if closeMe has been set in the meantime
-		if(closeMe) return;
-		
 		NSEventType t = [event type];
 		if([theTableView SP_NarrowDownCompletion_canHandleEvent:event]) {
 			// skip the rest
@@ -1142,6 +1142,10 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 {
 	theCharRange.location += delta;
 	theParseRange.location += delta;
+}
+
+- (BOOL)hasStartedIntercepting {
+  return startedIntercepting;
 }
 
 @end

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -2175,6 +2175,11 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 				   afterDelay:[[prefs valueForKey:SPCustomQueryAutoHelpDelay] doubleValue]];
 	}
 
+  if (completionIsOpen && completionPopup && ![completionPopup hasStartedIntercepting]) {
+    [completionPopup close];
+    completionPopup = nil;
+  }
+
 	// Cancel auto-completion timer
 	if([prefs boolForKey:SPCustomQueryAutoComplete])
 		[NSObject cancelPreviousPerformRequestsWithTarget:self


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

At a very high level `SPTextView`'s `- (void)keyDown:(NSEvent *)theEvent` does a few things
* `A1` - cancels previous timer/trigger to display autocomplete menu/popup
* `A2` - lets superclass handle keydown event which added character to textStorage for the view.
* `A3` - after textstograge is update, re-sets timer/trigger to display autocomplete popup.

When auto complete popup is already displayed, `SPNarrowDownCompletion` roughly does the following
* `B1` - inserts the first item in autocomplete popup into textview as a preview of the selection
* `B2` - intercepts NSEvents to adjust autocomplete list/preview
* `B3` - hands off event to `SPTextView` for it to be added to the text storage. 

The issue reported by #1591 appears to occur when `SPTextView` gets a key down too late for it to stop the previously set timer/trigger from executing. so Steps `A1` - `A3` start to happen and are quickly followed by `B1`. By the time `B2` starts to intercept NSEvents one snuck in already and messed up `SPTextView`'s contents.

## Changes:
- add a boolean to `SPNarrowDownCompletion` so that `SPTextView` can tell if an keyDown event it's processing was intercepted by `SPNarrowDownCompletion` or not. If it wasn't intercepted and we are displaying the popup then we hit this race condition so we manually close it so that it has a chance to correct the inserted "preview" characters back out of `SPTextView`.


## Closes following issues:
- Closes: #1591

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
  - [ ] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.1
  
## Screenshots:
![fixed](https://user-images.githubusercontent.com/1121410/201848066-241c4623-59df-4fd1-9fac-0dd378e0b5dd.gif)


## Additional notes:
