### PR TITLE
#fixed a bug that caused table content to be mangled after completing an automatic resize

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4346,10 +4346,8 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		[prefs setObject:[NSDictionary dictionaryWithDictionary:savedWidths] forKey:SPTableColumnWidths];
 	}
 
-	// Return the width, while the delegate is empty to prevent column resize notifications
-	[tableContentView setDelegate:nil];
-	[tableContentView performSelector:@selector(setDelegate:) withObject:self afterDelay:0.1];
-
+	// Instead of removing the delegate, we'll just return the width
+	// This preserves the text coloring state during column resizing
 	return targetWidth;
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Don't remove the delegate during column resize

## Closes following issues:
- Closes: #2215

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved column resizing in tables to preserve text coloring and prevent temporary loss of formatting during adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->