### PR TITLE
Raise row limit cap from 100k to 1M #fixed

### DIFF
--- a/Source/Interfaces/ContentPaginationView.xib
+++ b/Source/Interfaces/ContentPaginationView.xib
@@ -100,7 +100,7 @@
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OtF-Sn-bou">
                     <rect key="frame" x="241" y="28" width="15" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <stepperCell key="cell" controlSize="small" continuous="YES" alignment="left" minValue="1" maxValue="100000" doubleValue="100" valueWraps="YES" id="389-RH-6nn">
+                    <stepperCell key="cell" controlSize="small" continuous="YES" alignment="left" minValue="1" maxValue="1000000" doubleValue="100" valueWraps="YES" id="389-RH-6nn">
                         <font key="font" metaFont="message" size="11"/>
                     </stepperCell>
                     <connections>
@@ -116,7 +116,7 @@
                         <numberFormatter key="formatter" formatterBehavior="custom10_4" allowsFloats="NO" minimumIntegerDigits="1" maximumIntegerDigits="309" decimalSeparator="." groupingSeparator="," id="Pxb-UY-tce">
                             <real key="roundingIncrement" value="1"/>
                             <real key="minimum" value="0.0"/>
-                            <real key="maximum" value="100000"/>
+                            <real key="maximum" value="1000000"/>
                         </numberFormatter>
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>

--- a/Source/Interfaces/Preferences.xib
+++ b/Source/Interfaces/Preferences.xib
@@ -995,7 +995,7 @@ Gw
                             <nil key="negativeInfinitySymbol"/>
                             <nil key="positiveInfinitySymbol"/>
                             <real key="minimum" value="0.0"/>
-                            <real key="maximum" value="100000"/>
+                            <real key="maximum" value="1000000"/>
                         </numberFormatter>
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1012,7 +1012,7 @@ Gw
                         <constraint firstAttribute="height" constant="16" id="4O1-HE-XH8"/>
                         <constraint firstAttribute="width" constant="11" id="BgY-gn-Agc"/>
                     </constraints>
-                    <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100000" doubleValue="100" valueWraps="YES" id="523"/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="1000000" doubleValue="100" valueWraps="YES" id="523"/>
                     <connections>
                         <action selector="takeIntValueFrom:" target="520" id="530"/>
                         <binding destination="117" name="enabled" keyPath="values.LimitResults" id="625"/>


### PR DESCRIPTION
## Changes:
- Update NSNumberFormatter maximum and NSStepper maxValue from 100,000 to 1,000,000 in both Preferences.xib and ContentPaginationView.xib

## Closes following issues:
- Closes: #2259

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 16.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum input limits from 100,000 to 1,000,000 for pagination and query history settings, enabling users to work with larger datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->