### PR TITLE
#fixed Reset the relevant variables to prepare for the next time

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -987,10 +987,15 @@ asm(".desc ___crashreporter_info__, 0x10");
 			reconnectSucceeded = YES;
 			if (databaseToRestore) {
 				[self selectDatabase:databaseToRestore];
+				// When the connection is restored successfully, reset the relevant variables to prepare for the next time
+				databaseToRestore = nil;
 			}
 			if (encodingToRestore) {
 				[self setEncoding:encodingToRestore];
 				[self setEncodingUsesLatin1Transport:encodingUsesLatin1TransportToRestore];
+				// When the connection is restored successfully, reset the relevant variables to prepare for the next time
+				encodingToRestore = nil;
+				encodingUsesLatin1TransportToRestore = NO;
 			}
 		}
 			// If the connection failed and the connection is permitted to retry,


### PR DESCRIPTION
I have encountered this problem for a long time. Today I finally found a clue and tried to give a solution.

## Changes:
-  When the connection is restored successfully, reset the relevant variables to prepare for the next time


## Closes following issues:
- Closes:  
- https://github.com/Sequel-Ace/Sequel-Ace/issues/1594  
- https://github.com/Sequel-Ace/Sequel-Ace/issues/1806

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [*] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [*] Other (please specify): Chinese
- Xcode Version: 16.3
  
## Screenshots:
1.  Lost network in database A, and Reconnect the network when faild load data.
![iShot_2025-05-15_13 17 27-0001](https://github.com/user-attachments/assets/bd72d7ea-be76-4b1c-99bf-2c59e877aece)
2. Lost network in database B  **AGAIN.**
![iShot_2025-05-15_13 17 27-0002](https://github.com/user-attachments/assets/346a50cf-8a0c-410c-8d7e-3125c755f910)
3. After the second time network disconnection, when the connection was restored, the configuration saved during the first time network disconnection was used.
![iShot_2025-05-15_13 17 27-0003](https://github.com/user-attachments/assets/a03a13a0-5647-479a-ba77-e439cf89e518)


## Additional notes:

Follow the steps below to reproduce the bug
1. Connect to the remote server and select database A
2. **Turn off the network** and try to load the table in database A, and wait until it fails.
3. Turn on the network and reload the table in database A. It should be normal at this time.
4. Switch to database B and load the table data there. It should also be normal at this time.
5. **Turn off the network again (important),** try to read the table in database B, and wait until it fails.
6. Turn on the network again and try to read the table in database B. An error will occur at this time.

**In summary, after the second time network disconnection, when the connection was restored, the configuration saved during the first time network disconnection was used.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection stability by ensuring temporary state variables are properly cleared after a successful reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->