### PR TITLE
#fixed Refresh tables after export so the table list isn't grayed out

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1487,7 +1487,9 @@ set_input:
 	[exportProgressIndicator setUsesThreadedAnimation:YES];
 
 	// Open the progress sheet
-	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:exportProgressWindow completionHandler:nil];
+	[[tableDocumentInstance parentWindowControllerWindow] beginSheet:exportProgressWindow completionHandler:^(NSModalResponse returnCode) {
+		[self->tableDocumentInstance refreshTables];
+	}];
 
 	// CSV export
 	if (exportType == SPCSVExport) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Refresh table list after export to fix issue where table names appear grayed out

## Closes following issues:
- This partially fixes #2222 (export scenario, but not the font change)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
- Localizations:
  - [x] English
  - [x] Spanish
  - [ ] Other (please specify)
- Xcode Version:

## Additional notes:
I was looking for a way to trigger a re-draw of the table list, but given my unfamiliarity with AppKit and the UI code, I chose the simple solution of refreshing the table list which in turn re-draws it. Let me know if you would like me to make any changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table list now properly refreshes after completing a data export operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->