### PR TITLE
#fixed Prevent SAConnectionService from regressing SSH localhost support

### DIFF
--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -108,6 +108,31 @@ struct SAConnectionInfo {
         super.init()
     }
 
+    /// Returns the client-side MySQL host for the supplied connection details.
+    @objc class func resolvedMySQLConnectHost(for info: SAConnectionInfoObjC) -> String? {
+        let trimmedHost = info.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedHost = trimmedHost.lowercased()
+
+        switch info.type {
+        case .socket:
+            return nil
+
+        case .sshTunnel:
+            // Preserve explicit loopback values so localhost-specific grants
+            // continue to work through the local forwarded endpoint.
+            if normalizedHost == "localhost" || normalizedHost == "127.0.0.1" || normalizedHost == "::1" {
+                return trimmedHost
+            }
+            return "127.0.0.1"
+
+        case .tcpIP, .awsIAM:
+            return trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+
+        @unknown default:
+            return trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+        }
+    }
+
     // MARK: Basic Connection
 
     @objc var type: SAConnectionType {

--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -112,6 +112,7 @@ struct SAConnectionInfo {
     @objc class func resolvedMySQLConnectHost(for info: SAConnectionInfoObjC) -> String? {
         let trimmedHost = info.host.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedHost = trimmedHost.lowercased()
+        let fallbackHost = trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
 
         switch info.type {
         case .socket:
@@ -120,16 +121,19 @@ struct SAConnectionInfo {
         case .sshTunnel:
             // Preserve explicit loopback values so localhost-specific grants
             // continue to work through the local forwarded endpoint.
-            if normalizedHost == "localhost" || normalizedHost == "127.0.0.1" || normalizedHost == "::1" {
+            if normalizedHost == "localhost" {
+                return normalizedHost
+            }
+            if normalizedHost == "127.0.0.1" || normalizedHost == "::1" {
                 return trimmedHost
             }
             return "127.0.0.1"
 
         case .tcpIP, .awsIAM:
-            return trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+            return fallbackHost
 
         @unknown default:
-            return trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+            return fallbackHost
         }
     }
 

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -107,6 +107,17 @@ import Foundation
 /// making it testable and reusable from different UI contexts.
 @objc class SAConnectionService: NSObject {
 
+    @objc class func resolvedMySQLHost(for info: SAConnectionInfoObjC) -> String? {
+        switch info.type {
+        case .socket:
+            return nil
+        case .sshTunnel, .tcpIP, .awsIAM:
+            return info.host.isEmpty ? "127.0.0.1" : info.host
+        @unknown default:
+            return nil
+        }
+    }
+
     /// The delegate that receives MySQL connection callbacks (query logging, etc).
     @objc weak var mySQLDelegate: (any SPMySQLConnectionDelegate)?
 
@@ -231,7 +242,7 @@ import Foundation
 
             case .sshTunnel:
                 conn.useSocket = false
-                conn.host = "127.0.0.1"
+                conn.host = Self.resolvedMySQLHost(for: info)
                 if let tunnel = tunnel {
                     conn.port = UInt(tunnel.localPort())
                     conn.setProxy(tunnel)
@@ -239,7 +250,7 @@ import Foundation
 
             case .tcpIP, .awsIAM:
                 conn.useSocket = false
-                conn.host = info.host.isEmpty ? "127.0.0.1" : info.host
+                conn.host = Self.resolvedMySQLHost(for: info)
                 conn.port = UInt(info.port) ?? 3306
 
             @unknown default:

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -107,17 +107,6 @@ import Foundation
 /// making it testable and reusable from different UI contexts.
 @objc class SAConnectionService: NSObject {
 
-    @objc class func resolvedMySQLHost(for info: SAConnectionInfoObjC) -> String? {
-        switch info.type {
-        case .socket:
-            return nil
-        case .sshTunnel, .tcpIP, .awsIAM:
-            return info.host.isEmpty ? "127.0.0.1" : info.host
-        @unknown default:
-            return nil
-        }
-    }
-
     /// The delegate that receives MySQL connection callbacks (query logging, etc).
     @objc weak var mySQLDelegate: (any SPMySQLConnectionDelegate)?
 
@@ -219,6 +208,7 @@ import Foundation
 
     // MARK: - Private: MySQL Connection
 
+    /// Establishes the MySQL-side connection once any required SSH tunnel is ready.
     private func connectMySQL(
         info: SAConnectionInfoObjC,
         preferences: SAConnectionPreferences,
@@ -242,7 +232,7 @@ import Foundation
 
             case .sshTunnel:
                 conn.useSocket = false
-                conn.host = Self.resolvedMySQLHost(for: info)
+                conn.host = SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info) ?? "127.0.0.1"
                 if let tunnel = tunnel {
                     conn.port = UInt(tunnel.localPort())
                     conn.setProxy(tunnel)
@@ -250,7 +240,7 @@ import Foundation
 
             case .tcpIP, .awsIAM:
                 conn.useSocket = false
-                conn.host = Self.resolvedMySQLHost(for: info)
+                conn.host = SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info) ?? "127.0.0.1"
                 conn.port = UInt(info.port) ?? 3306
 
             @unknown default:

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -155,6 +155,15 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "localhost")
     }
 
+    /// Normalizes localhost spellings while still preserving loopback semantics.
+    func testResolvedMySQLConnectHostCanonicalizesLocalhostCasingForSSHTunnelConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = " LocalHost "
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "localhost")
+    }
+
     /// Ensures remote SSH target hosts do not leak into the local MySQL connect host.
     func testResolvedMySQLConnectHostUsesLoopbackForCustomHostForSSHTunnelConnections() {
         let info = SAConnectionInfoObjC()
@@ -171,6 +180,24 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         info.host = ""
 
         XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "127.0.0.1")
+    }
+
+    /// Falls back to loopback for blank TCP favorites after trimming user input.
+    func testResolvedMySQLConnectHostDefaultsToLoopbackForTCPIPConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .tcpIP
+        info.host = "   "
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "127.0.0.1")
+    }
+
+    /// Preserves explicit TCP hosts for non-SSH connections.
+    func testResolvedMySQLConnectHostPreservesCustomHostForTCPIPConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .tcpIP
+        info.host = "db.internal"
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "db.internal")
     }
 
     /// Leaves socket connections without a TCP host override.

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -62,6 +62,37 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(info.sshPassword, "sshpass")
     }
 
+    func testResolvedMySQLHostPreservesLocalhostForSSHTunnelConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = "localhost"
+
+        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "localhost")
+    }
+
+    func testResolvedMySQLHostPreservesCustomHostForSSHTunnelConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = "db.internal"
+
+        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "db.internal")
+    }
+
+    func testResolvedMySQLHostDefaultsToLoopbackWhenBlank() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = ""
+
+        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "127.0.0.1")
+    }
+
+    func testResolvedMySQLHostReturnsNilForSocketConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .socket
+
+        XCTAssertNil(SAConnectionService.resolvedMySQLHost(for: info))
+    }
+
     func testAWSIAMInfoSetup() {
         let info = SAConnectionInfoObjC()
         info.type = .awsIAM

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -62,37 +62,6 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(info.sshPassword, "sshpass")
     }
 
-    func testResolvedMySQLHostPreservesLocalhostForSSHTunnelConnections() {
-        let info = SAConnectionInfoObjC()
-        info.type = .sshTunnel
-        info.host = "localhost"
-
-        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "localhost")
-    }
-
-    func testResolvedMySQLHostPreservesCustomHostForSSHTunnelConnections() {
-        let info = SAConnectionInfoObjC()
-        info.type = .sshTunnel
-        info.host = "db.internal"
-
-        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "db.internal")
-    }
-
-    func testResolvedMySQLHostDefaultsToLoopbackWhenBlank() {
-        let info = SAConnectionInfoObjC()
-        info.type = .sshTunnel
-        info.host = ""
-
-        XCTAssertEqual(SAConnectionService.resolvedMySQLHost(for: info), "127.0.0.1")
-    }
-
-    func testResolvedMySQLHostReturnsNilForSocketConnections() {
-        let info = SAConnectionInfoObjC()
-        info.type = .socket
-
-        XCTAssertNil(SAConnectionService.resolvedMySQLHost(for: info))
-    }
-
     func testAWSIAMInfoSetup() {
         let info = SAConnectionInfoObjC()
         info.type = .awsIAM
@@ -175,5 +144,40 @@ final class SAConnectionInfoMappingTests: XCTestCase {
 
         XCTAssertEqual(info.allowDataLocalInfile, 1)
         XCTAssertEqual(info.enableClearTextPlugin, 1)
+    }
+
+    /// Ensures localhost-specific grants still work through SSH tunnel forwarding.
+    func testResolvedMySQLConnectHostPreservesLocalhostForSSHTunnelConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = "localhost"
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "localhost")
+    }
+
+    /// Ensures remote SSH target hosts do not leak into the local MySQL connect host.
+    func testResolvedMySQLConnectHostUsesLoopbackForCustomHostForSSHTunnelConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = "db.internal"
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "127.0.0.1")
+    }
+
+    /// Falls back to loopback when no explicit TCP host has been supplied.
+    func testResolvedMySQLConnectHostDefaultsToLoopbackWhenBlank() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.host = ""
+
+        XCTAssertEqual(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info), "127.0.0.1")
+    }
+
+    /// Leaves socket connections without a TCP host override.
+    func testResolvedMySQLConnectHostReturnsNilForSocketConnections() {
+        let info = SAConnectionInfoObjC()
+        info.type = .socket
+
+        XCTAssertNil(SAConnectionInfoObjC.resolvedMySQLConnectHost(for: info))
     }
 }


### PR DESCRIPTION
## Changes:
- keep SSH-tunnel MySQL client connections on the local forwarded endpoint, while still preserving explicit `localhost` and loopback values for grant-sensitive setups
- move MySQL connect-host resolution onto `SAConnectionInfoObjC`, trimming favorite input and canonicalizing `localhost` so the mapping logic is available to the Unit Tests target
- add regression tests for SSH `localhost`, mixed-case `localhost`, custom remote hosts, blank hosts, TCP favorites, and socket connections

## Closes following issues:
- Closes: n/a
- Refs: https://github.com/Sequel-Ace/Sequel-Ace/issues/459#issuecomment-4250911259

## Tested:
- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - GitHub Actions `PR Tests` passed on commit `8ded891b603e88290ea2874ce688802ac83e15d2`
  - Local focused `xcodebuild test` with `HOME`, `DerivedData`, and cloned packages redirected into `/tmp` still fails in this agent environment during SwiftPM package resolution with repeated `sandbox-exec: sandbox_apply: Operation not permitted`

## Screenshots:
- n/a

## Additional notes:
- The shipped `production/5.2.1-20100` path still hard-codes `127.0.0.1` for SSH-tunnel MySQL connections in `SPConnectionController`, so the original localhost report appears valid there as well.
- This PR fixes the corresponding `main`-branch Swift connection-service path, which had the same localhost-over-SSH behavior.
- For SSH favorites, `info.host` remains the tunnel's remote target. The MySQL client host must stay on loopback except when the saved host is already an explicit loopback value such as `localhost`, `127.0.0.1`, or `::1`.