### PR TITLE
#added New feature: drag-n-drop cell to filter 

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4406,10 +4406,37 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 		if (tmp && [tmp length])
 		{
-			[pboard declareTypes:@[NSPasteboardTypeTabularText, NSPasteboardTypeString] owner:nil];
+			// Also offer a single-cell pasteboard type so a drop onto the
+			// rule-filter input populates that one field with just the
+			// clicked cell's value, rather than the whole row's tab string.
+			// NOTE: -clickedRow / -clickedColumn are only valid during
+			// NSControl action dispatch, not during drag-source callbacks.
+			// During this callback NSApp.currentEvent is the mouseDown that
+			// started the drag, so we resolve the clicked cell via its
+			// location in the table's coordinate space.
+			NSString *cellValue = nil;
+			NSEvent *currentEvent = [NSApp currentEvent];
+			if (currentEvent) {
+				NSPoint locationInTable = [tableContentView convertPoint:[currentEvent locationInWindow] fromView:nil];
+				NSInteger hitRow = [tableContentView rowAtPoint:locationInTable];
+				NSInteger hitColumn = [tableContentView columnAtPoint:locationInTable];
+				if (hitColumn >= 0 && hitRow >= 0) {
+					cellValue = [tableContentView displayStringForRow:hitRow column:hitColumn];
+				}
+			}
+
+			NSString *cellValueType = [SPCellValuePasteboard pasteboardTypeRaw];
+			NSMutableArray<NSPasteboardType> *types = [NSMutableArray arrayWithObjects:NSPasteboardTypeTabularText, NSPasteboardTypeString, nil];
+			if (cellValue) {
+				[types addObject:cellValueType];
+			}
+			[pboard declareTypes:types owner:nil];
 
 			[pboard setString:tmp forType:NSPasteboardTypeString];
 			[pboard setString:tmp forType:NSPasteboardTypeTabularText];
+			if (cellValue) {
+				[pboard setString:cellValue forType:cellValueType];
+			}
 
 			return YES;
 		}

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4409,20 +4409,17 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 			// Also offer a single-cell pasteboard type so a drop onto the
 			// rule-filter input populates that one field with just the
 			// clicked cell's value, rather than the whole row's tab string.
-			// NOTE: -clickedRow / -clickedColumn are only valid during
-			// NSControl action dispatch, not during drag-source callbacks.
-			// During this callback NSApp.currentEvent is the mouseDown that
-			// started the drag, so we resolve the clicked cell via its
-			// location in the table's coordinate space.
+			// The clicked cell is the one captured by -[SPCopyTable mouseDown:]
+			// – -clickedRow / -clickedColumn are only valid during NSControl
+			// action dispatch, and NSApp.currentEvent here is the mouseDragged
+			// event that crossed the drag threshold rather than the original
+			// mouseDown, so it can resolve to a different cell if the pointer
+			// moved before the drag started.
 			NSString *cellValue = nil;
-			NSEvent *currentEvent = [NSApp currentEvent];
-			if (currentEvent) {
-				NSPoint locationInTable = [tableContentView convertPoint:[currentEvent locationInWindow] fromView:nil];
-				NSInteger hitRow = [tableContentView rowAtPoint:locationInTable];
-				NSInteger hitColumn = [tableContentView columnAtPoint:locationInTable];
-				if (hitColumn >= 0 && hitRow >= 0) {
-					cellValue = [tableContentView displayStringForRow:hitRow column:hitColumn];
-				}
+			NSInteger clickedRow = [tableContentView mouseDownRow];
+			NSInteger clickedCol = [tableContentView mouseDownColumn];
+			if (clickedRow >= 0 && clickedCol >= 0) {
+				cellValue = [tableContentView displayStringForRow:clickedRow column:clickedCol];
 			}
 
 			NSString *cellValueType = [SPCellValuePasteboard pasteboardTypeRaw];

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -584,7 +584,9 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		case RuleNodeTypeArgument: {
 			//an argument is a textfield
 			ArgNode *node = (ArgNode *)criterion;
-			NSTextField *textField = [[NSTextField alloc] init];
+			// Subclass accepts a cell-value drop from the result grid so a
+			// dragged cell populates this rule's argument with its value.
+			NSTextField *textField = [[SPFilterRuleTextField alloc] init];
 			[[textField cell] setSendsActionOnEndEditing:YES];
 			[[textField cell] setUsesSingleLineMode:YES];
 			[textField setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];

--- a/Source/Views/Controls/SPFilterRuleTextField.swift
+++ b/Source/Views/Controls/SPFilterRuleTextField.swift
@@ -8,65 +8,80 @@
 
 import Cocoa
 
-/// Custom pasteboard type carrying a single cell's display value.
-/// Used so the filter rule text field can distinguish a drag coming from
-/// our own result grid (and populate itself with just the clicked cell's
-/// value) from a generic text drag.
+/// Holder for the custom pasteboard-type identifier used to transfer a
+/// single result-grid cell value onto a filter-rule input. Exists as an
+/// `@objc` class so the raw identifier string can be referenced from
+/// Objective-C (the drag source) and Swift (the drop target) without
+/// duplicating the constant.
 @objc public class SPCellValuePasteboard: NSObject {
+    /// Reverse-DNS identifier of the custom pasteboard type.
     @objc public static let pasteboardTypeRaw: String = "com.sequel-ace.cell-value"
 }
 
-/// NSTextField subclass used for the argument input of a filter rule row
-/// in the Content tab's rule-editor filter. Accepts drops of a single cell
-/// value dragged out of the result table and populates its own string.
+/// `NSTextField` subclass used for the argument input of a filter rule
+/// row in the Content tab's rule-editor filter. Accepts drops of a
+/// single cell value dragged out of the result table and populates its
+/// own string.
 ///
 /// Why: the result-grid drag source also writes the whole row as a SQL
-/// INSERT statement / tab-separated values for drops onto Terminal, a
+/// `INSERT` statement / tab-separated values for drops onto Terminal, a
 /// text editor, etc. We don't want those long strings to land in the
-/// filter field. Registering for our custom type lets us accept only the
-/// clicked cell's value.
+/// filter field. Registering for our custom type lets us accept only
+/// the clicked cell's value.
 @objc public class SPFilterRuleTextField: NSTextField {
     private static let cellValueType = NSPasteboard.PasteboardType(SPCellValuePasteboard.pasteboardTypeRaw)
 
-    public override init(frame frameRect: NSRect) {
+    /// Programmatic initializer used by the rule-editor controller that
+    /// allocates these fields at runtime. Registers for the custom
+    /// pasteboard type so drops route through the view's drag handlers.
+    override public init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         registerForDraggedTypes([Self.cellValueType])
     }
 
+    /// Nib-loading initializer. Retained for parity with
+    /// `NSTextField`'s designated initializer surface – the rule editor
+    /// currently instantiates this class programmatically.
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         registerForDraggedTypes([Self.cellValueType])
     }
 
-    public override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+    /// Accept the drag only when the custom cell-value type is on the
+    /// pasteboard; otherwise the user sees the default no-drop cursor
+    /// and any unrelated string/URL payload falls through to AppKit.
+    override public func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         guard sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil else {
             return []
         }
         return .copy
     }
 
-    public override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+    /// Keep the drag feedback consistent while the pointer hovers; the
+    /// decision is re-evaluated on every movement in case AppKit adjusts
+    /// pasteboard contents during the session.
+    override public func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
         guard sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil else {
             return []
         }
         return .copy
     }
 
-    public override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+    /// Gate the real drop on the custom type being present so
+    /// `performDragOperation(_:)` doesn't run for accidental text drags.
+    override public func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
         return sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil
     }
 
-    public override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+    /// Read the custom payload and assign it to `stringValue`. The filter
+    /// is not auto-applied; the user hits Return (or clicks Apply
+    /// Filters) to run the query, matching the flow of typing a value
+    /// into the field directly.
+    override public func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         guard let value = sender.draggingPasteboard.string(forType: Self.cellValueType) else {
             return false
         }
         self.stringValue = value
-        // Trigger the same action the user would get by pressing Return or
-        // ending the edit, so the rule editor picks up the new value and
-        // the filter re-runs.
-        if let action = self.action {
-            NSApp.sendAction(action, to: self.target, from: self)
-        }
         return true
     }
 }

--- a/Source/Views/Controls/SPFilterRuleTextField.swift
+++ b/Source/Views/Controls/SPFilterRuleTextField.swift
@@ -1,0 +1,72 @@
+//
+//  SPFilterRuleTextField.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.04.17.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Cocoa
+
+/// Custom pasteboard type carrying a single cell's display value.
+/// Used so the filter rule text field can distinguish a drag coming from
+/// our own result grid (and populate itself with just the clicked cell's
+/// value) from a generic text drag.
+@objc public class SPCellValuePasteboard: NSObject {
+    @objc public static let pasteboardTypeRaw: String = "com.sequel-ace.cell-value"
+}
+
+/// NSTextField subclass used for the argument input of a filter rule row
+/// in the Content tab's rule-editor filter. Accepts drops of a single cell
+/// value dragged out of the result table and populates its own string.
+///
+/// Why: the result-grid drag source also writes the whole row as a SQL
+/// INSERT statement / tab-separated values for drops onto Terminal, a
+/// text editor, etc. We don't want those long strings to land in the
+/// filter field. Registering for our custom type lets us accept only the
+/// clicked cell's value.
+@objc public class SPFilterRuleTextField: NSTextField {
+    private static let cellValueType = NSPasteboard.PasteboardType(SPCellValuePasteboard.pasteboardTypeRaw)
+
+    public override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([Self.cellValueType])
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([Self.cellValueType])
+    }
+
+    public override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil else {
+            return []
+        }
+        return .copy
+    }
+
+    public override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil else {
+            return []
+        }
+        return .copy
+    }
+
+    public override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        return sender.draggingPasteboard.availableType(from: [Self.cellValueType]) != nil
+    }
+
+    public override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let value = sender.draggingPasteboard.string(forType: Self.cellValueType) else {
+            return false
+        }
+        self.stringValue = value
+        // Trigger the same action the user would get by pressing Return or
+        // ending the edit, so the rule editor picks up the new value and
+        // the filter re-runs.
+        if let action = self.action {
+            NSApp.sendAction(action, to: self.target, from: self)
+        }
+        return true
+    }
+}

--- a/Source/Views/TableViews/SPCopyTable.h
+++ b/Source/Views/TableViews/SPCopyTable.h
@@ -63,7 +63,17 @@ extern NSInteger SPEditMenuCopyAsSQLNoAutoInc;
 
 	NSRange fieldEditorSelectedRange;
 	NSString *tmpBlobFileDirectory;
+
+	// The row/column under the pointer on the most recent mouseDown. Kept so
+	// the drag-source callback can publish a single-cell payload derived from
+	// the exact cell the user pressed on, rather than re-hit-testing the
+	// drag's current event (which may have moved past the drag threshold).
+	NSInteger mouseDownRow;
+	NSInteger mouseDownColumn;
 }
+
+@property (readonly) NSInteger mouseDownRow;
+@property (readonly) NSInteger mouseDownColumn;
 
 @property (readwrite, copy) NSString *tmpBlobFileDirectory;
 

--- a/Source/Views/TableViews/SPCopyTable.h
+++ b/Source/Views/TableViews/SPCopyTable.h
@@ -90,6 +90,21 @@ extern NSInteger SPEditMenuCopyAsSQLNoAutoInc;
 - (NSString *)draggedRowsAsTabString;
 
 /*!
+	@method	 displayStringForRow:column:
+	@abstract   Returns the display string for a single cell at the given
+	  row and visible-column position, honouring the same NULL / blob /
+	  geometry formatting used for drag-out and copy.
+	@param	 row  Row index in the current result set
+	@param	 visibleColumn  Position of the column as currently shown on
+	  screen (ie after any user reordering); the stored column identifier
+	  is resolved from the table's column ordering, matching how
+	  -draggedRowsAsTabString sources its data.
+	@result  The display string for the cell, or nil when the position is
+	  out of range.
+*/
+- (NSString *)displayStringForRow:(NSInteger)row column:(NSInteger)visibleColumn;
+
+/*!
 	@method	 draggingSourceOperationMaskForLocal:
 	@discussion Allows for dragging out of the table to other applications
 	@param	  isLocal who cares

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -769,6 +769,55 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 	return result;
 }
 
+/**
+ * Return the display string for a single cell, matching the NULL / blob /
+ * geometry formatting used by -draggedRowsAsTabString. Used to write the
+ * clicked cell's value onto the pasteboard during a drag, so drops onto
+ * the rule-filter input populate only that cell's value.
+ */
+- (NSString *)displayStringForRow:(NSInteger)row column:(NSInteger)visibleColumn
+{
+	NSArray *columns = [self tableColumns];
+	NSInteger numColumns = (NSInteger)[columns count];
+	if (row < 0 || visibleColumn < 0 || visibleColumn >= numColumns) {
+		return nil;
+	}
+
+	// Resolve the on-screen column position to the underlying storage index,
+	// same mapping used by -draggedRowsAsTabString.
+	NSUInteger storageIndex = (NSUInteger)[[[columns safeObjectAtIndex:(NSUInteger)visibleColumn] identifier] integerValue];
+	id cellData = SPDataStorageObjectAtRowAndColumn(tableStorage, (NSUInteger)row, storageIndex);
+
+	if (!cellData) {
+		return nil;
+	}
+
+	NSString *nullString = [prefs objectForKey:SPNullValue];
+	BOOL hexBlobs = [prefs boolForKey:SPDisplayBinaryDataAsHex];
+
+	if ([cellData isNSNull]) {
+		return nullString;
+	}
+	if ([cellData isSPNotLoaded]) {
+		return NSLocalizedString(@"(not loaded)", @"value shown for hidden blob and text fields");
+	}
+	if ([cellData isKindOfClass:[NSData class]]) {
+		if (hexBlobs) {
+			return [NSString stringWithFormat:@"0x%@", [cellData dataToHexString]];
+		}
+		NSStringEncoding connectionEncoding = [mySQLConnection stringEncoding];
+		NSString *displayString = [[NSString alloc] initWithData:cellData encoding:connectionEncoding];
+		if (!displayString) {
+			displayString = [[NSString alloc] initWithData:cellData encoding:NSISOLatin1StringEncoding];
+		}
+		return displayString;
+	}
+	if ([cellData isKindOfClass:[SPMySQLGeometryData class]]) {
+		return [cellData wktString];
+	}
+	return [cellData description];
+}
+
 #pragma mark -
 
 /**

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -783,9 +783,20 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 		return nil;
 	}
 
-	// Resolve the on-screen column position to the underlying storage index,
-	// same mapping used by -draggedRowsAsTabString.
+	// Row / column indices get passed in from hit-tests and cached
+	// mouseDown positions, either of which can outlive a reload. Guard
+	// against both a stale row and a reordered column identifier that
+	// resolves outside the storage's column range before calling into
+	// SPDataStorageObjectAtRowAndColumn (which does not bounds-check).
+	if (!tableStorage || (NSUInteger)row >= [tableStorage count]) {
+		return nil;
+	}
+
 	NSUInteger storageIndex = (NSUInteger)[[[columns safeObjectAtIndex:(NSUInteger)visibleColumn] identifier] integerValue];
+	if (storageIndex >= [tableStorage columnCount]) {
+		return nil;
+	}
+
 	id cellData = SPDataStorageObjectAtRowAndColumn(tableStorage, (NSUInteger)row, storageIndex);
 
 	if (!cellData) {
@@ -1650,8 +1661,30 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 {
 	columnDefinitions = nil;
 	prefs = [NSUserDefaults standardUserDefaults];
+	mouseDownRow = -1;
+	mouseDownColumn = -1;
 
     [super awakeFromNib];
+}
+
+@synthesize mouseDownRow;
+@synthesize mouseDownColumn;
+
+/**
+ * Cache the row/column under the pointer at the moment the mouse goes
+ * down. -clickedRow / -clickedColumn are only valid during NSControl
+ * action dispatch and NSApp.currentEvent during a drag-source callback
+ * is the mouseDragged event that crossed the drag threshold (not the
+ * original mouseDown), so we record the click location here and read it
+ * back in -[SPTableContent tableView:writeRowsWithIndexes:toPasteboard:]
+ * when publishing the single-cell pasteboard payload.
+ */
+- (void)mouseDown:(NSEvent *)event
+{
+	NSPoint point = [self convertPoint:[event locationInWindow] fromView:nil];
+	mouseDownRow = [self rowAtPoint:point];
+	mouseDownColumn = [self columnAtPoint:point];
+	[super mouseDown:event];
 }
 
 @end

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -812,6 +812,17 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 	if ([cellData isSPNotLoaded]) {
 		return NSLocalizedString(@"(not loaded)", @"value shown for hidden blob and text fields");
 	}
+	// Honour any SABaseFormatter attached to the column's data cell (e.g.
+	// SAUuidFormatter) so the dropped value matches what the grid shows
+	// – same precedence used by -rowsAsTabStringWithHeaders... before the
+	// raw NSData path.
+	NSFormatter *cellFormatter = [[[columns safeObjectAtIndex:(NSUInteger)visibleColumn] dataCell] formatter];
+	if ([cellFormatter isKindOfClass:[SABaseFormatter class]]) {
+		NSString *formatted = [(SABaseFormatter *)cellFormatter stringForObjectValue:cellData];
+		if (formatted) {
+			return formatted;
+		}
+	}
 	if ([cellData isKindOfClass:[NSData class]]) {
 		if (hexBlobs) {
 			return [NSString stringWithFormat:@"0x%@", [cellData dataToHexString]];

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		17F5B39C1049B96A00FC794F /* SPSQLExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F5B39B1049B96A00FC794F /* SPSQLExporter.m */; };
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
+		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
 		1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
 		1A11E50425A327F1001CB721 /* SPPanelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A11E50325A327F1001CB721 /* SPPanelOptions.m */; };
@@ -770,6 +771,7 @@
 		17F90E471210B42700274C98 /* SPExportFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPExportFile.m; sourceTree = "<group>"; };
 		17FDB04A1280778B00DBBBC2 /* SPFontPreviewTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFontPreviewTextField.h; sourceTree = "<group>"; };
 		17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFontPreviewTextField.m; sourceTree = "<group>"; };
+		DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleTextField.swift; sourceTree = "<group>"; };
 		1A071B8B254D983700246912 /* SPNSMutableDictionaryAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPNSMutableDictionaryAdditions.h; sourceTree = "<group>"; };
 		1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPNSMutableDictionaryAdditions.m; sourceTree = "<group>"; };
 		1A0751DF25EAF37700FFDF6B /* ReportExceptionApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReportExceptionApplication.m; sourceTree = "<group>"; };
@@ -2194,6 +2196,7 @@
 			children = (
 				50E217B118174246009D3580 /* SPColorSelectorView.h */,
 				50E217B218174246009D3580 /* SPColorSelectorView.m */,
+				DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */,
 				17FDB04A1280778B00DBBBC2 /* SPFontPreviewTextField.h */,
 				17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */,
 				58D2A6A516FBDEFF002EB401 /* SPComboPopupButton.h */,
@@ -3082,6 +3085,7 @@
 				172A65110F7BED7A001E861A /* SPConsoleMessage.m in Sources */,
 				6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */,
 				FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */,
+				DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */,
 				1A24B627258A2E9A00541E88 /* SecureBookmarkData.swift in Sources */,
 				179F15060F7C433C00579954 /* SPEditorTokens.l in Sources */,
 				B5E92F1C0F75B2E800012500 /* SPExportController.m in Sources */,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->


Big fan of Sequel Ace, it's the tool I have open all day. 
One thing I kept wishing for: when I'm scanning results and spot a value I want to filter by, I'd love to just drag it into the filter field instead of selecting + copying + clicking the input + pasting. 


## Changes:
- Added `SPFilterRuleTextField` (`NSTextField` subclass) that accepts a custom pasteboard type on drop
- Added `-[SPCopyTable displayStringForRow:column:]` helper
- Updated the Content tab's drag writer to also publish the clicked cell's value under a new `com.sequel-ace.cell-value` pasteboard type
- Rule-editor argument field now uses `SPFilterRuleTextField` instead of a plain `NSTextField`

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screen recording: 

https://github.com/user-attachments/assets/5c230a01-c69e-4bd3-befd-259368302bd9


## Additional notes:

Supporting PR: https://github.com/Sequel-Ace/Sequel-Ace/pull/2387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support: table cells can now be dragged directly into filter rule input fields.
  * Enhanced cell value copying with improved handling for NULL values, binary data in hexadecimal format, and geometry data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->