### PR TITLE
Correct the date string value to default for DATE, and utilize any of the functions for the field default

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -945,8 +945,23 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
                 unichar firstChar = [trimmedWhiteSpace characterAtIndex:0];
                 unichar lastChar = [trimmedWhiteSpace characterAtIndex:[trimmedWhiteSpace length] - 1];
                 // Check if defaultValue is an expression
-                if ((firstChar == '(') && (lastChar = ')')) {
+                if (lastChar == ')') {
+                    // To check if brackets appear in pairs, then we assume the string is possibly an expression
+                    // if it's expression by this check so query will be executed and an error will be shown
+                    // TODO: Best possible solution would be checking the input value against the list of known functions/keywords
+                    NSUInteger checkBracketPairs = 0;
+                    for (NSUInteger i = 0; i < [trimmedWhiteSpace length]; i++) {
+                        if ([trimmedWhiteSpace characterAtIndex:i] == '(') {
+                          checkBracketPairs++;
+                        } else if ([trimmedWhiteSpace characterAtIndex:i] == ')') {
+                          checkBracketPairs--;
+                        }
+                    }
+                  
+                  // it means brackets are in pairs
+                  if (checkBracketPairs == 0) {
                     defaultValueIsExpression = YES;
+                  }
                 }
                 // Check if defaultValue is a string in quotes (single or double)
                 else if ( ((firstChar == '"') && (lastChar = '"')) || ((firstChar == '\'') && (lastChar = '\'')) ) {
@@ -982,8 +997,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			else if ([theRowType isEqualToString:@"BIT"]) {
 				[queryString appendFormat:@"\n DEFAULT %@", defaultValue];
 			}
-            // *CHAR, *TEXT and *ENUM must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP and DATETIME must always be wrapped in quotes.
-            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"ENUM"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME"]]) {
+            // *CHAR, *TEXT and *ENUM must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP, DATETIME and DATE must always be wrapped in quotes.
+            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"ENUM"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME",@"DATE"]]) {
                 // If default value is not an expresion or a string, add quotes.
                 if (!defaultValueIsExpression && !defaultValueIsString)
                     [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Able to use quoted date string for DATE field type
- Enhance default value checks by presuming paired brackets exist. I don't do the best solution (like my comment) yet because I think it would need to test a lot, and I don't have enough knowledge on building the list and how is it different between MySQL vs. MariaDB.
  - Before: Couldn't use functions for default value in GUI
  - After: See the second attached video

## Closes following issues:
- Closes: #2251

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:


https://github.com/user-attachments/assets/7a3bcf40-304c-46c2-b150-1ae7486d5f14




https://github.com/user-attachments/assets/f5898a4e-07f8-4dc0-90bf-af5cd9194c5b




## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of default values for DATE columns in table structure modifications to ensure correct quoting, preventing potential errors when altering tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->