### PR TITLE
Fixed: Unable to use CURRENT_TIMESTAMP as function's synonym

### DIFF
--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -1453,7 +1453,7 @@
       } else {
         // Before unquoting, try to detect if the default value is a function
         // this help providing more details of default values to logics after having definition
-        if ([detailParser isMatchedByRegex:SPFunctionNamePattern]) {
+        if ([detailParser isMatchedByRegex:SPFunctionNamePattern] || [detailParser isMatchedByRegex:SPCurrentTimestampPattern]) {
           [fieldDetails setValue:@YES forKey:@"isfunction"];
         }
         

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -500,7 +500,7 @@ NSString *SPBundleShellVariableAppCallbackURL               = @"SP_APP_CALLBACK_
 //                                                    CURRENT_TIMESTAMP    [            (           [n]          )    ]
 NSString *SPCurrentTimestampPattern = (@"(?i)^" OWS @"CURRENT_TIMESTAMP" @"(?:" OWS @"\\(" OWS @"(\\d*)" OWS @"\\)" @")?" OWS @"$");
 
-// Check it tests: https://regex101.com/r/RvAJfc/1
+// Function regex tests: https://regex101.com/r/IHJW5A/1
 NSString *SPFunctionNamePattern = (@"(?i)^" OWS @"\\w+" OWS @"\\(" OWS @"(\\d*|\\w+|" OWS @".*" OWS @")" OWS @"\\)" OWS @"$");
 #undef OWS
 


### PR DESCRIPTION
## Changes:
- Bring back CURRENT_TIMESTAMP, it's [what I removed in the prev change](https://github.com/Sequel-Ace/Sequel-Ace/pull/2082) as I didn't notice to handle synonym.
- Updated test cases for function regex

## Closes following issues:
- Closes: #2095 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [x] 14.x (Sonoma)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

https://github.com/user-attachments/assets/2752e80c-e704-4ce2-9f2f-ef003c6aaba7

## Additional notes:
Regarding this document https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html, it seems like Sequel Ace does not yet support some other synonyms. Modifying the current regex pattern may not be the best solution as certain logics are dependent on handling current_timestamp.