### PR TITLE
Fix: Premature closure of auto-completion popup

### DIFF
--- a/Source/Model/SPNarrowDownCompletion.m
+++ b/Source/Model/SPNarrowDownCompletion.m
@@ -873,13 +873,9 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 			else if([textualInputCharacters characterIsMember:key]) {
 				if (autocompletePlaceholderWasInserted) [self removeAutocompletionPlaceholderUsingFastMethod:YES];
 
-				if (autoCompletionMode) {
-					[theView setCompletionIsOpen:NO];
-					[self close];
-					[NSApp sendEvent:event];
-					return;
-				}
-
+				// Related to the fix of issue #625 (https://github.com/sequelpro/sequelpro/issues/625), 
+				// it has introduced a side effect where the auto-completion popup closes prematurely, 
+				// even when the user is still typing and the current input matches items in the list.
 				[NSApp sendEvent:event];
 
 				if(commaInsertionMode) break;


### PR DESCRIPTION
## Changes:
Address an issue where the auto-completion popup closes unexpectedly while the user is still typing and matches items in the list. This change ensures the popup remains open during valid input. Please also have looks on attached videos.

**Actual**: The auto-completion popup repeatedly closes and reopens with each keystroke, even when the current word still matches items in the completion list.
**Expected**: The popup should remain consistently visible as long as the current word matches items in the completion list. This behavior is just similar to coding IDEs or other DB tool (I'm also using Jetbrains Datagrip). With this fix, I want to have better experience when writing query with lots of keyword.

Here is an example of VSCode:

https://github.com/user-attachments/assets/2d8c1ee3-ff91-44a1-b01f-d83a458b8312


The issue came from the fix of this upstream issue: https://github.com/sequelpro/sequelpro/issues/625
See that PR here: https://github.com/Sequel-Ace/Sequel-Ace/commit/c58984f7fb82a089bdc508f0bdf7dc6df89cb979

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.4
  
## Screenshots:

**Before:**
Auto completion: ON (Popup on-off in every char I was completing for `host_summary` keyword)

https://github.com/user-attachments/assets/d56c2e9f-002c-4ce2-b46a-7283352834aa

**After:**

Auto completion: ON

https://github.com/user-attachments/assets/6d695114-1ded-4e7b-91bb-6b13f58cd386

Auto completion: OFF (I used ESC key to manually trigger auto-complete popup)

https://github.com/user-attachments/assets/5ccf1deb-852c-4d33-ab57-b91e90aa1373

To ensure the upstream issue wasn't reintroduced, I swiftly typed 'SELECT' within delay config = 0.1 seconds:

https://github.com/user-attachments/assets/0d8160fe-a962-41c5-924b-5cfdd34899e0



## Additional notes:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-completion popup behavior so it no longer closes prematurely while typing. The popup now remains open and continues to update suggestions as you enter text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->