### PR TITLE
#fixed Table History Navigation

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -671,7 +671,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     if (_isWorkingLevel) databaseListIsSelectable = NO;
 
     // Select the database
-    [self selectDatabase:[chooseDatabaseButton titleOfSelectedItem] item:[self table]];
+    [self selectDatabase:[chooseDatabaseButton titleOfSelectedItem] item: nil];
 }
 
 /**
@@ -3261,12 +3261,12 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     // Backward in history menu item
     if ((action == @selector(backForwardInHistory:)) && ([menuItem tag] == 0)) {
-        return (([[spHistoryControllerInstance history] count]) && ([spHistoryControllerInstance historyPosition] > 0));
+        return ([spHistoryControllerInstance countPrevious]);
     }
 
     // Forward in history menu item
     if ((action == @selector(backForwardInHistory:)) && ([menuItem tag] == 1)) {
-        return (([[spHistoryControllerInstance history] count]) && (([spHistoryControllerInstance historyPosition] + 1) < [[spHistoryControllerInstance history] count]));
+        return [spHistoryControllerInstance countForward];
     }
 
     // Show/hide console
@@ -5378,6 +5378,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [[chooseDatabaseButton onMainThread] selectItemWithTitle:targetDatabaseName];
 
             selectedDatabase = [[NSString alloc] initWithString:targetDatabaseName];
+            selectedTableName = targetItemName ? [[NSString alloc] initWithString:targetItemName] : nil;
 
             [databaseDataInstance resetAllData];
 

--- a/Source/Controllers/Other/SPHistoryController.h
+++ b/Source/Controllers/Other/SPHistoryController.h
@@ -31,6 +31,7 @@
 @class SPDatabaseDocument;
 @class SPTableContent;
 @class SPTablesList;
+@class SPTableHistoryManager, SPTableHistoryEntry;
 
 @interface SPHistoryController : NSObject 
 {
@@ -39,41 +40,28 @@
 
 	SPTableContent *tableContentInstance;
 	SPTablesList *tablesListInstance;
-	NSMutableArray *history;
 	NSMutableDictionary *tableContentStates;
-	NSUInteger historyPosition;
+	SPTableHistoryManager *historyManager;
 	BOOL modifyingState;
 	BOOL navigatingFK;
 	BOOL toolbarItemVisible;
 }
 
-@property (readonly) NSUInteger historyPosition;
-@property (readonly) NSMutableArray *history;
 @property (readwrite, assign) BOOL modifyingState;
 @property (readwrite, assign) BOOL navigatingFK;
 
 // Interface interaction
-- (void) updateToolbarItem;
+- (NSUInteger)countPrevious;
+- (NSUInteger)countForward;
 - (void)goBackInHistory;
 - (void)goForwardInHistory;
-- (IBAction) historyControlClicked:(NSSegmentedControl *)theControl;
-- (void) setupInterface;
-- (void) startDocumentTask:(NSNotification *)aNotification;
-- (void) endDocumentTask:(NSNotification *)aNotification;
+- (IBAction)historyControlClicked:(NSSegmentedControl *)theControl;
+- (void)setupInterface;
 
 // Adding or updating history entries
-- (void) updateHistoryEntries;
-
-// Loading history entries
-- (void) loadEntryAtPosition:(NSUInteger)position;
-- (void) loadEntryTaskWithPosition:(NSNumber *)positionNumber;
-- (void) loadEntryFromMenuItem:(id)theMenuItem;
+- (void)updateHistoryEntries;
 
 // Restoring view states
-- (void) restoreViewStates;
-
-// History entry details and description
-- (NSMenuItem *) menuEntryForHistoryEntryAtIndex:(NSInteger)theIndex;
-- (NSString *) nameForHistoryEntryDetails:(NSDictionary *)theEntry;
+- (void)restoreViewStates;
 
 @end

--- a/Source/Controllers/Other/SPHistoryController.m
+++ b/Source/Controllers/Other/SPHistoryController.m
@@ -420,7 +420,6 @@ static BOOL canCurrentReplaceEntry(SPTableHistoryEntry *curr, SPTableHistoryEntr
 	}
 	// views are the same, but the filter settings have changed, also store the position details on the *previous* history item
 	else if (viewIsTheSame || (!curr.filter && new.filter) || ![curr.filter isEqualToDictionary: new.filter]) {
-		// TODO: Investigate further, don't fully understand why we add a new item to history but also modify the current entry.
 		curr.viewPort = new.viewPort;
 		if (new.selectedRows) {
 			curr.selectedRows = new.selectedRows;
@@ -485,7 +484,6 @@ static NSString* menuItemDescriptionFor(SPTableHistoryEntry *entry) {
 
 	[name appendFormat: @"/%@", entry.table];
 
-	// TODO: Enhance this, non nil doesn't mean items are actually filtered.
 	if (entry.filter) {
 		name = [NSMutableString stringWithFormat: NSLocalizedString(@"%@ (Filtered)", @"History item filtered by values label"), name];
 	}

--- a/Source/Controllers/Other/SPHistoryController.m
+++ b/Source/Controllers/Other/SPHistoryController.m
@@ -35,154 +35,131 @@
 #import "SPThreadAdditions.h"
 #import "sequel-ace-Swift.h"
 
+
+@interface SPHistoryController ()
+
+- (void)loadEntryStart:(SPTableHistoryEntry *)entry;
+- (void)loadEntryTaskWithEntry:(SPTableHistoryEntry *)entry;
+- (void)loadEntryFromMenuItem:(NSMenuItem *)item;
+- (SPTableHistoryEntry *)buildEntry;
+- (void)doRetoreViewState:(SPTableHistoryEntry *)entry;
+- (void)updateToolbarItem;
+- (void)updateHistoryEntriesWithUpdateToolbarItem:(BOOL)updateMenuItems;
+
+// handling notifications
+- (void)startDocumentTask:(NSNotification *)aNotification;
+- (void)endDocumentTask:(NSNotification *)aNotification;
+- (void)toolbarDidRemoveItem:(NSNotification *)aNotification;
+- (void)toolbarWillAddItem:(NSNotification *)aNotification;
+
+@end
+
 @implementation SPHistoryController
 
-@synthesize history;
-@synthesize historyPosition;
 @synthesize modifyingState;
 @synthesize navigatingFK;
 
-#pragma mark Setup and teardown
+#pragma mark - Setup and teardown
 
 /**
  * Initialise by creating a blank history array.
  */
-- (id) init
-{
+- (id)init {
 	if ((self = [super init])) {
-		history = [[NSMutableArray alloc] init];
 		tableContentStates = [[NSMutableDictionary alloc] init];
-		historyPosition = NSNotFound;
+		historyManager = [[SPTableHistoryManager alloc] init];
 		modifyingState = NO;
 		navigatingFK = NO;
 	}
-	return self;	
+	return self;
 }
 
-- (void)awakeFromNib
-{
-    [super awakeFromNib];
+- (void)awakeFromNib {
+	[super awakeFromNib];
 	tableContentInstance = [theDocument tableContentInstance];
 	tablesListInstance = [theDocument tablesListInstance];
-
 	toolbarItemVisible = NO;
 
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toolbarWillAddItem:) name:NSToolbarWillAddItemNotification object:theDocument.mainToolbar];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toolbarDidRemoveItem:) name:NSToolbarDidRemoveItemNotification object:theDocument.mainToolbar];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(startDocumentTask:) name:SPDocumentTaskStartNotification object:theDocument];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(endDocumentTask:) name:SPDocumentTaskEndNotification object:theDocument];
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	[nc addObserver: self selector: @selector(toolbarWillAddItem:) name: NSToolbarWillAddItemNotification object: theDocument.mainToolbar];
+	[nc addObserver: self selector: @selector(toolbarDidRemoveItem:) name: NSToolbarDidRemoveItemNotification object: theDocument.mainToolbar];
+	[nc addObserver: self selector: @selector(startDocumentTask:) name: SPDocumentTaskStartNotification object: theDocument];
+	[nc addObserver: self selector: @selector(endDocumentTask:) name: SPDocumentTaskEndNotification object: theDocument];
 }
 
-- (void)dealloc
-{
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+- (void)dealloc {
+	[[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
-#pragma mark -
-#pragma mark Interface interaction
+#pragma mark - Interface interaction
+
+- (NSUInteger)countPrevious {
+	return historyManager.countPrevious;
+}
+
+- (NSUInteger)countForward {
+	return historyManager.countForward;
+}
 
 /**
  * Updates the toolbar item to reflect the current history state and position
  */
-- (void) updateToolbarItem
-{
-
+- (void)updateToolbarItem {
 	// If the toolbar item isn't visible, don't perform any actions - as manipulating
 	// items not on the toolbar can cause crashes.
-	if (!toolbarItemVisible) return;
-
-	BOOL backEnabled = NO;
-	BOOL forwardEnabled = NO;
-	NSInteger i;
-	NSMenu *navMenu;
+	if (!toolbarItemVisible || !historyControl) { return; }
 
 	// Set the active state of the segments if appropriate
-	if ([history count] && historyPosition > 0) backEnabled = YES;
-	if ([history count] && historyPosition + 1 < [history count]) forwardEnabled = YES;
-
-	if(!historyControl) return;
-
-	[historyControl setEnabled:backEnabled forSegment:0];
-	[historyControl setEnabled:forwardEnabled forSegment:1];
+	[historyControl setEnabled: historyManager.countPrevious > 0 forSegment: 0];
+	[historyControl setEnabled: historyManager.countForward > 0 forSegment: 1];
 
 	// Generate back and forward menus as appropriate to reflect the new state
-	if (backEnabled) {
-		navMenu = [[NSMenu alloc] init];
-		for (i = historyPosition - 1; i >= 0; i--) {
-			[navMenu addItem:[self menuEntryForHistoryEntryAtIndex:i]];
-		}
-		[historyControl setMenu:navMenu forSegment:0];
-	} else {
-		[historyControl setMenu:nil forSegment:0];
-	}
-	if (forwardEnabled) {
-		navMenu = [[NSMenu alloc] init];
-		for (i = historyPosition + 1; i < (NSInteger)[history count]; i++) {
-			[navMenu addItem:[self menuEntryForHistoryEntryAtIndex:i]];
-		}
-		[historyControl setMenu:navMenu forSegment:1];
-	} else {
-		[historyControl setMenu:nil forSegment:1];
-	}
+	[historyControl setMenu: menuForEntries(historyManager.backEntries, self) forSegment: 0];
+	[historyControl setMenu: menuForEntries(historyManager.forwardEntries, self) forSegment: 1];
 }
 
 /**
  * Go backward in the history.
  */
-- (void)goBackInHistory
-{
-	if (historyPosition == NSNotFound || !historyPosition) return;
-	
-	[self loadEntryAtPosition:historyPosition - 1];
+- (void)goBackInHistory {
+	[self loadEntryStart: historyManager.peakPrevious];
 }
 
 /**
  * Go forward in the history.
  */
-- (void)goForwardInHistory
-{
-	if (historyPosition == NSNotFound || historyPosition + 1 >= [history count]) return;
-	
-	[self loadEntryAtPosition:historyPosition + 1];
+- (void)goForwardInHistory {
+	[self loadEntryStart: historyManager.peakForward];
 }
 
 /**
  * Trigger a navigation action in response to a click
  */
-- (IBAction) historyControlClicked:(NSSegmentedControl *)theControl
-{
-
+- (IBAction)historyControlClicked:(NSSegmentedControl *)theControl {
 	// Ensure history navigation is permitted - trigger end editing and any required saves
-	if (![theDocument couldCommitCurrentViewActions]) return;
+	if (![theDocument couldCommitCurrentViewActions]) { return; }
 
-    
-    if ([theControl respondsToSelector:@selector(selectedSegment)]) {
-        switch ([theControl selectedSegment])
-        {
-                // Back button clicked:
-            case 0:
-                [self goBackInHistory];
-                break;
-                
-                // Forward button clicked:
-            case 1:
-                [self goForwardInHistory];
-                break;
-        }
-    }
-    else {
-        SPLog(@"theControl does not respondToSelector: selectedSegment. theControl class: %@", [theControl class]);
-    }
+	if ([theControl respondsToSelector:@selector(selectedSegment)]) {
+		switch ([theControl selectedSegment]) {
+			case 0: // Back button clicked:
+				[self goBackInHistory];
+				break;
+			case 1: // Forward button clicked:
+				[self goForwardInHistory];
+				break;
+		}
+	}
+	else {
+		SPLog(@"theControl does not respondToSelector: selectedSegment. theControl class: %@", [theControl class]);
+	}
 }
 
 /**
  * Set up the toolbar items as appropriate.
- * State tracking is necessary as manipulating items not on the toolbar
- * can cause crashes.
+ * State tracking is necessary as manipulating items not on the toolbar can cause crashes.
  */
 - (void)setupInterface {
 	NSArray *toolbarItems = [theDocument.mainToolbar items];
-
 	for (NSToolbarItem *toolbarItem in toolbarItems) {
 		if ([[toolbarItem itemIdentifier] isEqualToString:SPMainToolbarHistoryNavigation]) {
 			toolbarItemVisible = YES;
@@ -194,44 +171,43 @@
 /**
  * Disable the controls during a task.
  */
-- (void) startDocumentTask:(NSNotification *)aNotification
-{
+- (void)startDocumentTask:(NSNotification *)aNotification {
 	if (toolbarItemVisible) [historyControl setEnabled:NO];
 }
 
 /**
  * Enable the controls once a task has completed.
  */
-- (void) endDocumentTask:(NSNotification *)aNotification
-{
+- (void)endDocumentTask:(NSNotification *)aNotification {
 	if (toolbarItemVisible) [historyControl setEnabled:YES];
 }
 
 /**
  * Update the state when the item is added from the toolbar.
- * State tracking is necessary as manipulating items not on the toolbar
- * can cause crashes.
+ * State tracking is necessary as manipulating items not on the toolbar can cause crashes.
  */
-- (void) toolbarWillAddItem:(NSNotification *)aNotification {
-	if ([[[[aNotification userInfo] objectForKey:@"item"] itemIdentifier] isEqualToString:SPMainToolbarHistoryNavigation]) {
+- (void)toolbarWillAddItem:(NSNotification *)aNotification {
+	if ([[[[aNotification userInfo] objectForKey:@"item"] itemIdentifier] isEqualToString: SPMainToolbarHistoryNavigation]) {
 		toolbarItemVisible = YES;
-		[self performSelectorOnMainThread:@selector(updateToolbarItem) withObject:nil waitUntilDone:YES];
+		[self performSelectorOnMainThread:@selector(updateToolbarItem) withObject: nil waitUntilDone: YES];
 	}
 }
 
 /**
  * Update the state when the item is removed from the toolbar
- * State tracking is necessary as manipulating items not on the toolbar
- * can cause crashes.
+ * State tracking is necessary as manipulating items not on the toolbar can cause crashes.
  */
-- (void) toolbarDidRemoveItem:(NSNotification *)aNotification {
-	if ([[[[aNotification userInfo] objectForKey:@"item"] itemIdentifier] isEqualToString:SPMainToolbarHistoryNavigation]) {
+- (void)toolbarDidRemoveItem:(NSNotification *)aNotification {
+	if ([[[[aNotification userInfo] objectForKey:@"item"] itemIdentifier] isEqualToString: SPMainToolbarHistoryNavigation]) {
 		toolbarItemVisible = NO;
 	}
 }
 
-#pragma mark -
-#pragma mark Adding or updating history entries
+#pragma mark - Adding or updating history entries
+
+- (void)updateHistoryEntries {
+	[self updateHistoryEntriesWithUpdateToolbarItem: YES];
+}
 
 /**
  * Call to store or update a history item for the document state. Checks against
@@ -240,216 +216,112 @@
  * Table histories are created per table/filter setting, and while view changes
  * update the current history entry, they don't replace it.
  */
-- (void) updateHistoryEntries
-{
-
-    SPLog(@"updateHistoryEntries");
+- (void)updateHistoryEntriesWithUpdateToolbarItem:(BOOL)updateMenuItems {
+	SPLog(@"updateHistoryEntries");
 	// Don't modify anything if we're in the process of restoring an old history state
-	if (modifyingState) return;
+	if (modifyingState) { return; }
 
-	// TODO: Basically all of those next calls do stuff that must be done on the main thread (AND en block in order to be consistent). This needs to be refactored!
 	// Work out the current document details
-	NSString *theDatabase = [theDocument database];
-	NSString *theTable = [theDocument table];
-	SPTableViewType theView = [[theDocument onMainThread] currentlySelectedView];
-	NSString *contentSortCol = [tableContentInstance sortColumnName];
-	BOOL contentSortColIsAsc = [tableContentInstance sortColumnIsAscending];
-	NSUInteger contentPageNumber = [tableContentInstance pageNumber];
-	NSDictionary *contentSelectedRows = [[tableContentInstance onMainThread] selectionDetailsAllowingIndexSelection:YES];
-	NSRect contentViewport = [[tableContentInstance onMainThread] viewport];
-	NSDictionary *contentFilter = [[tableContentInstance onMainThread] filterSettings];
-	NSData *filterTableData = [[tableContentInstance onMainThread] filterTableData];
-	SPTableContentFilterSource activeFilter = [[tableContentInstance onMainThread] activeFilter];
-	if (!theDatabase) return;
+	SPTableHistoryEntry *newEntry = [[self onMainThread] buildEntry];
+	if (!newEntry.database) { return; }
 
-	// If a table is selected, save state information
-	if (theDatabase && theTable) {
-
-		// Save the table content state
-		NSMutableDictionary *contentState = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-												[NSNumber numberWithUnsignedInteger:contentPageNumber], @"page",
-												[NSValue valueWithRect:contentViewport], @"viewport",
-												[NSNumber numberWithBool:contentSortColIsAsc], @"sortIsAsc",
-												@(activeFilter), @"activeFilter",
-												nil];
-		if (contentSortCol) [contentState setObject:contentSortCol forKey:@"sortCol"];
-		if (contentSelectedRows) [contentState setObject:contentSelectedRows forKey:@"selection"];
-		if (contentFilter) [contentState setObject:contentFilter forKey:@"filterV2"];
-		if (filterTableData) [contentState setObject:filterTableData forKey:@"filterTable"];
-
-		// Update the table content states with this information - used when switching tables to restore last used view.
-		[tableContentStates setObject:contentState forKey:[NSString stringWithFormat:@"%@.%@", [theDatabase backtickQuotedString], [theTable backtickQuotedString]]];
+	// If a table is selected, update the table content states with this information - used when switching tables to restore last used view.
+	if (newEntry.table) {
+		NSString * const key = [NSString stringWithFormat:@"%@.%@", newEntry.database.backtickQuotedString, newEntry.table.backtickQuotedString];
+		[tableContentStates setObject: newEntry forKey: key];
 	}
 
-	// If there's any items after the current history position, remove them
-	if (historyPosition != NSNotFound && historyPosition < [history count] - 1) {
-        SPLog(@"If there's any items after the current history position, remove them");
-        NSRange tmpRange = NSMakeRange(historyPosition + 1, [history count] - historyPosition - 1);
-        SPLog(@"tmpRange.location=%lu tmpRange.length=%lu", (unsigned long)tmpRange.location, (unsigned long)tmpRange.length);
-        if(tmpRange.location + tmpRange.length < history.count -1){
-            [history removeObjectsInRange:tmpRange];
-        }
-
-	} else if (historyPosition != NSNotFound && historyPosition == [history count] - 1) {
-		NSMutableDictionary *currentHistoryEntry = [history safeObjectAtIndex:historyPosition];
-
-		BOOL databaseIsTheSame = [[currentHistoryEntry objectForKey:@"database"] isEqualToString:theDatabase];
-		BOOL tableIsTheSame    = [[currentHistoryEntry objectForKey:@"table"] isEqualToString:theTable];
-		BOOL viewIsTheSame     = ([[currentHistoryEntry objectForKey:@"view"] integerValue] == theView);
-		// If the table is the same, and the filter settings haven't changed, delete the
-		// last entry so it can be replaced.  This updates navigation within a table, rather than
-		// creating a new entry every time detail is changed.
-		if (
-			databaseIsTheSame &&
-			tableIsTheSame &&
-			(
-				!viewIsTheSame ||
-				(
-					(![currentHistoryEntry safeObjectForKey:@"contentFilterV2"] && !contentFilter) ||
-					[[currentHistoryEntry safeObjectForKey:@"contentFilterV2"] isEqualToDictionary:contentFilter]
-				)
-			)
-		) {
-			[history removeLastObject];
-		}
-		// If the only db/table/view are the same, but the filter settings have changed, also store the
-		// position details on the *previous* history item
-		else if (
-			databaseIsTheSame &&
-			tableIsTheSame &&
-			(
-				viewIsTheSame ||
-				(
-					(![currentHistoryEntry safeObjectForKey:@"contentFilterV2"] && contentFilter) ||
-					![[currentHistoryEntry safeObjectForKey:@"contentFilterV2"] isEqualToDictionary:contentFilter]
-				)
-			)
-		) {
-			[currentHistoryEntry setObject:[NSValue valueWithRect:contentViewport] forKey:@"contentViewport"];
-			if (contentSelectedRows) [currentHistoryEntry setObject:contentSelectedRows forKey:@"contentSelection"];
-		}
-		// Special case: if the last history item is currently active, and has no table,
-		// but the new selection does - delete the last entry, in order to replace it.
-		// This improves history flow.
-		else if (databaseIsTheSame && ![currentHistoryEntry safeObjectForKey:@"table"]) {
-            SPLog(@"history removeLastObject");
-			[history removeLastObject];
-		}
+	if (canCurrentReplaceEntry(historyManager.peakCurrent, newEntry)) {
+		[historyManager replaceTopWithEntry: newEntry];
+	}
+	else {
+		[historyManager push: newEntry];
 	}
 
-	// Construct and add the new history entry
-	NSMutableDictionary *newEntry = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-										theDatabase, @"database",
-										theTable, @"table",
-										[NSNumber numberWithUnsignedInteger:theView], @"view",
-										[NSNumber numberWithBool:contentSortColIsAsc], @"contentSortColIsAsc",
-										[NSNumber numberWithInteger:contentPageNumber], @"contentPageNumber",
-										[NSValue valueWithRect:contentViewport], @"contentViewport",
-										@(activeFilter), @"activeFilter",
-										nil];
-	if (contentSortCol) [newEntry setObject:contentSortCol forKey:@"contentSortCol"];
-	if (contentSelectedRows) [newEntry setObject:contentSelectedRows forKey:@"contentSelection"];
-	if (contentFilter) [newEntry setObject:contentFilter forKey:@"contentFilterV2"];
-
-	[history addObject:newEntry];
-
-	// If there are now more than fifty history entries, remove one from the start
-    if ([history count] > 50){
-        SPLog(@"[history count] > 50, removeLastObject");
-        [history removeObjectAtIndex:0];
-    }
-
-	historyPosition = [history count] - 1;
-
-	[[self onMainThread] updateToolbarItem];
+	if (updateMenuItems) {
+		[[self onMainThread] updateToolbarItem];
+	}
 }
 
-#pragma mark -
-#pragma mark Loading history entries
+- (SPTableHistoryEntry *)buildEntry {
+	return [[SPTableHistoryEntry alloc] initWithDatabase: theDocument.database
+												   table: theDocument.table
+													view: theDocument.currentlySelectedView
+												viewPort: tableContentInstance.viewport
+									  contentSortColName: tableContentInstance.sortColumnName
+									 contentSortColIsAsc: tableContentInstance.sortColumnIsAscending
+									   contentPageNumber: tableContentInstance.pageNumber
+											selectedRows: [tableContentInstance selectionDetailsAllowingIndexSelection: YES]
+											activeFilter: tableContentInstance.activeFilter
+												  filter: tableContentInstance.filterSettings
+											  filterData: tableContentInstance.filterTableData];
+}
+
+#pragma mark - Loading history entries
 
 /**
  * Load a history entry and attempt to return the interface to that state.
  * Performs the load in a task which is threaded as necessary.
  */
-- (void) loadEntryAtPosition:(NSUInteger)position
-{
-
+- (void)loadEntryStart:(SPTableHistoryEntry *)entry {
 	// Sanity check the input
-	if (position == NSNotFound || position >= [history count]) {
+	if (entry == nil) {
 		NSBeep();
 		return;
 	}
 
-	// Ensure a save of the current state - scroll position, selection - if we're at the last entry
-	if (historyPosition == [history count] - 1) [self updateHistoryEntries];
+	// Ensure a save of the current state - scroll position, selection
+	// Don't update menu items since we'll be shuffling history around anyways; updated in loadEntryTaskWithEntry
+	[self updateHistoryEntriesWithUpdateToolbarItem: NO];
 
 	// Start the task and perform the load
 	[theDocument startTaskWithDescription:NSLocalizedString(@"Loading history entry...", @"Loading history entry task desc")];
 	if ([NSThread isMainThread]) {
-		[NSThread detachNewThreadWithName:SPCtxt(@"SPHistoryController load of history entry", theDocument) target:self selector:@selector(loadEntryTaskWithPosition:) object:[NSNumber numberWithUnsignedInteger:position]];
+		[NSThread detachNewThreadWithName: SPCtxt(@"SPHistoryController load of history entry", theDocument)
+								   target: self
+								 selector: @selector(loadEntryTaskWithEntry:)
+								   object: entry];
 	} else {
-		[self loadEntryTaskWithPosition:[NSNumber numberWithUnsignedInteger:position]];
+		[self loadEntryTaskWithEntry: entry];
 	}
 }
-- (void) loadEntryTaskWithPosition:(NSNumber *)positionNumber
-{
+
+- (void)loadEntryTaskWithEntry:(SPTableHistoryEntry *)entry {
 	@autoreleasepool {
-		NSUInteger position = [positionNumber unsignedIntegerValue];
-
 		modifyingState = YES;
-
-		// Update the position and extract the history entry
-		historyPosition = position;
-		NSDictionary *historyEntry = [history objectAtIndex:historyPosition];
-
-		// Set table content details for restore
-		[tableContentInstance setSortColumnNameToRestore:[historyEntry objectForKey:@"contentSortCol"] isAscending:[[historyEntry objectForKey:@"contentSortColIsAsc"] boolValue]];
-		[tableContentInstance setPageToRestore:[[historyEntry objectForKey:@"contentPageNumber"] integerValue]];
-		[tableContentInstance setSelectionToRestore:[historyEntry objectForKey:@"contentSelection"]];
-		[tableContentInstance setViewportToRestore:[[historyEntry objectForKey:@"contentViewport"] rectValue]];
-		[tableContentInstance setFiltersToRestore:[historyEntry objectForKey:@"contentFilterV2"]];
-		[tableContentInstance setActiveFilterToRestore:(SPTableContentFilterSource)[[historyEntry objectForKey:@"activeFilter"] integerValue]];
+		[self doRetoreViewState: entry];
 
 		// If the database, table, and view are the same and content - just trigger a table reload (filters)
 		if (
-			[[theDocument database] isEqualToString:[historyEntry objectForKey:@"database"]]
-			&& [historyEntry objectForKey:@"table"]
-			&& [[theDocument table] isEqualToString:[historyEntry objectForKey:@"table"]]
-			&& [[historyEntry objectForKey:@"view"] integerValue] == [theDocument currentlySelectedView]
-			&& [[historyEntry objectForKey:@"view"] integerValue] == SPTableViewContent
+			[theDocument.database isEqualToString: entry.database]
+			&& entry.table
+			&& [theDocument.table isEqualToString: entry.table]
+			&& theDocument.currentlySelectedView == SPTableViewContent
+			&& theDocument.currentlySelectedView == entry.view
 		) {
-			[tableContentInstance loadTable:[historyEntry objectForKey:@"table"]];
-			modifyingState = NO;
-			[[self onMainThread] updateToolbarItem];
-			[theDocument endTask];
-			return;
+			[tableContentInstance loadTable: entry.table];
+			return completeLoadEntry(self, entry);
 		}
 
 		// If the same table was selected, mark the content as requiring a reload
-		if ([historyEntry objectForKey:@"table"] && [[theDocument table] isEqualToString:[historyEntry objectForKey:@"table"]]) {
-			[theDocument setContentRequiresReload:YES];
+		if (entry.table && [theDocument.table isEqualToString: entry.table]) {
+			[theDocument setContentRequiresReload: YES];
 		}
 
 		// Update the database and table name if necessary
-		[theDocument selectDatabase:[historyEntry objectForKey:@"database"] item:[historyEntry objectForKey:@"table"]];
+		[theDocument selectDatabase: entry.database item: entry.table];
 
 		// If the database or table couldn't be selected, error.
 		if (
-			(
-				![[theDocument database] isEqualToString:[historyEntry objectForKey:@"database"]] &&
-				([theDocument database] || [historyEntry objectForKey:@"database"])
-			) ||
-			(
-				![[theDocument table] isEqualToString:[historyEntry objectForKey:@"table"]] &&
-				([theDocument table] || [historyEntry objectForKey:@"table"])
-			)
+			( ![theDocument.database isEqualToString: entry.database] && (theDocument.database || entry.database) )
+			|| ( ![theDocument.table isEqualToString: entry.table] && (theDocument.table || entry.table) )
 		) {
-			goto abort_entry_load;
+			return abortEntryLoad(self);
 		}
 
 		// Check and set the view
-		if ([theDocument currentlySelectedView] != [[historyEntry objectForKey:@"view"] integerValue]) {
-			switch ([[historyEntry objectForKey:@"view"] integerValue]) {
+		if (theDocument.currentlySelectedView != entry.view) {
+			switch (entry.view) {
 				case SPTableViewStructure:
 					[theDocument viewStructure];
 					break;
@@ -469,114 +341,161 @@
 					[theDocument viewTriggers];
 					break;
 			}
-			if ([theDocument currentlySelectedView] != [[historyEntry objectForKey:@"view"] integerValue]) {
-				goto abort_entry_load;
+
+			if (theDocument.currentlySelectedView != entry.view) {
+				return abortEntryLoad(self);
 			}
 		}
 
-		modifyingState = NO;
-		[[self onMainThread] updateToolbarItem];
-
-		// End the task
-		[theDocument endTask];
-		return;
-
-abort_entry_load:
-		NSBeep();
-		modifyingState = NO;
-		[theDocument endTask];
+		completeLoadEntry(self, entry);
 	}
 }
 
 /**
  * Load a history entry from an associated menu item
  */
-- (void) loadEntryFromMenuItem:(id)theMenuItem
-{
-	[self loadEntryAtPosition:[theMenuItem tag]];
+- (void)loadEntryFromMenuItem:(NSMenuItem *)item {
+	[self loadEntryStart: item.representedObject];
 }
 
-#pragma mark -
-#pragma mark Restoring view states
+#pragma mark - Restoring view states
 
 /**
- * Check saved view states for the currently selected database and
- * table (if any), and restore them if present.
+ * Check saved view states for the currently selected database and table (if any), and restore them if present.
  */
-- (void) restoreViewStates
-{
-	NSString *theDatabase = [theDocument database];
-	NSString *theTable = [theDocument table];
-	NSDictionary *contentState;
-
+- (void)restoreViewStates {
 	// Return if the history state is currently being modified
-	if (modifyingState) return;
-	
+	if (modifyingState) { return; }
+
 	// Return (and disable navigatingFK), if we are navigating using a Foreign-Key button
 	if (navigatingFK) {
 		navigatingFK = NO;
 		return;
 	}
 
+	NSString *theDatabase = theDocument.database;
+	NSString *theTable = theDocument.table;
+
 	// Return if no database or table are selected
-	if (!theDatabase || !theTable) return;
+	if (!theDatabase || !theTable) { return; }
 
 	// Retrieve the saved content state, returning if none was found
-	contentState = [tableContentStates objectForKey:[NSString stringWithFormat:@"%@.%@", [theDatabase backtickQuotedString], [theTable backtickQuotedString]]];
-	if (!contentState) return;
+	NSString * const key = [NSString stringWithFormat:@"%@.%@", theDatabase.backtickQuotedString, theTable.backtickQuotedString];
+	SPTableHistoryEntry *entry = (SPTableHistoryEntry *)[tableContentStates objectForKey: key];
+	if (!entry) { return; }
 
+	[self doRetoreViewState: entry];
+}
+
+- (void)doRetoreViewState:(SPTableHistoryEntry *)entry {
 	// Restore the content view state
-	[tableContentInstance setSortColumnNameToRestore:[contentState objectForKey:@"sortCol"] isAscending:[[contentState objectForKey:@"sortIsAsc"] boolValue]];
-	[tableContentInstance setPageToRestore:[[contentState objectForKey:@"page"] unsignedIntegerValue]];
-	[tableContentInstance setSelectionToRestore:[contentState objectForKey:@"selection"]];
-	[tableContentInstance setViewportToRestore:[[contentState objectForKey:@"viewport"] rectValue]];
-	[tableContentInstance setFiltersToRestore:[contentState objectForKey:@"filterV2"]];
-	[tableContentInstance setActiveFilterToRestore:(SPTableContentFilterSource)[[contentState objectForKey:@"activeFilter"] integerValue]];
+	[tableContentInstance setSortColumnNameToRestore: entry.contentSortColName isAscending: entry.contentSortColIsAsc];
+	[tableContentInstance setPageToRestore: entry.contentPageNumber];
+	[tableContentInstance setSelectionToRestore: entry.selectedRows];
+	[tableContentInstance setViewportToRestore: entry.viewPort];
+	[tableContentInstance setFiltersToRestore: entry.filter];
+	[tableContentInstance setActiveFilterToRestore: (SPTableContentFilterSource)entry.activeFilter];
 }
 
-#pragma mark -
-#pragma mark History entry details and description
+#pragma mark - Private Helper c-Functions
 
-/**
- * Returns a menuitem for a history entry at a supplied index
- */
-- (NSMenuItem *) menuEntryForHistoryEntryAtIndex:(NSInteger)theIndex
-{
-	NSMenuItem *theMenuItem = [[NSMenuItem alloc] init];
-	NSDictionary *theHistoryEntry = [history objectAtIndex:theIndex];
+static BOOL canCurrentReplaceEntry(SPTableHistoryEntry *curr, SPTableHistoryEntry *new) {
+	// no entry to replace
+	if (!curr) { return NO; }
 
-	[theMenuItem setTag:theIndex];
-	[theMenuItem setTitle:[self nameForHistoryEntryDetails:theHistoryEntry]];
-	[theMenuItem setTarget:self];
-	[theMenuItem setAction:@selector(loadEntryFromMenuItem:)];
-	
-	return theMenuItem;
-}
+	// databases don't match, can't replace entry.
+	if (![curr.database isEqualToString: new.database]) { return NO; }
 
-/**
- * Returns a descriptive name for a history item dictionary
- */
-- (NSString *) nameForHistoryEntryDetails:(NSDictionary *)theEntry
-{
-	if (![theEntry objectForKey:@"database"]) return NSLocalizedString(@"(no selection)", @"History item title with nothing selected");
+	// Special case: if current entry has no table, replace it. This improves history flow.
+	if (!curr.table) { return YES; }
 
-	NSMutableString *theName = [NSMutableString stringWithString:[theEntry objectForKey:@"database"]];
-	if (![theEntry objectForKey:@"table"] || ![(NSString *)[theEntry objectForKey:@"table"] length]) return theName;
+	// tables don't match, can't replace entry.
+	if (![curr.table isEqualToString: new.table]) { return NO; }
 
-	[theName appendFormat:@"/%@", [theEntry objectForKey:@"table"]];
-
-	if ([theEntry objectForKey:@"contentFilterV2"]) {
-		theName = [NSMutableString stringWithFormat:NSLocalizedString(@"%@ (Filtered)", @"History item filtered by values label"), theName];
+	BOOL viewIsTheSame  = curr.view == new.view;
+	// If filter settings haven't changed, entry can be replaced.
+	// This updates navigation within a table, rather than creating a new entry every time detail is changed.
+	if (!viewIsTheSame || (!curr.filter && !new.filter) || [curr.filter isEqualToDictionary: new.filter]) {
+		return YES;
 	}
-
-	if ([theEntry objectForKey:@"contentPageNumber"]) {
-		NSUInteger pageNumber = [[theEntry objectForKey:@"contentPageNumber"] unsignedIntegerValue];
-		if (pageNumber > 1) {
-			theName = [NSMutableString stringWithFormat:NSLocalizedString(@"%@ (Page %lu)", @"History item with page number label"), theName, (unsigned long)pageNumber];
+	// views are the same, but the filter settings have changed, also store the position details on the *previous* history item
+	else if (viewIsTheSame || (!curr.filter && new.filter) || ![curr.filter isEqualToDictionary: new.filter]) {
+		// TODO: Investigate further, don't fully understand why we add a new item to history but also modify the current entry.
+		curr.viewPort = new.viewPort;
+		if (new.selectedRows) {
+			curr.selectedRows = new.selectedRows;
 		}
 	}
 
-	return theName;
+	return NO;
+}
+
+static void abortEntryLoad(SPHistoryController *c) {
+	NSBeep();
+	c->modifyingState = NO;
+	[[c onMainThread] updateToolbarItem];
+	[c->theDocument endTask];
+}
+
+static void completeLoadEntry(SPHistoryController *c, SPTableHistoryEntry *entry) {
+	[c->historyManager navigateTo: entry];
+	c->modifyingState = NO;
+	[[c onMainThread] updateToolbarItem];
+	[c->theDocument endTask];
+}
+
+static NSMenu* menuForEntries(NSArray *entries, SPHistoryController *target) {
+	if (entries == nil || entries.count == 0) { return nil; }
+
+	NSMenu *menu = [[NSMenu alloc] init];
+	for (NSInteger i = entries.count - 1; i >= 0; i--) {
+		NSMenuItem *item = menuEntryFor(entries[i], i, target);
+		if (item.menu) {
+			[item.menu removeItem: item];
+		}
+		[menu addItem: item];
+	}
+
+	return menu;
+}
+
+static NSMenuItem* menuEntryFor(SPTableHistoryEntry *entry, NSInteger index, SPHistoryController *target) {
+	if (entry.cachedMenuItem) {
+		return entry.cachedMenuItem;
+	}
+
+	NSMenuItem *item = [[NSMenuItem alloc] init];
+	[item setTitle: menuItemDescriptionFor(entry)];
+	[item setTarget: target];
+	[item setAction: @selector(loadEntryFromMenuItem:)];
+	[item setTag: index];
+	[item setRepresentedObject: entry];
+	entry.cachedMenuItem = item;
+
+	return item;
+}
+
+static NSString* menuItemDescriptionFor(SPTableHistoryEntry *entry) {
+	if (!entry.database) {
+		return NSLocalizedString(@"(no selection)", @"History item title with nothing selected");
+	}
+
+	NSMutableString *name = [NSMutableString stringWithString: entry.database];
+	if (!entry.table || !entry.table.length) { return name; }
+
+	[name appendFormat: @"/%@", entry.table];
+
+	// TODO: Enhance this, non nil doesn't mean items are actually filtered.
+	if (entry.filter) {
+		name = [NSMutableString stringWithFormat: NSLocalizedString(@"%@ (Filtered)", @"History item filtered by values label"), name];
+	}
+
+	if (entry.contentPageNumber > 0) {
+		unsigned long num = entry.contentPageNumber;
+		name = [NSMutableString stringWithFormat: NSLocalizedString(@"%@ (Page %lu)", @"History item with page number label"), name, num];
+	}
+
+	return name;
 }
 
 @end

--- a/Source/Controllers/Other/SPTableHistoryManager.swift
+++ b/Source/Controllers/Other/SPTableHistoryManager.swift
@@ -1,0 +1,161 @@
+//
+// Created by Luis Aguiniga on 2023.10.14
+//  Copyright © 2023 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+import OSLog
+
+@objc class SPTableHistoryManager: NSObject {
+	typealias Entry = SPTableHistoryEntry
+	@objc var countPrevious: Int { prevStack.count > 0 ? prevStack.count - 1 : 0 }
+	@objc var countForward: Int { nextStack.count }
+	@objc var peakCurrent: Entry? { prevStack.last }
+	@objc var peakPrevious: Entry? { prevStack.count >= 2 ? prevStack[prevStack.count - 2] : nil }
+	@objc var peakForward: Entry? { nextStack.last }
+	private var prevStack: [Entry] = []
+	private var nextStack: [Entry] = []
+
+	@objc func push(_ entry: Entry) {
+		doPush(entry)
+		logStack()
+	}
+
+	@objc func replaceTopWithEntry(_ entry: Entry) {
+		if prevStack.isNotEmpty { prevStack.removeLast() }
+		prevStack.append(entry)
+		logStack()
+	}
+
+	@objc func navigate(to entry: Entry) {
+		// move element between stacks until `entry` is "top" (last item) of `prevStack` stack
+		if prevStack.contains(entry) {
+			while let element = prevStack.last, entry != element {
+				prevStack.removeLast()
+				nextStack.append(element)
+			}
+		}
+		else if nextStack.contains(entry) {
+			while let element = nextStack.last {
+				nextStack.removeLast()
+				prevStack.append(element)
+				if element == entry { break; }
+			}
+		}
+		else {
+			// entry not in any stack, push on top, clearing forward history
+			doPush(entry)
+		}
+
+		logStack()
+	}
+
+	// last element is the current item so we won't generate menu item for it.
+	@objc func backEntries() -> [Entry] { Array(prevStack.dropLast()) }
+	@objc func forwardEntries() -> [Entry] { Array(nextStack) }
+
+	private func doPush(_ entry: Entry) {
+		prevStack.append(entry)
+		if prevStack.count > 50 {
+			prevStack.removeFirst()
+		}
+
+		if let last = nextStack.last, last === entry {
+			nextStack.removeLast()
+		}
+		else {
+			nextStack.removeAll()
+		}
+	}
+
+#if DEBUG
+	static let LOGGER: OSLog = OSLog(subsystem: "com.sequel-ace.sequel-ace", category: "SPTableHistoryManager")
+	private func logStack() {
+		if (self.prevStack.isNotEmpty) {
+			Self.LOGGER.debug("\nPrev Stack: \(makeStackString(self.prevStack, true))")
+		}
+		if (self.nextStack.isNotEmpty) {
+			Self.LOGGER.debug("\nNext Stack: \(makeStackString(self.nextStack, false))")
+		}
+	}
+	private func makeStackString(_ stack: [Entry], _ isPrev: Bool ) -> String {
+		guard !stack.isEmpty else { return "[]" }
+
+		var currDb = ""
+		var strings = stack.map { entry in
+			if currDb == entry.database {
+				return "\n  ::\(entry.table ?? "(null)")::\(entry.activeFilter)"
+			}
+			else {
+				currDb = entry.database ?? ""
+				return "\n  \(entry.debugDescription)"
+			}
+		}
+
+		if isPrev {
+			strings[strings.count-1] = "\n  <CURRENT> \(strings[strings.count-1].trimmedString)"
+		}
+
+		var msg = "["
+		msg.append(strings.reversed().joined(separator: ","))
+		msg.append("\n]")
+
+		return msg
+	}
+#else
+	private func logStack() {}
+#endif
+}
+
+@objc class SPTableHistoryEntry: NSObject {
+	@objc var database: String?
+	@objc var table: String?
+	@objc var view: Int
+	@objc var viewPort: NSRect
+	@objc var contentSortColName: String?
+	@objc var contentSortColIsAsc: Bool
+	@objc var contentPageNumber: Int
+	@objc var activeFilter: Int
+	@objc var selectedRows: [String: Any]?
+	@objc var filter: [String: Any]?
+	@objc var filterData: Data?
+	@objc weak var cachedMenuItem: NSMenuItem?
+	override var description: String { "\(database ?? "<null>").\(table ?? "<null>")" }
+
+	@objc init(database: String?, table: String?, view: Int, viewPort: NSRect,
+			   contentSortColName: String?, contentSortColIsAsc: Bool, contentPageNumber: Int, selectedRows: [String: Any]?,
+			   activeFilter: Int, filter: [String: Any]?, filterData: Data?) {
+		self.database = database
+		self.table = table
+		self.view = view
+		self.viewPort = viewPort
+		self.contentSortColName = contentSortColName
+		self.contentSortColIsAsc = contentSortColIsAsc
+		self.contentPageNumber = contentPageNumber
+		self.activeFilter = activeFilter
+		self.selectedRows = selectedRows
+		self.filter = filter
+		self.filterData = filterData
+		super.init()
+	}
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		C9F92712162D39E60051CB2E /* toolbar-switch-to-browse.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */; };
 		C9F92714162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */; };
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
+		FD6DFF872ADB40630057B713 /* SPTableHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */; };
 		FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
 /* End PBXBuildFile section */
 
@@ -993,8 +994,8 @@
 		588B2CC50FE5641E00EC5FC0 /* ssh-connected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ssh-connected.png"; sourceTree = "<group>"; };
 		588B2CC60FE5641E00EC5FC0 /* ssh-connecting.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ssh-connecting.png"; sourceTree = "<group>"; };
 		588B2CC70FE5641E00EC5FC0 /* ssh-disconnected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ssh-disconnected.png"; sourceTree = "<group>"; };
-		589235301020C1230011DE00 /* SPHistoryController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPHistoryController.m; sourceTree = "<group>"; };
-		589235311020C1230011DE00 /* SPHistoryController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPHistoryController.h; sourceTree = "<group>"; };
+		589235301020C1230011DE00 /* SPHistoryController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = SPHistoryController.m; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
+		589235311020C1230011DE00 /* SPHistoryController.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = SPHistoryController.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
 		589582131154F8F400EDCC28 /* SPMainThreadTrampoline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPMainThreadTrampoline.h; sourceTree = "<group>"; };
 		589582141154F8F400EDCC28 /* SPMainThreadTrampoline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPMainThreadTrampoline.m; sourceTree = "<group>"; };
 		58B9077D11BD9B64000826E5 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -1159,6 +1160,7 @@
 		C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse.png"; sourceTree = "<group>"; };
 		C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse@2x.png"; sourceTree = "<group>"; };
 		D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowTabAccessory.swift; sourceTree = "<group>"; };
+		FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SPTableHistoryManager.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1488,6 +1490,7 @@
 				1A96E4B52588F34C0055F5F5 /* SecureBookmarkManager.swift */,
 				589235311020C1230011DE00 /* SPHistoryController.h */,
 				589235301020C1230011DE00 /* SPHistoryController.m */,
+				FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */,
 				5806B76211A991EC00813A88 /* SPDocumentController.h */,
 				5806B76311A991EC00813A88 /* SPDocumentController.m */,
 				1A9EB9AD25651F5000FE60FF /* SQLiteHistoryManager.swift */,
@@ -2947,6 +2950,7 @@
 				3876E15D1CC0BA0300D85154 /* SPTableFooterPopUpButtonCell.m in Sources */,
 				51BC14F825BE135500F1CDC9 /* SPWindowController.swift in Sources */,
 				173C4366104455E0001F3A30 /* SPQueryFavoriteManager.m in Sources */,
+				FD6DFF872ADB40630057B713 /* SPTableHistoryManager.swift in Sources */,
 				173C44D81044A6B0001F3A30 /* SPOutlineView.m in Sources */,
 				500C1F921BFB5F9F0095DC7F /* SPPrivilegesMO.m in Sources */,
 				17F5B1511048C4E400FC794F /* SPCSVExporter.m in Sources */,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Refactored `SPHistoryController` to use a 2-"stack" based implementation
  This allows us to encapsulate the implementation details a bit better. As part of refactor I converted the "state" object to a custom class to have a more type safe approach and more concise code (i.e. `entry.database` vs `[entry objectForKey:@"database"] `). with 2-stack approach we can just shuffle entries between the stats and get
- Reduce outward facing API by moving methods into `.m` file where I think it makes more sense for them to be private methods.
- SPDatabaseDocument - when testing history across databases, I noticed we could end up in an invalid database/table combination because we keep the same table selected but that table might not exist in the new database selected. This led to invalid entries showing up in the history menu ie. `db1/table1` navigating to `db2` adds entry `db2/table1` even though table1 doesn't exist in the `db2`.
- Reduce NSMenuItem allocations - previously the `updateToolbarItem` got called multiple times per "user action" (navigating to different view/table or applying a filter). With each call,  the complete set of new menu + menu items were reallocated --  This means that when the history is full (50 items) we allocated 100 menu item instances per "user action". With fix, we only allocate a new menu item when we create a new history entry (1 per "user action").
- Miscellaneous formatting changes to try to make file more consistent.

## Closes following issues:
- Closes:  #1878

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [x] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.0
  
## Screenshots:

Can now navigate back/forward one at a time and jump around using menu items:
![history-demo](https://github.com/Sequel-Ace/Sequel-Ace/assets/1121410/1a722a62-3447-45fd-91e1-7d09f184491d)

## Additional notes:
