### PR TITLE
Fixed: Improve detecting default value by considering quote characters

### DIFF
--- a/Source/Controllers/DataControllers/SPTableData.m
+++ b/Source/Controllers/DataControllers/SPTableData.m
@@ -1445,18 +1445,14 @@
 		// Field defaults
 		} else if ([detailString isEqualToString:@"DEFAULT"] && (definitionPartsIndex + 1 < partsArrayLength)) {
 			detailParser = [[SPSQLParser alloc] initWithString:[definitionParts safeObjectAtIndex:definitionPartsIndex+1]];
-
-      // To know if default value is a function
-      [fieldDetails setValue:@NO forKey:@"isfunction"];
+      
+      // If field default is not a quoted string, then it's a function/expression
+      Boolean isQuotedString = [detailParser isQuotedString];
+      [fieldDetails setValue:@(!isQuotedString) forKey:@"isfunction"];
+      
       if([[detailParser unquotedString] isEqualToString:@"NULL"]) {
         [fieldDetails setObject:[NSNull null] forKey:@"default"];
       } else {
-        // Before unquoting, try to detect if the default value is a function
-        // this help providing more details of default values to logics after having definition
-        if ([detailParser isMatchedByRegex:SPFunctionNamePattern] || [detailParser isMatchedByRegex:SPCurrentTimestampPattern]) {
-          [fieldDetails setValue:@YES forKey:@"isfunction"];
-        }
-        
         // Unquote if string is quoted, otherwise do nothing
         [fieldDetails setValue:[detailParser unquotedString] forKey:@"default"];
       }

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -673,7 +673,6 @@ extern NSString *SPSnapshotBuildIndicator;
 extern const long SPBundleCurrentVersion;
 
 extern NSString *SPCurrentTimestampPattern;
-extern NSString *SPFunctionNamePattern;
 
 typedef NS_ENUM(NSInteger, SPBundleRedirectAction) {
 	SPBundleRedirectActionNone                 = 200,

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -500,10 +500,6 @@ NSString *SPBundleShellVariableAppCallbackURL               = @"SP_APP_CALLBACK_
 //                                                    CURRENT_TIMESTAMP    [            (           [n]          )    ]
 NSString *SPCurrentTimestampPattern = (@"(?i)^" OWS @"CURRENT_TIMESTAMP" @"(?:" OWS @"\\(" OWS @"(\\d*)" OWS @"\\)" @")?" OWS @"$");
 
-// Function regex tests: https://regex101.com/r/IHJW5A/1
-NSString *SPFunctionNamePattern = (@"(?i)^" OWS @"\\w+" OWS @"\\(" OWS @"(\\d*|\\w+|" OWS @".*" OWS @")" OWS @"\\)" OWS @"$");
-#undef OWS
-
 // URL scheme
 NSString *SPURLSchemeQueryInputPathHeader          = @"~/tmp/SP_QUERY_";
 NSString *SPURLSchemeQueryResultPathHeader         = @"~/tmp/SP_QUERY_RESULT_";

--- a/Source/Other/Parsing/SPSQLParser.h
+++ b/Source/Other/Parsing/SPSQLParser.h
@@ -117,6 +117,11 @@ typedef enum {
 - (void) deleteComments;
 
 /**
+ * To check if start/end characters are similar quote characters
+ */
+- (BOOL) isQuotedString;
+
+/**
  * Removes quotes surrounding the string if present, and un-escapes internal occurrences of the quote character,
  * before returning the resulting string.
  * If no quotes surround the current string, return the entire string; if the current string contains several

--- a/Source/Other/Parsing/SPSQLParser.m
+++ b/Source/Other/Parsing/SPSQLParser.m
@@ -170,6 +170,23 @@
 	}
 }
 
+- (BOOL) isQuotedString
+{
+  // If the first character is not a quote character, return the entire string.
+  unichar quoteCharacter = CFStringGetCharacterAtIndex((CFStringRef)string, 0);
+  if (quoteCharacter != CHAR_BTICK && quoteCharacter != CHAR_DQUOTE && quoteCharacter != CHAR_SQUOTE) {
+    return FALSE;
+  }
+  
+  // Get the end of the string
+  NSUInteger stringEndIndex = [self endIndexOfStringQuotedByCharacter:quoteCharacter startingAtIndex:1];
+  if (stringEndIndex == NSNotFound) {
+    return FALSE;
+  }
+  
+  return TRUE;
+}
+
 /**
  * Removes quotes surrounding the string if present, and un-escapes internal occurrences of the quote character before returning.
  */


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Revise the logic of detecting default value type by checking quote characters instead of using regex.

Just learned from the issue #2103 that MySQL actually keeps the parentheses if default value is `(curdate())` but MariaDB will transform it to `curdate()`. Because of that, then I considered using regex is not an optimal way anymore for detecting if default value is a function or a string value as default value could be done in many of string forms.

I used this schema for testing on MySQL 9 and MariaDB 11:

```sql
CREATE TABLE `test_with_default_values_4` (
  `id` bigint(10) NOT NULL AUTO_INCREMENT,
  `data_0` varchar(255) NOT NULL DEFAULT 'normal text',
  `data_2` varchar(255) NOT NULL DEFAULT 'json_object()',
  `data_3` varchar(255) NOT NULL DEFAULT 'json_objecttttt()',
  `data_4` char(2) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT 'ru',
  `data_5` datetime NOT NULL DEFAULT current_timestamp(),
  `data_6` datetime NOT NULL DEFAULT current_timestamp(),
  `data_8` date NOT NULL DEFAULT (curdate()),
  PRIMARY KEY (`id`)
);
```

## Closes following issues:
- Closes: #2103

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

on MySQL

https://github.com/user-attachments/assets/fefbb47b-2f34-431c-b606-fcb84d4ab519


on MariaDB

https://github.com/user-attachments/assets/8bda8d87-c59c-41f4-b548-8cee8482a420


## Additional notes: