### PR TITLE
fix: unexpected blue line on bottom of cell

### DIFF
--- a/Source/Views/Cells/SPTextAndLinkCell.m
+++ b/Source/Views/Cells/SPTextAndLinkCell.m
@@ -122,7 +122,7 @@ static inline NSRect SPTextLinkRectFromCellRect(NSRect inRect)
 
 	// Fast case for no arrow
 	if (!hasLink || !linkActive) {
-        NSRect textRect = NSMakeRect(aRect.origin.x, aRect.origin.y + 2.0f, aRect.size.width, aRect.size.height);
+		NSRect textRect = NSMakeRect(aRect.origin.x, aRect.origin.y + 2.0f, aRect.size.width, aRect.size.height - 2.0f);
 		[super drawInteriorWithFrame:textRect inView:controlView];
 		return;
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Adjust height of the cell as y-coordinate point has been moved upward.

## Closes following issues:
- Closes: #2194 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.3
  
## Screenshots:

I use arrow keys up/down in this demo

https://github.com/user-attachments/assets/ceb2b594-50b3-4188-9181-f855f03995db



## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the vertical alignment of text in cells when links are inactive, resulting in a cleaner and more refined visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->