### PR TITLE
#fixed Closing tab in Structure view causes freeze

### DIFF
--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -83,8 +83,6 @@
         SPDatabaseDocument *document = (SPDatabaseDocument *)[notification object];
         if (tableDocumentInstance == document) {
             [self setConnection:nil];
-
-            pthread_mutex_destroy(&dataProcessingLock);
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

When attempting to kill the ssh tunnel task, `SPTableData` gets stuck looping forever in `- (void)_loopWhileWorking`  because is is trying to lock a mutex that was destroyed in `- (void)documentWillClose:(NSNotification *)notification`; see screenshots below.


## Changes:
- I removed the call to `pthread_mutex_destroy` within `- (void)documentWillClose:(NSNotification *)notification`.
- Note, mutex still gets properly destroyed in `- (void)dealloc`. so change should be safe.

## Closes following issues:
- Closes: #1628

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

* call stack for 1st breakpoint hit (destroys mutex): 
  <img width="468" alt="callstack-1" src="https://github.com/Sequel-Ace/Sequel-Ace/assets/1121410/4abb782a-74cf-4ac4-a608-15f11fdb0b55">
* call stack for 2nd breakpoint hit (tries to lock now-destroyed-mutex so loops forever):
  <img width="468" alt="callstack-2" src="https://github.com/Sequel-Ace/Sequel-Ace/assets/1121410/48ba1f40-00ba-41c0-81a0-afa77507f959">

## Additional notes:
