### PR TITLE
#fixed Infinite recursion in SATaskManaging Swift stubs

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -292,9 +292,9 @@
 - (void)fadeInTaskProgressWindow:(nonnull NSTimer *)theTimer;
 - (void)setTaskDescription:(nonnull NSString *)description;
 - (void)setTaskPercentage:(CGFloat)taskPercentage;
-- (void)setTaskProgressToIndeterminateAfterDelay:(BOOL)afterDelay;
+- (void)setTaskProgressToIndeterminateAfterDelay:(BOOL)afterDelay NS_SWIFT_NAME(setTaskProgressToIndeterminate(afterDelay:));
 - (void)endTask;
-- (void)enableTaskCancellationWithTitle:(nonnull NSString *)buttonTitle callbackObject:(nullable id)callbackObject callbackFunction:(nullable SEL)callbackFunction;
+- (void)enableTaskCancellationWithTitle:(nonnull NSString *)buttonTitle callbackObject:(nullable NSObject *)callbackObject callbackFunction:(nullable SEL)callbackFunction NS_SWIFT_NAME(enableTaskCancellation(withTitle:callbackObject:callbackFunction:));
 - (void)disableTaskCancellation;
 - (IBAction)cancelTask:(id)sender;
 - (BOOL)isWorking;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1400,7 +1400,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Allow a task to be cancelled, enabling the button with a supplied title
  * and optionally supplying a callback object and function.
  */
-- (void) enableTaskCancellationWithTitle:(NSString *)buttonTitle callbackObject:(id)callbackObject callbackFunction:(SEL)callbackFunction
+- (void) enableTaskCancellationWithTitle:(NSString *)buttonTitle callbackObject:(NSObject *)callbackObject callbackFunction:(SEL)callbackFunction
 {
     // Ensure call on the main thread
     if (![NSThread isMainThread]) return [[self onMainThread] enableTaskCancellationWithTitle:buttonTitle callbackObject:callbackObject callbackFunction:callbackFunction];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
@@ -30,24 +30,16 @@ extension SPDatabaseDocument: SADatabaseDocumentProviding {}
 //   isWorking -> isWorking
 //   setDatabaseListIsSelectable(_:) -> setDatabaseListIsSelectable:
 //   setTaskDescription(_:) -> setTaskDescription:
-extension SPDatabaseDocument: SATaskManaging {
-    // Explicit forwarding stubs to bridge ObjC method signatures to Swift protocol.
-    // These call through to the ObjC implementations using the exact ObjC selectors.
-
-    public func setTaskProgressToIndeterminate(afterDelay: Bool) {
-        setTaskProgressToIndeterminateAfterDelay(afterDelay)
-    }
-
-    public func enableTaskCancellation(withTitle title: String, callbackObject: AnyObject?, callbackFunction: Selector?) {
-        // Use perform() to dispatch to the ObjC implementation directly,
-        // avoiding infinite recursion with this Swift stub (same selector name).
-        let sel = NSSelectorFromString("enableTaskCancellationWithTitle:callbackObject:callbackFunction:")
-        let impl = method(for: sel)
-        typealias ObjCMethod = @convention(c) (AnyObject, Selector, NSString, AnyObject?, Selector?) -> Void
-        let call = unsafeBitCast(impl, to: ObjCMethod.self)
-        call(self, sel, title as NSString, callbackObject, callbackFunction)
-    }
-}
+// The protocol requirements use @objc(...) to bind each Swift method to the
+// exact existing ObjC selector on SPDatabaseDocument (declared in
+// SPDatabaseDocument.h / implemented in SPDatabaseDocument.m), so conformance
+// is satisfied directly by those ObjC methods — no forwarding stub needed.
+//
+// The previous stubs recursed: a Swift method marked @objc with the same
+// selector as the ObjC method it tried to call ends up pointing at itself
+// in the class method table, so `method(for:)` (or a regular Swift call)
+// dispatches straight back into the stub until the stack overflows.
+extension SPDatabaseDocument: SATaskManaging {}
 
 // MARK: - Save Accessory
 

--- a/Source/Protocols/SATaskManaging.swift
+++ b/Source/Protocols/SATaskManaging.swift
@@ -38,7 +38,7 @@ import AppKit
 
     /// Enables the cancel button with a title and optional callback.
     @objc(enableTaskCancellationWithTitle:callbackObject:callbackFunction:)
-    func enableTaskCancellation(withTitle title: String, callbackObject: AnyObject?, callbackFunction: Selector?)
+    func enableTaskCancellation(withTitle title: String, callbackObject: NSObject?, callbackFunction: Selector?)
 
     /// Disables task cancellation (called automatically on endTask).
     @objc func disableTaskCancellation()


### PR DESCRIPTION
While working on a separate drag-and-drop feature for the Content-tab filter, I hit a crash whenever I opened the Content tab. It turned out to be unrelated to my feature and reproducible on plain `main`. 

This PR is byproduct of a drag-n-drop feature I wanted to contribute: https://github.com/Sequel-Ace/Sequel-Ace/pull/2388

## The bug

`SPDatabaseDocument.swift` declares two `@objc` forwarding stubs on `extension SPDatabaseDocument: SATaskManaging`:

- `enableTaskCancellation(withTitle:callbackObject:callbackFunction:)`
- `setTaskProgressToIndeterminate(afterDelay:)`

Each stub uses the same ObjC selector that the ObjC class already implements. At class load, the extension's `@objc` synthesis replaces the original ObjC `IMP` - so when the stub dispatches that selector (directly or via `method(for:)`), it loops back into itself until the stack overflows. Repro: open any table, switch to **Content** -> crash.


  ## Fix

- Remove both stubs. The `@objc(...)` annotations on the protocol already bind each requirement to the exact ObjC selector, so the existing ObjC implementations satisfy conformance directly.
- Add `NS_SWIFT_NAME(...)` on the two ObjC declarations in `SPDatabaseDocument.h` so Swift imports them under the Swift-level names the protocol expects.
- Loosen the protocol's `callbackObject` parameter from `AnyObject?` to `Any?` so it matches how ObjC `id` is bridged into Swift.


<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Described in 'Fix' section.

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Swift interoperability for task progress and cancellation APIs.
  * Streamlined internal task-management implementation for simpler protocol conformance.
  * Adjusted callback handling types for task cancellation (internal API alignment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->