### PR TITLE
Fix: Unable to update UUID field's value by text editor

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2856,7 +2856,11 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			NSString *escVal;
 			NSString *fmt = @"%@";
 			// If the field is of type BIT then it needs a binary prefix
-			if ([[[tableDataInstance columnWithName:[keys safeObjectAtIndex:i]] objectForKey:@"type"] isEqualToString:@"BIT"]) {
+      NSDictionary *field = [tableDataInstance columnWithName:[keys safeObjectAtIndex:i]];
+      NSString *fieldType = [field objectForKey:@"type"];
+      NSString *fieldTypeGroup = [field objectForKey:@"typegrouping"];
+      
+			if ([fieldType isEqualToString:@"BIT"]) {
 				escVal = [mySQLConnection escapeString:tempValue includingQuotes:NO];
 				fmt = @"b'%@'";
 			}
@@ -2865,7 +2869,12 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			}
 			// BLOB/TEXT data
 			else if ([tempValue isKindOfClass:[NSData class]]) {
-				escVal = [mySQLConnection escapeAndQuoteData:tempValue];
+        if ([fieldType isEqualToString:@"UUID"] && [fieldTypeGroup isEqualToString:@"blobdata"]) {
+          NSString *uuidVal = [[NSString alloc] initWithData:tempValue encoding:NSUTF8StringEncoding];
+          escVal = [mySQLConnection escapeAndQuoteString:uuidVal];
+        } else {
+          escVal = [mySQLConnection escapeAndQuoteData:tempValue];
+        }
 			}
 			else {
 				escVal = [mySQLConnection escapeAndQuoteString:tempValue];


### PR DESCRIPTION
## Changes:
- If the field is UUID type then convert its value to UUID string (like what user can see). Also fixed the copy functions to have the same thing.

Here is the query trace when updating value 
```sql
CREATE TABLE `jsontest` (
  `1` varchar(255) NOT NULL,
  `id` uuid DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

-- Used copy function by right click
INSERT INTO `jsontest` (`1`, `id`)
VALUES
	('2', '123e4567-e89b-1231-a456-426655140003'),
	('1', '123e4567-e89b-1231-a456-426655440001'); 


```


Before:
```sql
UPDATE `jsontest` SET `id` = '123e4567-e89b-12d3-a456-426655440001' WHERE `1` = '1' AND `id` = X'31323365343536372D653839622D313264332D613435362D343236363535343430303030'
```

After:
```sql
UPDATE `jsontest` SET `id` = '123e4567-e89b-1231-a456-426655440003' WHERE `1` = '1' AND `id` = '123e4567-e89b-1231-a456-426655440002' LIMIT 1
```

## Closes following issues:
- Closes: #1486 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.4
  
## Screenshots:

https://github.com/user-attachments/assets/e051b665-6b48-43fa-91ed-6a31abae160e


## Additional notes:
