### PR TITLE
#removed broken link from documentation

### DIFF
--- a/docs/get-started/local-connection.md
+++ b/docs/get-started/local-connection.md
@@ -1,6 +1,5 @@
 -   [Getting Connected](../get-started/)
 -   [Making Queries](../queries.html)
--   [Keyboard Shortcuts](../shortcuts.html)
 -   [Reference](../ref/)
 -   [Bundles](../bundles/)
 -   [Contribute](../contribute/)


### PR DESCRIPTION
## Changes:
removed broken keyboard shortcut links that doesn't exist. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the "Keyboard Shortcuts" link from the navigation list at the top of the local connection guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->