### PR TITLE
#Fixes Delete row fails for tables w/ UUID type primary key

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2905,8 +2905,20 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 			// BLOB/TEXT data
 			else if ([tempValue isKindOfClass:[NSData class]]) {
         if ([fieldType isEqualToString:@"UUID"] && [fieldTypeGroup isEqualToString:@"blobdata"]) {
-          NSString *uuidVal = [[NSString alloc] initWithData:tempValue encoding:NSUTF8StringEncoding];
-          escVal = [mySQLConnection escapeAndQuoteString:uuidVal];
+          // Convert UUID binary data to a proper MySQL UUID string format
+          NSMutableString *uuidString = [NSMutableString string];
+          const unsigned char *bytes = [tempValue bytes];
+          NSUInteger length = [tempValue length];
+          
+          // Format UUID as a string in the format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          for (NSUInteger i = 0; i < length; i++) {
+            if (i == 4 || i == 6 || i == 8 || i == 10) {
+              [uuidString appendString:@"-"];
+            }
+            [uuidString appendFormat:@"%02x", bytes[i]];
+          }
+          
+          escVal = [mySQLConnection escapeAndQuoteString:uuidString];
         } else {
           escVal = [mySQLConnection escapeAndQuoteData:tempValue];
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- 

## Closes following issues:
- Closes: #2211

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
