### PR TITLE
#fixed #1746 clicking foreign key arrows on _bin column filters correctly

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2386,6 +2386,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 			//when navigating binary relations (eg. raw UUID) do so via a hex-encoded value for charset safety
 			BOOL navigateAsHex = ([targetFilterValue isKindOfClass:[NSData class]] && [[columnDefinition objectForKey:@"typegrouping"] isEqualToString:@"binary"]);
 			if(navigateAsHex) targetFilterValue = [self->mySQLConnection escapeData:(NSData *)targetFilterValue includingQuotes:NO];
+            else if ([targetFilterValue isKindOfClass:[NSData class]] && [[columnDefinition objectForKey:@"collation"] hasSuffix:@"_bin"]) {
+                targetFilterValue = [(NSData *)targetFilterValue stringRepresentationUsingEncoding:[self->mySQLConnection stringEncoding]];
+            }
 
 			NSString *filterComparison = @"=";
 			if([targetFilterValue isNSNull]) filterComparison = @"IS NULL";


### PR DESCRIPTION
(this is my first ever pull request on any open source project 😬)

## Changes:
Foreign keys that are strings but with a _bin collation come in as NSData and when clicking the arrow link in the column would use the NSData description instead of the string value for filtering so it it didn't work. Now we simply convert to a string for filtering.

## Closes following issues:
- Closes: #1746

## Tested:
- Processors:
  - [ ] Intel
  - [X] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [X] 15.x (Sequoia)
- Localizations:
  - [X] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.3
  
## Screenshots:

<img width="802" alt="Screenshot 2025-05-29 at 12 39 14 PM" src="https://github.com/user-attachments/assets/1feae488-d1c4-4f2c-b316-aedc1b35cdd9" />
<img width="798" alt="Screenshot 2025-05-29 at 12 39 07 PM" src="https://github.com/user-attachments/assets/ef7709eb-fe14-408d-8f9b-64bdb1949eaa" />


## Additional notes:

I tested with the following SQL:

[fk_test_2025-05-29.txt](https://github.com/user-attachments/files/20510699/fk_test_2025-05-29.txt)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of navigation via foreign key links for columns with binary collation, ensuring that binary data is correctly converted to a string representation when appropriate. This enhances accuracy when filtering data in such cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->