### PR TITLE
#fixed Fix database duplication command for MySQL 8

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Databases & Tables.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Databases & Tables.m
@@ -208,6 +208,7 @@
 	// Perform the query and record state
 	SPMySQLResult *tableResult = [self queryString:tableQuery];
 	[tableResult setDefaultRowReturnType:SPMySQLResultRowAsArray];
+    [tableResult setReturnDataAsStrings:YES];
 
 	// Retrieve the result into an array if the query was successful
 	if (![self queryErrored]) {


### PR DESCRIPTION
MySQL 8 and maybe other engines return results from `SHOW TABLES` as blobs instead of strings. The NSData object containing the table name would then be passed around under the assumption that it is a string. Luckily it doesn't crash, but instead eventually fails [here](https://github.com/Sequel-Ace/Sequel-Ace/blob/8d66aa2b3b4dcffb6b6fb61463ce6ee97daee711/Source/Other/DatabaseActions/SPTableCopy.m#L149).

I adjusted the result object to always convert the table names to strings. This may need to be done elsewhere, but it fixed the issue at hand.

Going forward, I think we should figure out a way to bubble up internal assertions to the UI. Maybe log an error message to the console?

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- 

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.0.1
  
## Screenshots:

## Additional notes:
