### PR TITLE
#added Feature/bin16 as UUID

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 
 	NSColor *textForegroundColor;
 	NSColor *nullHighlightColor;
-	NSColor *binhexHighlightColor;
+	NSColor *displayOverrideHighlightColor;
 
 	SPFieldEditorController *fieldEditor;
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4190,7 +4190,11 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 				cellValue = [NSString stringWithString:[prefs objectForKey:SPNullValue]];
 			}
 
-			if ([self cellValueIsDisplayedAsHexForColumn:[[tableColumn identifier] integerValue]]) {
+			NSInteger idx = [[tableColumn identifier] integerValue];
+			if ([[tableColumn.dataCell formatter] isKindOfClass:[SABaseFormatter class]]) {
+				[fieldEditor setDisplayFormatter:[tableColumn.dataCell formatter]];
+			}
+			else if ([self cellValueIsDisplayedAsHexForColumn:idx]) {
 				[fieldEditor setTextMaxLength:[[self tableView:tableContentView objectValueForTableColumn:tableColumn row:rowIndex] length]];
 				isFieldEditable = NO;
 			}

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -101,7 +101,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 @end
 
-@interface SPTableContent ()
+@interface SPTableContent () <SATableHeaderViewDelegate>
 
 - (BOOL)cancelRowEditing;
 - (void)documentWillClose:(NSNotification *)notification;
@@ -175,7 +175,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		textForegroundColor  = [NSColor controlTextColor];
 		nullHighlightColor   = [NSColor systemGrayColor];
-		binhexHighlightColor = [NSColor systemBlueColor];
+		displayOverrideHighlightColor = [NSColor systemBlueColor];
 
 		kCellEditorErrorNoMatch = NSLocalizedString(@"Field is not editable. No matching record found.\nReload table, check the encoding, or try to add\na primary key field or more fields\nin the view declaration of '%@' to identify\nfield origin unambiguously.", @"Table Content result editing error - could not identify original row");
 		kCellEditorErrorNoMultiTabDb = NSLocalizedString(@"Field is not editable. Field has no or multiple table or database origin(s).",@"field is not editable due to no table/database");
@@ -378,18 +378,14 @@ static void *TableContentKVOContext = &TableContentKVOContext;
     SPLog(@"tableDetails: %@", tableDetails);
 
 	NSString *newTableName;
-	NSInteger sortColumnNumberToRestore = NSNotFound;
-	NSNumber *colWidth;
 	NSArray *columnNames;
 	NSMutableDictionary *preservedColumnWidths = nil;
-	NSTableColumn *theCol;
 
 	BOOL enableInteraction =
 	 ![[tableDocumentInstance selectedToolbarItemIdentifier] isEqualToString:SPMainToolbarTableContent] || 
 	 ![tableDocumentInstance isWorking];
 
 	if (!tableDetails) {
-		
 		// If no table is currently selected, no action required - return.
 		if (!selectedTable) return;
 
@@ -504,123 +500,11 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		}
 	}
 
-	NSString *nullValue = [prefs objectForKey:SPNullValue];
 	NSFont *tableFont = [NSUserDefaults getFont];
 	[tableContentView setRowHeight:2.0f+NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
 
 	// Add the new columns to the table
-	for (NSDictionary *columnDefinition in dataColumns ) {
-
-		// Set up the column
-		theCol = [[NSTableColumn alloc] initWithIdentifier:[columnDefinition objectForKey:@"datacolumnindex"]];
-
-        if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
-            [[theCol headerCell] setAttributedStringValue:[columnDefinition tableContentColumnHeaderAttributedString]];
-        } else {
-            [[theCol headerCell] setStringValue:[columnDefinition objectForKey:@"name"]];
-        }
-
-		[theCol setHeaderToolTip:[NSString stringWithFormat:@"%@ – %@%@%@%@", 
-			[columnDefinition objectForKey:@"name"], 
-			[columnDefinition objectForKey:@"type"], 
-			([columnDefinition objectForKey:@"length"]) ? [NSString stringWithFormat:@"(%@)", [columnDefinition objectForKey:@"length"]] : @"", 
-			([columnDefinition objectForKey:@"values"]) ? [NSString stringWithFormat:@"(\n- %@\n)", [[columnDefinition objectForKey:@"values"] componentsJoinedByString:@"\n- "]] : @"", 
-			([columnDefinition objectForKey:@"comment"] && [(NSString *)[columnDefinition objectForKey:@"comment"] length]) ? [NSString stringWithFormat:@"\n%@", [[columnDefinition objectForKey:@"comment"] stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"]] : @""
-			]];
-		
-		// Copy in the width if present in a reloaded table
-		if ([preservedColumnWidths objectForKey:[columnDefinition objectForKey:@"name"]]) {
-			[theCol setWidth:[[preservedColumnWidths objectForKey:[columnDefinition objectForKey:@"name"]] floatValue]];
-		}
-		
-		[theCol setEditable:YES];
-
-		// Set up the data cell depending on the column type
-		id dataCell;
-		if ([[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"enum"]) {
-			dataCell = [[SPComboBoxCell alloc] initTextCell:@""];
-			[dataCell setButtonBordered:NO];
-			[dataCell setBezeled:NO];
-			[dataCell setDrawsBackground:NO];
-			[dataCell setCompletes:YES];
-			[dataCell setControlSize:NSControlSizeSmall];
-            [dataCell setUsesSingleLineMode:YES];
-			// add prefs NULL value representation if NULL value is allowed for that field
-			if([[columnDefinition objectForKey:@"null"] boolValue])
-				[dataCell addItemWithObjectValue:nullValue];
-			[dataCell addItemsWithObjectValues:[columnDefinition objectForKey:@"values"]];
-
-		// Add a foreign key arrow if applicable
-		} else if ([columnDefinition objectForKey:@"foreignkeyreference"]) {
-			dataCell = [[SPTextAndLinkCell alloc] initTextCell:@""];
-			[dataCell setTarget:self action:@selector(clickLinkArrow:)];
-
-		// Otherwise instantiate a text-only cell
-		} else {
-			dataCell = [[SPTextAndLinkCell alloc] initTextCell:@""];
-		}
-
-		// Set the column to right-aligned for numeric data types
-		if ([[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"integer"]
-			|| [[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"float"])
-		{
-			[dataCell setAlignment:NSTextAlignmentRight];
-		}
-
-		[dataCell setEditable:YES];
-
-		// Set the line break mode and an NSFormatter subclass which displays line breaks nicely
-		[dataCell setLineBreakMode:NSLineBreakByTruncatingTail];
-		[dataCell setFormatter:[SPDataCellFormatter new]];
-
-		// Set field length limit if field is a varchar to match varchar length
-		if ([[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"string"]
-			|| [[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"bit"]) {
-			[[dataCell formatter] setTextLimit:[[columnDefinition objectForKey:@"length"] integerValue]];
-		}
-
-		// Set field type for validations
-		[[dataCell formatter] setFieldType:[columnDefinition objectForKey:@"type"]];
-
-		// Set the data cell font according to the preferences
-		[dataCell setFont:tableFont];
-
-		// Assign the data cell
-		[theCol setDataCell:dataCell];
-
-		// Set the width of this column to saved value if exists
-		colWidth = [[[[prefs objectForKey:SPTableColumnWidths] objectForKey:[NSString stringWithFormat:@"%@@%@", [tableDocumentInstance database], [tableDocumentInstance host]]] objectForKey:[tablesListInstance tableName]] objectForKey:[columnDefinition objectForKey:@"name"]];
-		if ( colWidth ) {
-			[theCol setWidth:[colWidth floatValue]];
-		}
-
-		// Set the column to be reselected for sorting if appropriate
-		if (sortColumnToRestore && [sortColumnToRestore isEqualToString:[columnDefinition objectForKey:@"name"]])
-			sortColumnNumberToRestore = [[columnDefinition objectForKey:@"datacolumnindex"] integerValue];
-
-		// Add the column to the table
-		[tableContentView addTableColumn:theCol];
-	}
-
-	// If the table has been reloaded and the previously selected sort column is still present, reselect it.
-	if (sortColumnNumberToRestore != NSNotFound) {
-		theCol = [tableContentView tableColumnWithIdentifier:[NSString stringWithFormat:@"%lld", (long long)sortColumnNumberToRestore]];
-		sortCol = [[NSNumber alloc] initWithInteger:sortColumnNumberToRestore];
-		[tableContentView setHighlightedTableColumn:theCol];
-		isDesc = !sortColumnToRestoreIsAsc;
-		if ( isDesc ) {
-			[tableContentView setIndicatorImage:[NSImage imageNamed:@"NSDescendingSortIndicator"] inTableColumn:theCol];
-		} else {
-			[tableContentView setIndicatorImage:[NSImage imageNamed:@"NSAscendingSortIndicator"] inTableColumn:theCol];
-		}
-
-	// Otherwise, clear sorting
-	} else {
-		if (sortCol) {
-			sortCol = nil;
-		}
-		isDesc = NO;
-	}
+	[self _buildTableColumns:preservedColumnWidths withFont:tableFont];
 
 	// Store the current first responder so filter field doesn't steal focus
 	id currentFirstResponder = [[tableDocumentInstance parentWindowControllerWindow] firstResponder];
@@ -665,6 +549,154 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	if (!previousTableRowsCount) {
 		[self clearTableValues];
 	}
+}
+
+- (void)_buildTableColumns:(NSMutableDictionary *)savedColumnWidths withFont:(NSFont *)font {
+    NSString *nullValue = [prefs objectForKey:SPNullValue];
+    BOOL displayColumnTypes = [prefs boolForKey:SPDisplayTableViewColumnTypes];
+    NSInteger sortColumnNumberToRestore = NSNotFound;
+    NSDictionary *formatOverrides = currentFormatters(self);
+
+    for (NSDictionary *columnDefinition in dataColumns) {
+        id name = columnDefinition[@"name"];
+        id columnIndex = columnDefinition[@"datacolumnindex"];
+
+        // Set up the column
+        NSTableColumn *column  = [[NSTableColumn alloc] initWithIdentifier:columnIndex];
+
+        if (displayColumnTypes) {
+            [[column headerCell] setAttributedStringValue:[columnDefinition tableContentColumnHeaderAttributedString]];
+        } else {
+            [[column headerCell] setStringValue:name];
+        }
+        [column setHeaderToolTip:buildTooltip(columnDefinition)];
+        [column setEditable:YES];
+
+        NSString *nameKey = column.headerCell.stringValue;
+        // Set up the data cell depending on the column type
+        [column setDataCell:configureDataCell(self, columnDefinition, nullValue, font, formatOverrides, nameKey)];
+
+        // Copy in the width if present in a reloaded table
+        if (savedColumnWidths[nameKey]) {
+            [column setWidth:[savedColumnWidths[nameKey] floatValue]];
+        }
+        else { // try to reload from sqlite
+            NSNumber *colWidth = savedWidthForColumn(self, nameKey);
+            if (colWidth) {
+                [column setWidth:[colWidth floatValue]];
+            }
+        }
+
+        // Set the column to be reselected for sorting if appropriate
+        if (sortColumnToRestore && [sortColumnToRestore isEqualToString:name]) {
+            sortColumnNumberToRestore = [columnIndex integerValue];
+        }
+
+        // Add the column to the table
+        [tableContentView addTableColumn:column];
+    }
+
+    if (sortColumnNumberToRestore != NSNotFound) {
+        // If the table has been reloaded and the previously selected sort column is still present, reselect it.
+        NSTableColumn *theCol = [tableContentView tableColumnWithIdentifier:[NSString stringWithFormat:@"%lld", (long long)sortColumnNumberToRestore]];
+        sortCol = [[NSNumber alloc] initWithInteger:sortColumnNumberToRestore];
+        [tableContentView setHighlightedTableColumn:theCol];
+        isDesc = !sortColumnToRestoreIsAsc;
+        if ( isDesc ) {
+            [tableContentView setIndicatorImage:[NSImage imageNamed:@"NSDescendingSortIndicator"] inTableColumn:theCol];
+        } else {
+            [tableContentView setIndicatorImage:[NSImage imageNamed:@"NSAscendingSortIndicator"] inTableColumn:theCol];
+        }
+    }
+    else {
+        // Otherwise, clear sorting
+        if (sortCol) {
+            sortCol = nil;
+        }
+        isDesc = NO;
+    }
+}
+
+static NSString* buildTooltip(NSDictionary *columnDefinition) {
+    id name = columnDefinition[@"name"];
+    id type = columnDefinition[@"type"];
+
+    id len  = columnDefinition [@"length"];
+    id lenStr = len ? [NSString stringWithFormat:@"(%@)", len] : @"";
+
+    id vals = columnDefinition[@"values"];
+    id valStr = vals ? [NSString stringWithFormat:@"(\n- %@\n)", [vals componentsJoinedByString:@"\n- "]] : @"";
+
+    id comm = columnDefinition[@"comment"];
+    id commentStr = (comm && [(NSString *)comm length])
+        ? [NSString stringWithFormat:@"\n%@", [comm stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"]]
+        : @"";
+
+    NSString *tooltip = [NSString stringWithFormat:@"%@ – %@%@%@%@", name, type, lenStr, valStr, commentStr ];
+    return tooltip;
+}
+
+static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString *nullValue, NSFont *tableFont, NSDictionary* formats, NSString *nameKey) {
+    id typegroup = colDefs[@"typegrouping"];
+    id cell;
+
+    if ([typegroup isEqualToString:@"enum"]) {
+        cell = [[SPComboBoxCell alloc] initTextCell:@""];
+        [cell setButtonBordered:NO];
+        [cell setBezeled:NO];
+        [cell setDrawsBackground:NO];
+        [cell setCompletes:YES];
+        [cell setControlSize:NSControlSizeSmall];
+        [cell setUsesSingleLineMode:YES];
+        // add prefs NULL value representation if NULL value is allowed for that field
+        if([colDefs[@"null"] boolValue])
+            [cell addItemWithObjectValue:nullValue];
+        [cell addItemsWithObjectValues:colDefs[@"values"]];
+    }
+    else if (colDefs[@"foreignkeyreference"]) {
+        // Add a foreign key arrow if applicable
+        cell = [[SPTextAndLinkCell alloc] initTextCell:@""];
+        [cell setTarget:tc action:@selector(clickLinkArrow:)];
+    }
+    else {
+        // Otherwise instantiate a text-only cell
+        cell = [[SPTextAndLinkCell alloc] initTextCell:@""];
+    }
+    [cell setEditable:YES];
+
+    // Set the column to right-aligned for numeric data types
+    if ([typegroup isEqualToString:@"integer"] || [typegroup isEqualToString:@"float"]) {
+        [cell setAlignment:NSTextAlignmentRight];
+    }
+
+    // Set field length limit if field is a varchar to match varchar length
+    if ([typegroup isEqualToString:@"string"] || [typegroup isEqualToString:@"bit"]) {
+        [[cell formatter] setTextLimit:[colDefs[@"length"] integerValue]];
+    }
+
+    // Set the line break mode and an NSFormatter subclass which displays line breaks nicely
+    [cell setLineBreakMode:NSLineBreakByTruncatingTail];
+    [cell setFont:tableFont];
+
+    if (formats[nameKey]) {
+        [cell setFormatter:formats[nameKey]];
+    }
+    else {
+        // default formatter
+        [cell setFormatter:[SPDataCellFormatter new]];
+        [[cell formatter] setFieldType:colDefs[@"type"]];
+    }
+
+    if ([typegroup isEqualToString:@"binary"]) {
+        // since UUID is the only one supported for now, only add menu if we encounter a valid type
+        // but we would relax this in the future if more formatters are added.
+        // NOTE: this is one menu for the whole table since the menu is configured on the headerView
+        if (tc->tableContentView.headerView.menu == nil) {
+            tc->tableContentView.headerView.menu = defaultColumnHeaderMenu(tc);
+        }
+    }
+
+    return cell;
 }
 
 - (NSString *)selectedTable
@@ -2260,6 +2292,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 					if (hide) {
 						str = @"&lt;BLOB&gt;";
 					}
+					else if ([[aTableColumn.dataCell formatter] isKindOfClass: [SABaseFormatter class]]) {
+						str = [(SABaseFormatter *)[aTableColumn.dataCell formatter] stringForObjectValue: o];
+					}
 					else if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
 						str = [NSString stringWithFormat:@"0x%@", [o dataToHexString]];
 					}
@@ -3589,12 +3624,12 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	if (isWorking) pthread_mutex_unlock(&tableValuesLock);
 	[tableContentView setDelegate:nil];
 	for (NSDictionary *columnDefinition in dataColumns) {
+		NSTableColumn *aTableColumn = [tableContentView tableColumnWithIdentifier:[columnDefinition objectForKey:@"datacolumnindex"]];
 
 		// Skip columns with saved widths
-		if ([[[[prefs objectForKey:SPTableColumnWidths] objectForKey:[NSString stringWithFormat:@"%@@%@", [tableDocumentInstance database], [tableDocumentInstance host]]] objectForKey:[tablesListInstance tableName]] objectForKey:[columnDefinition objectForKey:@"name"]]) continue;
+		if (savedWidthForColumn(self, aTableColumn.headerCell.stringValue)) continue;
 
 		// Otherwise set the column width
-		NSTableColumn *aTableColumn = [tableContentView tableColumnWithIdentifier:[columnDefinition objectForKey:@"datacolumnindex"]];
 		NSInteger targetWidth = [[columnWidths objectForKey:[columnDefinition objectForKey:@"datacolumnindex"]] integerValue];
 		[aTableColumn setWidth:targetWidth];
 	}
@@ -3799,8 +3834,12 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 			return [prefs objectForKey:SPNullValue];
 		}
 
-		if ([value isKindOfClass:[NSData class]]) {
+    if ([[tableColumn.dataCell formatter] isKindOfClass: [SABaseFormatter class]]) {
+      // if we have a base formatter, return the raw data so it can handel the formatting
+      return value;
+    }
 
+		if ([value isKindOfClass:[NSData class]]) {
 			if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
 				if ([(NSData *)value length] > 255) {
 					return [NSString stringWithFormat:@"0x%@…", [[(NSData *)value subdataWithRange:NSMakeRange(0, 255)] dataToHexString]];
@@ -3859,23 +3898,27 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		if (object) {
 			// Restore NULLs if necessary
-			if ([object isEqualToString:[prefs objectForKey:SPNullValue]] && [[column objectForKey:@"null"] boolValue]) {
-				object = [NSNull null];
-			}
-			else if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
-				// This is a binary object being edited as a hex string.
-				// Convert the string back to binary.
-				// Error checking is done in -control:textShouldEndEditing:
-				NSData *data = [NSData dataWithHexString:object];
-				if (!data) {
-					NSBeep();
-					return;
-				}
-				object = data;
-			}
+            if ([[tableColumn.dataCell formatter] isKindOfClass: [SABaseFormatter class]]) {
+                // noop -- object should already be in correct format based on Formatter handling.
+            }
+            // legacy handling:
+            else if ([object isEqualToString:[prefs objectForKey:SPNullValue]] && [[column objectForKey:@"null"] boolValue]) {
+                object = [NSNull null];
+            }
+            else if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
+                // This is a binary object being edited as a hex string.
+                // Convert the string back to binary.
+                // Error checking is done in -control:textShouldEndEditing:
+                NSData *data = [NSData dataWithHexString:object];
+                if (!data) {
+                    NSBeep();
+                    return;
+                }
+                object = data;
+            }
 
-			[tableValues replaceObjectInRow:rowIndex column:columnIndex withObject:object];
-		}
+            [tableValues replaceObjectInRow:rowIndex column:columnIndex withObject:object];
+        }
 		else {
 			[tableValues replaceObjectInRow:rowIndex column:columnIndex withObject:@""];
 		}
@@ -4050,44 +4093,30 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// Sometimes the column has no identifier. I can't figure out what is causing it, so we just skip over this item
 	if (![[[notification userInfo] objectForKey:@"NSTableColumn"] identifier]) return;
 
-	NSMutableDictionary *tableColumnWidths;
-	NSString *database = [NSString stringWithFormat:@"%@@%@", [tableDocumentInstance database], [tableDocumentInstance host]];
+	NSString *database = dbHostPrefKey(self);
 	NSString *table = [tablesListInstance tableName];
 
-
-    if (database == nil || table == nil){
-        SPLog(@"database or table is nil");
-    }
+	if (database == nil || table == nil){
+		SPLog(@"database or table is nil");
+	}
 
 	// Get tableColumnWidths object
-	if ([prefs objectForKey:SPTableColumnWidths] != nil ) {
-		tableColumnWidths = [NSMutableDictionary dictionaryWithDictionary:[prefs objectForKey:SPTableColumnWidths]];
-	}
-	else {
-		tableColumnWidths = [NSMutableDictionary dictionary];
-	}
+	NSMutableDictionary *savedWidths = [NSMutableDictionary dictionaryWithDictionary:[prefs objectForKey:SPTableColumnWidths]];
 
 	// Get the database object
-	if  ([tableColumnWidths safeObjectForKey:database] == nil) {
-		[tableColumnWidths safeSetObject:[NSMutableDictionary dictionary] forKey:database];
-	}
-	else {
-		[tableColumnWidths safeSetObject:[NSMutableDictionary dictionaryWithDictionary:[tableColumnWidths safeObjectForKey:database]] forKey:database];
-	}
+	NSMutableDictionary *dbWidths = [NSMutableDictionary dictionaryWithDictionary:[savedWidths safeObjectForKey:database]];
+	[savedWidths safeSetObject:dbWidths forKey:database];
 
 	// Get the table object
-	if  ([[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table] == nil) {
-		[[tableColumnWidths safeObjectForKey:database] safeSetObject:[NSMutableDictionary dictionary] forKey:table];
-	}
-	else {
-		[[tableColumnWidths safeObjectForKey:database] safeSetObject:[NSMutableDictionary dictionaryWithDictionary:[[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table]] forKey:table];
-	}
+	NSMutableDictionary *tableWidths = [NSMutableDictionary dictionaryWithDictionary:[dbWidths safeObjectForKey:table]];
+	[dbWidths safeSetObject:tableWidths forKey:table];
 
 	// Save column size
-	[[[tableColumnWidths safeObjectForKey:database] safeObjectForKey:table]
-     safeSetObject:[NSNumber numberWithDouble:[(NSTableColumn *)[[notification userInfo] safeObjectForKey:@"NSTableColumn"] width]]
-	 forKey:[[[[notification userInfo] safeObjectForKey:@"NSTableColumn"] headerCell] stringValue]];
-	[prefs setObject:tableColumnWidths forKey:SPTableColumnWidths];
+	NSTableColumn *column = (NSTableColumn *)[[notification userInfo] safeObjectForKey:@"NSTableColumn"];
+	[tableWidths safeSetObject:[NSNumber numberWithDouble:column.width] forKey:column.headerCell.stringValue];
+	
+	// save back to user defaults
+	[prefs setObject:savedWidths forKey:SPTableColumnWidths];
 }
 
 /**
@@ -4279,7 +4308,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	NSUInteger targetWidth = [tableContentView autodetectWidthForColumnDefinition:columnDefinition maxRows:500];
 
 	// Clear any saved widths for the column
-	NSString *dbKey = [NSString stringWithFormat:@"%@@%@", [tableDocumentInstance database], [tableDocumentInstance host]];
+	NSString *dbKey = dbHostPrefKey(self);
 	NSString *tableKey = [tablesListInstance tableName];
 	NSMutableDictionary *savedWidths = [NSMutableDictionary dictionaryWithDictionary:[prefs objectForKey:SPTableColumnWidths]];
 	NSMutableDictionary *dbDict = [NSMutableDictionary dictionaryWithDictionary:[savedWidths objectForKey:dbKey]];
@@ -4357,12 +4386,10 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		}
 		else {
 			[cell setTextColor:textForegroundColor];
-
-			if (
-				[self cellValueIsDisplayedAsHexForColumn:[[tableColumn identifier] integerValue]] &&
-				rowIndex != [tableContentView selectedRow]
-			) {
-				[cell setTextColor:binhexHighlightColor];
+			BOOL hasDisplayOverride = [self cellValueIsDisplayedAsHexForColumn:[[tableColumn identifier] integerValue]] ||
+				[[cell formatter] isKindOfClass:[SABaseFormatter class]];
+			if (hasDisplayOverride && rowIndex != [tableContentView selectedRow]) {
+				[cell setTextColor:displayOverrideHighlightColor];
 			}
 		}
 
@@ -4471,21 +4498,30 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	// Validate hex input
 	// We do this here because the textfield will still be selected with the pending changes if we bail out here
 	if(control == tableContentView) {
-		NSInteger columnIndex = [tableContentView editedColumn];
-		if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
-			// special case: the "NULL" string
-			NSDictionary *column = [dataColumns safeObjectAtIndex:columnIndex];
-			if ([[editor string] isEqualToString:[prefs objectForKey:SPNullValue]] && [[column objectForKey:@"null"] boolValue]) {
-				return YES;
-			}
-			// This is a binary object being edited as a hex string.
-			// Convert the string back to binary, checking for errors.
-			NSData *data = [NSData dataWithHexString:[editor string]];
-			if (!data) {
-				[NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Invalid hexadecimal value", @"table content : editing : error message title when parsing as hex string failed") message:NSLocalizedString(@"A valid hex string may only contain the numbers 0-9 and letters A-F (a-f). It can optionally begin with „0x“ and spaces will be ignored.\nAlternatively the syntax X'val' is supported, too.", @"table content : editing : error message description when parsing as hex string failed") callback:nil];
-				return NO;
-			}
-		}
+      NSInteger columnIndex = [tableContentView editedColumn];
+      NSTableColumn *col = tableContentView.tableColumns[columnIndex];
+
+      if ([[col.dataCell formatter] isKindOfClass:[SABaseFormatter class]]) {
+          return [[col.dataCell formatter] getObjectValue:nil forString:editor.string errorDescription:nil];
+      }
+      else if ([self cellValueIsDisplayedAsHexForColumn:columnIndex]) {
+          // special case: the "NULL" string
+          NSDictionary *column = [dataColumns safeObjectAtIndex:columnIndex];
+          if ([editor.string isEqualToString:[prefs objectForKey:SPNullValue]] && [[column objectForKey:@"null"] boolValue]) {
+              return YES;
+          }
+          // This is a binary object being edited as a hex string.
+          // Convert the string back to binary, checking for errors.
+          if (![NSData dataWithHexString: editor.string]) {
+              NSString *title = NSLocalizedString(@"Invalid hexadecimal value", @"table content : editing : error message title when parsing as hex string failed");
+              NSString *msg  = NSLocalizedString(
+                  @"A valid hex string may only contain the numbers 0-9 and letters A-F (a-f). It can optionally begin with „0x“ and spaces will be ignored.\nAlternatively the syntax X'val' is supported, too.",
+                  @"table content : editing : error message description when parsing as hex string failed"
+              );
+              [NSAlert createWarningAlertWithTitle:title message:msg callback:nil];
+              return NO;
+          }
+      }
 	}
 	return YES;
 }
@@ -4607,6 +4643,129 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 - (NSArray *)dataColumnDefinitions
 {
 	return dataColumns;
+}
+
+#pragma mark -
+#pragma mark Methods for Column Display Format
+
+- (void)toggleDisplayOverrideFormatter:(NSMenuItem *)item {
+    FormatterWithReference *ref = (FormatterWithReference *)item.representedObject;
+    NSTableColumn *col = (NSTableColumn *) ref.reference;
+    if (ref == nil || col == nil) { return; }
+
+    NSString *format = @""; // defaults to no override
+    if (item.state == NSControlStateValueOff) {
+        // turn on UUID format
+        item.state = NSControlStateValueOn;
+        format = item.title;
+        [col.dataCell setFormatter: ref.formatter];
+    }
+    else {
+        // turn off UUID format
+        item.state = NSControlStateValueOff;
+        [col.dataCell setFormatter: [SPDataCellFormatter new]]; // default formatter
+    }
+
+    [SQLiteDisplayFormatManager.sharedInstance replaceOverrideForHostName:tableDocumentInstance.host
+                                                             databaseName:tableDocumentInstance.database
+                                                                tableName:tableDocumentInstance.table
+                                                                  colName:col.headerCell.stringValue
+                                                                   format:format];
+    [tableContentView reloadData];
+}
+
+// Builds Menu with all display formats
+static NSMenu* defaultColumnHeaderMenu(SPTableContent *tc) {
+    NSMenu *menu = [[NSMenu alloc] init];
+
+    // section title required macOS 14+ so here we build a fake with disabled item + separator
+    NSMenuItem *item = [[NSMenuItem alloc] init];
+    item.title = NSLocalizedString(@"Display Format Override", "Title for menu when ctrl-clicking on content column header.");
+    item.enabled = false;
+    item.state = NSControlStateValueOff;
+    [menu addItem: item];
+    [menu addItem: [NSMenuItem separatorItem]];
+
+    item = [NSMenuItem new];
+    item.title = @"UUID";
+    item.state = NSControlStateValueOff;
+    item.target = tc;
+    item.action = @selector(toggleDisplayOverrideFormatter:);
+    item.enabled = YES;
+    item.representedObject = [FormatterWithReference newWithFormatter: [SAUUIDormatter new]];
+    [menu addItem: item];
+
+    return menu;
+}
+
+// Builds dictionary of String -> SABaseFormatter for columns with previously selected display overrides
+static NSDictionary* currentFormatters(SPTableContent *tc) {
+    NSDictionary *format = [SQLiteDisplayFormatManager.sharedInstance allDisplayOverridesForHostName:tc->tableDocumentInstance.host
+                                                                                        databaseName:tc->tableDocumentInstance.database
+                                                                                           tableName:tc->tableDocumentInstance.table];
+    if (![format count]) {
+        return @{};
+    }
+
+    NSDictionary *known = knownColumnFormatters(tc);
+    NSMutableDictionary *res = [[NSMutableDictionary alloc] init];
+    for (NSString *key in format) {
+        res[key] = known[format[key]];
+    }
+
+    return res;
+}
+
+static NSDictionary* knownColumnFormatters(SPTableContent *tc) {
+    return @{ 
+        @"UUID": [SAUUIDormatter new],
+        // In theory, we could extract hex handling to it's own formatter
+        // @"HEX": [SAHexormatter new]
+    };
+}
+
+#pragma mark -
+#pragma mark SPTableHeaderViewDelegate Methods
+
+- (NSMenu *)validateWithMenu:(NSMenu *)menu forTableColumn:(NSTableColumn *)col {
+    NSDictionary *columnDefinition = dataColumns[col.identifier.integerValue];
+    if (!columnDefinition) {
+        return nil;
+    }
+
+    NSString *format = [SQLiteDisplayFormatManager.sharedInstance displayOverrideForHostName:tableDocumentInstance.host
+                                                                                databaseName:tableDocumentInstance.database
+                                                                                   tableName:tableDocumentInstance.table
+                                                                                  columnName:col.headerCell.stringValue];
+    for (NSMenuItem *item in menu.itemArray) {
+        FormatterWithReference *ref = (FormatterWithReference *)item.representedObject;
+        if (ref == nil) { continue; }
+
+        item.state = ([item.title isEqualToString: format]) ? NSControlStateValueOn : NSControlStateValueOff;
+        // keep reference to column so we which to target when item is selected
+        ref.reference = col;
+    }
+
+    // currently only support: BINARY(16) => UUID
+    if ([[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"binary"]
+        && [[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"binary"]) {
+        return menu;
+    }
+
+    return nil;
+}
+
+#pragma mark -
+#pragma mark UserDefault Helper Functions
+
+static NSNumber* savedWidthForColumn(SPTableContent* tc, NSString *colKey) {
+    NSDictionary *savedWidths = [tc->prefs objectForKey:SPTableColumnWidths];
+    NSDictionary *dbHostPrefs = savedWidths[dbHostPrefKey(tc)];
+    return dbHostPrefs[tc->tablesListInstance.tableName][colKey];
+}
+
+static NSString* dbHostPrefKey(SPTableContent* tc) {
+    return [NSString stringWithFormat:@"%@@%@", tc->tableDocumentInstance.database, tc->tableDocumentInstance.host];
 }
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4747,8 +4747,7 @@ static NSDictionary* knownColumnFormatters(SPTableContent *tc) {
     }
 
     // currently only support: BINARY(16) => UUID
-    if ([[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"binary"]
-        && [[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"binary"]) {
+    if ([columnDefinition[@"typegrouping"] isEqualToString:@"binary"] && [columnDefinition[@"length"] integerValue] == 16) {
         return menu;
     }
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3835,7 +3835,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		}
 
     if ([[tableColumn.dataCell formatter] isKindOfClass: [SABaseFormatter class]]) {
-      // if we have a base formatter, return the raw data so it can handel the formatting
+      // if we have a base formatter, return the raw data so it can handle the formatting
       return value;
     }
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4692,7 +4692,7 @@ static NSMenu* defaultColumnHeaderMenu(SPTableContent *tc) {
     item.target = tc;
     item.action = @selector(toggleDisplayOverrideFormatter:);
     item.enabled = YES;
-    item.representedObject = [FormatterWithReference newWithFormatter: [SAUUIDormatter new]];
+    item.representedObject = [FormatterWithReference newWithFormatter: [SAUuidFormatter new]];
     [menu addItem: item];
 
     return menu;
@@ -4718,7 +4718,7 @@ static NSDictionary* currentFormatters(SPTableContent *tc) {
 
 static NSDictionary* knownColumnFormatters(SPTableContent *tc) {
     return @{ 
-        @"UUID": [SAUUIDormatter new],
+        @"UUID": [SAUuidFormatter new],
         // In theory, we could extract hex handling to it's own formatter
         // @"HEX": [SAHexormatter new]
     };

--- a/Source/Controllers/Other/SQLiteDisplayFormatManager.swift
+++ b/Source/Controllers/Other/SQLiteDisplayFormatManager.swift
@@ -1,0 +1,194 @@
+//
+//  Created by Luis Aguiniga on 2024.07.05.
+//  Copyright © 2024 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+import FMDB
+import OSLog
+
+@objc final class SQLiteDisplayFormatManager: NSObject {
+    typealias SchemaBuilder = (_ db: FMDatabase, _ schemaVersion: Int) throws -> Int
+
+    @objc static let sharedInstance = SQLiteDisplayFormatManager()
+
+    private let sqliteTableName = "ColumnDisplayOverrides"
+    private let dbFileName = "ColumnDisplayOverrides.db"
+    private var queue: FMDatabaseQueue
+    private let LOG = OSLog(subsystem: "com.sequel-ace.sequel-ace", category: "DisplayFormatManager")
+
+    override init() {
+        do {
+            let appSupportPath = try FileManager.default.applicationSupportDirectory(forSubDirectory: SPDataSupportFolder)
+            let sqLitePath = "\(appSupportPath)/\(dbFileName)"
+            queue = FMDatabaseQueue(path: sqLitePath)!
+            super.init()
+            setupDatabase()
+        }
+        catch {
+            LOG.error("Error initializing SQLite DB: \(error.localizedDescription)")
+            queue = FMDatabaseQueue(path: " ")!
+            super.init()
+        }
+    }
+
+    @objc func displayOverrideFor(hostName: String, databaseName: String, tableName: String, columnName: String) -> String? {
+        var found: String? = nil
+
+        let sql = """
+            SELECT hostName, databaseName, tableName, columnName, format
+            FROM \(self.sqliteTableName)
+            WHERE  hostName=? and databaseName=? and tableName=? and columnName=?
+            ORDER BY id DESC
+            """
+        queue.inDatabase { [self] db in
+            do {
+                let rs = try db.executeQuery(sql, values: [hostName, databaseName, tableName, columnName])
+                while rs.next() {
+                    let format = rs.string(forColumn: "format")!
+                    found = format
+                    break
+                }
+                rs.close()
+            }
+            catch {
+                LOG.error("Query '\(sql), failed with error: \(error.localizedDescription)")
+            }
+        }
+        queue.close()
+
+        return found
+    }
+
+    @objc func allDisplayOverridesFor(hostName: String, databaseName: String, tableName: String) -> [String:String] {
+        var formats = [String:String]()
+
+        let sql = """
+            SELECT hostName, databaseName, tableName, columnName, format
+            FROM \(self.sqliteTableName)
+            WHERE  hostName=? and databaseName=? and tableName=?
+            ORDER BY id DESC
+            """
+
+        queue.inDatabase { [self] db in
+            do {
+                let rs = try db.executeQuery(sql, values: [hostName, databaseName, tableName])
+                while rs.next() {
+                    let columnName = rs.string(forColumn: "columnName")!
+                    let format = rs.string(forColumn: "format")!
+                    formats[columnName] = format
+                }
+                rs.close()
+            }
+            catch {
+                LOG.error("Query '\(sql), failed with error: \(error.localizedDescription)")
+            }
+        }
+        queue.close()
+
+        return formats
+    }
+
+    @objc func replaceOverrideFor(hostName: String, databaseName: String, tableName: String, colName: String, format: String) {
+        let toAdd = [hostName, databaseName, tableName, colName, format];
+
+        let sql = """
+            INSERT OR REPLACE INTO \(sqliteTableName) (hostName, databaseName, tableName, columnName, format) VALUES (?, ?, ?, ?, ?)
+            """
+        queue.inDatabase { db in
+            do {
+                try db.executeUpdate(sql, values: toAdd)
+            }
+            catch {
+                LOG.error("\(error.localizedDescription)")
+            }
+        }
+        queue.close()
+    }
+
+    private func setupDatabase() {
+        let builder: SchemaBuilder = { [self] (db, schemaVersion: Int) in
+            db.beginTransaction()
+            var newSchemaVersion = schemaVersion
+
+            if schemaVersion < 1 {
+                let createTableSql = """
+                    CREATE TABLE \(sqliteTableName) (
+                      id            INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                      hostName      TEXT NOT NULL,
+                      databaseName  TEXT NOT NULL,
+                      tableName     TEXT NOT NULL,
+                      columnName    TEXT NOT NULL,
+                      format        TEXT NOT NULL,
+
+                      CONSTRAINT host_db_table UNIQUE (hostName, databaseName, tableName, columnName)
+                    )
+                    """
+                let createIndexSql = """
+                    CREATE UNIQUE INDEX IF NOT EXISTS host_db_table_idx ON \(sqliteTableName) (hostName, databaseName, tableName, columnName)
+                    """
+
+                do {
+                    try db.executeUpdate(createTableSql)
+                    try db.executeUpdate(createIndexSql)
+                }
+                catch {
+                    db.rollback()
+                    fatalError("Creating \(dbFileName) failed with error: \(error)")
+                }
+
+                newSchemaVersion = 1
+                LOG.debug("self.newSchemaVersion \(newSchemaVersion)")
+                LOG.info("Creating ColumnDisplayFormats Version 1 was successful!")
+            }
+
+            db.commit()
+            return newSchemaVersion
+        }
+
+        queue.inDatabase { db in
+            do {
+                let initialVersion = try loadCurrentSchemaVersion(db)
+                let finalVersion = try builder(db, initialVersion)
+                try finalizeSchemaVersion(db, initialVersion, finalVersion)
+            }
+            catch {
+                LOG.error("Processing schemaBlock resulted in error:: \(error)")
+            }
+        }
+        queue.close()
+    }
+
+    private func loadCurrentSchemaVersion(_ db: FMDatabase) throws -> Int {
+        var version = 0
+        let rs = try db.executeQuery("PRAGMA user_version")
+        if rs.next() {
+            version = rs.long(forColumnIndex: 0)
+            LOG.debug("startingSchemaVersion = \(version)")
+        }
+        rs.close()
+
+        return version
+    }
+
+    private func finalizeSchemaVersion(_ db: FMDatabase, _ initialVersion: Int, _ finalVersion: Int) throws {
+        guard finalVersion != initialVersion, finalVersion > 0 else {
+            return
+        }
+
+        let query = "PRAGMA user_version = \(finalVersion)"
+        LOG.debug("query = \(query)")
+        try db.executeUpdate(query)
+    }
+}
+
+
+fileprivate extension FMDatabase {
+    func executeQuery(_ sql: String) throws -> FMResultSet {
+        try self.executeQuery(sql, values: nil)
+    }
+
+    func executeUpdate(_ sql: String) throws {
+        try self.executeUpdate(sql, values: nil)
+    }
+}

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.h
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.h
@@ -30,6 +30,8 @@
 
 #import <Quartz/Quartz.h> // QuickLookUI
 
+@class SABaseFormatter;
+
 //This is an informal protocol
 @protocol _QLPreviewPanelController
 
@@ -206,6 +208,11 @@
  * The field encoding of the underlying table field for displaying it to the user.
  */
 @property(nonatomic, copy) NSString *fieldEncoding;
+
+/**
+ * The field encoding of the underlying table field for displaying it to the user.
+ */
+@property(nonatomic, copy) SABaseFormatter *displayFormatter;
 
 /**
  * Whether underlying table field allows NULL for several validations.

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -1297,15 +1297,17 @@ typedef enum {
 
 		adjTextMaxTextLength = originalMaxTextLength;
 
-		NSString *err = nil;
-		NSString *newStr = nil;
-		BOOL isValid = [self.displayFormatter isPartialStringValid:replacementString newEditingString:&newStr errorDescription:&err];
-		if (!isValid) {
-			NSBeep();
-			if (err != nil) {
-				[SPTooltip showWithObject: err];
+		if (self.displayFormatter) {
+			NSString *err = nil;
+			NSString *newStr = nil;
+			BOOL isValid = [self.displayFormatter isPartialStringValid:replacementString newEditingString:&newStr errorDescription:&err];
+			if (!isValid) {
+				NSBeep();
+				if (err != nil) {
+					[SPTooltip showWithObject: err];
+				}
+				return NO;
 			}
-			return NO;
 		}
 
 		// Otherwise, allow it

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -56,6 +56,7 @@ typedef enum {
 @synthesize textMaxLength = maxTextLength;
 @synthesize fieldType;
 @synthesize fieldEncoding;
+@synthesize displayFormatter;
 @synthesize allowNULL = _allowNULL;
 
 /**
@@ -197,6 +198,10 @@ typedef enum {
 
 #pragma mark -
 
+- (unsigned long long)maxLengthDateWithOverride {
+	return self.displayFormatter.maxLengthOverride != 0 ? self.displayFormatter.maxLengthOverride : maxTextLength;
+}
+
 /**
  * Main method for editing data. It will validate several settings and display a modal sheet for theWindow whioch waits until the user closes the sheet.
  *
@@ -218,41 +223,20 @@ typedef enum {
 				sender:(id)sender
 		   contextInfo:(NSDictionary *)theContextInfo
 {
-	usedSheet = nil;
-
-	_isEditable = isEditable;
-	contextInfo = theContextInfo;
-	callerInstance = sender;
-
-	_isGeometry = ([[fieldType uppercaseString] isEqualToString:@"GEOMETRY"]) ? YES : NO;
-	_isJSON     = ([[fieldType uppercaseString] isEqualToString:SPMySQLJsonType]);
-
-	// Set field label
-	NSMutableString *label = [NSMutableString string];
-
-	[label appendFormat:@"“%@”", fieldName];
-
-	if ([fieldType length] || maxTextLength > 0 || [fieldEncoding length] || !_allowNULL)
-		[label appendString:@" – "];
-
-	if ([fieldType length])
-		[label appendString:fieldType];
-
-	//skip length for JSON type since it's a constant and MySQL doesn't display it either
-	if (maxTextLength > 0 && !_isJSON)
-		[label appendFormat:@"(%lld) ", maxTextLength];
-
-	if (!_allowNULL)
-		[label appendString:@"NOT NULL "];
-
-	if ([fieldEncoding length])
-		[label appendString:fieldEncoding];
+	usedSheet       = nil;
+	_isEditable     = isEditable;
+	contextInfo     = theContextInfo;
+	callerInstance  = sender;
+	_isGeometry     = ([[fieldType uppercaseString] isEqualToString:@"GEOMETRY"]) ? YES : NO;
+	_isJSON         = ([[fieldType uppercaseString] isEqualToString:SPMySQLJsonType]);
+	NSString *label = [self buildLabelForField:fieldName];
 
 	if ([fieldType length] && [[fieldType uppercaseString] isEqualToString:@"BIT"]) {
-
+		usedSheet     = bitSheet;
 		sheetEditData = (NSString*)data;
 
 		[bitSheetNULLButton setEnabled:_allowNULL];
+		[bitSheetFieldName setStringValue:label];
 
 		// Check for NULL
 		if ([sheetEditData isEqualToString:[prefs objectForKey:SPNullValue]]) {
@@ -263,56 +247,40 @@ typedef enum {
 			[bitSheetNULLButton setState:NSControlStateValueOff];
 		}
 
-		[bitSheetFieldName setStringValue:label];
-
 		// Init according bit check boxes
 		NSUInteger i = 0;
 		NSUInteger maxBit = (NSUInteger)((maxTextLength > 64) ? 64 : maxTextLength);
 
-		if ([bitSheetNULLButton state] == NSControlStateValueOff && maxBit <= [(NSString*)sheetEditData length])
-			for (i = 0; i < maxBit; i++)
-			{
+		if ([bitSheetNULLButton state] == NSControlStateValueOff && maxBit <= [(NSString*)sheetEditData length]) {
+			for (i = 0; i < maxBit; i++) {
 				[(NSButton *)[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]]
 				 setState:([(NSString*)sheetEditData characterAtIndex:(maxBit - i - 1)] == '1') ? NSControlStateValueOn : NSControlStateValueOff];
 			}
+		}
 
-		for (i = maxBit; i < 64; i++)
-		{
+		for (i = maxBit; i < 64; i++) {
 			[[self valueForKeyPath:[NSString stringWithFormat:@"bitSheetBitButton%ld", (long)i]] setEnabled:NO];
 		}
 
 		[self updateBitSheet];
 
-		usedSheet = bitSheet;
 		[theWindow beginSheet:usedSheet completionHandler:^(NSModalResponse returnCode) {
 			// Remember spell cheecker status
 			[self->prefs setBool:[self->editTextView isContinuousSpellCheckingEnabled] forKey:SPBlobTextEditorSpellCheckingEnabled];
 		}];
-	} 
+	}
 	else {
-		usedSheet = editSheet;
+		usedSheet                  = editSheet;
+		sheetEditData              = data;
+		editSheetWillBeInitialized = YES;
+		encoding                   = anEncoding;
+		_isBlob                    = (!_isJSON && isFieldBlob); // we don't want the hex/image controls for JSON
+		BOOL isBinary              = ([[fieldType uppercaseString] isEqualToString:@"BINARY"] || [[fieldType uppercaseString] isEqualToString:@"VARBINARY"]);
 
-		NSFont *textEditorFont = [NSFont systemFontOfSize:[NSFont systemFontSize]];
-		// Based on user preferences, either use:
-		// 1. The font specifically chosen for the editor sheet textView (FieldEditorSheetFont, right-click in the textView, and choose "Font > Show Fonts" to do that);
-		// 2. The font used for the table view (SPGlobalFontSettings, per the "MySQL Content Font" preference option);
-		if ([prefs objectForKey:SPFieldEditorSheetFont]) {
-			textEditorFont = [NSUnarchiver unarchiveObjectWithData:[prefs dataForKey:SPFieldEditorSheetFont]];
-		} else if ([prefs objectForKey:SPGlobalFontSettings]) {
-			textEditorFont = [NSUserDefaults getFont];
-		}
-		[editTextView setFont:textEditorFont];
-
+		[editTextView setFont:[self selectFont]];
 		[editTextView setContinuousSpellCheckingEnabled:[prefs boolForKey:SPBlobTextEditorSpellCheckingEnabled]];
-
+		[editTextView setEditable:_isEditable];
 		[editSheetFieldName setStringValue:[NSString stringWithFormat:@"%@: %@", NSLocalizedString(@"Field", @"Field"), label]];
-
-		// Hide all views in editSheet
-		[hexTextView setHidden:YES];
-		[hexTextScrollView setHidden:YES];
-		[editImage setHidden:YES];
-		[editTextView setHidden:YES];
-		[editTextScrollView setHidden:YES];
 
 		if (!_isEditable) {
 			[editSheetOkButton setHidden:YES];
@@ -321,40 +289,26 @@ typedef enum {
 			[editSheetOpenButton setEnabled:NO];
 		}
 
-		editSheetWillBeInitialized = YES;
-
-		encoding = anEncoding;
-
-		// we don't want the hex/image controls for JSON
-		_isBlob = (!_isJSON && isFieldBlob);
-		
-		BOOL isBinary = ([[fieldType uppercaseString] isEqualToString:@"BINARY"] || [[fieldType uppercaseString] isEqualToString:@"VARBINARY"]);
-
-		sheetEditData = data;
-
 		// Hide all views in editSheet
-		[hexTextView setHidden:YES];
-		[hexTextScrollView setHidden:YES];
-		[editImage setHidden:YES];
-		[editTextView setHidden:YES];
-		[editTextScrollView setHidden:YES];
+		[self showEditText:NO];
+		[self showHexText:NO];
+		[self showJsonText:NO];
+		[self showImage:NO];
+		[editImage setEditable:_isEditable];
 
 		// Set window's min size since no segment and quicklook buttons are hidden
 		if (_isBlob || isBinary || _isGeometry) {
 			[usedSheet setFrameAutosaveName:@"SPFieldEditorBlobSheet"];
 			[usedSheet setMinSize:NSMakeSize(650, 200)];
-		} 
+		}
 		else {
 			[usedSheet setFrameAutosaveName:@"SPFieldEditorTextSheet"];
 			[usedSheet setMinSize:NSMakeSize(390, 150)];
 		}
 
-		[editTextView setEditable:_isEditable];
-		[editImage setEditable:_isEditable];
-
 		NSSize screen = [[NSScreen mainScreen] visibleFrame].size;
 		NSRect sheet = [usedSheet frame];
-		
+
 		[usedSheet setFrame:
 		 NSMakeRect(sheet.origin.x, sheet.origin.y, 
 					(sheet.size.width > screen.width) ? screen.width : sheet.size.width, 
@@ -367,16 +321,18 @@ typedef enum {
 		}];
 
 		[editSheetProgressBar startAnimation:self];
-        [editSheetSegmentControl setEnabled:NO forSegment:ImageSegment];
+		[editSheetSegmentControl setEnabled:NO forSegment:ImageSegment];
+		[hexTextView setString:@""]; // Set hex view to "" - load on demand only
 
 		NSImage *image = nil;
-
-		if ([sheetEditData isKindOfClass:[NSData class]]) {
-			image = [[NSImage alloc] initWithData:sheetEditData];
-
-			// Set hex view to "" - load on demand only
-			[hexTextView setString:@""];
-
+		if (self.displayFormatter) {
+			// data comes with it's own display formatter so let's use that.
+			stringValue = [self.displayFormatter stringForObjectValue: sheetEditData];
+			[self showEditText:YES];
+			[editSheetSegmentControl setSelectedSegment:TextSegment];
+		}
+		else if ([sheetEditData isKindOfClass:[NSData class]]) {
+			image       = [[NSImage alloc] initWithData:sheetEditData];
 			stringValue = [[NSString alloc] initWithData:sheetEditData encoding:encoding];
 
 			if (stringValue == nil) {
@@ -387,27 +343,17 @@ typedef enum {
 				stringValue	= [[NSString alloc] initWithFormat:@"0x%@", [sheetEditData dataToHexString]];
 			}
 
-			[hexTextView setHidden:NO];
-			[hexTextScrollView setHidden:NO];
-			[editImage setHidden:YES];
-			[editTextView setHidden:YES];
-			[editTextScrollView setHidden:YES];
 			[editSheetSegmentControl setSelectedSegment:HexSegment];
+			[self showHexText:YES];
 		}
 		else if ([sheetEditData isKindOfClass:[SPMySQLGeometryData class]]) {
 			SPGeometryDataView *v = [[SPGeometryDataView alloc] initWithCoordinates:[sheetEditData coordinates] targetDimension:2000.0f];
-
 			image = [v thumbnailImage];
-
 			stringValue = [sheetEditData wktString];
 
-			[hexTextView setString:@""];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
 			[editSheetSegmentControl setEnabled:NO forSegment:HexSegment];
 			[editSheetSegmentControl setSelectedSegment:TextSegment];
-			[editTextView setHidden:NO];
-			[editTextScrollView setHidden:NO];
+			[self showEditText:YES];
 		}
 		else {
 			// If the input is a JSON type column we can format it.
@@ -416,9 +362,9 @@ typedef enum {
       NSInteger indentWidth = [prefs integerForKey:SPCustomQuerySoftIndentWidth];
 
 			do {
-				if(_isJSON) {
+				if (_isJSON) {
           NSString *formatted = [SPJSONFormatter stringByFormattingString:sheetEditData useSoftIndent:useSoftIndent indentWidth:indentWidth];
-					if(formatted) {
+					if (formatted) {
 						stringValue = formatted;
 						break;
 					}
@@ -428,28 +374,17 @@ typedef enum {
 
 			[hexTextView setString:@""];
 
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[editImage setHidden:YES];
-			[editTextView setHidden:NO];
-			[editTextScrollView setHidden:NO];
+			[self showEditText:YES];
 			[editSheetSegmentControl setSelectedSegment:TextSegment];
 		}
 
+		[editImage setImage:image];
 		if (image) {
-            [editSheetSegmentControl setEnabled:YES forSegment:ImageSegment];
-			[editImage setImage:image];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[editImage setHidden:NO];
+			[editSheetSegmentControl setEnabled:YES forSegment:ImageSegment];
 			if(!_isGeometry) {
-				[editTextView setHidden:YES];
-				[editTextScrollView setHidden:YES];
+				[self showImage:YES];
 				[editSheetSegmentControl setSelectedSegment:ImageSegment];
 			}
-		}
-		else {
-			[editImage setImage:nil];
 		}
 
 		if (stringValue) {
@@ -457,16 +392,13 @@ typedef enum {
 
 			if (image == nil) {
 				if (!isBinary) {
-					[hexTextView setHidden:YES];
-					[hexTextScrollView setHidden:YES];
+					[self showHexText:NO];
 				}
 				else {
 					[editSheetSegmentControl setEnabled:NO forSegment:ImageSegment];
 				}
 
-				[editImage setHidden:YES];
-				[editTextView setHidden:NO];
-				[editTextScrollView setHidden:NO];
+				[self showEditText:YES];
 				[editSheetSegmentControl setSelectedSegment:TextSegment];
 			}
 
@@ -487,9 +419,49 @@ typedef enum {
 		}
 
 		editSheetWillBeInitialized = NO;
-
 		[editSheetProgressBar stopAnimation:self];
 	}
+}
+
+- (NSString *)buildLabelForField:(NSString *)fieldName {
+	// Set field label
+	NSMutableString *label = [NSMutableString string];
+
+	[label appendFormat:@"“%@”", fieldName];
+
+	if ([fieldType length] || maxTextLength > 0 || [fieldEncoding length] || !_allowNULL)
+		[label appendString:@" – "];
+
+	if ([fieldType length])
+		[label appendString:fieldType];
+
+	//skip length for JSON type since it's a constant and MySQL doesn't display it either
+	if (maxTextLength > 0 && !_isJSON)
+		[label appendFormat:@"(%lld) ", maxTextLength];
+
+	if (self.displayFormatter)
+		[label appendFormat:@"– %@ ", self.displayFormatter.label];
+
+	if (!_allowNULL)
+		[label appendString:@"NOT NULL "];
+
+	if ([fieldEncoding length])
+		[label appendString:fieldEncoding];
+
+	return label;
+}
+
+- (NSFont *)selectFont {
+	NSFont *textEditorFont = [NSFont systemFontOfSize:[NSFont systemFontSize]];
+	// Based on user preferences, either use:
+	// 1. The font specifically chosen for the editor sheet textView (FieldEditorSheetFont, right-click in the textView, and choose "Font > Show Fonts" to do that);
+	// 2. The font used for the table view (SPGlobalFontSettings, per the "MySQL Content Font" preference option);
+	if ([prefs objectForKey:SPFieldEditorSheetFont]) {
+		textEditorFont = [NSUnarchiver unarchiveObjectWithData:[prefs dataForKey:SPFieldEditorSheetFont]];
+	} else if ([prefs objectForKey:SPGlobalFontSettings]) {
+		textEditorFont = [NSUserDefaults getFont];
+	}
+	return textEditorFont;
 }
 
 /**
@@ -499,23 +471,11 @@ typedef enum {
 {
 	switch((FieldEditorSegment)[sender selectedSegment]){
 		case TextSegment:
-			[editTextView setHidden:NO];
-			[editTextScrollView setHidden:NO];
-			[editImage setHidden:YES];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[jsonTextView setHidden:YES];
-			[jsonTextScrollView setHidden:YES];
+			[self showEditText:YES];
 			[usedSheet makeFirstResponder:editTextView];
 			break;
 		case ImageSegment:
-			[editTextView setHidden:YES];
-			[editTextScrollView setHidden:YES];
-			[editImage setHidden:NO];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[jsonTextView setHidden:YES];
-			[jsonTextScrollView setHidden:YES];
+			[self showImage:YES];
 			[usedSheet makeFirstResponder:editImage];
 			break;
 		case HexSegment:
@@ -529,13 +489,7 @@ typedef enum {
 				}
 				[editSheetProgressBar stopAnimation:self];
 			}
-			[editTextView setHidden:YES];
-			[editTextScrollView setHidden:YES];
-			[editImage setHidden:YES];
-			[hexTextView setHidden:NO];
-			[hexTextScrollView setHidden:NO];
-			[jsonTextView setHidden:YES];
-			[jsonTextScrollView setHidden:YES];
+			[self showHexText:YES];
 			break;
 		case JsonSegment:
 			[usedSheet makeFirstResponder:jsonTextView];
@@ -582,13 +536,7 @@ typedef enum {
 
 
 			}
-			[editTextView setHidden:YES];
-			[editTextScrollView setHidden:YES];
-			[editImage setHidden:YES];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[jsonTextView setHidden:NO];
-			[jsonTextScrollView setHidden:NO];
+			[self showJsonText:YES];
 			break;
 	}
 }
@@ -643,9 +591,9 @@ typedef enum {
 	// - for max text length (except for NULL value string) select the part which won't be saved
 	//   and suppress closing the sheet
 	if (sender == editSheetOkButton) {
-		
-		unsigned long long maxLength = maxTextLength;
-		
+
+		unsigned long long maxLength = self.maxLengthDateWithOverride;
+
 		// For FLOAT fields ignore the decimal point in the text when comparing lengths
 		if ([[fieldType uppercaseString] isEqualToString:@"FLOAT"] && ([[[editTextView textStorage] string] rangeOfString:@"."].location != NSNotFound)) {
 			maxLength++;
@@ -655,13 +603,26 @@ typedef enum {
         NSString *nullValue = [[NSUserDefaults standardUserDefaults] objectForKey:SPNullValue];
         NSTextStorage *editTVtextStorage = [editTextView textStorage];
         NSString *editTVString = [editTVtextStorage string];
-        
+
 		if (maxLength > 0 && [editTVString characterCount] > (NSInteger)maxLength && ![editTVString isEqualToString:nullValue] && [nullValue contains:editTVString] == NO) {
 			[editTextView setSelectedRange:NSMakeRange((NSUInteger)maxLength, [editTVString characterCount] - (NSUInteger)maxLength)];
 			[editTextView scrollRangeToVisible:NSMakeRange([editTextView selectedRange].location,0)];
-			[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Text is too long. Maximum text length is set to %llu.", @"Text is too long. Maximum text length is set to %llu."), maxTextLength]];
-			
+			[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Text is too long. Maximum text length is set to %llu.", @"Text is too long. Maximum text length is set to %llu."), maxLength]];
+
 			return;
+		}
+
+		if (self.displayFormatter) {
+			NSString *_Nullable err = nil;
+			BOOL isValid = [self.displayFormatter getObjectValue:nil forString:[editTextView string] errorDescription:&err];
+			if (!isValid) {
+				NSBeep();
+				if (err != nil) {
+					[SPTooltip showWithObject: err];
+
+				}
+				return;
+			}
 		}
 
 		editSheetReturnCode = 1;
@@ -687,7 +648,7 @@ typedef enum {
 
 	if(callerInstance) {
 		id returnData = ( editSheetReturnCode && _isEditable ) ? (_isGeometry) ? [editTextView string] : sheetEditData : nil;
-		
+
 		//for MySQLs JSON type remove the formatting again, since it won't be stored anyway
 		if(_isJSON) {
 			NSString *unformatted = [SPJSONFormatter stringByUnformattingString:returnData];
@@ -707,21 +668,14 @@ typedef enum {
 {
 	if (returnCode == NSModalResponseOK) {
 		NSString *contents = nil;
-
 		editSheetWillBeInitialized = YES;
-
 		[editSheetProgressBar startAnimation:self];
-
-		// load new data/images
-		sheetEditData = [[NSData alloc] initWithContentsOfURL:[panel URL]];
+		sheetEditData = [[NSData alloc] initWithContentsOfURL:[panel URL]]; // load new data/images
 
 		NSImage *image = [[NSImage alloc] initWithData:sheetEditData];
 		contents = [[NSString alloc] initWithData:sheetEditData encoding:encoding];
 		if (contents == nil)
 			contents = [[NSString alloc] initWithData:sheetEditData encoding:NSASCIIStringEncoding];
-
-		// set the image preview, string contents and hex representation
-		[editImage setImage:image];
 
 		if(contents)
 			[editTextView setString:contents];
@@ -732,23 +686,15 @@ typedef enum {
 		if(![[hexTextView string] isEqualToString:@""])
 			[hexTextView setString:[sheetEditData dataToFormattedHexString]];
 
-		// If the image cell now contains a valid image, select the image view
-		if (image) {
+		// set the image preview, string contents and hex representation
+		[editImage setImage:image];
+		if (image) { // If the image cell now contains a valid image, select the image view
 			[editSheetSegmentControl setSelectedSegment:ImageSegment];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[editImage setHidden:NO];
-			[editTextView setHidden:YES];
-			[editTextScrollView setHidden:YES];
-
-			// Otherwise deselect the image view
-		} else {
+			[self showImage:YES];
+		}
+		else { // Otherwise deselect the image view
 			[editSheetSegmentControl setSelectedSegment:TextSegment];
-			[hexTextView setHidden:YES];
-			[hexTextScrollView setHidden:YES];
-			[editImage setHidden:YES];
-			[editTextView setHidden:NO];
-			[editTextScrollView setHidden:NO];
+			[self showEditText:YES];
 		}
 		if(contents)
 		[editSheetProgressBar stopAnimation:self];
@@ -1001,19 +947,13 @@ typedef enum {
  */
 -(void)processPasteImageData
 {
-
 	editSheetWillBeInitialized = YES;
-
-	NSImage *image = nil;
-
-	image = [[NSImage alloc] initWithPasteboard:[NSPasteboard generalPasteboard]];
+	NSImage *image = [[NSImage alloc] initWithPasteboard:[NSPasteboard generalPasteboard]];
 	if (image) {
-
 		[editImage setImage:image];
-
 		sheetEditData = [[NSData alloc] initWithData:[image TIFFRepresentationUsingCompression:NSTIFFCompressionLZW factor:1]];
-
 		NSString *contents = [[NSString alloc] initWithData:sheetEditData encoding:encoding];
+		
 		if (contents == nil)
 			contents = [[NSString alloc] initWithData:sheetEditData encoding:NSASCIIStringEncoding];
 
@@ -1022,7 +962,6 @@ typedef enum {
 			[editTextView setString:contents];
 		if(![[hexTextView string] isEqualToString:@""])
 			[hexTextView setString:[sheetEditData dataToFormattedHexString]];
-
 	}
 
 	editSheetWillBeInitialized = NO;
@@ -1035,7 +974,6 @@ typedef enum {
  */
 - (void)processUpdatedImageData:(NSData *)data
 {
-
 	editSheetWillBeInitialized = YES;
 
 	// If the image was not processed, set a blank string as the contents of the edit and hex views.
@@ -1253,7 +1191,7 @@ typedef enum {
 			intValue >>= 1;
 			i++;
 		}
-		
+
 		[self updateBitSheet];
 	}
 }
@@ -1263,14 +1201,15 @@ typedef enum {
  */
 - (BOOL)textView:(NSTextView *)textView shouldChangeTextInRange:(NSRange)r replacementString:(NSString *)replacementString
 {
-    if (replacementString == nil || [replacementString characterCount] == 0) {
-        editTextViewWasChanged = YES; // Backspace
-        return YES;
-    }
-    
-	if (textView == editTextView && 
-		(maxTextLength > 0) && 
-		![[[[editTextView textStorage] string] stringByAppendingString:replacementString] isEqualToString:[prefs objectForKey:SPNullValue]])
+	if (replacementString == nil || [replacementString characterCount] == 0) {
+		editTextViewWasChanged = YES; // Backspace
+		return YES;
+	}
+
+	unsigned long long adjTextMaxTextLength = self.maxLengthDateWithOverride;
+
+	if (textView == editTextView && (adjTextMaxTextLength > 0) &&
+			![[[[editTextView textStorage] string] stringByAppendingString:replacementString] isEqualToString:[prefs objectForKey:SPNullValue]])
 	{
 		NSInteger newLength;
 
@@ -1287,13 +1226,13 @@ typedef enum {
 		if (r.location == NSNotFound) return NO;
 
 		// Length checking while using the Input Manager (eg for Japanese)
-		if ([textView hasMarkedText] && (maxTextLength > 0) && (r.location < maxTextLength)) {
+		if ([textView hasMarkedText] && (adjTextMaxTextLength > 0) && (r.location < adjTextMaxTextLength)) {
 
 			// User tries to insert a new char but max text length was already reached - return NO
-			if (!r.length && ([[[textView textStorage] string] characterCount] >= (NSInteger)maxTextLength)) {
-				[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu.", @"Maximum text length is set to %llu."), maxTextLength]];
+			if (!r.length && ([[[textView textStorage] string] characterCount] >= (NSInteger)adjTextMaxTextLength)) {
+				[SPTooltip showWithObject:[NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu.", @"Maximum text length is set to %llu."), adjTextMaxTextLength]];
 				[textView unmarkText];
-				
+
 				return NO;
 			}
 			// Otherwise allow it if insertion point is valid for eg
@@ -1302,7 +1241,7 @@ typedef enum {
 			// 4 which is larger than max length.
 			// TODO this doesn't solve the problem of inserting more than one char. For now
 			// that part which won't be saved will be hilited if user pressed the OK button.
-			else if (r.location < maxTextLength) {
+			else if (r.location < adjTextMaxTextLength) {
 				return YES;
 			}
 		}
@@ -1311,52 +1250,63 @@ typedef enum {
 		newLength = [[[textView textStorage] string] characterCount] + [replacementString characterCount] - r.length;
 
 		NSUInteger textLength = [[[textView textStorage] string] characterCount];
-		
-		unsigned long long originalMaxTextLength = maxTextLength;
-		
+
+		unsigned long long originalMaxTextLength = adjTextMaxTextLength;
+
 		// For FLOAT fields ignore the decimal point in the text when comparing lengths
-		if ([[fieldType uppercaseString] isEqualToString:@"FLOAT"] && 
-			([[[textView textStorage] string] rangeOfString:@"."].location != NSNotFound)) {
-			
-			if ((NSUInteger)newLength == (maxTextLength + 1)) {
-				maxTextLength++;
+		if ([[fieldType uppercaseString] isEqualToString:@"FLOAT"] &&
+				([[[textView textStorage] string] rangeOfString:@"."].location != NSNotFound)) {
+
+			if ((NSUInteger)newLength == (adjTextMaxTextLength + 1)) {
+				adjTextMaxTextLength++;
 				textLength--;
 			}
-			else if ((NSUInteger)newLength > maxTextLength) {
+			else if ((NSUInteger)newLength > adjTextMaxTextLength) {
 				textLength--;
 			}
 		}
 
 		// If it's too long, disallow the change but try
 		// to insert a text chunk partially to maxTextLength.
-		if ((NSUInteger)newLength > maxTextLength) {
-			if ((maxTextLength - textLength + [textView selectedRange].length) <= [replacementString characterCount]) {
-			
+		if ((NSUInteger)newLength > adjTextMaxTextLength) {
+			if ((adjTextMaxTextLength - textLength + [textView selectedRange].length) <= [replacementString characterCount]) {
+
 				NSString *tooltip = nil;
-				
-				if (maxTextLength - textLength + [textView selectedRange].length) {
-					tooltip = [NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu. Inserted text was truncated.", @"Maximum text length is set to %llu. Inserted text was truncated."), maxTextLength];
+
+				if (adjTextMaxTextLength - textLength + [textView selectedRange].length) {
+					tooltip = [NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu. Inserted text was truncated.", @"Maximum text length is set to %llu. Inserted text was truncated."), adjTextMaxTextLength];
 				}
 				else {
-					tooltip = [NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu.", @"Maximum text length is set to %llu."), maxTextLength];
+					tooltip = [NSString stringWithFormat:NSLocalizedString(@"Maximum text length is set to %llu.", @"Maximum text length is set to %llu."), adjTextMaxTextLength];
 				}
-				
+
 				[SPTooltip showWithObject:tooltip];
 
-				[textView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:[replacementString substringToIndex:(NSUInteger)maxTextLength - textLength +[textView selectedRange].length]]];
+				[textView.textStorage appendAttributedString:[[NSAttributedString alloc] initWithString:[replacementString substringToIndex:(NSUInteger)adjTextMaxTextLength - textLength +[textView selectedRange].length]]];
 			}
-			
-			maxTextLength = originalMaxTextLength;
-			
+
+			adjTextMaxTextLength = originalMaxTextLength;
+
 			return NO;
 		}
 
-		maxTextLength = originalMaxTextLength;
+		adjTextMaxTextLength = originalMaxTextLength;
+
+		NSString *err = nil;
+		NSString *newStr = nil;
+		BOOL isValid = [self.displayFormatter isPartialStringValid:replacementString newEditingString:&newStr errorDescription:&err];
+		if (!isValid) {
+			NSBeep();
+			if (err != nil) {
+				[SPTooltip showWithObject: err];
+			}
+			return NO;
+		}
 
 		// Otherwise, allow it
 		return YES;
 	}
-	
+
 	return YES;
 }
 
@@ -1378,7 +1328,7 @@ typedef enum {
 		// clear the image and hex (since i doubt someone can "type" a gif)
 		[editImage setImage:nil];
 		[hexTextView setString:@""];
-		
+
 		// set edit data to text
 		sheetEditData = [NSString stringWithString:[editTextView string]];
 	}
@@ -1471,6 +1421,52 @@ typedef enum {
 - (void)setDoGroupDueToChars
 {
 	doGroupDueToChars = YES;
+}
+
+#pragma mark -
+#pragma mark UI Helper Methods
+
+- (void)showHexText:(BOOL)show {
+	BOOL hidden = !show;
+	[hexTextView setHidden:hidden];
+	[hexTextScrollView setHidden:hidden];
+	if (show) { // hide others
+		[self showEditText:hidden];
+		[self showJsonText:hidden];
+		[self showImage:hidden];
+	}
+}
+
+- (void)showEditText:(BOOL)show {
+	BOOL hidden = !show;
+	[editTextView setHidden:hidden];
+	[editTextScrollView setHidden:hidden];
+	if (show) { // hide others
+		[self showHexText:hidden];
+		[self showJsonText:hidden];
+		[self showImage:hidden];
+	}
+}
+
+- (void)showJsonText:(BOOL)show {
+	BOOL hidden = !show;
+	[jsonTextView setHidden:hidden];
+	[jsonTextScrollView setHidden:hidden];
+	if (show) { // hide others
+		[self showHexText:hidden];
+		[self showEditText:hidden];
+		[self showImage:hidden];
+	}
+}
+
+- (void)showImage:(BOOL)show {
+	BOOL hidden = !show;
+	[editImage setHidden:hidden];
+	if (show) { // hide others
+		[self showHexText:hidden];
+		[self showEditText:hidden];
+		[self showJsonText:hidden];
+	}
 }
 
 @end

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -614,7 +614,7 @@ typedef enum {
 
 		if (self.displayFormatter) {
 			NSString *_Nullable err = nil;
-			BOOL isValid = [self.displayFormatter getObjectValue:nil forString:[editTextView string] errorDescription:&err];
+			BOOL isValid = [self.displayFormatter getObjectValue:nil forString:sheetEditData errorDescription:&err];
 			if (!isValid) {
 				NSBeep();
 				if (err != nil) {
@@ -654,6 +654,11 @@ typedef enum {
 			NSString *unformatted = [SPJSONFormatter stringByUnformattingString:returnData];
 			if(unformatted) returnData = unformatted;
 		}
+    else if (self.displayFormatter) {
+      id convertedDate;
+      [self.displayFormatter getObjectValue:&convertedDate forString:sheetEditData errorDescription:nil];
+      returnData = convertedDate;
+    }
 
 		if([callerInstance respondsToSelector:@selector(processFieldEditorResult:contextInfo:)]) {
 			[(id <SPFieldEditorControllerDelegate>)callerInstance processFieldEditorResult:returnData contextInfo:contextInfo];

--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1107,9 +1107,12 @@
                                                                             <rect key="frame" x="680" y="17" width="15" height="450"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                         </scroller>
-                                                                        <tableHeaderView key="headerView" wantsLayer="YES" id="3920">
+                                                                        <tableHeaderView key="headerView" wantsLayer="YES" id="3920" customClass="SATableHeaderView" customModule="Sequel_Ace" customModuleProvider="target">
                                                                             <rect key="frame" x="0.0" y="0.0" width="693" height="17"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
+                                                                            <connections>
+                                                                                <outlet property="delegate" destination="67" id="QYB-GC-Os2"/>
+                                                                            </connections>
                                                                         </tableHeaderView>
                                                                     </scrollView>
                                                                     <button toolTip="Add row (⌥⌘A)" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5175">

--- a/Source/Other/Formatters/SABaseFormatter.swift
+++ b/Source/Other/Formatters/SABaseFormatter.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 
-@objc open class SABaseFormatter: Formatter {
+@objc class SABaseFormatter: Formatter {
 
     /// Max length to use for Field Editor
     @objc var maxLengthOverride: UInt { 0 }

--- a/Source/Other/Formatters/SABaseFormatter.swift
+++ b/Source/Other/Formatters/SABaseFormatter.swift
@@ -1,0 +1,32 @@
+//
+//  Created by Luis Aguiniga on 2024.07.07
+//  Copyright © 2024 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+
+@objc open class SABaseFormatter: Formatter {
+
+    /// Max length to use for Field Editor
+    @objc var maxLengthOverride: UInt { 0 }
+
+    // Short label to append to field description in Popup Field Editor
+    @objc var label: String { "" }
+
+}
+
+/// Helper class for MenuItem to keep track of both the formatter and contet Table Column
+@objc final class FormatterWithReference: NSObject {
+    @objc var formatter: SABaseFormatter
+    @objc var reference: AnyObject?
+
+    @objc static func newWith(formatter: SABaseFormatter) -> FormatterWithReference {
+        FormatterWithReference(formatter: formatter)
+    }
+
+    init(formatter: SABaseFormatter, reference: AnyObject? = nil) {
+        self.formatter = formatter
+        self.reference = reference
+    }
+}

--- a/Source/Other/Formatters/SAUUIDormatter.swift
+++ b/Source/Other/Formatters/SAUUIDormatter.swift
@@ -1,0 +1,163 @@
+//
+//  Created by Luis Aguiniga on 2024.07.07
+//  Copyright © 2024 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+
+@objc final class SAUUIDormatter: SABaseFormatter {
+    static let REGEX_PAIRS = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .caseInsensitive)
+    static let REGEX_VALID_CHARS = try! NSRegularExpression(pattern: "[^0-9a-f\\-]", options: .caseInsensitive)
+    static var nullStr: String? { UserDefaults.standard.string(forKey: SPNullValue) }
+
+    static func invalidCharactersInUuid(in str: String) -> NSString {
+        return String(format: NSLocalizedString("Invalid UUID Character in: %@", comment: "Invalid UUID Character"), str) as NSString
+    }
+
+    static func invalidUuid(_ str: String) -> NSString {
+        return String(format: NSLocalizedString("Invalid UUID: %@", comment: "Invalid UUID"), str) as NSString
+    }
+
+    // MARK: - SABaseFormatter Overrides
+
+    override var maxLengthOverride: UInt { 36 } // 32 + 4 hyphens
+
+    override var label: String { NSLocalizedString("UUID Display Override", comment: "Field Editor Label") }
+
+    // MARK: - Formatter Overrides
+
+    override func string(for obj: Any?) -> String? {
+        guard let data = obj as? Data else {
+            return nil
+        }
+
+        return convertToUuidString(data)
+    }
+
+    override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
+                                 for string: String,
+                                 errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+        guard !isNullValue(string) && string != "" else {
+            obj?.pointee = NSNull()
+            return true
+        }
+
+        guard containsOnlyValidUuidCharacters(string) else {
+            error?.pointee = Self.invalidCharactersInUuid(in: string)
+            return false
+        }
+
+        guard let data = hexToData(string) else {
+            error?.pointee = Self.invalidUuid(string)
+            return false
+        }
+        obj?.pointee = data as NSData
+
+        return true
+    }
+
+    override func isPartialStringValid(_ partialString: String, newEditingString
+                                       newString: AutoreleasingUnsafeMutablePointer<NSString?>?,
+                                       errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+        guard containsOnlyValidUuidCharacters(partialString) else {
+            error?.pointee = Self.invalidCharactersInUuid(in: partialString)
+            return false
+        }
+
+        return true
+    }
+
+    override func isPartialStringValid(_ partialStringPtr: AutoreleasingUnsafeMutablePointer<NSString>,
+                                       proposedSelectedRange proposedSelRangePtr: NSRangePointer?,
+                                       originalString origString: String,
+                                       originalSelectedRange origSelRange: NSRange,
+                                       errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+        let newString = partialStringPtr.pointee as String
+
+        if isPartialMatchForNullValue(newString) {
+            return true
+        }
+
+        guard containsOnlyValidUuidCharacters(newString) else {
+            error?.pointee = Self.invalidCharactersInUuid(in: newString)
+            return false
+        }
+
+        guard removeHyphens(newString).lengthOfBytes(using: .utf8) <= 32 else {
+            error?.pointee = Self.invalidUuid(newString)
+            return false
+        }
+
+        return true
+    }
+
+    // MARK: - Helper Methods
+
+    func isPartialMatchForNullValue(_ s: String) -> Bool {
+        if let nul = Self.nullStr, nul.contains(s) {
+            // not valid characters but user could be trying null the value out.
+            return true
+        }
+        return false
+    }
+
+    func isNullValue(_ s: String) -> Bool {
+        if let NUL = Self.nullStr, NUL == s {
+            // not valid characters but user could be trying null the value out.
+            return true
+        }
+        return false
+    }
+
+    func containsOnlyValidUuidCharacters(_ s: String) -> Bool {
+        if isPartialMatchForNullValue(s) {
+            return true
+        }
+
+        let range = NSRange(s.startIndex..., in: s)
+        return Self.REGEX_VALID_CHARS.matches(in: s, range: range).isEmpty
+    }
+
+    func hexToData(_ s: String) -> Data? {
+        let hex = removeHyphens(s)
+        let len = hex.lengthOfBytes(using: .utf8)
+        guard len == 32 || len == 0 else {
+            return nil
+        }
+
+        var data = Data(capacity: 16)
+        let range = NSRange(hex.startIndex..., in: hex)
+
+        Self.REGEX_PAIRS.enumerateMatches(in: hex, range: range) { match, _, _ in
+            let pair = (hex as NSString).substring(with: match!.range)
+            let byte = UInt8(pair, radix: 16)!
+            data.append(byte)
+        }
+
+        return data
+    }
+
+    func removeHyphens(_ s: String) -> String {
+        if s.contains("-") {
+            return s.replacingOccurrences(of: "-", with: "").trimmedString
+        }
+
+        return s.trimmedString
+    }
+
+    // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html
+    func convertToUuidString(_ data: Data) -> String? {
+        guard data.count == 16 else {
+            return nil
+        }
+
+        var str = data.map({ byte in String(format: "%02hhX", byte)}).joined()
+        str.insert("-", at: str.index(str.startIndex, offsetBy: 8))
+        str.insert("-", at: str.index(str.startIndex, offsetBy: 13))
+        str.insert("-", at: str.index(str.startIndex, offsetBy: 18))
+        str.insert("-", at: str.index(str.startIndex, offsetBy: 23))
+
+        return str
+    }
+}

--- a/Source/Other/Formatters/SAUuidFormatter.swift
+++ b/Source/Other/Formatters/SAUuidFormatter.swift
@@ -6,7 +6,8 @@
 import Foundation
 
 
-@objc final class SAUUIDormatter: SABaseFormatter {
+
+@objc final class SAUuidFormatter: SABaseFormatter {
     static let REGEX_PAIRS = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .caseInsensitive)
     static let REGEX_VALID_CHARS = try! NSRegularExpression(pattern: "[^0-9a-f\\-]", options: .caseInsensitive)
     static var nullStr: String? { UserDefaults.standard.string(forKey: SPNullValue) }

--- a/Source/Other/Formatters/SAUuidFormatter.swift
+++ b/Source/Other/Formatters/SAUuidFormatter.swift
@@ -6,18 +6,34 @@
 import Foundation
 
 
-
 @objc final class SAUuidFormatter: SABaseFormatter {
     static let REGEX_PAIRS = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .caseInsensitive)
     static let REGEX_VALID_CHARS = try! NSRegularExpression(pattern: "[^0-9a-f\\-]", options: .caseInsensitive)
-    static var nullStr: String? { UserDefaults.standard.string(forKey: SPNullValue) }
 
     static func invalidCharactersInUuid(in str: String) -> NSString {
         return String(format: NSLocalizedString("Invalid UUID Character in: %@", comment: "Invalid UUID Character"), str) as NSString
     }
-
     static func invalidUuid(_ str: String) -> NSString {
         return String(format: NSLocalizedString("Invalid UUID: %@", comment: "Invalid UUID"), str) as NSString
+    }
+
+    var nullStr: String? { self.userDefaults.string(forKey: "NullValue") }
+    let userDefaults: UserDefaults
+
+    @objc override init() {
+        self.userDefaults = UserDefaults.standard
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        self.userDefaults = UserDefaults.standard
+        super.init(coder: coder)
+    }
+
+    /// For Unit Testing Only -- See UT `SAUuidFormatterTests` for how UserDefaults are mocked.
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+        super.init()
     }
 
     // MARK: - SABaseFormatter Overrides
@@ -96,7 +112,7 @@ import Foundation
     // MARK: - Helper Methods
 
     func isPartialMatchForNullValue(_ s: String) -> Bool {
-        if let nul = Self.nullStr, nul.contains(s) {
+        if let nul = self.nullStr, nul.contains(s) {
             // not valid characters but user could be trying null the value out.
             return true
         }
@@ -104,7 +120,7 @@ import Foundation
     }
 
     func isNullValue(_ s: String) -> Bool {
-        if let NUL = Self.nullStr, NUL == s {
+        if let NUL = self.nullStr, NUL == s {
             // not valid characters but user could be trying null the value out.
             return true
         }

--- a/Source/Views/TableViews/SATableHeaderView.swift
+++ b/Source/Views/TableViews/SATableHeaderView.swift
@@ -1,0 +1,27 @@
+//
+//  Created by Luis Aguiniga on 2024.07.05.
+//  Copyright © 2024 Sequel-Ace. All rights reserved.
+//
+
+import Cocoa
+
+
+@objc protocol SATableHeaderViewDelegate: AnyObject {
+    func validate(menu: NSMenu, forTableColumn col: NSTableColumn) -> NSMenu?
+}
+
+/// Takes the table header's Menu (same for all columns) and allows
+/// delegate to contextualize it for the clicked column.
+@objc class SATableHeaderView: NSTableHeaderView {
+    @IBOutlet weak var delegate: SATableHeaderViewDelegate?
+    
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard let menu = self.menu else { return nil }
+        guard let delegate = self.delegate  else { return menu }
+        
+        let idx = self.column(at: self.convert(event.locationInWindow, from: nil))
+        guard idx >= 0, let col = self.tableView?.tableColumns[idx] else { return menu }
+        
+        return delegate.validate(menu: menu, forTableColumn: col)
+    }
+}

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -196,6 +196,11 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 					[result appendFormat:@"%@\t", nullString];
 				else if ([cellData isSPNotLoaded])
 					[result appendFormat:@"%@\t", NSLocalizedString(@"(not loaded)", @"value shown for hidden blob and text fields")];
+        else if ([[[columns[c] dataCell] formatter] isKindOfClass:[SABaseFormatter class]]) {
+          SABaseFormatter *formatter = (SABaseFormatter *)[[columns[c] dataCell] formatter];
+          NSString *displayString = [formatter stringForObjectValue:cellData];
+          [result appendFormat:@"%@\t", displayString];
+        }
 				else if ([cellData isKindOfClass:[NSData class]]) {
 					if(withBlobHandling == kBlobInclude) {
 						NSString *displayString;
@@ -329,6 +334,11 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 					[result appendFormat:@"\"%@\",", nullString];
 				else if ([cellData isSPNotLoaded])
 					[result appendFormat:@"\"%@\",", NSLocalizedString(@"(not loaded)", @"value shown for hidden blob and text fields")];
+        else if ([[[columns[c] dataCell] formatter] isKindOfClass:[SABaseFormatter class]]) {
+          SABaseFormatter *formatter = (SABaseFormatter *)[[columns[c] dataCell] formatter];
+          NSString *displayString = [formatter stringForObjectValue:cellData];
+          [result appendFormat:@"\"%@\",", displayString];
+        }
 				else if ([cellData isKindOfClass:[NSData class]]) {
 					if(withBlobHandling == kBlobInclude) {
 						NSString *displayString;

--- a/UnitTests/SAUuidFormatterTests.swift
+++ b/UnitTests/SAUuidFormatterTests.swift
@@ -1,0 +1,225 @@
+//
+//  Created by Luis Aguiniga on 2024.07.30
+//  Copyright © 2024 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+
+class SAUuidFormatterTests: XCTestCase {
+  let formatter = SAUuidFormatter()
+
+  func testFormatterMaxLengthOverride() {
+    XCTAssertEqual(formatter.maxLengthOverride, 36)
+  }
+
+  func testFormatterLabelOverride() {
+    XCTAssertEqual(formatter.label, "UUID Display Override")
+  }
+
+  func testEmptyStringToNSNull() {
+    let input = ""
+    let helper = Helper()
+
+    XCTAssertTrue(formatter.getObjectValue(helper.autoPtr, for: input, errorDescription: helper.autoErrorPtr))
+    XCTAssertTrue(helper.obj.pointee is NSNull)
+    XCTAssertNil(helper.err.pointee)
+  }
+
+  func testNilValueIsValidButAsNSNull() {
+    let input = "NULL"
+    let helper = Helper()
+    let mockFormatter = SAUuidFormatter(userDefaults: MockUserDefault(mockNullValue: "NULL"))
+
+    XCTAssertTrue(mockFormatter.getObjectValue(helper.autoPtr, for: input, errorDescription: helper.autoErrorPtr))
+    XCTAssertTrue(helper.obj.pointee is NSNull)
+    XCTAssertNil(helper.err.pointee)
+  }
+
+  func testNilObjectToNilString() {
+    XCTAssertNil(formatter.string(for: nil))
+  }
+
+  func testUuidDataRoundTrip() {
+    let input = "772EFFB2-FB9F-FFFF-FFFF-7E50977355E4"
+    let helper = Helper()
+
+
+    XCTAssertTrue(formatter.getObjectValue(helper.autoPtr, for: input, errorDescription: helper.autoErrorPtr))
+    XCTAssertTrue(helper.obj.pointee is NSData)
+
+    let data = helper.obj.pointee as! NSData
+    XCTAssertEqual(data.length, 16)
+
+    let convertedString = formatter.string(for: data)
+    XCTAssertNotNil(convertedString)
+    XCTAssertEqual(convertedString!, input)
+  }
+
+  func testInvalidCharacters() {
+    let input = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    let helper = Helper()
+
+    XCTAssertFalse(formatter.getObjectValue(helper.autoPtr, for: input, errorDescription: helper.autoErrorPtr))
+    XCTAssertNotNil(helper.err.pointee)
+    XCTAssertEqual(helper.err.pointee!, "Invalid UUID Character in: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+  }
+
+  func testInvalidLength() {
+    let input = "01234567-89AB-CDEF"
+    let helper = Helper()
+
+    XCTAssertFalse(formatter.getObjectValue(helper.autoPtr, for: input, errorDescription: helper.autoErrorPtr))
+    XCTAssertNotNil(helper.err.pointee)
+    XCTAssertEqual(helper.err.pointee!, "Invalid UUID: 01234567-89AB-CDEF")
+  }
+
+  func testValidPartial() {
+    let input = "01234567-89AB-CDEF"
+    let helper = Helper()
+
+    XCTAssertTrue(formatter.isPartialStringValid(input, newEditingString: helper.autoStrPtr, errorDescription: helper.autoErrorPtr))
+    XCTAssertNil(helper.err.pointee)
+  }
+
+  func testInvalidPartial() {
+    let input = "01234567-89AB-XXXX"
+    let helper = Helper()
+
+    XCTAssertFalse(formatter.isPartialStringValid(input, newEditingString: helper.autoStrPtr, errorDescription: helper.autoErrorPtr))
+    XCTAssertNotNil(helper.err.pointee)
+    XCTAssertEqual(helper.err.pointee!, "Invalid UUID Character in: 01234567-89AB-XXXX")
+  }
+
+  func testPartialNullValueIsValid() {
+    let input = "NU"
+    let helper = Helper()
+    let mockFormatter = SAUuidFormatter(userDefaults: MockUserDefault(mockNullValue: "NUL"))
+
+    XCTAssertTrue(mockFormatter.isPartialStringValid(input, newEditingString: helper.autoStrPtr, errorDescription: helper.autoErrorPtr))
+  }
+
+  func testValidPartialSecondOverride() {
+    let input = "01234567-89AB-CDEF"
+    let helper = Helper()
+    helper.partialStr.pointee = input as NSString
+
+    let res = formatter.isPartialStringValid(
+      helper.autoPartialStr,
+      proposedSelectedRange: nil,
+      originalString: input,
+      originalSelectedRange: NSRange(location: 0, length: 0),
+      errorDescription: helper.autoErrorPtr
+    )
+    XCTAssertTrue(res)
+    XCTAssertNil(helper.err.pointee)
+  }
+
+  func testPartialNullValidPartialSecondOverride() {
+    let input = "NU"
+    let helper = Helper()
+    helper.partialStr.pointee = input as NSString
+    let mockFormatter = SAUuidFormatter(userDefaults: MockUserDefault(mockNullValue: "NUL"))
+
+    let res = mockFormatter.isPartialStringValid(
+      helper.autoPartialStr,
+      proposedSelectedRange: nil,
+      originalString: input,
+      originalSelectedRange: NSRange(location: 0, length: 0),
+      errorDescription: helper.autoErrorPtr
+    )
+    XCTAssertTrue(res)
+    XCTAssertNil(helper.err.pointee)
+  }
+
+  func testInvalidPartialSecondOverride() {
+    let input = "01234567-89AB-XXXX"
+    let helper = Helper()
+    helper.partialStr.pointee = input as NSString
+
+    let res = formatter.isPartialStringValid(
+      helper.autoPartialStr,
+      proposedSelectedRange: nil,
+      originalString: input,
+      originalSelectedRange: NSRange(location: 14, length: 4),
+      errorDescription: helper.autoErrorPtr
+    )
+    XCTAssertFalse(res)
+    XCTAssertNotNil(helper.err.pointee)
+  }
+
+  func testInvalidPartialSecondOverrideTooLong() {
+    let input = "01234567-89AB-CDEF-0123-456789ABCDEF000"
+    let helper = Helper()
+    helper.partialStr.pointee = input as NSString
+
+    let res = formatter.isPartialStringValid(
+      helper.autoPartialStr,
+      proposedSelectedRange: nil,
+      originalString: input,
+      originalSelectedRange: NSRange(location: 14, length: 4),
+      errorDescription: helper.autoErrorPtr
+    )
+    XCTAssertFalse(res)
+    XCTAssertNotNil(helper.err.pointee)
+  }
+
+  class Helper {
+    let obj: UnsafeMutablePointer<AnyObject?>
+    var autoPtr: AutoreleasingUnsafeMutablePointer<AnyObject?> {
+      AutoreleasingUnsafeMutablePointer<AnyObject?>(obj)
+    }
+
+    let err: UnsafeMutablePointer<NSString?>
+    var autoErrorPtr: AutoreleasingUnsafeMutablePointer<NSString?> {
+      AutoreleasingUnsafeMutablePointer<NSString?>(err)
+    }
+
+    let str: UnsafeMutablePointer<NSString?>
+    var autoStrPtr: AutoreleasingUnsafeMutablePointer<NSString?> {
+      AutoreleasingUnsafeMutablePointer<NSString?>(str)
+    }
+
+    let partialStr: UnsafeMutablePointer<NSString>
+    var autoPartialStr: AutoreleasingUnsafeMutablePointer<NSString> {
+      AutoreleasingUnsafeMutablePointer<NSString>(partialStr)
+    }
+
+    init() {
+      obj = UnsafeMutablePointer<AnyObject?>.allocate(capacity: 1)
+      err = UnsafeMutablePointer<NSString?>.allocate(capacity: 1)
+      str = UnsafeMutablePointer<NSString?>.allocate(capacity: 1)
+      partialStr = UnsafeMutablePointer<NSString>.allocate(capacity: 1)
+      partialStr.initialize(to: "" as NSString)
+    }
+
+    deinit {
+      obj.deallocate()
+      err.deallocate()
+      str.deallocate()
+      partialStr.deinitialize(count: 1)
+      partialStr.deallocate()
+    }
+  }
+
+  class MockUserDefault: UserDefaults {
+    let mockNullValue: String
+
+    convenience init(mockNullValue: String) {
+      self.init(mockNullValue: mockNullValue, suiteName: "Mock User Defaults")!
+    }
+
+    init?(mockNullValue: String, suiteName suitename: String?) {
+      UserDefaults().removePersistentDomain(forName: suitename!)
+
+      self.mockNullValue = mockNullValue
+      super.init(suiteName: suitename)
+    }
+
+    override func string(forKey defaultName: String) -> String? {
+      guard defaultName == "NullValue" else { return nil }
+      return mockNullValue
+    }
+  }
+}

--- a/UnitTests/SAUuidFormatterTests.swift
+++ b/UnitTests/SAUuidFormatterTests.swift
@@ -7,7 +7,7 @@ import AppKit
 import XCTest
 
 
-class SAUuidFormatterTests: XCTestCase {
+final class SAUuidFormatterTests: XCTestCase {
   let formatter = SAUuidFormatter()
 
   func testFormatterMaxLengthOverride() {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -437,6 +437,10 @@
 		C9F92712162D39E60051CB2E /* toolbar-switch-to-browse.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */; };
 		C9F92714162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */; };
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
+		FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */; };
+		FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */; };
+		FD18C8992C3C9B2F002A5D57 /* SAUUIDormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */; };
+		FD2056052C3A7E90008DD271 /* SABaseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */; };
 		FD6DFF872ADB40630057B713 /* SPTableHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */; };
 		FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
 /* End PBXBuildFile section */
@@ -1163,6 +1167,10 @@
 		C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse.png"; sourceTree = "<group>"; };
 		C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse@2x.png"; sourceTree = "<group>"; };
 		D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowTabAccessory.swift; sourceTree = "<group>"; };
+		FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SATableHeaderView.swift; sourceTree = "<group>"; };
+		FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SQLiteDisplayFormatManager.swift; sourceTree = "<group>"; };
+		FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SAUUIDormatter.swift; sourceTree = "<group>"; };
+		FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SABaseFormatter.swift; sourceTree = "<group>"; };
 		FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SPTableHistoryManager.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
 /* End PBXFileReference section */
 
@@ -1506,6 +1514,7 @@
 				1A6D28FD25DD8018007509F1 /* ProgressWindowController.storyboard */,
 				1A4DC22C25DECEA000DA4FE1 /* ProgressWindowController.swift */,
 				44011DFD0DC2836DB08A0619 /* SQLitePinnedTableManager.swift */,
+				FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */,
 			);
 			path = Other;
 			sourceTree = "<group>";
@@ -1700,6 +1709,7 @@
 				BC398A2B121D526200BE3EF4 /* SPCopyTable.h */,
 				BC398A2C121D526200BE3EF4 /* SPCopyTable.m */,
 				171C398D16BD634600209EC6 /* SPDatabaseContentViewDelegate.h */,
+				FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */,
 			);
 			name = "Table Views";
 			path = TableViews;
@@ -1874,6 +1884,7 @@
 		17E6416E0EF01F3B001BC333 /* Other */ = {
 			isa = PBXGroup;
 			children = (
+				FD2056032C3A7E64008DD271 /* Formatters */,
 				51F4AFB924B26646006144D5 /* Extensions */,
 				507FF10E1BBCC4A900104523 /* Utility */,
 				1198F5B01174EDA700670590 /* Database Actions */,
@@ -2420,6 +2431,15 @@
 			path = CategoryAdditions;
 			sourceTree = "<group>";
 		};
+		FD2056032C3A7E64008DD271 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */,
+				FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */,
+			);
+			path = Formatters;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2902,6 +2922,7 @@
 				1A2711CF2539D9B10066ED58 /* SPReachability.m in Sources */,
 				172A65110F7BED7A001E861A /* SPConsoleMessage.m in Sources */,
 				6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */,
+				FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */,
 				1A24B627258A2E9A00541E88 /* SecureBookmarkData.swift in Sources */,
 				179F15060F7C433C00579954 /* SPEditorTokens.l in Sources */,
 				B5E92F1C0F75B2E800012500 /* SPExportController.m in Sources */,
@@ -2945,6 +2966,7 @@
 				503B02CA1AE82C5E0060CAB1 /* SPTableFilterParser.m in Sources */,
 				1A9F343F257B0DBE0062EC87 /* SPBundleManager.m in Sources */,
 				4D90B79A101E0CDF00D116A1 /* SPUserManager.m in Sources */,
+				FD18C8992C3C9B2F002A5D57 /* SAUUIDormatter.swift in Sources */,
 				4D90B79E101E0CF200D116A1 /* SPUserManager.xcdatamodel in Sources */,
 				4D90B79F101E0CF200D116A1 /* SPUserMO.m in Sources */,
 				584192A1101E57BB0089807F /* NSMutableArray-MultipleSort.m in Sources */,
@@ -2985,6 +3007,7 @@
 				BC2777A011514B940034DF6A /* SPNavigatorController.m in Sources */,
 				589582151154F8F400EDCC28 /* SPMainThreadTrampoline.m in Sources */,
 				BC4DF1981158FB280059FABD /* SPNavigatorOutlineView.m in Sources */,
+				FD2056052C3A7E90008DD271 /* SABaseFormatter.swift in Sources */,
 				5885CF4A116A63B200A85ACB /* SPFileHandle.m in Sources */,
 				1198F5B31174EDD500670590 /* SPDatabaseCopy.m in Sources */,
 				1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */,
@@ -3030,6 +3053,7 @@
 				17D3C6D3128B1C900047709F /* SPFavoritesOutlineView.m in Sources */,
 				50D3C3521A77135F00B5429C /* SPParserUtils.c in Sources */,
 				1A8B53572584520800526DED /* SPURLAdditions.m in Sources */,
+				FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */,
 				513515D2259354BB001E4533 /* NSImageExtensions.swift in Sources */,
 				BC68BFC7128D4EAE004907D9 /* SPBundleEditorController.m in Sources */,
 				BC1944D01297291800A236CD /* SPBundleCommandTextView.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -442,6 +442,9 @@
 		FD18C8992C3C9B2F002A5D57 /* SAUuidFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */; };
 		FD2056052C3A7E90008DD271 /* SABaseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */; };
 		FD6DFF872ADB40630057B713 /* SPTableHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */; };
+		FD8099A72C59DCFA0084646F /* SAUuidFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8099A62C59DCFA0084646F /* SAUuidFormatterTests.swift */; };
+		FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */; };
+		FD8099A92C59DE1D0084646F /* SABaseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */; };
 		FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
 /* End PBXBuildFile section */
 
@@ -1172,6 +1175,7 @@
 		FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SAUuidFormatter.swift; sourceTree = "<group>"; };
 		FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SABaseFormatter.swift; sourceTree = "<group>"; };
 		FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SPTableHistoryManager.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
+		FD8099A62C59DCFA0084646F /* SAUuidFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAUuidFormatterTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2251,6 +2255,7 @@
 				1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */,
 				1AE6C1CC25B07E9500880D73 /* SPFunctionsTests.m */,
 				8AEACADD4B36D9819ADC93DD /* TableSortHelperTests.swift */,
+				FD8099A62C59DCFA0084646F /* SAUuidFormatterTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -2823,6 +2828,7 @@
 				1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */,
 				50837F771E50E007004FAE8A /* SPJSONFormatter.m in Sources */,
 				505F568F1BCEE485007467DD /* SPFunctions.m in Sources */,
+				FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */,
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
@@ -2849,6 +2855,7 @@
 				50837F741E50DCD4004FAE8A /* SPJSONFormatterTests.m in Sources */,
 				1AB925922551550200063446 /* NumberFormatterExtension.swift in Sources */,
 				50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */,
+				FD8099A92C59DE1D0084646F /* SABaseFormatter.swift in Sources */,
 				50EA92651AB23EC8008D3C4F /* SPDatabaseAction.m in Sources */,
 				1A94997A25518549000BC793 /* DateComponentsFormatterExtension.swift in Sources */,
 				50EA92641AB23EAD008D3C4F /* SPDatabaseCopy.m in Sources */,
@@ -2858,6 +2865,7 @@
 				1A2DD55A25939BEE00616E7E /* SPTestingUtils.m in Sources */,
 				1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */,
 				1798F1C4155018E2004B0AB8 /* SPMutableArrayAdditionsTests.m in Sources */,
+				FD8099A72C59DCFA0084646F /* SAUuidFormatterTests.swift in Sources */,
 				1A4CB06B25926D7C00EDF804 /* StringRegexExtension.swift in Sources */,
 				1AEA768425EF05D500AC4DA6 /* ByteCountFormatterExtension.swift in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
 		FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */; };
 		FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */; };
-		FD18C8992C3C9B2F002A5D57 /* SAUUIDormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */; };
+		FD18C8992C3C9B2F002A5D57 /* SAUuidFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */; };
 		FD2056052C3A7E90008DD271 /* SABaseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */; };
 		FD6DFF872ADB40630057B713 /* SPTableHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */; };
 		FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
@@ -1169,7 +1169,7 @@
 		D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowTabAccessory.swift; sourceTree = "<group>"; };
 		FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SATableHeaderView.swift; sourceTree = "<group>"; };
 		FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SQLiteDisplayFormatManager.swift; sourceTree = "<group>"; };
-		FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SAUUIDormatter.swift; sourceTree = "<group>"; };
+		FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SAUuidFormatter.swift; sourceTree = "<group>"; };
 		FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SABaseFormatter.swift; sourceTree = "<group>"; };
 		FD6DFF862ADB40630057B713 /* SPTableHistoryManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SPTableHistoryManager.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; };
 /* End PBXFileReference section */
@@ -2435,7 +2435,7 @@
 			isa = PBXGroup;
 			children = (
 				FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */,
-				FD18C8982C3C9B2F002A5D57 /* SAUUIDormatter.swift */,
+				FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -2966,7 +2966,7 @@
 				503B02CA1AE82C5E0060CAB1 /* SPTableFilterParser.m in Sources */,
 				1A9F343F257B0DBE0062EC87 /* SPBundleManager.m in Sources */,
 				4D90B79A101E0CDF00D116A1 /* SPUserManager.m in Sources */,
-				FD18C8992C3C9B2F002A5D57 /* SAUUIDormatter.swift in Sources */,
+				FD18C8992C3C9B2F002A5D57 /* SAUuidFormatter.swift in Sources */,
 				4D90B79E101E0CF200D116A1 /* SPUserManager.xcdatamodel in Sources */,
 				4D90B79F101E0CF200D116A1 /* SPUserMO.m in Sources */,
 				584192A1101E57BB0089807F /* NSMutableArray-MultipleSort.m in Sources */,


### PR DESCRIPTION
<!--
Thanks for sending: a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
* New class `SATableHeaderView` with protocol `SATableHeaderViewDelegate` - Allows detecting column header that was ctrl/right clicked so that we can customize the menu shown.
	* `DBview.xib` - hooked in header view for context table header
* New class `SABaseFormatter` - base formatter class, allows extending to get other formatters. For example, we could move the hex formatting over to a subclass of this
* New class `SAUuidFormatter` - UUID Formatter for BINARY(16) fields.
  * New Uit Tests: `SAUuidFormatterTests
* New class `SQLiteDisplayFormatManager` - tracks column display overrides
* Edited class `SPTableContent`
	* **Renamed** `binhexHighlightColor` to `displayOverrideHighlightColor`
	* **Refactored** `setTableDetails` - extracted a few chuncks of code to help with the readability/group related setup code into name static c functions
		* `- (void)_buildTableColumns:(NSMutableDictionary *)savedColumnWidths withFont:(NSFont *)font`
		* `static NSString* buildTooltip(NSDictionary *columnDefinition)`
		* `static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString *nullValue, NSFont *tableFont, NSDictionary* formats, NSString *nameKey)`
		* `static NSDictionary* currentFormatters(SPTableContent *tc)`
		* `static NSDictionary* knownColumnFormatters(SPTableContent *tc)`
	* **Modified** handful of methods to allow most of the converting to go through the formatter:
		* in `- (NSArray *)currentDataResultWithNULLs:(BOOL)includeNULLs hideBLOBs:(BOOL)hide`
		* in `- (id)tableView:(SPCopyTable *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex`
		* in `- (void)tableView:(NSTableView *)tableView setObjectValue:(id)object forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex`
		* in `- (BOOL)tableView:(NSTableView *)tableView shouldEditTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex`
		* in `- (void)tableView:(SPCopyTable *)tableView willDisplayCell:(id)cell forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex`
		* in `- (BOOL)control:(NSControl *)control textShouldEndEditing:(NSText *)editor`
	* **Misc fix** I noticed column sizes weren't getting restored properly and it was due to inconsistent lookup key usage. In some cases it was using just column name, in others it was using header label which could contain the type in it. Storing the widths was using header string value so I made lookups consistent with that.
		* `- (void)autosizeColumns`
		*  `static NSNumber* savedWidthForColumn(SPTableContent* tc, NSString *colKey)`
		* `static NSString* dbHostPrefKey(SPTableContent* tc)`
* `SPFieldEditorController`
  * Added in SABaseFormatter to allow custom formatter to do validation checks. For UUID this allows user to edit the UUID manually and it converts it back to binary before sending the update into the database.
  * *Misc Change*: Nit but I cleaned up some of the show/hide code that was highly repetative through the file. So created a handful of simple methods that when one part is shown, it auto hides the others. I know it's a little out scope so happy to undo this if necessary.
* `SPCopyTable` Use Formatter to convert data before feeding into table Bundle item/runner.

## Closes following issues:
- Closes:  #348

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.4
  
## Screenshots:

## Additional notes:
* Note: Changes only apply to Content view; table in Query view not supported.