### PR TITLE
#fixed Fixed incorrect file type for saved connections

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
@@ -14,7 +14,6 @@ extension SPDatabaseDocument {
             Swift.print("❌ SaveSPFAccessory accessory dialog could not be loaded.")
             return
         }
-        panel.allowedFileTypes = [SPBundleFileExtension]
 
         guard let appDelegate = NSApp.delegate as? SPAppController else {
             return


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- The method was overwriting the file types already being specified before the prep method call

## Closes following issues:
- Closes: 

## Tested: #1769
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
