### PR TITLE
Fix: Escaping textdata/string for binary data when exporting to SQL

### DIFF
--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -517,6 +517,7 @@
                         for (NSUInteger t = 0; t < colCountRetained; t++)
                         {
                             id object = [row safeObjectAtIndex:t];
+                          	NSDictionary *fieldDetails = [[tableDetails safeObjectForKey:@"columns"] safeObjectAtIndex:t];
 
                             // Add NULL values directly to the output row; use a pointer comparison to the singleton
                             // instance for speed.
@@ -530,7 +531,7 @@
                             }
 
                             // If the field is of type BIT, the values need a binary prefix of b'x'.
-                            else if ([[[[tableDetails safeObjectForKey:@"columns"] safeObjectAtIndex:t] safeObjectForKey:@"type"] isEqualToString:@"BIT"]) {
+                            else if ([[fieldDetails safeObjectForKey:@"type"] isEqualToString:@"BIT"]) {
                                 [sqlString appendFormat:@"b'%@'", [object description]];
                             }
 
@@ -559,11 +560,17 @@
                                     NSString *data = [[NSString alloc] initWithData:object encoding:[self exportOutputEncoding]];
 
                                     if (data == nil) {
-#warning This can corrupt data! Check if this case ever happens and if so, export as hex-string
-                                        data = [[NSString alloc] initWithData:object encoding:NSASCIIStringEncoding];
+                                    // warning This can corrupt data! Check if this case ever happens and if so, export as hex-string
+                                      data = [[NSString alloc] initWithData:object encoding:NSASCIIStringEncoding];
                                     }
-
-                                    [sqlString appendFormat:@"'%@'", data];
+                                  
+                                    NSString *fieldTypeGroup = [fieldDetails objectForKey:@"typegrouping"];
+                                  	if ([fieldTypeGroup isEqualToString:@"textdata"] || [fieldTypeGroup isEqualToString:@"string"]) {
+                                      [sqlString appendStringOrNil:[connection escapeAndQuoteString:data]];
+                                    } else {
+                                      // it's possible that the fieldType could eq to blob
+                                      [sqlString appendFormat:@"'%@'", data];
+                                    }
                                 }
                             }
 


### PR DESCRIPTION


## Changes:
- Apply escaping string in case the field has COLLATE = binary type and field type is one of CHAR, VARCHAR, *TEXT types, JSON.


Test data: 
```sql
CREATE TABLE `crop_entries` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `form_id` bigint(20) unsigned NOT NULL,
  `policy_type` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `share_farmers_insured` tinyint(1) DEFAULT NULL,
  `all_properties_insured` tinyint(1) DEFAULT NULL,
  `suffered_damage` tinyint(1) DEFAULT NULL,
  `reducing_excess_default` tinyint(1) DEFAULT '0',
  `comments` text COLLATE utf8mb4_unicode_ci,
  `crop_failure_notes` text COLLATE utf8mb4_unicode_ci,
  `insurance_history` tinyint(1) NOT NULL DEFAULT '0',
  `insurance_history_notes` longtext COLLATE utf8mb4_unicode_ci,
  `street_address` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `city` varchar(60) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `state` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `postcode` varchar(10) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `shire` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `completed_by_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `data_cache` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
  `agworld_cache` longtext COLLATE utf8mb4_unicode_ci,
  `created_at` timestamp NULL DEFAULT NULL,
  `updated_at` timestamp NULL DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=2574 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

INSERT INTO `crop_entries_example` (`id`, `form_id`, `policy_type`, `share_farmers_insured`, `all_properties_insured`, `suffered_damage`, `reducing_excess_default`, `comments`, `crop_failure_notes`, `insurance_history`, `insurance_history_notes`, `street_address`, `city`, `state`, `postcode`, `shire`, `completed_by_name`, `data_cache`, `agworld_cache`, `created_at`, `updated_at`)
VALUES
	('1651', '1829', 'pre-harvest', NULL, '1', '0', '0', 'nil', 'lack of rain', '0', NULL, 'REDACTED', 'REDACTED', 'SA', '5000', '', 'REDACTED', '{ \"cropSelected\": [ { \"barley\": true, \"wheat\": true, \"oats\": true }, { \"barley\": true }, { \"barley\": true }, { \"barley\": true } ], \"cropDefaultValue\": [ { \"barley\": \"0\", \"wheat\": \"0\", \"oats\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" } ], \"cropDefaultYield\": [ { \"barley\": \"0\", \"wheat\": \"0\", \"oats\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" } ], \"cropDefaultReducingExcess\": [ { \"barley\": false, \"wheat\": false, \"oats\": false }, { \"barley\": false }, { \"barley\": false }, { \"barley\": false } ], \"cropDefaultExcess\": [ { \"barley\": 5, \"wheat\": 5, \"oats\": 5 }, { \"barley\": 5 }, { \"barley\": 5 }, { \"barley\": 5 } ], \"fields\": [ { \"0\": { \"name\": \"FOX\'S MULBERRY\", \"crop_type\": \"barley\", \"area\": 36, \"cover_type\": \"\", \"insured_yield\": \"0\", \"insured_value\": \"0\", \"fire_cover\": true, \"hail_cover\": false, \"interest\": \"\", \"excess\": \"0\", \"reducing_excess\": false, \"share_farmer_name\": \"\", \"share_farmer_insurer\": \"\", \"share_farmer_agreement\": \"\", \"boundary\": \"\" } } ], \"properties\": [ { \"name\": \"REDACTED\", \"shire\": \"Fergusson - SA\", \"latitude\": \"\", \"longitude\": \"\", \"area\": 1411, \"expected_shire\": \"FERGUSSON - SA\" } ] }', NULL, '2024-09-17 13:52:26', '2024-10-10 14:58:47');
```

Exported data after fixing:
```sql
# ************************************************************
# Sequel Ace SQL dump
# Version 20076
#
# https://sequel-ace.com/
# https://github.com/Sequel-Ace/Sequel-Ace
#
# Host: 127.0.0.1 (MySQL 11.0.2-MariaDB-1:11.0.2+maria~ubu2204)
# Database: [REDACTED]
# Generation Time: 2024-10-19 13:57:57 +0000
# ************************************************************


/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
SET NAMES utf8mb4;
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
/*!40101 SET @OLD_SQL_MODE='NO_AUTO_VALUE_ON_ZERO', SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;


# Dump of table crop_entries
# ------------------------------------------------------------

DROP TABLE IF EXISTS `crop_entries`;

CREATE TABLE `crop_entries` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `form_id` bigint(20) unsigned NOT NULL,
  `policy_type` varchar(20) DEFAULT NULL,
  `share_farmers_insured` tinyint(1) DEFAULT NULL,
  `all_properties_insured` tinyint(1) DEFAULT NULL,
  `suffered_damage` tinyint(1) DEFAULT NULL,
  `reducing_excess_default` tinyint(1) DEFAULT 0,
  `comments` text DEFAULT NULL,
  `crop_failure_notes` text DEFAULT NULL,
  `insurance_history` tinyint(1) NOT NULL DEFAULT 0,
  `insurance_history_notes` longtext DEFAULT NULL,
  `street_address` varchar(100) DEFAULT NULL,
  `city` varchar(60) DEFAULT NULL,
  `state` varchar(20) DEFAULT NULL,
  `postcode` varchar(10) DEFAULT NULL,
  `shire` varchar(50) DEFAULT NULL,
  `completed_by_name` varchar(255) DEFAULT NULL,
  `data_cache` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
  `agworld_cache` longtext DEFAULT NULL,
  `created_at` timestamp NULL DEFAULT NULL,
  `updated_at` timestamp NULL DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

LOCK TABLES `crop_entries` WRITE;
/*!40000 ALTER TABLE `crop_entries` DISABLE KEYS */;

INSERT INTO `crop_entries` (`id`, `form_id`, `policy_type`, `share_farmers_insured`, `all_properties_insured`, `suffered_damage`, `reducing_excess_default`, `comments`, `crop_failure_notes`, `insurance_history`, `insurance_history_notes`, `street_address`, `city`, `state`, `postcode`, `shire`, `completed_by_name`, `data_cache`, `agworld_cache`, `created_at`, `updated_at`)
VALUES
	(1651,1829,'pre-harvest',NULL,1,0,0,'nil','lack of rain',0,NULL,'REDACTED','REDACTED','SA','5000','','REDACTED','{ \"cropSelected\": [ { \"barley\": true, \"wheat\": true, \"oats\": true }, { \"barley\": true }, { \"barley\": true }, { \"barley\": true } ], \"cropDefaultValue\": [ { \"barley\": \"0\", \"wheat\": \"0\", \"oats\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" } ], \"cropDefaultYield\": [ { \"barley\": \"0\", \"wheat\": \"0\", \"oats\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" }, { \"barley\": \"0\" } ], \"cropDefaultReducingExcess\": [ { \"barley\": false, \"wheat\": false, \"oats\": false }, { \"barley\": false }, { \"barley\": false }, { \"barley\": false } ], \"cropDefaultExcess\": [ { \"barley\": 5, \"wheat\": 5, \"oats\": 5 }, { \"barley\": 5 }, { \"barley\": 5 }, { \"barley\": 5 } ], \"fields\": [ { \"0\": { \"name\": \"FOX\'S MULBERRY\", \"crop_type\": \"barley\", \"area\": 36, \"cover_type\": \"\", \"insured_yield\": \"0\", \"insured_value\": \"0\", \"fire_cover\": true, \"hail_cover\": false, \"interest\": \"\", \"excess\": \"0\", \"reducing_excess\": false, \"share_farmer_name\": \"\", \"share_farmer_insurer\": \"\", \"share_farmer_agreement\": \"\", \"boundary\": \"\" } } ], \"properties\": [ { \"name\": \"REDACTED\", \"shire\": \"Fergusson - SA\", \"latitude\": \"\", \"longitude\": \"\", \"area\": 1411, \"expected_shire\": \"FERGUSSON - SA\" } ] }',NULL,'2024-09-17 13:52:26','2024-10-10 14:58:47');

/*!40000 ALTER TABLE `crop_entries` ENABLE KEYS */;
UNLOCK TABLES;



/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
```

## Closes following issues:
Closes: 
- #1956 
- #2116

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.0
  
## Screenshots:



## Additional notes:
