### PR TITLE
Temporary Hotfix: Kill the task after termination #fixed

### DIFF
--- a/Source/Other/CategoryAdditions/SPTaskAdditions.m
+++ b/Source/Other/CategoryAdditions/SPTaskAdditions.m
@@ -24,12 +24,20 @@
 
 - (void)SPterminate{
 
+    int processID = self.processIdentifier;
+
+    [self terminate];
+
+    NSTask *killTask = [[NSTask alloc] init];
+    [killTask setLaunchPath:@"/bin/sh"];
     SPMainQSync(^{
-        [SPAppDelegate.sshProcessIDs removeObject:@(self.processIdentifier)];
+        [killTask setArguments:@[@"-c",[NSString stringWithFormat:@"kill -9 %@", [NSString stringWithFormat:@"%i", processID]]]];
+        [killTask launch];
+        [killTask waitUntilExit];
+
+        [SPAppDelegate.sshProcessIDs removeObject:@(processID)];
         SPLog(@"sshProcessIDs count: %lu", (unsigned long)SPAppDelegate.sshProcessIDs.count);
     });
-    
-    [self terminate];
 }
 
 @end

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -942,6 +942,8 @@ static unsigned short getRandomPort(void);
 	
 	[answerAvailableLock tryLock];
 	[answerAvailableLock unlock];
+    
+    NSLog(@"Dealloc called %s", __FILE_NAME__);
 }
 
 @end


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Kill the SSH task after termination

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1625

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 14.2

## Additional notes:
This does not fix the memory leak, just the CPU leak. Will need more debugging