### PR TITLE
#fixed Ability to clear out saved passwords

### DIFF
--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -188,10 +188,14 @@
  * Delete a password from the user's Keychain for the supplied name and account.
  */
 - (void)deletePasswordForName:(NSString *)name account:(NSString *)account {
-    
+
     if (![self isValidName:name acount:account]) {
         return;
     }
+
+    // Set to empty string before deleting to regain keychain ownership
+    [self updateItemWithName:name account:account toPassword:@""];
+
 	OSStatus status;
 	SecKeychainItemRef itemRef = nil;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Write an empty password before deleting. This might fix up ownership issues preventing password clears

## Closes following issues:
- Closes: #1710

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
