### PR TITLE
Improved picking query from fav/history lists

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -357,7 +357,15 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             if ([[textView.textStorage string] length] > 0) {
                 [selectedFaveQueryStr insertString:@"\n" atIndex:0];
             }
-            [textView insertAsSnippet:selectedFaveQueryStr atRange:[textView selectedRange]];
+          
+            NSRange selectedRange = [textView selectedRange];
+            // If no selected range, then make a new range then use it for appending query
+            if (!selectedRange.length) {
+              selectedRange = NSMakeRange(textView.textStorage.length, 0);
+              NSUInteger caretPosition = selectedRange.location;
+            }
+          
+            [textView insertAsSnippet:selectedFaveQueryStr atRange:selectedRange];
         }
     }
 }
@@ -389,7 +397,15 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             if ([[textView.textStorage string] length] > 0) {
                 [selectedHistoryQueryStr insertString:@"\n" atIndex:0];
             }
-            [textView insertAsSnippet:selectedHistoryQueryStr atRange:[textView selectedRange]];
+          
+            NSRange selectedRange = [textView selectedRange];
+            // If no selected range, then make a new range then use it for appending query
+            if (!selectedRange.length) {
+              selectedRange = NSMakeRange(textView.textStorage.length, 0);
+              NSUInteger caretPosition = selectedRange.location;
+            }
+          
+            [textView insertAsSnippet:selectedHistoryQueryStr atRange:selectedRange];
         }
 
     }


### PR DESCRIPTION
## Changes:
- Added append mode when picking query from `Query Favorites`/`Query History` list if there is no selected range

## Closes following issues:
- Closes: #2048

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Version 15.4 
  
## Screenshots:

Before:

https://github.com/user-attachments/assets/eb9df7e9-9fa4-4564-92f6-7e2f9665b94a

After:

https://github.com/user-attachments/assets/095a2fe5-11eb-4a2e-ab69-e416b951d481

## Additional notes:
- Detect the latest query and adding a semicolon (if missing) seems a challenge to me, so I hope it will be done in another PR if I know how to do it.