### PR TITLE
#changed Font handling improvements

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3734,6 +3734,16 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 			[tableContentView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
 			[tableContentView setFont:tableFont];
+			
+			// Update header cells
+			for (NSTableColumn *column in [tableContentView tableColumns]) {
+				if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
+					[[column headerCell] setAttributedStringValue:[[dataColumns objectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString]];
+				} else {
+					[[column headerCell] setFont:tableFont];
+				}
+			}
+			
 			[tableContentView reloadData];
 		}
 		// Display binary data as Hex

--- a/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
@@ -88,12 +88,34 @@ static NSString *SPDatabaseImage = @"database-small";
 
 	NSFontPanel *panel = [[NSFontManager sharedFontManager] fontPanel:YES];
 	[panel setPanelFont:[NSUserDefaults getFont] isMultiple:NO];
+	
+	// Create an accessory view with a system font button
+	NSView *accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 200, 30)];
+	NSButton *systemFontButton = [[NSButton alloc] initWithFrame:NSMakeRect(10, 5, 180, 20)];
+	[systemFontButton setTitle:NSLocalizedString(@"Use System Font", @"System Font button in font panel")];
+	[systemFontButton setBezelStyle:NSBezelStyleRounded];
+	[systemFontButton setTarget:self];
+	[systemFontButton setAction:@selector(changeDefaultFont:)];
+	[systemFontButton setTag:1001];
+	[accessoryView addSubview:systemFontButton];
+	
+	[panel setAccessoryView:accessoryView];
 	[panel makeKeyAndOrderFront:self];
 }
 
 - (void)changeDefaultFont:(id)sender {
-	[(SPPreferenceController *)[[[self view] window] delegate] changeDefaultFont:nil];
-	[self updateDisplayedFontName];
+	if ([sender isKindOfClass:[NSControl class]] && [sender tag] == 1001) {
+		NSFont *systemFont = [NSUserDefaults getSystemFont];
+		[NSUserDefaults saveFont:systemFont];
+		
+		// Update the font panel to show the system font
+		NSFontPanel *panel = [[NSFontManager sharedFontManager] fontPanel:NO];
+		if (panel) {
+			[panel setPanelFont:systemFont isMultiple:NO];
+		}
+	}
+
+    [(SPPreferenceController *)[[[self view] window] delegate] changeDefaultFont:nil];
 }
 
 #pragma mark -

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -175,6 +175,9 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		[tablesListView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
 		[tablesListView setFont:tableFont];
 		[tablesListView reloadData];
+		// Force a visual refresh of the table list
+		[tablesListView setNeedsDisplay:YES];
+		[tablesListView displayIfNeeded];
 	}
 	else {
 		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
@@ -217,6 +220,9 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 		[self->tables removeAllObjects];
 		[self->tableTypes removeAllObjects];
 		[self->tablesListView reloadData];
+		// Force a visual refresh of the table list
+		[self->tablesListView setNeedsDisplay:YES];
+		[self->tablesListView displayIfNeeded];
 	});
 
 	if ([tableDocumentInstance database]) {
@@ -630,7 +636,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	}
 
     // from docs:
-    // A window that uses NSWindowStyleMaskBorderless can’t become key or main
+    // A window that uses NSWindowStyleMaskBorderless can't become key or main
     // meaning it can't take input, so switch the style here.
     // It doesn't change how the popup looks.
     copyTableSheet.styleMask = NSWindowStyleMaskTitled;


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Added a button to reset back to the system font
- Made font changes instantly apply to table content view column names
- Update table lists when export and font change executed

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:
<img width="445" alt="Screenshot 2025-04-19 at 12 16 04" src="https://github.com/user-attachments/assets/f2f004e1-189b-4600-81cb-ab06013e7479" />

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Use System Font" button to the font selection panel, allowing users to quickly switch to the system font for table results.

- **Improvements**
  - Table view header cells now update immediately to reflect changes in global font settings and user preferences for displaying column types.
  - Tables list view refreshes visually right after font or table data changes, ensuring immediate UI updates.

- **Style**
  - Fixed a minor comment typo for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->