### PR TITLE
Adjust size of connection error alert #changed

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2418,7 +2418,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
 
     // Only display the connection error message if there is a window visible
     if ([[dbDocument parentWindowControllerWindow] isVisible]) {
-        NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0,0,800,300)];
+        NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0,0,488,140)];
         NSText *errorMessageTextView = [[NSText alloc] initWithFrame:scrollView.bounds];
 
         [errorMessageTextView setString:errorMessage];

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2419,14 +2419,19 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
     // Only display the connection error message if there is a window visible
     if ([[dbDocument parentWindowControllerWindow] isVisible]) {
         NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0,0,488,140)];
-        NSText *errorMessageTextView = [[NSText alloc] initWithFrame:scrollView.bounds];
+        [scrollView setDrawsBackground:NO];
+        [scrollView setHasVerticalScroller:YES];
+        
+        NSScroller *verticalScroller = [scrollView verticalScroller];
+        CGFloat scrollbarWidth = NSWidth([verticalScroller frame]);
+        NSRect textViewFrame = scrollView.bounds;
+        textViewFrame.size.width = scrollView.frame.size.width - scrollbarWidth;
 
+        NSText *errorMessageTextView = [[NSText alloc] initWithFrame:textViewFrame];
         [errorMessageTextView setString:errorMessage];
         [errorMessageTextView setEditable:NO];
         [errorMessageTextView setDrawsBackground:NO];
 
-        [scrollView setDrawsBackground:NO];
-        [scrollView setHasVerticalScroller:YES];
         [scrollView setDocumentView:errorMessageTextView];
 
         errorShowing = YES;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Sets the width of the alert to the default width when there is long text
- Prevents horizontal elastic scrolling by subtracting the scroll bar width from the text view

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
Before:
<img src="https://github.com/Sequel-Ace/Sequel-Ace/assets/2276355/c41089d6-bedc-4d95-8ff9-628ba3f74c70" width="75%">

After:
<img src="https://github.com/Sequel-Ace/Sequel-Ace/assets/2276355/d9d3c743-f51d-4612-b5c6-8404c17a734a" width="75%">



## Additional notes:
