### PR TITLE
Throw an error if ssh config file is inaccessible

### DIFF
--- a/Source/Controllers/Preferences/SPPreferenceController.h
+++ b/Source/Controllers/Preferences/SPPreferenceController.h
@@ -63,12 +63,12 @@
 	NSToolbarItem *generalItem;
 	NSToolbarItem *notificationsItem;
 	NSToolbarItem *tablesItem;
-	NSToolbarItem *networkItem;
 	NSToolbarItem *editorItem;
 	NSToolbarItem *shortcutItem;
     SPPreferenceFontChangeTarget fontChangeTarget;
 
     @package
+    NSToolbarItem *networkItem;
 	NSToolbarItem *fileItem;
 	
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Check if the SSH config file is valid before trying to connect
- If the config is not valid, offer the user to fix this issue
<img width="644" alt="Screenshot 2025-04-22 at 19 21 02" src="https://github.com/user-attachments/assets/9ba1c8ab-2865-44fd-8350-a33c3cc59e28" />


## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a check to ensure the SSH config file is accessible before starting an SSH tunnel connection. If not accessible, users are prompted with options to adjust network settings, reset to the default config, or cancel the connection attempt.
- **Bug Fixes**
  - Prevented connection attempts when the SSH config file cannot be read, improving reliability and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->