### PR TITLE
Modernization Phase A3: Collapse view-switching methods into SAViewMode

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -45,10 +45,11 @@ SPDatabaseDocument.m at 6,592 lines is the biggest bottleneck. Break it apart:
 - Move the progress window, indicators, and timer management out of the document
 - Files: `SPDatabaseDocument.m`, new `SATaskController.swift`
 
-**A3. Extract view state switching to use SAViewMode (~188 lines)**
+**A3. Extract view state switching to use SAViewMode (~188 lines)** — ✅ Done
 - `viewStructure`, `viewContent`, `viewQuery`, `viewStatus`, `viewRelations`, `viewTriggers`
-- Replace 6 repetitive methods with a single `switchToView(_ mode: SAViewMode)` that uses the enum
-- `SAViewMode` already exists — just wire it into the document
+- Replaced 6 repetitive method bodies with a shared `-[SPDatabaseDocument switchToViewMode:]` that consults `SAViewMode` for tab index, toolbar identifier, and prefs value
+- Added ObjC accessors on `SAViewModeHelper` (`tabIndexFor:`, `toolbarIdentifierFor:`, `preferencesValueFor:`)
+- View-specific extras (focus change for query, table load + focus for status) stay in the per-mode wrappers
 - Files: `SPDatabaseDocument.m`, `SPDatabaseDocument+ViewMode.swift`
 
 **A4. Extract window title management (~57 lines)**
@@ -120,7 +121,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 
 ## Recommended order
 
-1. **Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum
+1. ~~**Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum~~ ✅ Done
 2. **Phase B3** (SAViewMode tests) — validate before and after
 3. **Phase A1** (database list manager) — high value, moderate effort
 4. **Phase A4** (window title) — quick, easy

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument+ViewMode.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument+ViewMode.swift
@@ -155,4 +155,19 @@ import AppKit
     @objc static var allToolbarIdentifiers: [String] {
         SAViewMode.allCases.map { $0.toolbarIdentifier.rawValue }
     }
+
+    /// Tab view index for the given mode.
+    @objc static func tabIndex(for mode: SAViewMode) -> Int {
+        return mode.tabIndex
+    }
+
+    /// Toolbar identifier string for the given mode.
+    @objc static func toolbarIdentifier(for mode: SAViewMode) -> String {
+        return mode.toolbarIdentifier.rawValue
+    }
+
+    /// Legacy SPViewMode preferences value for the given mode.
+    @objc static func preferencesValue(for mode: SAViewMode) -> Int {
+        return mode.preferencesValue
+    }
 }

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -5553,9 +5553,15 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 #pragma mark -
 #pragma mark Tab view control and delegate methods
 
-//WARNING: Might be called from code in background threads
-- (void)viewStructure {
-
+/**
+ * Shared view-switching path used by viewStructure/Content/Query/Status/Relations/Triggers.
+ * Returns YES if the switch went through, NO if it was cancelled because the current
+ * view had uncommitted edits.
+ *
+ * WARNING: Safe to call from background threads — execution hops to the main queue.
+ */
+- (BOOL)switchToViewMode:(SAViewMode)mode {
+    __block BOOL didSwitch = NO;
     SPMainQSync(^{
         // Cancel the selection if currently editing a view and unable to save
         if (![self couldCommitCurrentViewActions]) {
@@ -5563,104 +5569,51 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             return;
         }
 
-        [self->tableTabView selectTabViewItemAtIndex:0];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarTableStructure];
+        [self->tableTabView selectTabViewItemAtIndex:[SAViewModeHelper tabIndexFor:mode]];
+        [self.mainToolbar setSelectedItemIdentifier:[SAViewModeHelper toolbarIdentifierFor:mode]];
         [self->spHistoryControllerInstance updateHistoryEntries];
-
-        [self->prefs setInteger:SPStructureViewMode forKey:SPLastViewMode];
-
+        [self->prefs setInteger:[SAViewModeHelper preferencesValueFor:mode] forKey:SPLastViewMode];
+        didSwitch = YES;
     });
+    return didSwitch;
+}
+
+//WARNING: Might be called from code in background threads
+- (void)viewStructure {
+    [self switchToViewMode:SAViewModeStructure];
 }
 
 - (void)viewContent {
-    SPMainQSync(^{
-        // Cancel the selection if currently editing a view and unable to save
-        if (![self couldCommitCurrentViewActions]) {
-            [self.mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
-            return;
-        }
-
-        [self->tableTabView selectTabViewItemAtIndex:1];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarTableContent];
-        [self->spHistoryControllerInstance updateHistoryEntries];
-        [self->prefs setInteger:SPContentViewMode forKey:SPLastViewMode];
-    });
+    [self switchToViewMode:SAViewModeContent];
 }
 
 - (void)viewQuery {
+    if (![self switchToViewMode:SAViewModeQuery]) return;
+
     SPMainQSync(^{
-        // Cancel the selection if currently editing a view and unable to save
-        if (![self couldCommitCurrentViewActions]) {
-            [self.mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
-            return;
-        }
-
-        [self->tableTabView selectTabViewItemAtIndex:2];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarCustomQuery];
-        [self->spHistoryControllerInstance updateHistoryEntries];
-
         // Set the focus on the text field
         [[self.parentWindowController window] makeFirstResponder:self->customQueryTextView];
-
-        [self->prefs setInteger:SPQueryEditorViewMode forKey:SPLastViewMode];
     });
-
 }
 
 - (void)viewStatus {
+    if (![self switchToViewMode:SAViewModeStatus]) return;
+
     SPMainQSync(^{
-        // Cancel the selection if currently editing a view and unable to save
-        if (![self couldCommitCurrentViewActions]) {
-            [self.mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
-            return;
-        }
-
-        [self->tableTabView selectTabViewItemAtIndex:3];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarTableInfo];
-        [self->spHistoryControllerInstance updateHistoryEntries];
-
         if ([[self table] length]) {
             [self->extendedTableInfoInstance loadTable:[self table]];
         }
 
         [[self.parentWindowController window] makeFirstResponder:[self->extendedTableInfoInstance valueForKeyPath:@"tableCreateSyntaxTextView"]];
-
-        [self->prefs setInteger:SPTableInfoViewMode forKey:SPLastViewMode];
     });
-
 }
 
 - (void)viewRelations {
-    SPMainQSync(^{
-        // Cancel the selection if currently editing a view and unable to save
-        if (![self couldCommitCurrentViewActions]) {
-            [self.mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
-            return;
-        }
-
-        [self->tableTabView selectTabViewItemAtIndex:4];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarTableRelations];
-        [self->spHistoryControllerInstance updateHistoryEntries];
-
-        [self->prefs setInteger:SPRelationsViewMode forKey:SPLastViewMode];
-    });
-
+    [self switchToViewMode:SAViewModeRelations];
 }
 
 - (void)viewTriggers {
-    SPMainQSync(^{
-        // Cancel the selection if currently editing a view and unable to save
-        if (![self couldCommitCurrentViewActions]) {
-            [self.mainToolbar setSelectedItemIdentifier:*SPViewModeToMainToolbarMap[[self->prefs integerForKey:SPLastViewMode]]];
-            return;
-        }
-
-        [self->tableTabView selectTabViewItemAtIndex:5];
-        [self.mainToolbar setSelectedItemIdentifier:SPMainToolbarTableTriggers];
-        [self->spHistoryControllerInstance updateHistoryEntries];
-
-        [self->prefs setInteger:SPTriggersViewMode forKey:SPLastViewMode];
-    });
+    [self switchToViewMode:SAViewModeTriggers];
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase A3 from [`.claude/modernization-followup-plan.md`](https://github.com/Sequel-Ace/Sequel-Ace/blob/main/.claude/modernization-followup-plan.md): wire the existing `SAViewMode` Swift enum into `SPDatabaseDocument`'s view-switching code.

- **Collapsed six repetitive methods** — `viewStructure`, `viewContent`, `viewQuery`, `viewStatus`, `viewRelations`, `viewTriggers` all duplicated the same ~12-line dispatch (uncommitted-edits guard, tab selection, toolbar identifier, history update, prefs store). They now share `-[SPDatabaseDocument switchToViewMode:]` which reads everything off `SAViewMode`.
- **Added ObjC bridges** on `SAViewModeHelper`: `tabIndexFor:`, `toolbarIdentifierFor:`, `preferencesValueFor:` — so ObjC callers can use the enum without per-case switches.
- **Preserved view-specific behavior** — `viewQuery` still focuses `customQueryTextView`; `viewStatus` still loads the table and focuses `tableCreateSyntaxTextView`. These now run only when the switch actually committed (i.e. the uncommitted-edits guard didn't bail).
- **Marked A3 done** in the follow-up plan.

### Diffstat

| File | Change |
|------|--------|
| `SPDatabaseDocument.m` | -73 / +26 (−47 net) |
| `SPDatabaseDocument+ViewMode.swift` | +15 |
| `.claude/modernization-followup-plan.md` | docs |

Behavior preserved: same tab indexes, same toolbar identifiers, same prefs values, same `couldCommitCurrentViewActions` guard.

## Test plan

- [x] Build succeeds with zero errors (verified via Xcode build, only pre-existing deprecation/nullability warnings remain)
- [ ] Toolbar tab buttons switch to the correct tab (Structure / Content / Query / Status / Relations / Triggers)
- [ ] Selecting a tab while an uncommitted view edit is pending shows the "cancel edits?" prompt and resets the toolbar to the last view
- [ ] Switching to Query focuses the SQL text view
- [ ] Switching to Status loads the selected table's info and focuses the create-syntax text view
- [ ] `SPLastViewMode` preference round-trips correctly across launches
- [ ] Unit tests pass (`xcodebuild test -scheme "Unit Tests"`)

## Follow-ups

Next from the plan: **B3** (unit tests for SAViewMode round-trip / toolbar factory) as a safety net before **A1** (extract `SADatabaseListManager`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated view mode switching logic to reduce code duplication and improve maintainability.
  * Enhanced internal helper methods for view mode configuration retrieval.

* **Chores**
  * Updated modernization documentation for completed development phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2402)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->