### PR TITLE
fix: Keep original order of table list

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -284,9 +284,6 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 			}
 		}
 
-		// Reorder the tables in alphabetical order
-		[tables sortArrayUsingSelector:@selector(localizedCompare:) withPairedMutableArrays:tableTypes, nil];
-
 		/* Grab the procedures and functions
 		 *
 		 * Using information_schema gives us more info (for information window perhaps?) but breaks


### PR DESCRIPTION
## Changes:
- Fix: Show table list with its original order.

## Closes following issues:
- Closes: #2138 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

After fix:
![image](https://github.com/user-attachments/assets/d8d97a06-1980-4ad9-b553-ab6682acb62a)

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the table list display in the app. Tables are now shown in the order they are retrieved, instead of being sorted alphabetically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->