### PR TITLE
Show warning when renaming table by interacting with table list

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -1686,7 +1686,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
                                  message:[NSString stringWithFormat:NSLocalizedString(@"Do you want to rename '%@' table to '%@'?", @"rename table description"), 
                                           selectedTableName,
                                           newTableName]
-                      primaryButtonTitle:NSLocalizedString(@"Confirm", @"table structure : indexes : delete index : error 1553 : delete index and FK button")
+                      primaryButtonTitle:NSLocalizedString(@"Confirm", @"Confirmation for renaming table")
                     primaryButtonHandler:^{
       [self renameTableOfType:self->selectedTableType from:self->selectedTableName to:newTableName];
       isRenamed = YES;


### PR DESCRIPTION
## Changes:
I made it as general warning, not showing at the time of executing the query.

## Closes following issues:
- Closes: #1449

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.4
  
## Screenshots:

https://github.com/user-attachments/assets/4dc7ee69-0bc0-4661-9689-4350054bf753

## Additional notes:
