### PR TITLE
#fixed String-type or Enum field default missing quote wraps if other attribute changed

### DIFF
--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -717,11 +717,6 @@
 			// Split the remaining field definition string by spaces and process
 			[tableColumn addEntriesFromDictionary:[self parseFieldDefinitionStringParts:[fieldsParser splitStringByCharacter:' ' skippingBrackets:YES]]];
 
-			//if column is not null, but doesn't have a default value, set empty string
-			if([[tableColumn objectForKey:@"null"] integerValue] == 0 && [[tableColumn objectForKey:@"autoincrement"] integerValue] == 0 && ![tableColumn objectForKey:@"default"]) {
-				[tableColumn setObject:@"" forKey:@"default"];
-			}
-
 			// Store the column.
 			NSMutableDictionary *d = [NSMutableDictionary dictionaryWithCapacity:1];
 			[d setDictionary:tableColumn];

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -976,8 +976,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			else if ([theRowType isEqualToString:@"BIT"]) {
 				[queryString appendFormat:@"\n DEFAULT %@", defaultValue];
 			}
-            // *CHAR and *TEXT must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP and DATETIME must always be wrapped in quotes.
-            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME"]]) {
+            // *CHAR, *TEXT and *ENUM must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP and DATETIME must always be wrapped in quotes.
+            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"ENUM"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME"]]) {
                 // If default value is not an expresion or a string, add quotes.
                 if (!defaultValueIsExpression && !defaultValueIsString)
                     [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];
@@ -1563,7 +1563,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		else if ([[theField objectForKey:@"default"] isNSNull]) {
 			[theField setObject:[prefs stringForKey:SPNullValue] forKey:@"default"];
 		}
-        else if ([type hasSuffix:@"CHAR"] || [type hasSuffix:@"TEXT"]) {
+        else if ([type hasSuffix:@"CHAR"] || [type hasSuffix:@"TEXT"] || [type hasSuffix:@"ENUM"]) {
             [theField setObject:[mySQLConnection escapeAndQuoteString:[theField objectForKey:@"default"]] forKey:@"default"];
         }
 

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1563,6 +1563,9 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		else if ([[theField objectForKey:@"default"] isNSNull]) {
 			[theField setObject:[prefs stringForKey:SPNullValue] forKey:@"default"];
 		}
+        else if ([type hasSuffix:@"CHAR"] || [type hasSuffix:@"TEXT"]) {
+            [theField setObject:[mySQLConnection escapeAndQuoteString:[theField objectForKey:@"default"]] forKey:@"default"];
+        }
 
 		// Init Extra field
 		[theField setObject:@"None" forKey:@"Extra"];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Quote wrap strings when they are displayed as default values in the UI. This allows for true differentiation between all three possible "empty" string defaults:
  - No default => Leave the field totally empty
  - Default empty string => Set the value to `''`
  - Default Null => Set the value to NULL 
- Quote wrap ENUMs too to fix issue https://github.com/Sequel-Ace/Sequel-Ace/issues/1541

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1569
- Closes https://github.com/Sequel-Ace/Sequel-Ace/issues/1541

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
<img width="782" alt="Screenshot 2022-12-28 at 11 46 11" src="https://user-images.githubusercontent.com/10710367/209864576-47a0da4c-e4eb-42fe-86e5-07dc7c0832fc.png">

## Additional notes:
