### PR TITLE
#added support goto database.table with the "Go to Database"

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -698,7 +698,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     // Start a task
-    [self startTaskWithDescription:[NSString stringWithFormat:NSLocalizedString(@"Loading database '%@'...", @"Loading database task string"), [[chooseDatabaseButton onMainThread] titleOfSelectedItem]]];
+    [self startTaskWithDescription:[NSString stringWithFormat:NSLocalizedString(@"Loading database '%@'...", @"Loading database task string"), database]];
 
     NSDictionary *selectionDetails = [NSDictionary dictionaryWithObjectsAndKeys:database, @"database", item, @"item", nil];
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -5391,7 +5391,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [[chooseDatabaseButton onMainThread] selectItemWithTitle:targetDatabaseName];
 
             selectedDatabase = [[NSString alloc] initWithString:targetDatabaseName];
-            selectedTableName = targetItemName ? [[NSString alloc] initWithString:targetItemName] : nil;
+            selectedTableName = nil;
 
             [databaseDataInstance resetAllData];
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1065,7 +1065,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [gotoDatabaseController setDatabaseList:dbList];
 
     if ([gotoDatabaseController runModal]) {
-        [self selectDatabase:[gotoDatabaseController selectedDatabase] item:nil];
+        NSString *database =[gotoDatabaseController selectedDatabase];
+        if ([database rangeOfString:@"."].location != NSNotFound){
+            NSArray *components = [database componentsSeparatedByString:@"."];
+            [self selectDatabase:[components firstObject] item:[components lastObject]];
+        }else{
+            [self selectDatabase:database item:nil];
+        }
     }
 }
 


### PR DESCRIPTION

## Changes:
- The default function is to go to the specified database, and the newly added ability is to be able to return to the table in the specified database.

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [*] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [*] Other (please specify):Chinese
- Xcode Version:
  
## Screenshots:
1. Enter the target location in the format of "database.tablename"
<img width="1010" alt="iShot_2025-05-15_14 58 05" src="https://github.com/user-attachments/assets/edd813b7-fb9d-4172-8556-2c3547768a71" />
2. Go
<img width="1006" alt="iShot_2025-05-15_14 58 18" src="https://github.com/user-attachments/assets/56c5b847-ab05-416c-84e9-82f2062c129b" />


## Additional notes:
This capability is for faster viewing of target table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for selecting both a database and an item simultaneously when using a dot-separated selection.
- **Bug Fixes**
  - Improved accuracy of task descriptions during database selection.
  - Ensured the selected table name is cleared when switching databases for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->