### PR TITLE
Cleanup crashes and inconsistencies with font handling #fixed

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1804,7 +1804,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     
     // Update font size on the table
     NSFont *tableFont = [NSUserDefaults getFont];
-    NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
+    NSFont *headerFont = [[NSFontManager sharedFontManager] convertFont:tableFont toSize:MAX(tableFont.pointSize * 0.75, 11.0)];
     [customQueryView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
     
     // If there are no table columns to add, return
@@ -3265,7 +3265,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     // Result Table Font preference changed
     else if ([keyPath isEqualToString:SPGlobalFontSettings]) {
         NSFont *tableFont = [NSUserDefaults getFont];
-        NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
+        NSFont *headerFont = [[NSFontManager sharedFontManager] convertFont:tableFont toSize:MAX(tableFont.pointSize * 0.75, 11.0)];
         [customQueryView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
         [customQueryView setFont:tableFont];
 
@@ -3274,13 +3274,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
                 NSAttributedString *attrString = [[cqColumnDefinition safeObjectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString];
 
-                // Need to create a mutable copy to modify the font
-                NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithAttributedString:attrString];
-
-                // Apply font to the entire string
-                [newAttrString addAttribute:NSFontAttributeName value:headerFont range:NSMakeRange(0, [newAttrString length])];
-
-                [[column headerCell] setAttributedStringValue:newAttrString];
+                [[column headerCell] setAttributedStringValue:attrString];
             } else {
                 [[column headerCell] setFont:headerFont];
             }

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1804,6 +1804,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     
     // Update font size on the table
     NSFont *tableFont = [NSUserDefaults getFont];
+    NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
     [customQueryView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
     
     // If there are no table columns to add, return
@@ -1833,7 +1834,10 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         {
             [dataCell setAlignment:NSTextAlignmentRight];
         }
-        
+
+        // Set the header font to match table font
+        [[theCol headerCell] setFont:headerFont];
+
         // Set field type for validations
         [[dataCell formatter] setFieldType:[columnDefinition objectForKey:@"type"]];
         [theCol setDataCell:dataCell];
@@ -3261,8 +3265,30 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
     // Result Table Font preference changed
     else if ([keyPath isEqualToString:SPGlobalFontSettings]) {
         NSFont *tableFont = [NSUserDefaults getFont];
+        NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
         [customQueryView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
         [customQueryView setFont:tableFont];
+
+        // Update header cells
+        for (NSTableColumn *column in [customQueryView tableColumns]) {
+            if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
+                NSAttributedString *attrString = [[cqColumnDefinition safeObjectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString];
+
+                // Need to create a mutable copy to modify the font
+                NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithAttributedString:attrString];
+
+                // Apply font to the entire string
+                [newAttrString addAttribute:NSFontAttributeName value:headerFont range:NSMakeRange(0, [newAttrString length])];
+
+                [[column headerCell] setAttributedStringValue:newAttrString];
+            } else {
+                [[column headerCell] setFont:headerFont];
+            }
+        }
+
+        // Force header view to redraw
+        [customQueryView.headerView setNeedsDisplay:YES];
+
         [customQueryView reloadData];
     } else if ([keyPath isEqualToString:SPCustomQueryEnableBracketHighlighting]) {
         self.bracketHighlighter.enabled = [[change valueForKey:NSKeyValueChangeNewKey] boolValue];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -556,6 +556,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
     BOOL displayColumnTypes = [prefs boolForKey:SPDisplayTableViewColumnTypes];
     NSInteger sortColumnNumberToRestore = NSNotFound;
     NSDictionary *formatOverrides = currentFormatters(self);
+    NSFont *headerFont = [NSFont fontWithDescriptor:font.fontDescriptor size:MAX(font.pointSize * 0.75, 11.0)];
 
     for (NSDictionary *columnDefinition in dataColumns) {
         id name = columnDefinition[@"name"];
@@ -563,6 +564,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
         // Set up the column
         NSTableColumn *column  = [[NSTableColumn alloc] initWithIdentifier:columnIndex];
+
+        // Set the header font to match table font
+        [[column headerCell] setFont:headerFont];
 
         if (displayColumnTypes) {
             [[column headerCell] setAttributedStringValue:[columnDefinition tableContentColumnHeaderAttributedString]];
@@ -2876,6 +2880,12 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		}
 	}
 
+	// Check again to make sure keys array is not empty before proceeding
+	if (![keys count]) {
+		SPLog(@"Keys array is empty in argumentForRow:excludingLimits:, aborting to prevent crash");
+		return @"";
+	}
+
 	NSMutableString *argument = [NSMutableString string];
 	// Walk through the keys list constructing the argument list
 	for (NSUInteger i = 0 ; i < [keys count]; i++ ) {
@@ -2885,11 +2895,11 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		id tempValue;
 		// Use the selected row if appropriate
 		if ( row >= 0 ) {
-			tempValue = [tableValues cellDataAtRow:row column:[[[tableDataInstance columnWithName:[keys safeObjectAtIndex:i]] objectForKey:@"datacolumnindex"] integerValue]];
+			tempValue = [tableValues cellDataAtRow:row column:[[[tableDataInstance columnWithName:[keys safeObjectAtIndex:i]] safeObjectForKey:@"datacolumnindex"] integerValue]];
 		}
 		// Otherwise use the oldRow
 		else {
-			tempValue = [oldRow objectAtIndex:[[[tableDataInstance columnWithName:[keys safeObjectAtIndex:i]] objectForKey:@"datacolumnindex"] integerValue]];
+			tempValue = [oldRow safeObjectAtIndex:[[[tableDataInstance columnWithName:[keys safeObjectAtIndex:i]] safeObjectForKey:@"datacolumnindex"] integerValue]];
 		}
 
 		if ([tempValue isNSNull]) {
@@ -2904,9 +2914,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 			NSString *fmt = @"%@";
 			// If the field is of type BIT then it needs a binary prefix
       NSDictionary *field = [tableDataInstance columnWithName:[keys safeObjectAtIndex:i]];
-      NSString *fieldType = [field objectForKey:@"type"];
-      NSString *fieldTypeGroup = [field objectForKey:@"typegrouping"];
-      
+      NSString *fieldType = [field safeObjectForKey:@"type"];
+      NSString *fieldTypeGroup = [field safeObjectForKey:@"typegrouping"];
+
 			if ([fieldType isEqualToString:@"BIT"]) {
 				escVal = [mySQLConnection escapeString:tempValue includingQuotes:NO];
 				fmt = @"b'%@'";
@@ -3731,6 +3741,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		// Table font preference changed
 		else if ([keyPath isEqualToString:SPGlobalFontSettings]) {
 			NSFont *tableFont = [NSUserDefaults getFont];
+            NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
 
 			[tableContentView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
 			[tableContentView setFont:tableFont];
@@ -3738,11 +3749,22 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 			// Update header cells
 			for (NSTableColumn *column in [tableContentView tableColumns]) {
 				if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
-					[[column headerCell] setAttributedStringValue:[[dataColumns objectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString]];
+                    NSAttributedString *attrString = [[dataColumns safeObjectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString];
+                    
+                    // Need to create a mutable copy to modify the font
+                    NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithAttributedString:attrString];
+                    
+                    // Apply font to the entire string
+                    [newAttrString addAttribute:NSFontAttributeName value:headerFont range:NSMakeRange(0, [newAttrString length])];
+
+                    [[column headerCell] setAttributedStringValue:newAttrString];
 				} else {
-					[[column headerCell] setFont:tableFont];
+					[[column headerCell] setFont:headerFont];
 				}
 			}
+
+            // Force header view to redraw
+            [tableContentView.headerView setNeedsDisplay:YES];
 			
 			[tableContentView reloadData];
 		}
@@ -3953,7 +3975,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		return NO;
 	}
 
-	NSDictionary *columnDefinition = [[(id <SPDatabaseContentViewDelegate>)[tableContentView delegate] dataColumnDefinitions] objectAtIndex:columnIndex];
+	NSDictionary *columnDefinition = [[(id <SPDatabaseContentViewDelegate>)[tableContentView delegate] dataColumnDefinitions] safeObjectAtIndex:columnIndex];
 	NSString *typeGrouping = columnDefinition[@"typegrouping"];
 
 	if ([typeGrouping isEqual:@"binary"]) {

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -556,7 +556,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
     BOOL displayColumnTypes = [prefs boolForKey:SPDisplayTableViewColumnTypes];
     NSInteger sortColumnNumberToRestore = NSNotFound;
     NSDictionary *formatOverrides = currentFormatters(self);
-    NSFont *headerFont = [NSFont fontWithDescriptor:font.fontDescriptor size:MAX(font.pointSize * 0.75, 11.0)];
+    NSFont *headerFont = [[NSFontManager sharedFontManager] convertFont:font toSize:MAX(font.pointSize * 0.75, 11.0)];
 
     for (NSDictionary *columnDefinition in dataColumns) {
         id name = columnDefinition[@"name"];
@@ -3741,7 +3741,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		// Table font preference changed
 		else if ([keyPath isEqualToString:SPGlobalFontSettings]) {
 			NSFont *tableFont = [NSUserDefaults getFont];
-            NSFont *headerFont = [NSFont fontWithDescriptor:tableFont.fontDescriptor size:MAX(tableFont.pointSize * 0.75, 11.0)];
+            NSFont *headerFont = [[NSFontManager sharedFontManager] convertFont:tableFont toSize:MAX(tableFont.pointSize * 0.75, 11.0)];
 
 			[tableContentView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
 			[tableContentView setFont:tableFont];
@@ -3751,13 +3751,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 				if ([prefs boolForKey:SPDisplayTableViewColumnTypes]) {
                     NSAttributedString *attrString = [[dataColumns safeObjectAtIndex:[[column identifier] integerValue]] tableContentColumnHeaderAttributedString];
                     
-                    // Need to create a mutable copy to modify the font
-                    NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithAttributedString:attrString];
-                    
-                    // Apply font to the entire string
-                    [newAttrString addAttribute:NSFontAttributeName value:headerFont range:NSMakeRange(0, [newAttrString length])];
-
-                    [[column headerCell] setAttributedStringValue:newAttrString];
+                    [[column headerCell] setAttributedStringValue:attrString];
 				} else {
 					[[column headerCell] setFont:headerFont];
 				}

--- a/Source/Controllers/Preferences/SPPreferenceController.m
+++ b/Source/Controllers/Preferences/SPPreferenceController.m
@@ -139,6 +139,9 @@
 			font = [[NSFontPanel sharedFontPanel] panelConvertFont:[NSUserDefaults getFont]];
 			[NSUserDefaults saveFont:font];
             [generalPreferencePane updateDisplayedFontName];
+            
+            // Post notification to ensure all views update
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"SPFontChangedNotification" object:self];
 			break;
 		case SPPrefFontChangeTargetEditor:
 			font = [[NSFontPanel sharedFontPanel] panelConvertFont:[NSUnarchiver unarchiveObjectWithData:[prefs dataForKey:SPCustomQueryEditorFont]]];

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -166,6 +166,16 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 }
 
 /**
+ * Close any open font panels to avoid them reopening on next launch
+ */
+- (void)closeFontPanelIfOpen {
+    NSFontPanel *fontPanel = [[NSFontManager sharedFontManager] fontPanel:NO];
+    if (fontPanel && [fontPanel isVisible]) {
+        [fontPanel close];
+    }
+}
+
+/**
  * Initialisation stuff upon nib awakening
  */
 - (void)awakeFromNib
@@ -1592,6 +1602,9 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     if (shouldSaveFavorites) {
         [[SPFavoritesController sharedFavoritesController] saveFavoritesSynchronously];
     }
+
+    // Close any open font panels to prevent them reopening on next launch
+    [self closeFontPanelIfOpen];
 
     return NSTerminateNow;
 }

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -159,6 +159,12 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	for (NSTableColumn *column in [tablesListView tableColumns]) {
 		[[column dataCell] setFont:tableFont];
 	}
+	
+	// Add observer for custom font change notification
+	[[NSNotificationCenter defaultCenter] addObserver:self 
+	                                         selector:@selector(fontChanged:) 
+	                                             name:@"SPFontChangedNotification" 
+	                                           object:nil];
 }
 
 #pragma mark -
@@ -3008,8 +3014,22 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[prefs removeObserver:self forKeyPath:SPGlobalFontSettings];
-
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:@"SPFontChangedNotification" object:nil];
+	
     NSLog(@"Dealloc called %s", __FILE_NAME__);
+}
+
+// Add method to handle direct font change notification
+- (void)fontChanged:(NSNotification *)notification
+{
+    // Update font in tables list view
+    NSFont *tableFont = [NSUserDefaults getFont];
+    [tablesListView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
+    [tablesListView setFont:tableFont];
+    [tablesListView reloadData];
+    // Force a visual refresh of the table list
+    [tablesListView setNeedsDisplay:YES];
+    [tablesListView displayIfNeeded];
 }
 
 @end

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -159,12 +159,6 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 	for (NSTableColumn *column in [tablesListView tableColumns]) {
 		[[column dataCell] setFont:tableFont];
 	}
-	
-	// Add observer for custom font change notification
-	[[NSNotificationCenter defaultCenter] addObserver:self 
-	                                         selector:@selector(fontChanged:) 
-	                                             name:@"SPFontChangedNotification" 
-	                                           object:nil];
 }
 
 #pragma mark -
@@ -3014,22 +3008,8 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[prefs removeObserver:self forKeyPath:SPGlobalFontSettings];
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:@"SPFontChangedNotification" object:nil];
 	
     NSLog(@"Dealloc called %s", __FILE_NAME__);
-}
-
-// Add method to handle direct font change notification
-- (void)fontChanged:(NSNotification *)notification
-{
-    // Update font in tables list view
-    NSFont *tableFont = [NSUserDefaults getFont];
-    [tablesListView setRowHeight:4.0f + NSSizeToCGSize([@"{ǞṶḹÜ∑zgyf" sizeWithAttributes:@{NSFontAttributeName : tableFont}]).height];
-    [tablesListView setFont:tableFont];
-    [tablesListView reloadData];
-    // Force a visual refresh of the table list
-    [tablesListView setNeedsDisplay:YES];
-    [tablesListView displayIfNeeded];
 }
 
 @end

--- a/Source/Other/Extensions/NSDictionaryExtension.swift
+++ b/Source/Other/Extensions/NSDictionaryExtension.swift
@@ -13,11 +13,16 @@ import Foundation
         guard let columnName: String = value(forKey: "name") as? String else {
             return NSAttributedString(string: "")
         }
-        let font = UserDefaults.getFont()
-        let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: NSFontManager.shared.convert(font, toSize: 11)])
+        let tableFont = UserDefaults.getFont()
+        let headerFont = NSFont(descriptor: tableFont.fontDescriptor, size: Swift.max(tableFont.pointSize * 0.75, 11.0)) ?? tableFont
+        
+        let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: headerFont])
+        
         if let columnType: String = value(forKey: "type") as? String {
             attributedString.append(NSAttributedString(string: NSString.columnHeaderSplittingSpace as String))
-            attributedString.append(NSAttributedString(string: columnType, attributes: [.font: NSFontManager.shared.convert(font, toSize: 8), .foregroundColor: NSColor.gray]))
+            
+            let smallerHeaderFont = NSFontManager.shared.convert(headerFont, toSize: headerFont.pointSize * 0.75)
+            attributedString.append(NSAttributedString(string: columnType, attributes: [.font: smallerHeaderFont, .foregroundColor: NSColor.gray]))
         }
         return attributedString
     }

--- a/Source/Other/Extensions/NSDictionaryExtension.swift
+++ b/Source/Other/Extensions/NSDictionaryExtension.swift
@@ -14,8 +14,8 @@ import Foundation
             return NSAttributedString(string: "")
         }
         let tableFont = UserDefaults.getFont()
-        let headerFont = NSFont(descriptor: tableFont.fontDescriptor, size: Swift.max(tableFont.pointSize * 0.75, 11.0)) ?? tableFont
-        
+        let headerFont = NSFontManager.shared.convert(tableFont, toSize: Swift.max(tableFont.pointSize * 0.75, 11.0))
+
         let attributedString = NSMutableAttributedString(string: columnName, attributes: [.font: headerFont])
         
         if let columnType: String = value(forKey: "type") as? String {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Font size changes now impact headers as well
- Favorites now no longer overlap titles with larger font sizes
- Font size changes instantly apply to sidebar items

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Favorites and tables list views now dynamically adjust row heights and fonts based on user font preferences.
  - Table and query result headers scale font size relative to the main table font for improved readability and consistency.
  - Open font panels are automatically closed when quitting the application.

- **Bug Fixes**
  - Improved handling of empty or missing data to prevent potential crashes in table operations.
  - UI updates now immediately reflect font changes across relevant views for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->