### PR TITLE
#fixed Bundles not getting the current selected table name passed

### DIFF
--- a/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
+++ b/Source/Controllers/BundleSupport/SPBundleCommandRunner.m
@@ -150,11 +150,7 @@
 	// Create and set an unique process ID for each SPDatabaseDocument which has to passed
 	// for each sequelace:// scheme command as user to be able to identify the url scheme command.
 	// Furthermore this id is used to communicate with the called command as file name.
-	SPDatabaseDocument *databaseDocument = nil;
-    if ([[[NSApp mainWindow] delegate] isKindOfClass:[SPAppController class]]) {
-        SPAppController *appController = (SPAppController *)[[NSApp mainWindow] delegate];
-        databaseDocument = appController.frontDocument;
-    }
+    SPDatabaseDocument *databaseDocument = [SPAppDelegate frontDocument];
 	// Check if connected
     if ([databaseDocument getConnection] == nil) {
         databaseDocument = nil;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Grab document from the SPAppDelegate instead of deriving from main window

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1645

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
Not 100% sure on this fix. The open table in action doesn't really work for me in general for some reason so I didn't test this one well. Does this look good, @Kaspik?