### PR TITLE
Fix filter editor's dark background on Mac OS 12 #fixed

### DIFF
--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1011,7 +1011,7 @@
                                                                     <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="CIQ-tc-1Fn">
                                                                         <rect key="frame" x="2" y="0.0" width="576" height="29"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <clipView key="contentView" copiesOnScroll="NO" id="kdv-Wp-s5h">
+                                                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="kdv-Wp-s5h">
                                                                             <rect key="frame" x="0.0" y="0.0" width="576" height="29"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             <subviews>


### PR DESCRIPTION
## Changes:
- Changed background of DBView filter editor to non-drawing

## Closes following issues:
- Closes: #1841

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [x] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [x] German
- Xcode Version: 14
  
## Screenshots:
Before:
<img width="294" alt="Bildschirmfoto 2023-10-16 um 19 07 38" src="https://github.com/Sequel-Ace/Sequel-Ace/assets/30213185/8c26ed4b-5eca-448d-8399-a45c5a340276">
After:
<img width="305" alt="Bildschirmfoto 2023-10-17 um 17 28 31" src="https://github.com/Sequel-Ace/Sequel-Ace/assets/30213185/1748cbcf-c956-42c9-bd1d-341887309567">

## Additional notes:
