### PR TITLE
#fixed Beep-on-application-start - cleanup delete logic

### DIFF
--- a/Source/Controllers/Other/SPBundleManager.m
+++ b/Source/Controllers/Other/SPBundleManager.m
@@ -184,7 +184,6 @@ static SPBundleManager *sharedManager = nil;
 
 #pragma mark - legacy bundle rename
 - (void)renameLegacyBundles{
-
 	SPLog(@"renameLegacyBundles");
 
 	// if we find any legacy bundles we'll need to change the dict, so take a copy
@@ -192,7 +191,6 @@ static SPBundleManager *sharedManager = nil;
 
 	[bundleItemsCopy enumerateKeysAndObjectsUsingBlock:^(NSString *scope, NSArray *bundles, BOOL *stop1) {
 		[bundles enumerateObjectsUsingBlock:^(id bundle, NSUInteger idx, BOOL *stop){
-
 			NSString *path = bundle[SPBundleInternPathToFileKey];
             if (![path containsString:SPUserBundleFileExtension]) {
                 // Already migrated
@@ -203,45 +201,42 @@ static SPBundleManager *sharedManager = nil;
             SPLog(@"obj2 = %@",bundle);
 
             NSString *legacyPath = path.stringByDeletingLastPathComponent;
+            NSString *legacyBundleName = [legacyPath lastPathComponent];
 
-            NSMutableString *migratedPath = [[NSMutableString alloc] initWithCapacity:path.stringByDeletingLastPathComponent.length];
-            [migratedPath setString:[path.stringByDeletingLastPathComponent dropSuffixWithSuffix:SPUserBundleFileExtension]];
-            [migratedPath appendString:SPUserBundleFileExtensionV2];
-            NSString *bundlePath = migratedPath.lastPathComponent;
-
-            SPLog(@"migratedPath %@", migratedPath);
-            SPLog(@"legacyPath %@", legacyPath);
-            SPLog(@"bundlePath %@", bundlePath);
-
-            NSError *error = nil;
-
+            // Check if a migrated version already exists
+            NSString *migratedPath = [legacyPath stringByAppendingString:@"_"];
             if ([fileManager fileExistsAtPath:migratedPath isDirectory:nil]) {
-                SPLog(@"File exists at path: %@", migratedPath);
+                SPLog(@"Migrated version already exists at path: %@", migratedPath);
+                // Remove the old legacy bundle since we already have a migrated version
+                NSError *removeError = nil;
+                if (![fileManager removeItemAtPath:legacyPath error:&removeError]) {
+                    SPLog(@"Could not remove legacy bundle at %@. Error: %@", legacyPath, removeError.localizedDescription);
+                    [self doOrDoNotBeep:legacyPath];
+                }
                 return;
             }
             
-            SPLog(@"File DOES NOT YET exist at “%@”", migratedPath);
+            SPLog(@"Migrating bundle from %@ to %@", legacyPath, migratedPath);
 
+            NSError *error = nil;
             if (![fileManager moveItemAtPath:legacyPath toPath:migratedPath error:&error]) {
-                SPLog(@"Could not move “%@” to %@. Error: %@", legacyPath, migratedPath, error.localizedDescription);
+                SPLog(@"Could not move %@ to %@. Error: %@", legacyPath, migratedPath, error.localizedDescription);
                 [self doOrDoNotBeep:legacyPath];
                 return;
             }
-            SPLog(@"File renamed successfully “%@”", migratedPath);
+            SPLog(@"Bundle migrated successfully to %@", migratedPath);
             
             [migratedLegacyBundles safeAddObject:migratedPath];
 
-            // we need to add the new bundle version
+            // Verify the migrated bundle
             NSString *infoPath = [NSString stringWithFormat:@"%@/%@", migratedPath, SPBundleFileName];
             NSError *readError = nil;
-            SPLog(@"infoPath %@", infoPath);
             NSDictionary *cmdData = [SPBundleManager.shared loadBundleAt:infoPath error:&readError];
             
             if(!cmdData || readError) {
-                SPLog(@"“%@” file couldn't be read. (error=%@)", infoPath, readError.localizedDescription);
+                SPLog(@"Migrated bundle %@ is invalid. Error: %@", infoPath, readError.localizedDescription);
                 [self doOrDoNotBeep:infoPath];
-
-                // remove the dodgy bundle
+                // Clean up the invalid migrated bundle
                 [self removeBundle:migratedPath.lastPathComponent];
                 return;
             }
@@ -539,7 +534,7 @@ static SPBundleManager *sharedManager = nil;
 									BOOL isDir;
 									NSString *newInfoPath = [NSString stringWithFormat:@"%@/%@/%@", [bundlePaths objectAtIndex:0], bundle, SPBundleFileName];
 									NSString *orgPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:1], bundle];
-									NSString *newPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:0], bundle];
+									NSString *newPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectForKey:0], bundle];
 									if([fileManager fileExistsAtPath:newPath isDirectory:&isDir] && isDir)
 										newPath = [NSString stringWithFormat:@"%@_%ld", newPath, (long)(random() % 35000)];
 									error = nil;

--- a/Source/Controllers/Other/SPBundleManager.m
+++ b/Source/Controllers/Other/SPBundleManager.m
@@ -534,7 +534,7 @@ static SPBundleManager *sharedManager = nil;
 									BOOL isDir;
 									NSString *newInfoPath = [NSString stringWithFormat:@"%@/%@/%@", [bundlePaths objectAtIndex:0], bundle, SPBundleFileName];
 									NSString *orgPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:1], bundle];
-									NSString *newPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectForKey:0], bundle];
+									NSString *newPath = [NSString stringWithFormat:@"%@/%@", [bundlePaths objectAtIndex:0], bundle];
 									if([fileManager fileExistsAtPath:newPath isDirectory:&isDir] && isDir)
 										newPath = [NSString stringWithFormat:@"%@_%ld", newPath, (long)(random() % 35000)];
 									error = nil;

--- a/Source/Controllers/Other/SPBundleManager.m
+++ b/Source/Controllers/Other/SPBundleManager.m
@@ -201,10 +201,19 @@ static SPBundleManager *sharedManager = nil;
             SPLog(@"obj2 = %@",bundle);
 
             NSString *legacyPath = path.stringByDeletingLastPathComponent;
-            NSString *legacyBundleName = [legacyPath lastPathComponent];
+
+            NSMutableString *migratedPath = [[NSMutableString alloc] initWithCapacity:path.stringByDeletingLastPathComponent.length];
+            [migratedPath setString:[path.stringByDeletingLastPathComponent dropSuffixWithSuffix:SPUserBundleFileExtension]];
+            [migratedPath appendString:SPUserBundleFileExtensionV2];
+            NSString *bundlePath = migratedPath.lastPathComponent;
+
+            SPLog(@"migratedPath %@", migratedPath);
+            SPLog(@"legacyPath %@", legacyPath);
+            SPLog(@"bundlePath %@", bundlePath);
+
+            NSError *error = nil;
 
             // Check if a migrated version already exists
-            NSString *migratedPath = [legacyPath stringByAppendingString:@"_"];
             if ([fileManager fileExistsAtPath:migratedPath isDirectory:nil]) {
                 SPLog(@"Migrated version already exists at path: %@", migratedPath);
                 // Remove the old legacy bundle since we already have a migrated version
@@ -218,13 +227,12 @@ static SPBundleManager *sharedManager = nil;
             
             SPLog(@"Migrating bundle from %@ to %@", legacyPath, migratedPath);
 
-            NSError *error = nil;
             if (![fileManager moveItemAtPath:legacyPath toPath:migratedPath error:&error]) {
-                SPLog(@"Could not move %@ to %@. Error: %@", legacyPath, migratedPath, error.localizedDescription);
+                SPLog(@"Could not move “%@” to %@. Error: %@", legacyPath, migratedPath, error.localizedDescription);
                 [self doOrDoNotBeep:legacyPath];
                 return;
             }
-            SPLog(@"Bundle migrated successfully to %@", migratedPath);
+            SPLog(@"Bundle migrated successfully to “%@”", migratedPath);
             
             [migratedLegacyBundles safeAddObject:migratedPath];
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Make bundle migration actually delete the source bundle

## Closes following issues:
- Closes: #2173

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the migration process for legacy content to ensure existing updates are checked and outdated versions are properly handled.
  - Improved error notifications and logging to provide clearer feedback during the migration, including alerts when removal attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->