### PR TITLE
fixed: Crash when default value contains only whitespace

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -938,6 +938,10 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
             BOOL defaultValueIsString = NO;
             if ([defaultValue length]) {
                 NSString *trimmedWhiteSpace = [defaultValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                // if trimmed string is empty, revert to original to avoid crash
+                if ([trimmedWhiteSpace isEqualToString: @""]) {
+                  trimmedWhiteSpace = defaultValue;
+                }
                 unichar firstChar = [trimmedWhiteSpace characterAtIndex:0];
                 unichar lastChar = [trimmedWhiteSpace characterAtIndex:[trimmedWhiteSpace length] - 1];
                 // Check if defaultValue is an expression


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Restore default value back to original if trimmed version ends up being empty.

## Closes following issues:
- Closes: #1853

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: `Version 15.0 (15A240d)`
  
## Screenshots:

## Additional notes:
