### PR TITLE
Fixed: Custom input value can't be applied if field has default value

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2597,7 +2597,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 				fieldValue = [mySQLConnection escapeAndQuoteData:rowObject];
 			} else {
 				NSString *desc = [rowObject description];
-				if ([[fieldDefinition objectForKey:@"isfunction"] boolValue]) {
+				if ([[fieldDefinition objectForKey:@"isfunction"] boolValue] && desc == defaultFieldValue) {
 					fieldValue = desc;
 				} else if ([fieldTypeGroup isEqualToString:@"bit"]) {
 					fieldValue = [NSString stringWithFormat:@"b'%@'", ((![desc length] || [desc isEqualToString:@"0"]) ? @"0" : desc)];


### PR DESCRIPTION
## Changes:
Improve the condition to verify if the input value matches the default value when the default value is a function.

Tested with this schema:
```sql
CREATE TABLE `test_with_default_values_2` (
  `id` bigint(10) NOT NULL AUTO_INCREMENT,
  `data_0` varchar(255) NOT NULL DEFAULT 'normal text',
  `data_1` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT json_object() CHECK (json_valid(`data_1`)),
  `data_2` varchar(255) NOT NULL DEFAULT 'json_object()',
  `data_3` varchar(255) NOT NULL DEFAULT 'json_objecttttt()',
  `data_4` char(2) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT 'ru',
  `data_5` datetime NOT NULL DEFAULT current_timestamp(),
  `data_6` datetime NOT NULL DEFAULT current_timestamp(),
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
```

## Closes following issues:
- Closes: #2101 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 15
  
## Screenshots:

https://github.com/user-attachments/assets/9a6a8952-1174-4c47-9af4-4de362dc6260



## Additional notes:
