### PR TITLE
fix the "Initializing 'NSRange' (aka 'struct _NSRange') with an expre…

### DIFF
--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -325,14 +325,15 @@ static CGFloat slow_in_out (CGFloat t)
 
 	//If first responder is a textview return the caret position
 	if(([fr isMemberOfClass:[NSTextView class]] && [fr alignment] == NSTextAlignmentLeft) || [[[fr class] description] isEqualToString:@"SPTextView"]) {
-		NSRange range = NSMakeRange([fr selectedRange].location,1);
-		NSRange glyphRange = [[fr layoutManager] glyphRangeForCharacterRange:range actualCharacterRange:NULL];
-		NSRect boundingRect = [[fr layoutManager] boundingRectForGlyphRange:glyphRange inTextContainer:[fr textContainer]];
-		boundingRect = [fr convertRect: boundingRect toView:NULL];
+		NSTextView *frTextView = (NSTextView *)fr;
+		NSRange range = NSMakeRange([frTextView selectedRange].location,1);
+		NSRange glyphRange = [[frTextView layoutManager] glyphRangeForCharacterRange:range actualCharacterRange:NULL];
+		NSRect boundingRect = [[frTextView layoutManager] boundingRectForGlyphRange:glyphRange inTextContainer:[frTextView textContainer]];
+		boundingRect = [frTextView convertRect: boundingRect toView:NULL];
 
 		NSPoint oppositeOrigin = NSMakePoint(NSMaxX(boundingRect), NSMaxY(boundingRect));
-        pos = [[fr window] convertPointToScreen:oppositeOrigin];
-		NSFont* font = [fr font];
+        pos = [[frTextView window] convertPointToScreen:oppositeOrigin];
+		NSFont* font = [frTextView font];
 		if(font) pos.y -= [font pointSize]*1.3f;
 		return pos;
 	// Otherwise return mouse location


### PR DESCRIPTION
fixed the build errors when build in Xcode 14.3
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- fixed the "Initializing 'NSRange' (aka 'struct _NSRange') with an expression of incompatible type 'id'" build error when build in Xcode 14.3

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  14.3
## Screenshots:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5081116/236665278-b4b015d5-b8f1-4801-b4ad-3faae6a55f0b.png">

## Additional notes:
