### PR TITLE
Use regex to check if default value is a function

### DIFF
--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -1450,12 +1450,14 @@
       [fieldDetails setValue:@NO forKey:@"isfunction"];
       if([[detailParser unquotedString] isEqualToString:@"NULL"]) {
         [fieldDetails setObject:[NSNull null] forKey:@"default"];
-      }else {
-        // Example values: function_name(), 'function_name()', 'invalid_function_name()', etc.
+      } else {
+        // Before unquoting, try to detect if the default value is a function
+        // this help providing more details of default values to logics after having definition
         if ([detailParser isMatchedByRegex:SPFunctionNamePattern]) {
           [fieldDetails setValue:@YES forKey:@"isfunction"];
         }
         
+        // Unquote if string is quoted, otherwise do nothing
         [fieldDetails setValue:[detailParser unquotedString] forKey:@"default"];
       }
 			definitionPartsIndex++;

--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -1445,10 +1445,19 @@
 		// Field defaults
 		} else if ([detailString isEqualToString:@"DEFAULT"] && (definitionPartsIndex + 1 < partsArrayLength)) {
 			detailParser = [[SPSQLParser alloc] initWithString:[definitionParts safeObjectAtIndex:definitionPartsIndex+1]];
-			if([[detailParser unquotedString] isEqualToString:@"NULL"])
-				[fieldDetails setObject:[NSNull null] forKey:@"default"];
-			else
-				[fieldDetails setValue:[detailParser unquotedString] forKey:@"default"];
+
+      // To know if default value is a function
+      [fieldDetails setValue:@NO forKey:@"isfunction"];
+      if([[detailParser unquotedString] isEqualToString:@"NULL"]) {
+        [fieldDetails setObject:[NSNull null] forKey:@"default"];
+      }else {
+        // Example values: function_name(), 'function_name()', 'invalid_function_name()', etc.
+        if ([detailParser isMatchedByRegex:SPFunctionNamePattern]) {
+          [fieldDetails setValue:@YES forKey:@"isfunction"];
+        }
+        
+        [fieldDetails setValue:[detailParser unquotedString] forKey:@"default"];
+      }
 			definitionPartsIndex++;
 
 		// Special timestamp/datetime case - Whether fields are set to update the current timestamp

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -290,7 +290,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 									[tableDataInstance getConstraints], @"constraints",
 									nil];
 
-    SPLog(@"calling setTableDetails:%@", tableDetails);
+  SPLog(@"calling setTableDetails:%@", tableDetails);
 	[[self onMainThread] setTableDetails:tableDetails];
 
 	// Init copyTable with necessary information for copying selected rows as SQL INSERT
@@ -2597,7 +2597,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 				fieldValue = [mySQLConnection escapeAndQuoteData:rowObject];
 			} else {
 				NSString *desc = [rowObject description];
-				if (desc == defaultFieldValue || [desc isMatchedByRegex:SPCurrentTimestampPattern]) {
+				if ([[fieldDefinition objectForKey:@"isfunction"] boolValue]) {
 					fieldValue = desc;
 				} else if ([fieldTypeGroup isEqualToString:@"bit"]) {
 					fieldValue = [NSString stringWithFormat:@"b'%@'", ((![desc length] || [desc isEqualToString:@"0"]) ? @"0" : desc)];

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -673,6 +673,7 @@ extern NSString *SPSnapshotBuildIndicator;
 extern const long SPBundleCurrentVersion;
 
 extern NSString *SPCurrentTimestampPattern;
+extern NSString *SPFunctionNamePattern;
 
 typedef NS_ENUM(NSInteger, SPBundleRedirectAction) {
 	SPBundleRedirectActionNone                 = 200,

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -499,6 +499,9 @@ NSString *SPBundleShellVariableAppCallbackURL               = @"SP_APP_CALLBACK_
 #define OWS @"\\s*" /* optional whitespace */
 //                                                    CURRENT_TIMESTAMP    [            (           [n]          )    ]
 NSString *SPCurrentTimestampPattern = (@"(?i)^" OWS @"CURRENT_TIMESTAMP" @"(?:" OWS @"\\(" OWS @"(\\d*)" OWS @"\\)" @")?" OWS @"$");
+
+// Check it tests: https://regex101.com/r/RvAJfc/1
+NSString *SPFunctionNamePattern = (@"(?i)^" OWS @"\\w+" OWS @"\\(" OWS @"(\\d*|\\w+|" OWS @".*" OWS @")" OWS @"\\)" OWS @"$");
 #undef OWS
 
 // URL scheme


### PR DESCRIPTION
## Changes:
- I added a regex to check if default value could probably a function.  Please try to test more here if you want https://regex101.com/r/RvAJfc/1
- When parsing SHOW CREATE TABLE `table_name` , use the above regex to check against default value if it's a function, store that check result in a definition field
- Improve processing default value if inserting from table view by using that definition

Given here is the table schema that i would like to use for testing:

```sql
CREATE TABLE `test_with_default_values` (
  `id` bigint(10) NOT NULL AUTO_INCREMENT,
  `data_0` varchar(255) not null default 'normal text',
  `data_1` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT json_object() CHECK (json_valid(`data_1`)),
  `data_2` varchar(255) not null default 'json_object()',
  `data_3` varchar(255) not null default 'json_objecttttt()',
  `data_4` char(2) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT 'ru',
  `data_5` datetime not null default current_timestamp(),
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=20 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
```

Here are the debug logs which contain all definitions of each field.
```
-[SPTableContent deriveQueryString]:2600: rowObject: normal text, fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    comment = "";
    datacolumnindex = 1;
    default = "normal text";
    isfunction = 0;
    length = 255;
    name = "data_0";
    null = 0;
    onupdatetimestamp = 0;
    type = VARCHAR;
    typegrouping = string;
    unparsed = "";
    unsigned = 0;
    zerofill = 0;
}, default: normal text
-[SPTableContent deriveQueryString]:2600: rowObject: json_object(), fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    collation = "utf8mb4_bin";
    comment = "";
    datacolumnindex = 2;
    default = "json_object()";
    encoding = utf8mb4;
    isfunction = 1;
    name = "data_1";
    null = 1;
    onupdatetimestamp = 0;
    type = LONGTEXT;
    typegrouping = textdata;
    unparsed = " CHECK (json_valid(`data_1`))";
    unsigned = 0;
    zerofill = 0;
}, default: json_object()
-[SPTableContent deriveQueryString]:2600: rowObject: json_object(), fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    comment = "";
    datacolumnindex = 3;
    default = "json_object()";
    isfunction = 0;
    length = 255;
    name = "data_2";
    null = 0;
    onupdatetimestamp = 0;
    type = VARCHAR;
    typegrouping = string;
    unparsed = "";
    unsigned = 0;
    zerofill = 0;
}, default: json_object()
-[SPTableContent deriveQueryString]:2600: rowObject: json_objecttttt(), fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    comment = "";
    datacolumnindex = 4;
    default = "json_objecttttt()";
    isfunction = 0;
    length = 255;
    name = "data_3";
    null = 0;
    onupdatetimestamp = 0;
    type = VARCHAR;
    typegrouping = string;
    unparsed = "";
    unsigned = 0;
    zerofill = 0;
}, default: json_objecttttt()
-[SPTableContent deriveQueryString]:2600: rowObject: ru, fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    collation = "ascii_general_ci";
    comment = "";
    datacolumnindex = 5;
    default = ru;
    encoding = ascii;
    isfunction = 0;
    length = 2;
    name = "data_4";
    null = 0;
    onupdatetimestamp = 0;
    type = CHAR;
    typegrouping = string;
    unparsed = "";
    unsigned = 0;
    zerofill = 0;
}, default: ru
-[SPTableContent deriveQueryString]:2600: rowObject: current_timestamp(), fieldDefinition: {
    autoincrement = 0;
    binary = 0;
    comment = "";
    datacolumnindex = 6;
    default = "current_timestamp()";
    isfunction = 1;
    name = "data_5";
    null = 0;
    onupdatetimestamp = 0;
    type = DATETIME;
    typegrouping = date;
    unparsed = "";
    unsigned = 0;
    zerofill = 0;
}, default: current_timestamp()
```

## Closes following issues:
- Closes: #2079

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15.4

## Demo

https://github.com/user-attachments/assets/e9572853-1f23-41a4-b107-6400fc818b0f

```sql
-- Copied from table after inserting
INSERT INTO `test_with_default_values` (`id`, `data_0`, `data_1`, `data_2`, `data_3`, `data_4`, `data_5`) VALUES (NULL, 'normal text', json_object(), 'json_object()', 'json_objecttttt()', 'ru', current_timestamp());


select * from test_with_default_values;
-- Copied as SQL INSERT from table view after above selecting
INSERT INTO `test_with_default_values` (`id`, `data_0`, `data_1`, `data_2`, `data_3`, `data_4`, `data_5`)
VALUES
	('20', 'normal text', '{}', 'json_object()', 'json_objecttttt()', 'ru', '2024-09-03 06:23:50');
```
