### PR TITLE
#fixed Fix crash on content view for tables that have column names containing $s

### DIFF
--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1182,7 +1182,8 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
                     // FIXME: oh ... is the regex is wrong.
                     // (?<foo>bar) = Define a named group named "foo" consisting of pattern bar.
                     // so (?<!\\\\)\\$CURRENT_FIELD" looks like the start of a group name,
-					[tip replaceOccurrencesOfRegex:@"(?<!\\\\)\\$CURRENT_FIELD" withString:[[colNode name] backtickQuotedString]];
+                    [tip replaceOccurrencesOfRegex:@"(?<!\\\\)\\$CURRENT_FIELD" withString:[NSRegularExpression escapedPatternForString:[[colNode name] backtickQuotedString]]];
+
 					[tip flushCachedRegexData];
 					tooltip = [NSString stringWithString:tip];
 				} else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Escape column names before passing them into regex for rendering filtering tooltips

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1648

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
