### PR TITLE
Fix window losing focus when running query #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -329,7 +329,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [taskProgressWindow setOpaque:NO];
     [taskProgressWindow setBackgroundColor:[NSColor clearColor]];
     [taskProgressWindow setAlphaValue:0.0f];
+    [taskProgressWindow setIsVisible:NO];
     [taskProgressWindow setContentView:taskProgressLayer];
+    [self.parentWindowControllerWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
 
     alterDatabaseCharsetHelper = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseAlterEncodingButton CollationButton:databaseAlterCollationButton];
     addDatabaseCharsetHelper   = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseEncodingButton CollationButton:databaseCollationButton];
@@ -1239,7 +1241,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Keep the window hidden for the first ~0.5 secs
     if (timeSinceFadeInStart < 0.5) return;
 
-    [self.parentWindowControllerWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
+    [taskProgressWindow setIsVisible:YES];
 
     CGFloat alphaValue = [taskProgressWindow alphaValue];
 
@@ -1382,7 +1384,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [taskProgressIndicator stopAnimation:self];
         }
         [taskProgressWindow setAlphaValue:0.0f];
-        [self.parentWindowControllerWindow removeChildWindow:taskProgressWindow];
+        [taskProgressWindow setIsVisible:NO];
         taskDisplayIsIndeterminate = YES;
         [taskProgressIndicator setIndeterminate:YES];
 


### PR DESCRIPTION
## Changes:
- The window is losing focus when the query progress window appears. This fixes it by changing from add/removing the child window each time to hiding/showing it instead.

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1618

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.0
