### PR TITLE
Revert enum vertical centering back to 5.0.4

### DIFF
--- a/Source/Views/Cells/SPComboBoxCell.m
+++ b/Source/Views/Cells/SPComboBoxCell.m
@@ -136,9 +136,9 @@ static NSString *_CellWillDismissNotification = @"NSComboBoxCellWillDismissNotif
  */
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-	// Center the content vertically in the cell
-	CGFloat verticalOffset = (cellFrame.size.height - [self.font boundingRectForFont].size.height) / 2.0;
-	[super drawInteriorWithFrame:NSMakeRect(cellFrame.origin.x, cellFrame.origin.y + verticalOffset, cellFrame.size.width, cellFrame.size.height) inView:controlView];
+    //Weird offset hack to fix enums and structure view ComboBoxCell labels from floating up or down randomly
+    [super drawInteriorWithFrame:NSMakeRect(cellFrame.origin.x, cellFrame.origin.y + (self.font.pointSize-13.0) / 2.0, cellFrame.size.width, cellFrame.size.height) inView:controlView];
+
 }
 
 @end


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- [#fixed Fix Enum Alignment in Content View by Jason-Morcos · Pull Request #2216 · Sequel-Ace/Sequel-Ace](https://github.com/Sequel-Ace/Sequel-Ace/pull/2216#issuecomment-2817237548)

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:
