### PR TITLE
#fixed font size changing when enabling column types

### DIFF
--- a/Source/Other/Extensions/NSDictionaryExtension.swift
+++ b/Source/Other/Extensions/NSDictionaryExtension.swift
@@ -14,7 +14,7 @@ import Foundation
             return NSAttributedString(string: "")
         }
         let font = UserDefaults.getFont()
-        let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: font])
+        let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: NSFontManager.shared.convert(font, toSize: 11)])
         if let columnType: String = value(forKey: "type") as? String {
             attributedString.append(NSAttributedString(string: NSString.columnHeaderSplittingSpace as String))
             attributedString.append(NSAttributedString(string: columnType, attributes: [.font: NSFontManager.shared.convert(font, toSize: 8), .foregroundColor: NSColor.gray]))


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Correct font size when data types are enabled

## Closes following issues:
- Closes: #1678

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [x] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
<img width="122" alt="image" src="https://user-images.githubusercontent.com/11057501/212568953-73b5da8c-7dd3-4c53-8a8e-0ae837791fdf.png">
<img width="118" alt="image" src="https://user-images.githubusercontent.com/11057501/212568958-4bdc46ee-5f4e-4a94-8a8a-4af247512ba4.png">

## Additional notes: