### PR TITLE
#1966 Debug: Changing column name on UUID type (MariaDB) fails

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -885,7 +885,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 	if(!specialFieldTypes) {
 
-		if ([theRowType isEqualToString:@"JSON"]) {
+		if ([theRowType isEqualToString:@"JSON"] || [theRowType isEqualToString:@"UUID"]) {
 			// we "see" JSON as a string, but it is not internally to MySQL and so doesn't allow CHARACTER SET/BINARY/COLLATE either.
 		}
 		else if ([fieldValidation isFieldTypeString:theRowType]) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Fixed:
- Changing column name on UUID type (MariaDB) fixed.

## Closes following issues:
- Closes: #1966

## Tested:
- Processors:
  - [ ] Intel
  - [X] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [X] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.2
  
## Screenshots:

## Additional notes:
