### PR TITLE
fix: data types of copy as sql insert

### DIFF
--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -522,13 +522,13 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
             data[kFieldType]  = t;
             data[kFieldTypeGroup] = tGroup;
             // Numeric data
-            if ([t isEqualToString:@"bit"] || [t isEqualToString:@"integer"] || [t isEqualToString:@"float"])
+            if ([tGroup isEqualToString:@"bit"] || [tGroup isEqualToString:@"integer"] || [tGroup isEqualToString:@"float"])
                 data[kColType] = @(0);
             // Blob data or long text data
-            else if ([t isEqualToString:@"blobdata"] || [t isEqualToString:@"textdata"])
+            else if ([tGroup isEqualToString:@"blobdata"] || [tGroup isEqualToString:@"textdata"])
                 data[kColType] = @(2);
             // GEOMETRY data
-            else if ([t isEqualToString:@"geometry"])
+            else if ([tGroup isEqualToString:@"geometry"])
                 data[kColType] = @(3);
         }
         if (data)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- It must use field group (tGroup) instead of type (t).

## Closes following issues:
- Closes: 

#2297 
#2279
#2252

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.0.1
  
## Screenshots:

https://github.com/user-attachments/assets/191f6ded-fe45-4523-b54b-d1447f5d8f4b




## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of table export functionality by refining how column data types are categorized and processed during SQL export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->