### PR TITLE
Fix Toggle JSON Format when `python` is unavailable

### DIFF
--- a/SharedSupport/Default Bundles/Toggle JSON Format.saBundle/command.plist
+++ b/SharedSupport/Default Bundles/Toggle JSON Format.saBundle/command.plist
@@ -27,7 +27,14 @@ if [ "$FORMAT" -eq "1" ]; then
 
 else
 
-	DATA=$(echo "$DATA" | python -mjson.tool)
+	if command -v python3 &gt;/dev/null 2&gt;&amp;1; then
+		DATA=$(echo "$DATA" | python3 -mjson.tool)
+	elif command -v python &gt;/dev/null 2&gt;&amp;1; then
+		DATA=$(echo "$DATA" | python -mjson.tool)
+	else
+		echo "&lt;font&gt;Python is required to format JSON data. Install python3 and try again.&lt;/font&gt;"
+		exit $SP_BUNDLE_EXIT_SHOW_AS_HTML_TOOLTIP
+	fi
 
 fi
 


### PR DESCRIPTION
## Summary
- update the default `Toggle JSON Format` bundle to prefer `python3` for pretty printing
- fallback to `python` for older setups
- show a clear bundle error message when neither binary is available

## Related
- Fixes #2293

## Testing
- Not run (bundle script change only)