### PR TITLE
Add prompt if app should close before termination #added

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -612,6 +612,12 @@
 /* unsaved changes informative message */
 "Changes have been made, which will be lost if this window is closed. Are you sure you want to continue" = "Changes have been made, which will be lost if this window is closed. Are you sure you want to continue";
 
+/* quitting app informal alert title */
+"Close the app?" = "Close the app?";
+
+/* quitting app informal alert body */
+"Are you sure you want to quit the app?" = "Are you sure you want to quit the app?";
+
 /* character set client: %@ */
 "character set client: %@" = "character set client: %@";
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -1531,6 +1531,13 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
  */
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
 {
+    if ([sender keyWindow] != nil) {
+        BOOL answer = [self dialogOKCancelWithQuestion:NSLocalizedString(@"Close the app?", @"quitting app informal alert title") text:NSLocalizedString(@"Are you sure you want to quit the app?", @"quitting app informal alert body")];
+        if (answer == NO) {
+            return NSTerminateCancel;
+        }
+    }
+
     BOOL shouldSaveFavorites = NO;
 
     // removing vacuum here. See: https://www.sqlite.org/lang_vacuum.html
@@ -1581,7 +1588,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         [[SPFavoritesController sharedFavoritesController] saveFavoritesSynchronously];
     }
 
-    return YES;
+    return NSTerminateNow;
 }
 
 #pragma mark -

--- a/Source/Controllers/SPAppController.swift
+++ b/Source/Controllers/SPAppController.swift
@@ -207,3 +207,15 @@ extension SPAppController {
         tabManager.activeWindowController?.databaseDocument.showMySQLHelp()
     }
 }
+
+extension SPAppController {
+    @objc func dialogOKCancel(question: String, text: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = question
+        alert.informativeText = text
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}


### PR DESCRIPTION
## Changes:
- Add prompt to the user when quitting the app

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/1971

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.3