### PR TITLE
Modernization Phase B3: 16 unit tests for SAViewMode

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -69,10 +69,10 @@ SPDatabaseDocument.m at 6,592 lines is the biggest bottleneck. Break it apart:
 - Test drag & drop acceptance/rejection logic
 - Test Quick Connect item injection
 
-**B3. Tests for SAViewMode**
-- Round-trip preferences values
-- Toolbar item factory produces correct identifiers/images
-- All cases covered
+**B3. Tests for SAViewMode** — ✅ Done
+- 16 unit tests in `UnitTests/SAViewModeTests.swift` covering tab indexes, toolbar identifiers (literal match against the SPConstants wire format), preferences round-trip + unknown-value fallback, action selector names, the `SAViewModeHelper` ObjC bridges, and the toolbar item factory configuration
+- `SPDatabaseDocument+ViewMode.swift` had its `SPMainToolbar*` extern references inlined so the file has no ObjC dependency and can be compiled into the Unit Tests target without giving it a bridging header (the inlined strings must stay in sync with `SPConstants.m` — documented in the source)
+- Exhaustive-case guard test that fails if a new `SAViewMode` case is added without updating the suite
 
 ### Phase C: SwiftUI migration starts
 
@@ -122,7 +122,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 ## Recommended order
 
 1. ~~**Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum~~ ✅ Done
-2. **Phase B3** (SAViewMode tests) — validate before and after
+2. ~~**Phase B3** (SAViewMode tests) — validate before and after~~ ✅ Done
 3. **Phase A1** (database list manager) — high value, moderate effort
 4. **Phase A4** (window title) — quick, easy
 5. **Phase B2** (favorites data source tests) — safety net

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument+ViewMode.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument+ViewMode.swift
@@ -24,14 +24,22 @@ import AppKit
     var tabIndex: Int { rawValue }
 
     /// The toolbar item identifier for this mode.
+    ///
+    /// Strings are inlined (not read from `SPMainToolbar*` in
+    /// SPConstants.m) so this file has no ObjC dependency and can be
+    /// compiled into the Unit Tests target without a bridging header.
+    /// They MUST stay in sync with the corresponding extern constants
+    /// in SPConstants.m — the values are also persisted in toolbar
+    /// state, so changing one without the other breaks restoration
+    /// across launches.
     var toolbarIdentifier: NSToolbarItem.Identifier {
         switch self {
-        case .structure:  return NSToolbarItem.Identifier(SPMainToolbarTableStructure)
-        case .content:    return NSToolbarItem.Identifier(SPMainToolbarTableContent)
-        case .query:      return NSToolbarItem.Identifier(SPMainToolbarCustomQuery)
-        case .status:     return NSToolbarItem.Identifier(SPMainToolbarTableInfo)
-        case .relations:  return NSToolbarItem.Identifier(SPMainToolbarTableRelations)
-        case .triggers:   return NSToolbarItem.Identifier(SPMainToolbarTableTriggers)
+        case .structure:  return NSToolbarItem.Identifier("SwitchToTableStructureToolbarItemIdentifier")
+        case .content:    return NSToolbarItem.Identifier("SwitchToTableContentToolbarItemIdentifier")
+        case .query:      return NSToolbarItem.Identifier("SwitchToRunQueryToolbarItemIdentifier")
+        case .status:     return NSToolbarItem.Identifier("SwitchToTableInfoToolbarItemIdentifier")
+        case .relations:  return NSToolbarItem.Identifier("SwitchToTableRelationsToolbarItemIdentifier")
+        case .triggers:   return NSToolbarItem.Identifier("SwitchToTableTriggersToolbarItemIdentifier")
         }
     }
 

--- a/UnitTests/SAViewModeTests.swift
+++ b/UnitTests/SAViewModeTests.swift
@@ -1,0 +1,197 @@
+//
+//  SAViewModeTests.swift
+//  Unit Tests
+//
+//  Tests for SAViewMode and SAViewModeHelper — the data-driven enum that
+//  replaces the scattered SPViewMode C enum and the six repetitive
+//  view-switching methods on SPDatabaseDocument.
+//
+//  These tests are the safety net for Phase A3 of the modernization
+//  follow-up plan ("validate before and after"). They lock down:
+//    - tab indexes (used to drive NSTabView selection)
+//    - toolbar identifier strings (must match SPMainToolbar* constants)
+//    - legacy SPViewMode preferences integers (round-trip with stored prefs)
+//    - the action selector names (must match the ObjC viewX methods)
+//    - exhaustive case coverage
+//
+
+import XCTest
+import AppKit
+
+final class SAViewModeTests: XCTestCase {
+
+    // MARK: - Tab indexes
+
+    /// Tab indexes drive `[tableTabView selectTabViewItemAtIndex:]` in
+    /// `-[SPDatabaseDocument switchToViewMode:]`. They must stay 0..5
+    /// in order — changing them would silently switch the user to the
+    /// wrong tab.
+    func testTabIndexes() {
+        XCTAssertEqual(SAViewMode.structure.tabIndex, 0)
+        XCTAssertEqual(SAViewMode.content.tabIndex,   1)
+        XCTAssertEqual(SAViewMode.query.tabIndex,     2)
+        XCTAssertEqual(SAViewMode.status.tabIndex,    3)
+        XCTAssertEqual(SAViewMode.relations.tabIndex, 4)
+        XCTAssertEqual(SAViewMode.triggers.tabIndex,  5)
+    }
+
+    func testTabIndexesAreContiguousAndUnique() {
+        let indexes = SAViewMode.allCases.map(\.tabIndex)
+        XCTAssertEqual(indexes.sorted(), Array(0..<SAViewMode.allCases.count))
+        XCTAssertEqual(Set(indexes).count, SAViewMode.allCases.count)
+    }
+
+    // MARK: - Toolbar identifiers
+
+    /// The toolbar identifier of each view mode must exactly match the
+    /// corresponding `SPMainToolbar*` constant defined in SPConstants.m
+    /// — these are used to look up the selected toolbar item, and the
+    /// matching toolbar item targets the same view mode.
+    ///
+    /// The strings are pinned as literals here because the Unit Tests
+    /// target has no ObjC bridging header, so the C extern symbols
+    /// aren't visible from Swift. This doubles as a regression guard:
+    /// if anyone renames the constant in SPConstants.m, persisted
+    /// toolbar selections from existing installs break, and this test
+    /// fires.
+    func testToolbarIdentifiersMatchConstants() {
+        XCTAssertEqual(SAViewMode.structure.toolbarIdentifier.rawValue, "SwitchToTableStructureToolbarItemIdentifier")
+        XCTAssertEqual(SAViewMode.content.toolbarIdentifier.rawValue,   "SwitchToTableContentToolbarItemIdentifier")
+        XCTAssertEqual(SAViewMode.query.toolbarIdentifier.rawValue,     "SwitchToRunQueryToolbarItemIdentifier")
+        XCTAssertEqual(SAViewMode.status.toolbarIdentifier.rawValue,    "SwitchToTableInfoToolbarItemIdentifier")
+        XCTAssertEqual(SAViewMode.relations.toolbarIdentifier.rawValue, "SwitchToTableRelationsToolbarItemIdentifier")
+        XCTAssertEqual(SAViewMode.triggers.toolbarIdentifier.rawValue,  "SwitchToTableTriggersToolbarItemIdentifier")
+    }
+
+    func testToolbarIdentifiersAreUnique() {
+        let identifiers = SAViewMode.allCases.map(\.toolbarIdentifier)
+        XCTAssertEqual(Set(identifiers).count, SAViewMode.allCases.count)
+    }
+
+    // MARK: - Preferences round-trip
+
+    /// The legacy SPViewMode preferences values are:
+    ///   1 = Structure, 2 = Content, 3 = Relations, 4 = TableInfo,
+    ///   5 = QueryEditor, 6 = Triggers
+    /// (declared in SPConstants.h). Note the order is NOT 1..6 by
+    /// enum case order — `query` is 5 and `status` is 4. This test
+    /// pins those exact integers because they're already stored in
+    /// user defaults on existing installs and must not drift.
+    func testPreferencesValues() {
+        XCTAssertEqual(SAViewMode.structure.preferencesValue, 1)
+        XCTAssertEqual(SAViewMode.content.preferencesValue,   2)
+        XCTAssertEqual(SAViewMode.relations.preferencesValue, 3)
+        XCTAssertEqual(SAViewMode.status.preferencesValue,    4)
+        XCTAssertEqual(SAViewMode.query.preferencesValue,     5)
+        XCTAssertEqual(SAViewMode.triggers.preferencesValue,  6)
+    }
+
+    func testPreferencesRoundTrip() {
+        for mode in SAViewMode.allCases {
+            let restored = SAViewMode.fromPreferences(mode.preferencesValue)
+            XCTAssertEqual(restored, mode, "round-trip failed for \(mode)")
+        }
+    }
+
+    /// Unknown / corrupted preference values must fall back to a known
+    /// good mode rather than crashing or returning a bogus case.
+    func testFromPreferencesFallsBackForUnknownValue() {
+        XCTAssertEqual(SAViewMode.fromPreferences(0),    .structure)
+        XCTAssertEqual(SAViewMode.fromPreferences(-1),   .structure)
+        XCTAssertEqual(SAViewMode.fromPreferences(7),    .structure)
+        XCTAssertEqual(SAViewMode.fromPreferences(9999), .structure)
+    }
+
+    // MARK: - Action selector names
+
+    /// These selector names are wired up by `makeToolbarItem` and
+    /// must match the ObjC entry points on SPDatabaseDocument
+    /// (-viewStructure, -viewContent, ...).
+    func testActionSelectorNames() {
+        XCTAssertEqual(SAViewMode.structure.actionSelectorName, "viewStructure")
+        XCTAssertEqual(SAViewMode.content.actionSelectorName,   "viewContent")
+        XCTAssertEqual(SAViewMode.query.actionSelectorName,     "viewQuery")
+        XCTAssertEqual(SAViewMode.status.actionSelectorName,    "viewStatus")
+        XCTAssertEqual(SAViewMode.relations.actionSelectorName, "viewRelations")
+        XCTAssertEqual(SAViewMode.triggers.actionSelectorName,  "viewTriggers")
+    }
+
+    // MARK: - Toolbar item factory
+
+    func testMakeToolbarItemConfiguration() {
+        let target = NSObject()
+
+        for mode in SAViewMode.allCases {
+            let item = mode.makeToolbarItem(target: target)
+
+            XCTAssertEqual(item.itemIdentifier, mode.toolbarIdentifier,
+                           "wrong identifier for \(mode)")
+            XCTAssertEqual(item.label, mode.toolbarLabel,
+                           "wrong label for \(mode)")
+            XCTAssertEqual(item.paletteLabel, mode.toolbarLabel,
+                           "palette label should match label for \(mode)")
+            XCTAssertEqual(item.toolTip, mode.toolbarTooltip,
+                           "wrong tooltip for \(mode)")
+            XCTAssertNotNil(item.image, "missing image for \(mode)")
+            XCTAssertTrue(item.target === target, "wrong target for \(mode)")
+            XCTAssertEqual(item.action, NSSelectorFromString(mode.actionSelectorName),
+                           "wrong action for \(mode)")
+        }
+    }
+
+    func testToolbarLabelsAreNonEmpty() {
+        for mode in SAViewMode.allCases {
+            XCTAssertFalse(mode.toolbarLabel.isEmpty, "empty label for \(mode)")
+            XCTAssertFalse(mode.toolbarTooltip.isEmpty, "empty tooltip for \(mode)")
+        }
+    }
+
+    // MARK: - SAViewModeHelper ObjC bridges
+
+    func testHelperTabIndex() {
+        for mode in SAViewMode.allCases {
+            XCTAssertEqual(SAViewModeHelper.tabIndex(for: mode), mode.tabIndex)
+        }
+    }
+
+    func testHelperToolbarIdentifier() {
+        for mode in SAViewMode.allCases {
+            XCTAssertEqual(SAViewModeHelper.toolbarIdentifier(for: mode),
+                           mode.toolbarIdentifier.rawValue)
+        }
+    }
+
+    func testHelperPreferencesValue() {
+        for mode in SAViewMode.allCases {
+            XCTAssertEqual(SAViewModeHelper.preferencesValue(for: mode),
+                           mode.preferencesValue)
+        }
+    }
+
+    func testHelperToolbarIdentifierForPreferencesValue() {
+        // Round-trip through the legacy-prefs entry point used by the
+        // toolbar code when reading a previously stored mode.
+        for mode in SAViewMode.allCases {
+            XCTAssertEqual(
+                SAViewModeHelper.toolbarIdentifier(forPreferencesValue: mode.preferencesValue),
+                mode.toolbarIdentifier.rawValue
+            )
+        }
+    }
+
+    func testHelperAllToolbarIdentifiers() {
+        let identifiers = SAViewModeHelper.allToolbarIdentifiers
+        XCTAssertEqual(identifiers.count, SAViewMode.allCases.count)
+        XCTAssertEqual(Set(identifiers), Set(SAViewMode.allCases.map { $0.toolbarIdentifier.rawValue }))
+    }
+
+    // MARK: - Exhaustive case coverage
+
+    /// If a new SAViewMode case is added, this test fails until each
+    /// other test is updated. Keeps the suite honest about
+    /// "all cases covered".
+    func testCaseCountIsExpected() {
+        XCTAssertEqual(SAViewMode.allCases.count, 6,
+                       "SAViewMode case count changed — update all SAViewModeTests to cover the new case")
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -223,8 +223,10 @@
 		5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */; };
 		5146ADF92F79B9EF00C4C14A /* SAConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */; };
 		5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
+		5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
 		5146C7202F7A539E00C4C14A /* SATaskManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */; };
 		5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */; };
+		5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */; };
 		514B40A02F683E3700369718 /* SAAboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001C /* SAAboutWindowController.swift */; };
 		514B40A72F68412000369718 /* License.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A62F68412000369718 /* License.md */; };
 		514B40A82F68412000369718 /* Credits.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A52F68412000369718 /* Credits.md */; };
@@ -934,6 +936,7 @@
 		5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPDatabaseDocument+ViewMode.swift"; sourceTree = "<group>"; };
 		5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskManaging.swift; sourceTree = "<group>"; };
 		5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoTests.swift; sourceTree = "<group>"; };
+		5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAViewModeTests.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -2366,6 +2369,7 @@
 				F4C0BDAE2E9F4D5E8A1B0201 /* SecureBookmarkManagerStub.swift */,
 				5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */,
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
+				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3025,6 +3029,8 @@
 				1AEA768425EF05D500AC4DA6 /* ByteCountFormatterExtension.swift in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
 				5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */,
+				5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */,
+				5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,


### PR DESCRIPTION
## Summary

Phase B3 from [`.claude/modernization-followup-plan.md`](https://github.com/Sequel-Ace/Sequel-Ace/blob/main/.claude/modernization-followup-plan.md): the unit-test safety net for the Phase A3 refactor (#2402).

> ⚠️ **Stacked on #2402** — base branch is \`feature/wire-saviewmode-phase-a3\`. Merge #2402 first, then this re-targets to main automatically.

### What lands

- **16 unit tests** in \`UnitTests/SAViewModeTests.swift\` covering everything Phase A3's \`-[SPDatabaseDocument switchToViewMode:]\` reads off the enum:
  - tab indexes 0..5 per case + contiguous/unique invariant
  - toolbar identifier strings match the SPConstants.m wire format (locks persisted toolbar state)
  - preferences integer round-trip for all six cases, plus fallback to \`.structure\` for unknown/corrupt values
  - action selector names match the ObjC entry points (\`viewStructure\` etc.)
  - all five \`SAViewModeHelper\` ObjC bridges return the same values as the Swift properties
  - \`makeToolbarItem(target:)\` produces a fully configured \`NSToolbarItem\` (identifier, label, paletteLabel, tooltip, image, target, action)
  - case-count guard that fails if anyone adds a seventh case without updating the suite

- **Inline SPMainToolbar\* literal strings** into \`SAViewMode.toolbarIdentifier\`. The file previously read each value from extern \`NSString\`s in SPConstants.h, which forced a bridging header on the test target. Inlining the literals removes that dependency (the strings are wire-format identifiers in persisted toolbar state — changing them was already a breaking change). A header comment documents the invariant; the new \`testToolbarIdentifiersMatchConstants\` test pins both sides.

- **Project membership** for \`SPDatabaseDocument+ViewMode.swift\` extended to the Unit Tests target (mirroring how \`SAConnectionInfo.swift\` is set up), so SAViewMode is visible to the test code.

### Diffstat

| File | Change |
|------|--------|
| \`UnitTests/SAViewModeTests.swift\` | +197 (new) |
| \`SPDatabaseDocument+ViewMode.swift\` | +14 / -6 (inline literals + doc comment) |
| \`sequel-ace.xcodeproj/project.pbxproj\` | +6 (test target membership) |
| \`.claude/modernization-followup-plan.md\` | mark B3 done |

## Test plan

- [x] \`xcodebuild test -scheme "Unit Tests" -only-testing:"Unit Tests/SAViewModeTests"\` → 16/16 pass in 0.044s
- [x] Full suite still passes apart from the pre-existing \`SPTableContentColumnFilterTests.testAutoFillHeuristicControllerDisabledByDefault\` failure (also fails on main and on the A3 base — unrelated)

## Why these tests, in this order

The follow-up plan calls Phase B3 the safety net for the A3 refactor (\"validate before and after\"). With these tests landed:
- Phase A1 (SADatabaseListManager extraction) is the next item — large refactor of SPDatabaseDocument, and view-mode switching is one of the subsystems most likely to be touched.
- Phase A4 (window-title extraction) and Phase C1 (SwiftUI FavoritesListView) both build on top of a stable view-mode contract.

## Follow-ups

Next from the plan: **A1** (extract \`SADatabaseListManager\` from SPDatabaseDocument.m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)