### PR TITLE
#changed Guard MS App Center Calls in Try catch

### DIFF
--- a/Source/Controllers/Other/ReportExceptionApplication.m
+++ b/Source/Controllers/Other/ReportExceptionApplication.m
@@ -32,9 +32,14 @@
 
     // forward exception to MSACCrashes
     NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-    if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
-        [MSACCrashes applicationDidReportException:exception];
+    @try {
+        if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
+            [MSACCrashes applicationDidReportException:exception];
+        }
+    } @catch (NSException * e) {
+        SPLog(@"MSACAppCenter Exception on Crash Report: %@", e);
     }
+
     [super reportException:exception];
 }
 

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -194,27 +194,32 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
 
     NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-    if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
-        // Send time interval for non-critical logs
-        // must set before calling AppCenter.start
-        // 5 mins?
-        [MSACAnalytics setTransmissionInterval:60*5];
+    @try {
+        if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
+            // Send time interval for non-critical logs
+            // must set before calling AppCenter.start
+            // 5 mins?
+            [MSACAnalytics setTransmissionInterval:60*5];
 
-        // Use 30 MB for storage for logs
-        [MSACAppCenter setMaxStorageSize:(30 * 1024 * 1024) completionHandler:nil];
-        [MSACAppCenter start:@"65535bfb-1763-40fd-896b-a3aaae06227f" withServices:@[[MSACAnalytics class], [MSACCrashes class]]];
+            // Use 30 MB for storage for logs
+            [MSACAppCenter setMaxStorageSize:(30 * 1024 * 1024) completionHandler:nil];
+            [MSACAppCenter start:@"65535bfb-1763-40fd-896b-a3aaae06227f" withServices:@[[MSACAnalytics class], [MSACCrashes class]]];
 
 #ifdef DEBUG
-        // default is 5 = MSACLogLevelWarning
-        [MSACAppCenter setLogLevel:MSACLogLevelDebug];
+            // default is 5 = MSACLogLevelWarning
+            [MSACAppCenter setLogLevel:MSACLogLevelDebug];
 #endif
 
-        if(MSACAppCenter.isEnabled == YES && MSACAppCenter.isConfigured == YES){
-            SPLog(@"Started MSACAppCenter. sdkVersion: %@. defaultLogLevel: %lu", MSACAppCenter.sdkVersion, (unsigned long) MSACAppCenter.logLevel);
+            if(MSACAppCenter.isEnabled == YES && MSACAppCenter.isConfigured == YES){
+                SPLog(@"Started MSACAppCenter. sdkVersion: %@. defaultLogLevel: %lu", MSACAppCenter.sdkVersion, (unsigned long) MSACAppCenter.logLevel);
+            }
+            else{
+                SPLog(@"MSACAppCenter FAILED to start.");
+            }
         }
-        else{
-            SPLog(@"MSACAppCenter FAILED to start.");
-        }
+    }
+    @catch (NSException * e) {
+        SPLog(@"MSACAppCenter Exception on Init: %@", e);
     }
 
 

--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -192,10 +192,18 @@ static CGFloat slow_in_out (CGFloat t)
         
         if(errorDict.count > 0){
             NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-            if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
-                executeOnBackgroundThread(^{
-                    [MSACAnalytics trackEvent:@"error" withProperties:errorDict];
-                });
+            @try {
+                if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
+                    executeOnBackgroundThread(^{
+                        @try {
+                            [MSACAnalytics trackEvent:@"error" withProperties:errorDict];
+                        } @catch (NSException * e) {
+                            SPLog(@"MSACAppCenter Exception on trackEvent Report callback: %@", e);
+                        }
+                    });
+                }
+            } @catch (NSException * e) {
+                SPLog(@"MSACAppCenter Exception on trackEvent Report: %@", e);
             }
         }
 

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -539,9 +539,13 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 	} // end of column loop
 
     if(errorDict.count > 0){
-        SPLog(@"autoIncrement error");        
-        if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
-            [MSACAnalytics trackEvent:@"error" withProperties:errorDict];
+        SPLog(@"autoIncrement error");
+        @try {
+            if ([prefs boolForKey:SPSaveApplicationUsageAnalytics]) {
+                [MSACAnalytics trackEvent:@"error" withProperties:errorDict];
+            }
+        } @catch (NSException * e) {
+            SPLog(@"MSACAppCenter Exception on trackEvent Report: %@", e);
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->
Suggest reviewing this one with whitespace diffs ignored

## Changes:
- Noticed some intermittent Xcode crash reports around MS App Center. Guarding the calls to make these non-required should be safe and mitigate those crashes

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
