### PR TITLE
#fixed Fix Enum Alignment in Content View

### DIFF
--- a/Source/Views/Cells/SPComboBoxCell.m
+++ b/Source/Views/Cells/SPComboBoxCell.m
@@ -136,23 +136,9 @@ static NSString *_CellWillDismissNotification = @"NSComboBoxCellWillDismissNotif
  */
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-    // Calculate the vertical center offset based on the cell height and font metrics
-    CGFloat cellHeight = cellFrame.size.height;
-    CGFloat fontHeight = [self.font boundingRectForFont].size.height;
-    
-    // For ENUM cells, we need to account for the popup button width
-    CGFloat buttonWidth = 0;
-    if ([self isKindOfClass:[SPComboBoxCell class]]) {
-        buttonWidth = 16.0; // Standard width for the popup button
-    }
-    
-    // Create a new frame that centers the content vertically and accounts for the button
-    NSRect contentFrame = NSMakeRect(cellFrame.origin.x, 
-                                    cellFrame.origin.y + (cellHeight - fontHeight) / 2.0,
-                                    cellFrame.size.width - buttonWidth, 
-                                    fontHeight);
-    
-    [super drawInteriorWithFrame:contentFrame inView:controlView];
+    //Weird offset hack to fix enums and structure view ComboBoxCell labels from floating up or down randomly
+    [super drawInteriorWithFrame:NSMakeRect(cellFrame.origin.x, cellFrame.origin.y + (self.font.pointSize-13.0) / 2.0, cellFrame.size.width, cellFrame.size.height) inView:controlView];
+
 }
 
 @end

--- a/Source/Views/Cells/SPComboBoxCell.m
+++ b/Source/Views/Cells/SPComboBoxCell.m
@@ -136,9 +136,9 @@ static NSString *_CellWillDismissNotification = @"NSComboBoxCellWillDismissNotif
  */
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-    //Weird offset hack to fix enums and structure view ComboBoxCell labels from floating up or down randomly
-    [super drawInteriorWithFrame:NSMakeRect(cellFrame.origin.x, cellFrame.origin.y + (self.font.pointSize-13.0) / 2.0, cellFrame.size.width, cellFrame.size.height) inView:controlView];
-
+	// Center the content vertically in the cell
+	CGFloat verticalOffset = (cellFrame.size.height - [self.font boundingRectForFont].size.height) / 2.0;
+	[super drawInteriorWithFrame:NSMakeRect(cellFrame.origin.x, cellFrame.origin.y + verticalOffset, cellFrame.size.width, cellFrame.size.height) inView:controlView];
 }
 
 @end


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Take Two! @nexbridge FYI

## Closes following issues:
- Closes: #2201 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the visual alignment of content in combo box cells by vertically centering it within the cell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->