### PR TITLE
fix #2049: switch to use formatter for JSON beautifying instead of us…

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -541,6 +541,8 @@ typedef enum {
                     if ([sheetEditData respondsToSelector:@selector(dataUsingEncoding:)]) {
                         NSError *error = nil;
                         NSData *jsonData = [sheetEditData dataUsingEncoding:NSUTF8StringEncoding];
+                        
+                        // Validate by NSJSONSerialization
                         id jsonObject = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingMutableContainers error:&error];
 
                         if(error != nil){
@@ -548,34 +550,17 @@ typedef enum {
                             [jsonTextView setString:NSLocalizedString(@"Invalid JSON",@"Message for field editor JSON segment when JSON is invalid")];
                         }
                         else{
-                            if([NSJSONSerialization isValidJSONObject:jsonObject]){
-                                SPLog(@"isValidJSONObject : %@", jsonObject);
-                                NSData *prettyJsonData = [NSJSONSerialization dataWithJSONObject:jsonObject options:NSJSONWritingPrettyPrinted error:&error];
-
-                                if(error != nil){
-                                    SPLog(@"dataWithJSONObject error : %@", error.localizedDescription);
-                                    [jsonTextView setString:NSLocalizedString(@"Invalid JSON",@"Message for field editor JSON segment when JSON is invalid")];
-                                }
-                                else{
-                                    NSString *prettyPrintedJson = [[NSString alloc] initWithData:prettyJsonData encoding:NSUTF8StringEncoding];
-                                    if(prettyPrintedJson != nil){
-                                        SPLog(@"prettyPrintedJson : %@", prettyPrintedJson);
-                                        [jsonTextView setString:prettyPrintedJson];
-                                    }
-                                    else{
-                                        SPLog(@"prettyPrintedJson is nil");
-                                        [jsonTextView setString:NSLocalizedString(@"Invalid JSON",@"Message for field editor JSON segment when JSON is invalid")];
-                                    }
-                                }
-                            }
-                            else{
-                                if(sheetEditData != nil){
-                                    [jsonTextView setString:sheetEditData];
-                                }
-                                else{
-                                    [jsonTextView setString:NSLocalizedString(@"Invalid JSON",@"Message for field editor JSON segment when JSON is invalid")];
-                                }
-                            }
+                          // Re-format by custom formatter instead of using NSJSONSerialization
+                          // to avoid the data conversion issue of NSJSONSerialization (e.g: float number issue)
+                          NSString *prettyPrintedJson = [SPJSONFormatter stringByFormattingString:sheetEditData];
+                          if(prettyPrintedJson != nil){
+                            SPLog(@"prettyPrintedJson : %@", prettyPrintedJson);
+                            [jsonTextView setString:prettyPrintedJson];
+                          }
+                          else{
+                            SPLog(@"prettyPrintedJson is nil");
+                            [jsonTextView setString:NSLocalizedString(@"Invalid JSON",@"Message for field editor JSON segment when JSON is invalid")];
+                          }
                         }
                     }
                     else{


### PR DESCRIPTION
## Changes:
- Switch to use the JSON formatter for JSON beautifying instead of using built-in serializer as it only considers indentations and not types of data.
- Also simplify the logic of the function by removing redundant steps

## Closes following issues:
- Closes: https://github.com/Sequel-Ace/Sequel-Ace/issues/2019

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Version 15.4
  
## Screenshots:

- Case 1: JSON data with multiple levels
![image](https://github.com/user-attachments/assets/58367489-5394-49f1-b047-7e90c1d45dbd)
![image](https://github.com/user-attachments/assets/0c7f6856-7411-4661-9f42-d7cfec76060e)

- Case 2: mentioned in https://github.com/Sequel-Ace/Sequel-Ace/issues/2019
![image](https://github.com/user-attachments/assets/5e82bd16-d3ea-4dc6-944b-e4834d4fa4e4)
![image](https://github.com/user-attachments/assets/019b48a3-ae72-4f72-b4fc-54053a38e1a4)

- Case 3: Invalid JSON
![image](https://github.com/user-attachments/assets/732cdd2a-4343-42dc-a7d4-53bf6c352561)
![image](https://github.com/user-attachments/assets/6db1f1c3-0e54-4139-b90f-b4c567ff37ee)

## Additional notes: -