### PR TITLE
#fixed 'failed connection'-alert not being able to close when the error message it too long

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2418,10 +2418,21 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
 	// Only display the connection error message if there is a window visible
 	if ([[dbDocument parentWindowControllerWindow] isVisible]) {
-        errorShowing = YES;
+		NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0,0,800,300)];
+		NSTextView *errorMessageTextView = [[NSTextView alloc] initWithFrame:scrollView.bounds];
+
+		[errorMessageTextView insertText:errorMessage replacementRange:NSMakeRange(0, 0)];
+		[errorMessageTextView setEditable:NO];
+		[errorMessageTextView setDrawsBackground:NO];
+
+		[scrollView setDrawsBackground:NO];
+		[scrollView setHasVerticalScroller:YES];
+		[scrollView setDocumentView:errorMessageTextView];
+
+		errorShowing = YES;
 		NSAlert *alert = [[NSAlert alloc] init];
 		[alert setMessageText:theTitle];
-		[alert setInformativeText:errorMessage];
+		[alert setAccessoryView:scrollView];
 		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
 		if (isSSHTunnelBindError) {
 			[alert addButtonWithTitle:NSLocalizedString(@"Use Standard Connection", @"use standard connection button")];

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2419,9 +2419,9 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 	// Only display the connection error message if there is a window visible
 	if ([[dbDocument parentWindowControllerWindow] isVisible]) {
 		NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0,0,800,300)];
-		NSTextView *errorMessageTextView = [[NSTextView alloc] initWithFrame:scrollView.bounds];
+		NSText *errorMessageTextView = [[NSText alloc] initWithFrame:scrollView.bounds];
 
-		[errorMessageTextView insertText:errorMessage replacementRange:NSMakeRange(0, 0)];
+		[errorMessageTextView setString:errorMessage];
 		[errorMessageTextView setEditable:NO];
 		[errorMessageTextView setDrawsBackground:NO];
 


### PR DESCRIPTION
This PR fixes a bug that made it impossible for an `NSAlert` to be closed and locks the app completely. Specifically, when Sequel Ace for some reason was not able to establish a connection with a database, an alert is shown displaying the error. If this error message happens to be longer than the screen height, it wouldn't be possible to click the `OK` button to close the alert (see screenshot). You actually had to force quit the process through the Activity Monitor because the app won't quit normally when an alert is shown on screen.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Instead of directly displaying the error message in the `InformativeText`, it is now properly displayed in a `NSScrollView`

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Xcode Version: Version 14.3.1 (14E300c)
  
## Screenshots:
![Screenshot 2023-08-04 at 15 16 55](https://github.com/Sequel-Ace/Sequel-Ace/assets/8634939/d46892ee-9a61-4c5b-b3e4-3cb3ecddd848)

## Additional notes:
