### PR TITLE
#fixed Crash Closing Field Editor on Binary Column with UUID with a format override

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -628,12 +628,11 @@ typedef enum {
 
 		if (self.displayFormatter) {
 			NSString *_Nullable err = nil;
-			BOOL isValid = [self.displayFormatter getObjectValue:nil forString:sheetEditData errorDescription:&err];
+			BOOL isValid = [self.displayFormatter getObjectValue:nil forString:[editTextView string] errorDescription:&err];
 			if (!isValid) {
 				NSBeep();
 				if (err != nil) {
 					[SPTooltip showWithObject: err];
-
 				}
 				return;
 			}
@@ -670,7 +669,7 @@ typedef enum {
 		}
     else if (self.displayFormatter) {
       id convertedDate;
-      [self.displayFormatter getObjectValue:&convertedDate forString:sheetEditData errorDescription:nil];
+      [self.displayFormatter getObjectValue:&convertedDate forString:[editTextView string] errorDescription:nil];
       returnData = convertedDate;
     }
 

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -668,9 +668,9 @@ typedef enum {
 			if(unformatted) returnData = unformatted;
 		}
     else if (self.displayFormatter) {
-      id convertedDate;
-      [self.displayFormatter getObjectValue:&convertedDate forString:[editTextView string] errorDescription:nil];
-      returnData = convertedDate;
+      id convertedData;
+      [self.displayFormatter getObjectValue:&convertedData forString:[editTextView string] errorDescription:nil];
+      returnData = convertedData;
     }
 
 		if([callerInstance respondsToSelector:@selector(processFieldEditorResult:contextInfo:)]) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Background:
When `SPFieldEditorController` is first opened (for this binary 16 with UUID override use-case) it is fed the raw binary data `NSData` but when we edit the value, notification triggers :

`- (void)textViewDidChangeSelection:(NSNotification *)notification` which was converting it to String:
```
sheetEditData = [NSString stringWithString:[editTextView string]];
```

I didn't catch this line before and in my testing for #2054 I would ALWAYS edit the value and save so the above conversion always happened and this made it appear `sheetEditData` was always an `NSString` with the UUID value I needed to convert back to binary. However,  if we open the field editor and close without editing `textViewDidChangeSelection:` is never called so I inadvertently fed the original `NSData` into the `displayFormatter` as the string it should format back from.


## Changes:
- Always use field editor string value to feed to displayFormatter to convert back to original datatype/format -- `NSData` in this case.

## Closes following issues:
- Closes: #2067

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
