### PR TITLE
Ability to re-format JSON (in field data editor) by soft-indent setting

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -412,9 +412,12 @@ typedef enum {
 		else {
 			// If the input is a JSON type column we can format it.
 			// Since MySQL internally stores JSON in binary, it does not retain any formatting
+      BOOL useSoftIndent = [prefs boolForKey:SPCustomQuerySoftIndent];
+      NSInteger indentWidth = [prefs integerForKey:SPCustomQuerySoftIndentWidth];
+
 			do {
 				if(_isJSON) {
-					NSString *formatted = [SPJSONFormatter stringByFormattingString:sheetEditData];
+          NSString *formatted = [SPJSONFormatter stringByFormattingString:sheetEditData useSoftIndent:useSoftIndent indentWidth:indentWidth];
 					if(formatted) {
 						stringValue = formatted;
 						break;
@@ -552,7 +555,9 @@ typedef enum {
                         else{
                           // Re-format by custom formatter instead of using NSJSONSerialization
                           // to avoid the data conversion issue of NSJSONSerialization (e.g: float number issue)
-                          NSString *prettyPrintedJson = [SPJSONFormatter stringByFormattingString:sheetEditData];
+                          BOOL useSoftIndent = [prefs boolForKey:SPCustomQuerySoftIndent];
+                          NSInteger indentWidth = [prefs integerForKey:SPCustomQuerySoftIndentWidth];
+                          NSString *prettyPrintedJson = [SPJSONFormatter stringByFormattingString:sheetEditData useSoftIndent:useSoftIndent indentWidth:indentWidth];
                           if(prettyPrintedJson != nil){
                             SPLog(@"prettyPrintedJson : %@", prettyPrintedJson);
                             [jsonTextView setString:prettyPrintedJson];

--- a/Source/Other/Parsing/SPJSONFormatter.h
+++ b/Source/Other/Parsing/SPJSONFormatter.h
@@ -109,6 +109,8 @@ int SPJSONTokenizerGetNextToken(SPJSONTokenizerState *stateInfo, SPJSONTokenInfo
  *
  * @return The formatted string or nil if formatting failed.
  */
++ (NSString *)stringByFormattingString:(NSString *)input useSoftIndent:(BOOL)useSoftIndent indentWidth:(NSInteger)indentWidth;
+
 + (NSString *)stringByFormattingString:(NSString *)input;
 
 /**


### PR DESCRIPTION
## Changes:
- This PR depends on https://github.com/Sequel-Ace/Sequel-Ace/pull/2044 to cover all cases
- Ability to re-format JSON with soft-indent setting

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
- When indent width = 2:
![SCR-20240713-qwkk](https://github.com/user-attachments/assets/00f2450f-bf99-4d8b-8f42-a7bdb35053ab)
- When indent width = 10:
![SCR-20240713-qwqq](https://github.com/user-attachments/assets/089d48f0-44f0-4a6f-b15d-bca5622e256d)

## Additional notes: