### PR TITLE
#fixed Allow for specifying connection timeout of zero - https://github.com/…

### DIFF
--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -314,7 +314,6 @@ static unsigned short getRandomPort(void);
 		}
 
 		NSInteger connectionTimeout = [[[NSUserDefaults standardUserDefaults] objectForKey:SPConnectionTimeoutValue] integerValue];
-		if (!connectionTimeout) connectionTimeout = 10;
 		BOOL useKeepAlive = [[[NSUserDefaults standardUserDefaults] objectForKey:SPUseKeepAlive] doubleValue];
 		double keepAliveInterval = [[[NSUserDefaults standardUserDefaults] objectForKey:SPKeepAliveInterval] doubleValue];
 		if (!keepAliveInterval) keepAliveInterval = 0;
@@ -393,7 +392,9 @@ static unsigned short getRandomPort(void);
 		TA(@"-o",@"ExitOnForwardFailure=yes");
 
 		// Specify a connection timeout based on the preferences value
-		TA(@"-o",([NSString stringWithFormat:@"ConnectTimeout=%ld", (long)connectionTimeout]));
+        if(connectionTimeout > 0) {
+            TA(@"-o",([NSString stringWithFormat:@"ConnectTimeout=%ld", (long)connectionTimeout]));
+        }
 
 		// Allow three password prompts
 		TA(@"-o",@"NumberOfPasswordPrompts=3");


### PR DESCRIPTION
…Sequel-Ace/Sequel-Ace/issues/1852

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- If connection timeout is zero, don't default to 10 seconds but instead don't pass the argument at all

## Closes following issues:
- Closes: Allow for speicfying connection timeout of zero - https://github.com/Sequel-Ace/Sequel-Ace/issues/1852

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
