### PR TITLE
#fixed german translation for "Truncate"

### DIFF
--- a/Resources/Localization/de.lproj/Localizable.strings
+++ b/Resources/Localization/de.lproj/Localizable.strings
@@ -2895,7 +2895,7 @@ Befehle werden anwendungsweit ausgeführt";
 "Triggers for table: %@" = "Auslöser für Tabelle: % @";
 
 /* truncate button */
-"Truncate" = "Webformular-Eingabetabellen kürzen.";
+"Truncate" = "Leeren";
 
 /* truncate tables message */
 "Truncate selected tables?" = "Ausgewählte Tabellen abschneiden?";


### PR DESCRIPTION
## Changes:
- fix german translation for "Truncate"

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
  - [ ] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [x] German
- Xcode Version: 14.2
  
## Additional notes:

i speak german fluently. the current translation does not make any sense.
