### PR TITLE
Fix duplicated tables in exports #fixed

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -708,7 +708,7 @@ set_input:
 	
 	// For all modes, retrieve table and view names
 	{
-		NSArray *tablesAndViews = [tablesListInstance allTableAndViewNames];
+        NSOrderedSet *tablesAndViews = [[NSOrderedSet alloc] initWithArray:[[tablesListInstance allTableAndViewNames] sortedArrayUsingSelector:@selector(compare:)]];
 
 		for (id itemName in tablesAndViews) {
 			[tables safeAddObject:[NSMutableArray arrayWithObjects:

--- a/Source/Controllers/SubviewControllers/SPTablesList.h
+++ b/Source/Controllers/SubviewControllers/SPTablesList.h
@@ -162,6 +162,7 @@
 - (nullable NSString *)tableName;
 - (SPTableType)tableType;
 - (nonnull NSArray *)tables;
+- (nonnull NSArray *)pinnedTables;
 - (nonnull NSArray *)tableTypes;
 - (nonnull NSArray *)allTableAndViewNames;
 - (nonnull NSArray *)allTableNames;

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -1316,6 +1316,14 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 }
 
 /**
+ * Database tables accessor
+ */
+- (NSArray *)pinnedTables
+{
+    return pinnedTables;
+}
+
+/**
  * Database tables accessors for a given table type.
  */
 - (NSArray *)allTableAndViewNames

--- a/Source/Other/CategoryAdditions/SPMutableArrayAdditions.h
+++ b/Source/Other/CategoryAdditions/SPMutableArrayAdditions.h
@@ -47,3 +47,13 @@
 - (void)safeSetArray:(NSArray* _Nonnull)arr;
 
 @end
+
+@interface NSMutableOrderedSet (SPMutableArrayAdditions)
+
+- (nullable id)safeObjectAtIndex:(NSUInteger)idx;
+- (void)safeAddObject:(nullable id)obj;
+- (void)safeReplaceObjectAtIndex:(NSUInteger)index withObject:(nullable id)anObject;
+- (void)safeRemoveObjectAtIndex:(NSUInteger)index;
+- (void)addObjectIfNotContains:(id _Nonnull)obj;
+
+@end

--- a/Source/Other/CategoryAdditions/SPMutableArrayAdditions.m
+++ b/Source/Other/CategoryAdditions/SPMutableArrayAdditions.m
@@ -89,3 +89,36 @@
 }
 
 @end
+
+@implementation NSMutableOrderedSet (SPMutableArrayAdditions)
+
+- (id)safeObjectAtIndex:(NSUInteger)idx{
+    return idx < self.count ? [self objectAtIndex:idx] : nil;
+}
+
+- (void)safeAddObject:(id)obj{
+    if (obj != nil) {
+        [self addObject:obj];
+    }
+}
+
+- (void)addObjectIfNotContains:(id)obj{
+    if (obj != nil && [self containsObject:obj] == NO) {
+        [self addObject:obj];
+    }
+}
+
+- (void)safeReplaceObjectAtIndex:(NSUInteger)index withObject:(nullable id)anObject{
+    if (anObject != nil && index < self.count) {
+        [self replaceObjectAtIndex:index withObject:anObject];
+    }
+}
+
+- (void)safeRemoveObjectAtIndex:(NSUInteger)index{
+    id object = [self safeObjectAtIndex:index];
+    if (object != nil && object != [NSNull null]) {
+        [self removeObjectAtIndex:index];
+    }
+}
+
+@end


### PR DESCRIPTION
## Changes:
- Filter out pinned tables

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1501

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.3