### PR TITLE
#fixed Pasting content in unloaded text/blob field causes crash

### DIFF
--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -1291,14 +1291,14 @@ NSString *kHeader     = @"HEADER";
 
 
     //Check for null
-	if ([cellValue isNSNull])
-	{
+    if ([cellValue isNSNull])
+    {
         //Null should always be inline
         return NO;
     }
 
     //Check string lengths
-    if (editLongerTextInSheet && [cellValue length] > editInSheetForLongTextLengthThreshold) {
+    if (editLongerTextInSheet && [cellValue isKindOfClass:[NSString class]] && [cellValue length] > editInSheetForLongTextLengthThreshold) {
         return YES;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

Error:
```
2022-11-21 19:37:24.099408-0800 Sequel Ace[81812:5636897] -[SPNotLoaded length]: unrecognized selector sent to instance 0x600003e44150
2022-11-21 19:37:24.099970-0800 Sequel Ace[81812:5636897] [General] An uncaught exception was raised
```

Crash occurs when when `[prefs boolForKey:SPEditInSheetForLongText]` == `YES` and SequelAce attempts to get length of an `SPNotLoaded` instance. 

## Changes:
- Check for instance to be an NSString before trying to get it's length. 
Note: this only appears to happen when the underlying value is `NULL` -- if `SPEditInSheetForLongText` is disabled and the value is `NULL` then we have an instance of  `NSNull` instead of `SPNotLoaded` and case is handled by prior if statement. When value is not `NULL` then we have an `NSString` so checking for string class should do the trick here.

## Closes following issues:
- Closes: #1553

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
  - [ ] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
 