### PR TITLE
#fixed Fixed data interpreting buttons hidden on editor popup

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -339,12 +339,6 @@ typedef enum {
 		[editTextView setHidden:YES];
 		[editTextScrollView setHidden:YES];
 
-		// Hide QuickLook button and text/image/hex control for text data
-		[editSheetQuickLookButton setHidden:((!_isBlob && !isBinary) || _isGeometry)];
-		[editSheetSegmentControl setHidden:(!_isBlob && !isBinary && !_isGeometry)];
-
-		[editSheetSegmentControl setEnabled:YES forSegment:ImageSegment];
-
 		// Set window's min size since no segment and quicklook buttons are hidden
 		if (_isBlob || isBinary || _isGeometry) {
 			[usedSheet setFrameAutosaveName:@"SPFieldEditorBlobSheet"];
@@ -373,6 +367,7 @@ typedef enum {
 		}];
 
 		[editSheetProgressBar startAnimation:self];
+        [editSheetSegmentControl setEnabled:NO forSegment:ImageSegment];
 
 		NSImage *image = nil;
 
@@ -439,6 +434,7 @@ typedef enum {
 		}
 
 		if (image) {
+            [editSheetSegmentControl setEnabled:YES forSegment:ImageSegment];
 			[editImage setImage:image];
 			[hexTextView setHidden:YES];
 			[hexTextScrollView setHidden:YES];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Fixed the buttons to format as json/hex/other being hidden to aggressively

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1733

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
