### PR TITLE
Improve TLS defaults and scope reconnect reachability probes

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -49,8 +49,11 @@
 - (void)_restoreConnectionVariables;
 - (void)_validateThreadSetup;
 + (void)_removeThreadVariables:(NSNotification *)aNotification;
++ (NSArray<NSString *> *)defaultSSLCipherList;
++ (NSArray<NSString *> *)legacySSLCipherList;
 + (NSString *)_defaultSSLCipherListString;
 + (NSString *)_defaultTLSSuiteListString;
++ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
 + (NSString *)_reachabilityProbeHostForHost:(NSString *)host useSocket:(BOOL)useSocket hasProxy:(BOOL)hasProxy;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -160,11 +160,16 @@
 @property (readwrite, copy) NSString *sslCACertificatePath;
 
 /**
- * List of supported ciphers for SSL/TLS connections.
+ * List of pre-TLS 1.3 ciphers for SSL/TLS connections.
  * This is a colon-separated string of names as used by
  * `openssl ciphers`. The order of entries specifies
  * their preference (earlier = better).
- * A value of nil (default) means SPMySQL will use its built-in cipher list.
+ * A value of nil (default) means SPMySQLConnection will use its built-in
+ * pre-TLS 1.3 cipher list when calling `mysql_ssl_set()`.
+ *
+ * TLS 1.3 ciphersuites are configured separately via `MYSQL_OPT_TLS_CIPHERSUITES`
+ * using SPMySQLConnection's built-in `_defaultTLSSuiteListString` and are not
+ * currently overridden by `sslCipherList`.
  */
 @property (readwrite, copy) NSString *sslCipherList;
 
@@ -186,9 +191,6 @@
 @property (readwrite, assign, nonatomic) SPMySQLClientFlags clientFlags;
 - (void)addClientFlags:(SPMySQLClientFlags)opts;
 - (void)removeClientFlags:(SPMySQLClientFlags)opts;
-
-+ (NSArray<NSString *> *)defaultSSLCipherList;
-+ (NSArray<NSString *> *)legacySSLCipherList;
 
 #pragma mark -
 #pragma mark Connection and disconnection

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -30,6 +30,7 @@
 
 #import "SPMySQL Private APIs.h"
 #import "SPMySQLKeepAliveTimer.h"
+#include <arpa/inet.h>
 #include <mach/mach_time.h>
 #include <pthread.h>
 #include <SystemConfiguration/SCNetworkReachability.h>
@@ -46,6 +47,25 @@
 // Thread flag constant
 static pthread_key_t mySQLThreadInitFlagKey;
 static void *mySQLThreadFlag;
+
+static BOOL SPHostIsLoopbackIPv4Address(NSString *normalizedHost)
+{
+	struct in_addr ipv4Address;
+	if (inet_pton(AF_INET, [normalizedHost UTF8String], &ipv4Address) == 1) {
+		return ((ntohl(ipv4Address.s_addr) >> 24) == 127);
+	}
+
+	NSArray<NSString *> *components = [normalizedHost componentsSeparatedByString:@"."];
+	if (![components count] || [components count] > 4) return NO;
+	if (![[components firstObject] isEqualToString:@"127"]) return NO;
+
+	NSCharacterSet *nonDigitCharacters = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+	for (NSString *component in components) {
+		if (![component length] || [component rangeOfCharacterFromSet:nonDigitCharacters].location != NSNotFound) return NO;
+	}
+
+	return YES;
+}
 
 #pragma mark Class constants
 
@@ -237,6 +257,46 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 	return defaultTLSSuiteListString;
 }
 
++ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker
+{
+	NSMutableArray<NSString *> *enabledCiphers = [NSMutableArray array];
+	NSMutableArray<NSString *> *disabledCiphers = [NSMutableArray array];
+	NSMutableSet<NSString *> *validCiphers = [NSMutableSet setWithArray:[self defaultSSLCipherList]];
+	BOOL inDisabledSection = NO;
+
+	[validCiphers addObjectsFromArray:[self legacySSLCipherList]];
+
+	for (NSString *savedCipher in [savedCipherString componentsSeparatedByString:@":"]) {
+		if ([savedCipher isEqualToString:disabledMarker]) {
+			inDisabledSection = YES;
+			continue;
+		}
+		if (![validCiphers containsObject:savedCipher]) continue;
+		if ([enabledCiphers containsObject:savedCipher] || [disabledCiphers containsObject:savedCipher]) continue;
+		[(inDisabledSection ? disabledCiphers : enabledCiphers) addObject:savedCipher];
+	}
+
+	NSUInteger enabledInsertIndex = 0;
+	for (NSString *cipher in [self defaultSSLCipherList]) {
+		if (![enabledCiphers containsObject:cipher] && ![disabledCiphers containsObject:cipher]) {
+			[enabledCiphers insertObject:cipher atIndex:enabledInsertIndex++];
+		}
+	}
+
+	NSUInteger disabledInsertIndex = 0;
+	for (NSString *cipher in [self legacySSLCipherList]) {
+		if (![enabledCiphers containsObject:cipher] && ![disabledCiphers containsObject:cipher]) {
+			[disabledCiphers insertObject:cipher atIndex:disabledInsertIndex++];
+		}
+	}
+
+	NSMutableArray<NSString *> *mergedCiphers = [NSMutableArray arrayWithArray:enabledCiphers];
+	[mergedCiphers addObject:disabledMarker];
+	[mergedCiphers addObjectsFromArray:disabledCiphers];
+
+	return mergedCiphers;
+}
+
 + (NSString *)_reachabilityProbeHostForHost:(NSString *)aHost useSocket:(BOOL)shouldUseSocket hasProxy:(BOOL)hasProxy
 {
 	if (hasProxy || shouldUseSocket || ![aHost length]) return nil;
@@ -249,7 +309,7 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 	if (![trimmedHost length]) return nil;
 
 	NSString *normalizedHost = [trimmedHost lowercaseString];
-	if ([normalizedHost isEqualToString:@"localhost"] || [trimmedHost isEqualToString:@"127.0.0.1"] || [trimmedHost isEqualToString:@"::1"]) {
+	if ([normalizedHost isEqualToString:@"localhost"] || [normalizedHost isEqualToString:@"::1"] || SPHostIsLoopbackIPv4Address(normalizedHost)) {
 		return nil;
 	}
 

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -39,6 +39,12 @@
 static NSString *SPSSLCipherListMarkerItem = @"--";
 static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 
+@interface SPMySQLConnection (CipherPreferenceMerging)
++ (NSArray<NSString *> *)defaultSSLCipherList;
++ (NSArray<NSString *> *)legacySSLCipherList;
++ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
+@end
+
 @interface SPNetworkPreferencePane ()
 - (void)updateHiddenFiles;
 - (void)loadSSLCiphers;
@@ -644,27 +650,8 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	
 	NSString *userCipherString = [prefs stringForKey:SPSSLCipherListKey];
 	if(userCipherString) {
-		//expand user list
-		NSArray *userCipherList = [userCipherString componentsSeparatedByString:@":"];
-		
-		//compare the users list to the valid list and only copy over valid items
-		for (NSString *userCipher in userCipherList) {
-			if (![supportedCiphers containsObject:userCipher] || [sslCiphers containsObject:userCipher]) {
-				SPLog(@"Unknown ssl cipher in users' list: %@",userCipher);
-				continue;
-			}
-			[sslCiphers addObject:userCipher];
-		}
-		
-		//now we do the reverse and add valid ciphers that are not yet in the users list.
-		//We'll just assume the ones not in the users' list are newer and therefore better and add
-		//them at the top
-		NSUInteger shift = 0;
-		for (NSString *validCipher in supportedCiphers) {
-			if(![sslCiphers containsObject:validCipher]) {
-				[sslCiphers insertObject:validCipher atIndex:shift++];
-			}
-		}
+		// Preserve the disabled marker when merging newly supported ciphers into saved user prefs.
+		[sslCiphers addObjectsFromArray:[SPMySQLConnection _mergedSSLCipherPreferenceListFromSavedCipherString:userCipherString disabledMarker:SPSSLCipherListMarkerItem]];
 	}
 	else {
 		//no user prefs configured, so we'll just go with the defaults

--- a/UnitTests/SPFunctionsTests.m
+++ b/UnitTests/SPFunctionsTests.m
@@ -14,7 +14,10 @@
 #import <XCTest/XCTest.h>
 
 @interface SPMySQLConnection (TestingPrivateAPI)
++ (NSArray<NSString *> *)defaultSSLCipherList;
++ (NSArray<NSString *> *)legacySSLCipherList;
 + (NSString *)_defaultTLSSuiteListString;
++ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
 + (NSString *)_reachabilityProbeHostForHost:(NSString *)host useSocket:(BOOL)useSocket hasProxy:(BOOL)hasProxy;
 @end
 
@@ -178,9 +181,31 @@
     XCTAssertNil([SPMySQLConnection _reachabilityProbeHostForHost:@"db.lan" useSocket:NO hasProxy:YES]);
     XCTAssertNil([SPMySQLConnection _reachabilityProbeHostForHost:@" localhost " useSocket:NO hasProxy:NO]);
     XCTAssertNil([SPMySQLConnection _reachabilityProbeHostForHost:@"127.0.0.1" useSocket:NO hasProxy:NO]);
+    XCTAssertNil([SPMySQLConnection _reachabilityProbeHostForHost:@"127.0.0.2" useSocket:NO hasProxy:NO]);
     XCTAssertNil([SPMySQLConnection _reachabilityProbeHostForHost:@"[::1]" useSocket:NO hasProxy:NO]);
     XCTAssertEqualObjects([SPMySQLConnection _reachabilityProbeHostForHost:@" db.example.test " useSocket:NO hasProxy:NO], @"db.example.test");
     XCTAssertEqualObjects([SPMySQLConnection _reachabilityProbeHostForHost:@"[2001:db8::5]" useSocket:NO hasProxy:NO], @"2001:db8::5");
+}
+
+- (void)testMergedCipherPreferencesKeepMissingLegacySuitesBelowDisabledMarker
+{
+    NSString *savedCipherString = [@[
+        @"CAMELLIA128-SHA",
+        @"ECDHE-RSA-AES256-GCM-SHA384",
+        @"--",
+        @"AES256-SHA",
+    ] componentsJoinedByString:@":"];
+
+    NSArray<NSString *> *mergedCiphers = [SPMySQLConnection _mergedSSLCipherPreferenceListFromSavedCipherString:savedCipherString disabledMarker:@"--"];
+    NSUInteger markerIndex = [mergedCiphers indexOfObject:@"--"];
+    NSUInteger userEnabledLegacyIndex = [mergedCiphers indexOfObject:@"CAMELLIA128-SHA"];
+    NSUInteger userDisabledModernIndex = [mergedCiphers indexOfObject:@"AES256-SHA"];
+    NSUInteger missingLegacyIndex = [mergedCiphers indexOfObject:@"RC4-MD5"];
+
+    XCTAssertNotEqual(markerIndex, NSNotFound);
+    XCTAssertLessThan(userEnabledLegacyIndex, markerIndex);
+    XCTAssertGreaterThan(userDisabledModernIndex, markerIndex);
+    XCTAssertGreaterThan(missingLegacyIndex, markerIndex);
 }
 
 // 0.0354 s


### PR DESCRIPTION
## Summary
- modernize the default TLS cipher list used by `SPMySQLConnection`
- add explicit TLS 1.3 ciphersuite defaults while still honoring user-provided pre-TLS-1.3 cipher overrides
- keep the Network preferences cipher list in sync with the connection-layer defaults
- stop reconnect reachability gating from probing unrelated hosts and only consider direct remote TCP hosts
- add regression coverage for the new cipher defaults and the reachability host-selection helper

## Why
The current SSL defaults are dated enough to cause inconsistent behavior against newer MySQL and MariaDB servers, while the reconnect reachability gate can incorrectly hold up a reconnect when an unrelated external host is unavailable. This change narrows the reachability logic to the actual connection target and updates the TLS defaults to better match modern server expectations.

## What changed
- replaced the old hardcoded cipher string with shared modern and legacy cipher lists in `SPMySQLConnection`
- added a dedicated default TLS 1.3 ciphersuite string via `MYSQL_OPT_TLS_CIPHERSUITES`
- updated the Network preferences pane to build its list from the same shared cipher definitions used at connection time
- extracted a small helper to decide whether a reconnect reachability probe should run at all, and if so which host it should use
- made the reachability helper return early for socket, proxy, loopback, and empty-host cases so reconnects are not blocked by unrelated network checks
- added unit tests covering the cipher defaults and the pure string logic used to choose the reachability probe host

## Review notes
- I reviewed the diff for regressions around saved cipher preferences, custom cipher overrides, and reconnect behavior and did not find any blocking issues.
- I also verified that the reachability test is environment-independent: it only exercises string normalization/filtering and uses reserved example hostnames rather than any local DNS setup.
- I considered adding a preferences-pane unit test for the composed list ordering, but the current Unit Tests target does not link `SPNetworkPreferencePane`, so that would have required broadening the test target just for this change.

## Testing
- `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS" -only-testing:"Unit Tests/SPFunctionsTests"`
- `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS"`

## Risk
- Low to moderate. The connection path is intentionally changed for TLS defaults and reconnect gating, but both behaviors now have focused regression coverage and the full local unit suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS 1.3 cipher suite configuration support for MySQL connections.
  * Public access to default and legacy SSL cipher lists.

* **Improvements**
  * Dynamic SSL/TLS cipher handling replaces hardcoded lists.
  * Improved network reachability probing with lower CPU usage and better probe host selection.
  * Preference UI now uses merged cipher-preference logic preserving disabled markers.

* **Documentation**
  * Clarified sslCipherList behavior and interaction with TLS 1.3 suites.

* **Tests**
  * Added unit tests for cipher lists, merging behavior, and probe-host selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->