### PR TITLE
Progress window is modal #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -329,9 +329,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [taskProgressWindow setOpaque:NO];
     [taskProgressWindow setBackgroundColor:[NSColor clearColor]];
     [taskProgressWindow setAlphaValue:0.0f];
-    [taskProgressWindow setIsVisible:NO];
     [taskProgressWindow setContentView:taskProgressLayer];
-    [self.parentWindowControllerWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
 
     alterDatabaseCharsetHelper = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseAlterEncodingButton CollationButton:databaseAlterCollationButton];
     addDatabaseCharsetHelper   = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseEncodingButton CollationButton:databaseCollationButton];
@@ -1233,7 +1231,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Keep the window hidden for the first ~0.5 secs
     if (timeSinceFadeInStart < 0.5) return;
 
-    [taskProgressWindow setIsVisible:YES];
+    if ([taskProgressWindow parentWindow] == nil) {
+        [self.parentWindowControllerWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
+    }
 
     CGFloat alphaValue = [taskProgressWindow alphaValue];
 
@@ -1376,7 +1376,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [taskProgressIndicator stopAnimation:self];
         }
         [taskProgressWindow setAlphaValue:0.0f];
-        [taskProgressWindow setIsVisible:NO];
+        [taskProgressWindow orderOut:self];
         taskDisplayIsIndeterminate = YES;
         [taskProgressIndicator setIndeterminate:YES];
 


### PR DESCRIPTION
## Changes:
- [Fix for window losing focus](#1849) introduced a regression - the [progress window is no longer modal](1879). This is because setIsVisible:false has the side-effect of disassociating the window from its parent. This pull request fixes it in a different way - replace removeChildWindow with orderOut. This stops Sequel-Ace from losing focus, while retaining the parent relationship and the modal behavior.

## Closes following issues:
- Closes: #1879

## Tested:
- Processors:
  - [x] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.0