### PR TITLE
Fix process-list copy/save regression from missing serializer bridge

### DIFF
--- a/Source/Controllers/SubviewControllers/SPProcessListController.m
+++ b/Source/Controllers/SubviewControllers/SPProcessListController.m
@@ -70,6 +70,16 @@ static NSString * const SPKillIdKey   = @"SPKillId";
 @synthesize connection;
 
 #pragma mark -
+#pragma mark Serialization
+
++ (NSString *)_serializedProcessRow:(NSDictionary *)process includeProgress:(BOOL)includeProgress
+{
+	if (![process isKindOfClass:[NSDictionary class]]) return @"";
+
+	return [SPProcessListRowSerializer serializedProcessRow:process includeProgress:includeProgress];
+}
+
+#pragma mark -
 #pragma mark Initialisation
 
 - (instancetype)init


### PR DESCRIPTION
## Summary
- add missing `+[SPProcessListController _serializedProcessRow:includeProgress:]` implementation
- delegate serialization to `SPProcessListRowSerializer` to preserve existing formatting behavior
- prevent runtime `unrecognized selector` crash when copying/saving process list rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened process row data handling with enhanced validation and improved serialization, ensuring greater reliability and consistency across all process list operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->