### PR TITLE
fix: MySQL filter #2153

### DIFF
--- a/Source/Controllers/SubviewControllers/SPProcessListController.m
+++ b/Source/Controllers/SubviewControllers/SPProcessListController.m
@@ -683,6 +683,8 @@ static NSString * const SPKillIdKey   = @"SPKillId";
 	// Perform filtering
 	for (NSDictionary *process in processes) 
 	{
+    BOOL isProcessColumnHidden = [processListTableView tableColumnWithIdentifier:SPTableViewProgressColumnIdentifier].isHidden;
+    
 		if (([[[process objectForKey:@"Id"] stringValue] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound) ||
 			([[process objectForKey:@"User"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound) ||
 			([[process objectForKey:@"Host"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound) ||
@@ -691,7 +693,7 @@ static NSString * const SPKillIdKey   = @"SPKillId";
 			((![[process objectForKey:@"Time"] isNSNull]) && ([[[process objectForKey:@"Time"] stringValue] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound)) ||
 			((![[process objectForKey:@"State"] isNSNull]) && ([[process objectForKey:@"State"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound)) ||
 			((![[process objectForKey:@"Info"] isNSNull]) && ([[process objectForKey:@"Info"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound)) ||
-      ((![[process objectForKey:@"Progress"] isNSNull]) && ([[process objectForKey:@"Progress"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound)))
+      (!isProcessColumnHidden && (![[process objectForKey:@"Progress"] isNSNull]) && ([[process objectForKey:@"Progress"] rangeOfString:filterString options:NSCaseInsensitiveSearch].location != NSNotFound)))
 		{
 			[processesFiltered addObject:process];
 		}


### PR DESCRIPTION
The system only applies filtering to the Process column when displayed and the database is MariaDB. 
It means filtering is definitely broken on MySQL because MySQL doesn't support Process column. 

## Changes:
- Check if Process column is hidden on filtering logic.

## Closes following issues:
- Closes: #2153 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 10.13.x (High Sierra)
  - [ ] 10.14.x (Mojave)
  - [ ] 10.15.x (Catalina)
  - [ ] 11.x (Big Sur)
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.2
  
## Screenshots:

https://github.com/user-attachments/assets/346f399e-da58-45ef-93ee-02215584d594

## Additional notes:

The initial PR that caused the problem can be found at: https://github.com/Sequel-Ace/Sequel-Ace/pull/2085. Actually @Jason-Morcos has mentioned that as a code review comment but I believe I have resolved that comment by mistake. Sorry about that.