### PR TITLE
#fixed #1842: Re-enable 'Save ... to Favorites" option

### DIFF
--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1523,7 +1523,7 @@ Gw
                                                                                                             <menuItem title="Save Query to Favorites" tag="100000" toolTip="Save current query, selection, or - if no selection or current query could be found - the entire content to Favorite." id="7265">
                                                                                                                 <modifierMask key="keyEquivalentModifierMask" option="YES"/>
                                                                                                             </menuItem>
-                                                                                                            <menuItem title="Save All to Favorites" tag="100001" alternate="YES" toolTip="Save editor content to Favorite. Press ⌥ to restrict for current query or selection." id="7269">
+                                                                                                            <menuItem title="Save All to Favorites" tag="100001" toolTip="Save editor content to Favorite. Press ⌥ to restrict for current query or selection." id="7269">
                                                                                                                 <modifierMask key="keyEquivalentModifierMask"/>
                                                                                                             </menuItem>
                                                                                                             <menuItem title="Edit Favorites..." id="7266"/>


### PR DESCRIPTION
## Changes:
- I found that the source already had a feature called "Save ... to Favorites" (... = Current, Selection) and it works well, but it might be disabled accidentally by the `alternate` attribute of the next `menuItem`.

## Closes following issues:
- Closes: #1842 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.0.1
  
## Screenshots:

Before:
![image](https://github.com/Sequel-Ace/Sequel-Ace/assets/3168632/21d254c0-a877-4b9a-8957-ec29241b4eee)

After:
- When selected nothing
![image](https://github.com/Sequel-Ace/Sequel-Ace/assets/3168632/29f094fd-8beb-4d42-8401-0dc67c3561b9)

- When selected a query
![image](https://github.com/Sequel-Ace/Sequel-Ace/assets/3168632/5f145e1f-c39e-45e4-abbc-5bd3dce39e05)

## Additional notes:
