### PR TITLE
#fixed Fixed issues with setting user passwords containing special characters

### DIFF
--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -1008,10 +1008,10 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 				{
 					if(!first) [alterStmt appendString:@", "];
 					[alterStmt appendFormat:@"%@@%@ IDENTIFIED WITH %@ BY %@", //note: "BY" -> plaintext, "AS" -> hash
-                                            [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
-                                            [[self connection] escapeAndQuoteString:[child host]],
-                                            [[self connection] escapeAndQuoteString:[user valueForKey:@"plugin"]],
-					                        (![newPass isNSNull] && [newPass length]) ? [[self connection] escapeAndQuoteString:newPass] : @"''"];
+                        [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
+                        [[self connection] escapeAndQuoteString: [child host]],
+                        [[self connection] escapeAndQuoteString: [user valueForKey:@"plugin"]],
+                        (![newPass isNSNull] && [newPass length]) ? [[self connection] escapeAndQuoteString:newPass] : @"''"];
 					first = NO;
 				}
 				[connection queryString:alterStmt];
@@ -1024,10 +1024,10 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 				for (SPUserMO *child in hosts)
 				{
 					NSString *changePasswordStatement = [NSString stringWithFormat:
-														 @"SET PASSWORD FOR %@@%@ = PASSWORD(%@)",
-                                                         [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
-                                                         [[self connection] escapeAndQuoteString:[child host]],
-														 ([user valueForKey:@"password"]) ? [[self connection] escapeAndQuoteString:[user valueForKey:@"password"]] : @"''"];
+                        @"SET PASSWORD FOR %@@%@ = PASSWORD(%@)",
+                        [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
+                        [[self connection] escapeAndQuoteString: [child host]],
+                        ([user valueForKey:@"password"]) ? [[self connection] escapeAndQuoteString:[user valueForKey:@"password"]] : @"''"];
 					
 					[connection queryString:changePasswordStatement];
 					if(![self _checkAndDisplayMySqlError]) return NO;

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -1008,10 +1008,10 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 				{
 					if(!first) [alterStmt appendString:@", "];
 					[alterStmt appendFormat:@"%@@%@ IDENTIFIED WITH %@ BY %@", //note: "BY" -> plaintext, "AS" -> hash
-					                        [[user valueForKey:@"user"] tickQuotedString],
-					                        [[child host] tickQuotedString],
-					                        [[user valueForKey:@"plugin"] tickQuotedString],
-					                        (![newPass isNSNull] && [newPass length]) ? [newPass tickQuotedString] : @"''"];
+                                            [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
+                                            [[self connection] escapeAndQuoteString:[child host]],
+                                            [[self connection] escapeAndQuoteString:[user valueForKey:@"plugin"]],
+					                        (![newPass isNSNull] && [newPass length]) ? [[self connection] escapeAndQuoteString:newPass] : @"''"];
 					first = NO;
 				}
 				[connection queryString:alterStmt];
@@ -1025,9 +1025,9 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 				{
 					NSString *changePasswordStatement = [NSString stringWithFormat:
 														 @"SET PASSWORD FOR %@@%@ = PASSWORD(%@)",
-														 [[user valueForKey:@"user"] tickQuotedString],
-														 [[child host] tickQuotedString],
-														 ([user valueForKey:@"password"]) ? [[user valueForKey:@"password"] tickQuotedString] : @"''"];
+                                                         [[self connection] escapeAndQuoteString: [user valueForKey:@"user"]],
+                                                         [[self connection] escapeAndQuoteString:[child host]],
+														 ([user valueForKey:@"password"]) ? [[self connection] escapeAndQuoteString:[user valueForKey:@"password"]] : @"''"];
 					
 					[connection queryString:changePasswordStatement];
 					if(![self _checkAndDisplayMySqlError]) return NO;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Escape string before passing them in user management

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1573

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
