### PR TITLE
fix: Crash on MariaDB >= 11.3 caused by a new db privilege

### DIFF
--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -108,7 +108,8 @@ static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 			@"repl_slave_priv":          @"replication_slave_priv",
 			@"repl_client_priv":         @"replication_client_priv",
 			@"truncate_versioning_priv": @"delete_versioning_rows_priv", // MariaDB only, 10.3.4 only
-			@"delete_history_priv":      @"delete_versioning_rows_priv", // MariaDB only, since 10.3.5
+			@"delete_history_priv":      @"delete_versioning_rows_priv", // MariaDB only, since 10.3.5,
+			@"show_create_routine_priv": @"show_create_routine_priv", // MariaDB only, since 11.3.1, see more: https://jira.mariadb.org/browse/MDEV-29167
 		};
 	
         schemas = [[NSMutableArray alloc] init];

--- a/Source/Model/CoreData/SPUserManager.xcdatamodel/contents
+++ b/Source/Model/CoreData/SPUserManager.xcdatamodel/contents
@@ -22,6 +22,7 @@
         <attribute name="show_view_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="trigger_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="update_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="show_create_routine_priv" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="userManager" optional="YES" transient="YES" syncable="YES"/>
         <relationship name="user" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="SPUser" inverseName="schema_privileges" inverseEntity="SPUser" indexed="YES" syncable="YES"/>
     </entity>


### PR DESCRIPTION
## Changes:
- On MariaDB >= 11.3.1, it has a new privilege https://jira.mariadb.org/browse/MDEV-29167, so Sequel-Ace should support that.

## Closes following issues:
- Closes: #2141 and #1972

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

See the new privilege in this screenshot:
![image](https://github.com/user-attachments/assets/02e5817c-b553-4f4d-8583-b9628cb68323)

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user permission management by adding support for an additional privilege related to routine operations.
	- Updated the permissions mapping to align with newer database capabilities, ensuring improved and more granular access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->