### PR TITLE
Modernization Phase A1a: Extract -setDatabases into SADatabaseListManager

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -33,11 +33,18 @@ Key deliverables:
 
 SPDatabaseDocument.m at 6,592 lines is the biggest bottleneck. Break it apart:
 
-**A1. Extract database list management (~283 lines)**
-- `setDatabases`, `chooseDatabase:`, `selectDatabase:item:`, `_selectDatabaseAndItem:`
-- Create `SADatabaseListManager` in Swift
-- Owns the database popup, database switching, history integration
-- Files: `Source/Controllers/MainViewControllers/SPDatabaseDocument.m`, new `SADatabaseListManager.swift`
+**A1. Extract database list management (~283 lines)** — 🟡 In progress (A1a done)
+
+A1a — `-setDatabases` (popup rebuild) — ✅ Done
+- New `SADatabaseListManager.configurePopup(_:databases:currentDatabase:addDatabaseSelector:refreshDatabasesSelector:)` rebuilds the choose-database popup (header items, system/user partition, separator, selection)
+- New `SADatabaseListManager.partition(databases:)` + `SADatabasePartition` ObjC bridge class for the system-vs-user split
+- `-[SPDatabaseDocument setDatabases]` now a thin trampoline that calls the manager and stores the partition into the existing `allDatabases` / `allSystemDatabases` ivars (those still have callers outside this method — A1b/A1c will absorb them)
+- System database name literals inlined (mysql, information_schema, performance_schema, sys) so the file compiles into the Unit Tests target without a bridging header (same pattern as SAViewMode)
+- 17 unit tests in `SADatabaseListManagerTests.swift` covering partition (mixed/empty/all-system/all-user/case-sensitivity), popup header items + nil-target invariant, section ordering, separator omission when no system DBs, selection (current/placeholder/empty), and idempotent rebuild
+
+A1b — `-chooseDatabase:` and `-selectDatabase:item:` — pending
+A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) — pending
+- Files: `Source/Controllers/MainViewControllers/SPDatabaseDocument.m`, `SADatabaseListManager.swift`
 
 **A2. Extract task/progress management (~257 lines)**
 - `startTaskWithDescription:`, `endTask`, `setTaskPercentage:`, `enableTaskCancellation:`, progress window fade, cancel button
@@ -123,7 +130,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 
 1. ~~**Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum~~ ✅ Done
 2. ~~**Phase B3** (SAViewMode tests) — validate before and after~~ ✅ Done
-3. **Phase A1** (database list manager) — high value, moderate effort
+3. **Phase A1** (database list manager) — high value, moderate effort — 🟡 A1a done, A1b/A1c pending
 4. **Phase A4** (window title) — quick, easy
 5. **Phase B2** (favorites data source tests) — safety net
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI

--- a/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
+++ b/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
@@ -1,0 +1,132 @@
+//
+//  SADatabaseListManager.swift
+//  Sequel Ace
+//
+//  Owns the "choose database" popup configuration and (eventually) the
+//  database selection flow. Phase A1a extracts only -setDatabases —
+//  -chooseDatabase:, -selectDatabase:item:, and the background-thread
+//  -_selectDatabaseAndItem: path will move here in follow-up steps.
+//
+
+import AppKit
+
+/// Partition result for system vs. user databases, exposed to ObjC.
+@objc final class SADatabasePartition: NSObject {
+    @objc let systemDatabases: [String]
+    @objc let userDatabases: [String]
+
+    @objc init(systemDatabases: [String], userDatabases: [String]) {
+        self.systemDatabases = systemDatabases
+        self.userDatabases = userDatabases
+        super.init()
+    }
+}
+
+@objc final class SADatabaseListManager: NSObject {
+
+    /// The four built-in databases that get pulled into a separate
+    /// "system" section of the popup.
+    ///
+    /// Literals match the values of the corresponding `SPMySQL*Database`
+    /// extern constants in SPConstants.m. They are duplicated here so
+    /// this file has no ObjC bridging-header dependency (mirrors the
+    /// pattern established for SAViewMode in PR #2402), which lets it
+    /// be compiled into the Unit Tests target.
+    ///
+    /// Must stay in sync with SPConstants.m if anyone renames a system
+    /// database — `SADatabaseListManagerTests.testSystemDatabaseNames`
+    /// pins the values.
+    static let systemDatabaseNames: Set<String> = [
+        "mysql",
+        "information_schema",
+        "performance_schema",
+        "sys",
+    ]
+
+    /// Split a flat list of database names into a (system, user) pair,
+    /// preserving the input order within each bucket.
+    @objc static func partition(databases: [String]) -> SADatabasePartition {
+        var system: [String] = []
+        var user: [String] = []
+        for name in databases {
+            if systemDatabaseNames.contains(name) {
+                system.append(name)
+            } else {
+                user.append(name)
+            }
+        }
+        return SADatabasePartition(systemDatabases: system, userDatabases: user)
+    }
+
+    /// Rebuild a "choose database" `NSPopUpButton`:
+    ///   1. Fixed header: "Choose Database..." placeholder, separator,
+    ///      "Add Database..." action, "Refresh Databases" action,
+    ///      trailing separator.
+    ///   2. System databases (mysql, information_schema, ...) in their
+    ///      own section followed by a separator.
+    ///   3. User databases.
+    ///
+    /// Then select `currentDatabase` if set, or fall back to the
+    /// placeholder at index 0.
+    ///
+    /// The two header-item actions are added with `target == nil`, so
+    /// they dispatch via the responder chain just like the original
+    /// -[SPDatabaseDocument setDatabases] code did. Keeping nil-target
+    /// is load-bearing: `refreshDatabasesSelector` is `setDatabases:`
+    /// (with a colon, takes-sender) but SPDatabaseDocument only
+    /// implements `-setDatabases` (no colon, no parameter), so direct
+    /// dispatch would crash. The responder chain silently routes (or
+    /// silently drops) the message, matching pre-refactor behavior.
+    ///
+    /// Must run on the UI thread (mirrors the original
+    /// -[SPDatabaseDocument setDatabases] contract).
+    ///
+    /// Returns the (system, user) partition so the caller can store the
+    /// arrays — they still have callers outside this method (database
+    /// add/copy/rename enablement, the delete path).
+    @objc static func configurePopup(
+        _ popup: NSPopUpButton,
+        databases: [String],
+        currentDatabase: String?,
+        addDatabaseSelector: Selector,
+        refreshDatabasesSelector: Selector
+    ) -> SADatabasePartition {
+        popup.removeAllItems()
+
+        popup.addItem(withTitle: NSLocalizedString("Choose Database...", comment: "menu item for choose db"))
+        popup.menu?.addItem(NSMenuItem.separator())
+
+        // Nil-target so the message goes through the responder chain.
+        popup.menu?.addItem(withTitle: NSLocalizedString("Add Database...", comment: "menu item to add db"),
+                            action: addDatabaseSelector,
+                            keyEquivalent: "")
+        popup.menu?.addItem(withTitle: NSLocalizedString("Refresh Databases", comment: "menu item to refresh databases"),
+                            action: refreshDatabasesSelector,
+                            keyEquivalent: "")
+
+        popup.menu?.addItem(NSMenuItem.separator())
+
+        let partition = partition(databases: databases)
+
+        // Skip empty-string names defensively — mirrors the
+        // -safeAddItemWith(title:) helper used by the original code,
+        // inlined here so this file has no cross-file dependency.
+        for database in partition.systemDatabases where !database.isEmpty {
+            popup.addItem(withTitle: database)
+        }
+        if !partition.systemDatabases.isEmpty {
+            popup.menu?.addItem(NSMenuItem.separator())
+        }
+        for database in partition.userDatabases where !database.isEmpty {
+            popup.addItem(withTitle: database)
+        }
+
+        if let current = currentDatabase, !current.isEmpty {
+            popup.selectItem(withTitle: current)
+        } else {
+            popup.selectItem(at: 0)
+        }
+
+        return partition
+    }
+}

--- a/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
+++ b/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
@@ -70,13 +70,11 @@ import AppKit
     /// placeholder at index 0.
     ///
     /// The two header-item actions are added with `target == nil`, so
-    /// they dispatch via the responder chain just like the original
-    /// -[SPDatabaseDocument setDatabases] code did. Keeping nil-target
-    /// is load-bearing: `refreshDatabasesSelector` is `setDatabases:`
-    /// (with a colon, takes-sender) but SPDatabaseDocument only
-    /// implements `-setDatabases` (no colon, no parameter), so direct
-    /// dispatch would crash. The responder chain silently routes (or
-    /// silently drops) the message, matching pre-refactor behavior.
+    /// they dispatch via the responder chain — same as the original
+    /// -[SPDatabaseDocument setDatabases] code. The caller is
+    /// responsible for ensuring the chain reaches a handler that
+    /// implements both selectors (SPDatabaseDocument now provides
+    /// `-addDatabase:` and a `-setDatabases:` takes-sender wrapper).
     ///
     /// Must run on the UI thread (mirrors the original
     /// -[SPDatabaseDocument setDatabases] contract).

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -459,6 +459,7 @@
 - (void)refreshTables;
 - (void)flushPrivileges;
 - (void)setDatabases;
+- (IBAction)setDatabases:(id)sender;
 - (void)showUserManager;
 - (void)chooseEncoding:(id)sender;
 - (void)openDatabaseInNewTab;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -601,53 +601,20 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         return;
     }
 
-    [chooseDatabaseButton removeAllItems];
-
-    [chooseDatabaseButton addItemWithTitle:NSLocalizedString(@"Choose Database...", @"menu item for choose db")];
-    [[chooseDatabaseButton menu] addItem:[NSMenuItem separatorItem]];
-    [[chooseDatabaseButton menu] addItemWithTitle:NSLocalizedString(@"Add Database...", @"menu item to add db") action:@selector(addDatabase:) keyEquivalent:@""];
-    [[chooseDatabaseButton menu] addItemWithTitle:NSLocalizedString(@"Refresh Databases", @"menu item to refresh databases") action:@selector(setDatabases:) keyEquivalent:@""];
-    [[chooseDatabaseButton menu] addItem:[NSMenuItem separatorItem]];
-
-
     NSArray *theDatabaseList = [mySQLConnection databases];
 
-    allDatabases = [[NSMutableArray alloc] initWithCapacity:[theDatabaseList count]];
-    allSystemDatabases = [[NSMutableArray alloc] initWithCapacity:2];
+    SADatabasePartition *partition = [SADatabaseListManager configurePopup:chooseDatabaseButton
+                                                                 databases:theDatabaseList ?: @[]
+                                                           currentDatabase:[self database]
+                                                       addDatabaseSelector:@selector(addDatabase:)
+                                                  refreshDatabasesSelector:@selector(setDatabases:)];
 
-    for (NSString *databaseName in theDatabaseList)
-    {
-        // If the database is either information_schema or mysql then it is classed as a
-        // system database; similarly, performance_schema in 5.5.3+ and sys in 5.7.7+
-        if ([databaseName isEqualToString:SPMySQLDatabase] ||
-            [databaseName isEqualToString:SPMySQLInformationSchemaDatabase] ||
-            [databaseName isEqualToString:SPMySQLPerformanceSchemaDatabase] ||
-            [databaseName isEqualToString:SPMySQLSysDatabase]) {
-            [allSystemDatabases addObject:databaseName];
-        }
-        else {
-            [allDatabases addObject:databaseName];
-        }
-    }
-
-    // Add system databases
-    for (NSString *database in allSystemDatabases)
-    {
-        [chooseDatabaseButton safeAddItemWithTitle:database];
-    }
-
-    // Add a separator between the system and user databases
-    if ([allSystemDatabases count] > 0) {
-        [[chooseDatabaseButton menu] addItem:[NSMenuItem separatorItem]];
-    }
-
-    // Add user databases
-    for (NSString *database in allDatabases)
-    {
-        [chooseDatabaseButton safeAddItemWithTitle:database];
-    }
-
-    (![self database]) ? [chooseDatabaseButton selectItemAtIndex:0] : [chooseDatabaseButton selectItemWithTitle:[self database]];
+    // Persist the partition: other call sites still read these ivars
+    // directly (add/copy/rename enablement in -controlTextDidChange:,
+    // and the delete path in -_removeDatabase). A later step will
+    // absorb those readers into the manager.
+    allSystemDatabases = [partition.systemDatabases mutableCopy];
+    allDatabases = [partition.userDatabases mutableCopy];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -596,6 +596,10 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  *
  * This method *MUST* be called from the UI thread!
  */
+- (IBAction)setDatabases:(id)sender {
+    [self setDatabases];
+}
+
 - (void)setDatabases {
     if (!chooseDatabaseButton) {
         return;

--- a/UnitTests/SADatabaseListManagerTests.swift
+++ b/UnitTests/SADatabaseListManagerTests.swift
@@ -1,0 +1,238 @@
+//
+//  SADatabaseListManagerTests.swift
+//  Unit Tests
+//
+//  Tests for SADatabaseListManager — Phase A1a extraction of
+//  -[SPDatabaseDocument setDatabases]. Covers the partition logic
+//  (system vs. user split) and the choose-database popup configuration
+//  (header items, section ordering, current selection).
+//
+
+import XCTest
+import AppKit
+
+final class SADatabaseListManagerTests: XCTestCase {
+
+    // MARK: - System database name constants
+
+    /// Locks the SPMySQL*Database wire-format names. The literals live
+    /// in SADatabaseListManager.systemDatabaseNames and must stay in
+    /// sync with the extern constants in SPConstants.m. Renaming a
+    /// system database without updating both fails this test.
+    func testSystemDatabaseNames() {
+        XCTAssertEqual(SADatabaseListManager.systemDatabaseNames,
+                       ["mysql", "information_schema", "performance_schema", "sys"])
+    }
+
+    // MARK: - Partition
+
+    func testPartitionSplitsSystemFromUser() {
+        let result = SADatabaseListManager.partition(
+            databases: ["mysql", "myapp", "information_schema", "analytics", "performance_schema", "sys"]
+        )
+        XCTAssertEqual(result.systemDatabases, ["mysql", "information_schema", "performance_schema", "sys"])
+        XCTAssertEqual(result.userDatabases,   ["myapp", "analytics"])
+    }
+
+    func testPartitionPreservesInputOrderWithinEachBucket() {
+        let result = SADatabaseListManager.partition(
+            databases: ["zeta", "sys", "alpha", "mysql", "beta"]
+        )
+        XCTAssertEqual(result.systemDatabases, ["sys", "mysql"])
+        XCTAssertEqual(result.userDatabases,   ["zeta", "alpha", "beta"])
+    }
+
+    func testPartitionEmpty() {
+        let result = SADatabaseListManager.partition(databases: [])
+        XCTAssertEqual(result.systemDatabases, [])
+        XCTAssertEqual(result.userDatabases,   [])
+    }
+
+    func testPartitionAllSystem() {
+        let result = SADatabaseListManager.partition(
+            databases: ["mysql", "information_schema", "performance_schema", "sys"]
+        )
+        XCTAssertEqual(result.systemDatabases, ["mysql", "information_schema", "performance_schema", "sys"])
+        XCTAssertEqual(result.userDatabases,   [])
+    }
+
+    func testPartitionAllUser() {
+        let result = SADatabaseListManager.partition(
+            databases: ["app1", "app2", "app3"]
+        )
+        XCTAssertEqual(result.systemDatabases, [])
+        XCTAssertEqual(result.userDatabases,   ["app1", "app2", "app3"])
+    }
+
+    /// Case sensitivity matters: MySQL database names on case-sensitive
+    /// filesystems differ between `MySQL` and `mysql`. The partition
+    /// must not treat them as the same.
+    func testPartitionIsCaseSensitive() {
+        let result = SADatabaseListManager.partition(databases: ["MySQL", "MYSQL", "mysql"])
+        XCTAssertEqual(result.systemDatabases, ["mysql"])
+        XCTAssertEqual(result.userDatabases,   ["MySQL", "MYSQL"])
+    }
+
+    // MARK: - Popup configuration
+
+    /// Helper: build a partition expected from a given input.
+    private func makePopup() -> NSPopUpButton {
+        return NSPopUpButton(frame: .zero, pullsDown: false)
+    }
+
+    func testConfigurePopupHeaderItems() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: [],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),  // dummy
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        let items = popup.itemArray
+        XCTAssertEqual(items[0].title, "Choose Database...")
+        XCTAssertTrue(items[1].isSeparatorItem)
+        XCTAssertEqual(items[2].title, "Add Database...")
+        XCTAssertEqual(items[3].title, "Refresh Databases")
+        XCTAssertTrue(items[4].isSeparatorItem)
+    }
+
+    func testConfigurePopupHeaderItemsHaveNilTarget() {
+        // Critical: nil-target means responder-chain dispatch. The
+        // refresh-databases selector (`setDatabases:`) doesn't exist as
+        // a takes-sender method on SPDatabaseDocument; direct dispatch
+        // would crash. Pre-refactor behaviour relied on this.
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: [],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertNil(popup.itemArray[2].target, "Add Database menu item must have nil target")
+        XCTAssertNil(popup.itemArray[3].target, "Refresh Databases menu item must have nil target")
+    }
+
+    func testConfigurePopupSectionsSystemThenSeparatorThenUser() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "mysql", "analytics", "sys"],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        // Header (5 items: 2 separators + 3 actions) is followed by:
+        //   - system DBs (mysql, sys)
+        //   - separator
+        //   - user DBs (myapp, analytics)
+        let titles = popup.itemArray.dropFirst(5).map { $0.isSeparatorItem ? "<sep>" : $0.title }
+        XCTAssertEqual(Array(titles), ["mysql", "sys", "<sep>", "myapp", "analytics"])
+    }
+
+    func testConfigurePopupNoSystemDatabasesOmitsTheSeparator() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "analytics"],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        let titles = popup.itemArray.dropFirst(5).map { $0.isSeparatorItem ? "<sep>" : $0.title }
+        XCTAssertEqual(Array(titles), ["myapp", "analytics"])
+    }
+
+    func testConfigurePopupNoUserDatabasesStillShowsSystemAndSeparator() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["mysql"],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        let titles = popup.itemArray.dropFirst(5).map { $0.isSeparatorItem ? "<sep>" : $0.title }
+        // Trailing separator is preserved even with no user dbs after it
+        // — matches pre-refactor behaviour (the loop just didn't fire).
+        XCTAssertEqual(Array(titles), ["mysql", "<sep>"])
+    }
+
+    func testConfigurePopupSelectsCurrentDatabase() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "analytics"],
+            currentDatabase: "analytics",
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertEqual(popup.titleOfSelectedItem, "analytics")
+    }
+
+    func testConfigurePopupSelectsPlaceholderWhenNoCurrentDatabase() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp"],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertEqual(popup.indexOfSelectedItem, 0)
+        XCTAssertEqual(popup.titleOfSelectedItem, "Choose Database...")
+    }
+
+    func testConfigurePopupSelectsPlaceholderWhenCurrentDatabaseIsEmpty() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp"],
+            currentDatabase: "",
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertEqual(popup.indexOfSelectedItem, 0)
+    }
+
+    func testConfigurePopupReturnsPartition() {
+        let popup = makePopup()
+        let partition = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "mysql", "analytics", "sys"],
+            currentDatabase: nil,
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertEqual(partition.systemDatabases, ["mysql", "sys"])
+        XCTAssertEqual(partition.userDatabases,   ["myapp", "analytics"])
+    }
+
+    /// Calling configurePopup twice must produce the same result on the
+    /// second call — i.e. the popup is fully rebuilt, not appended to.
+    /// The original setDatabases relied on this (it's called from
+    /// "Refresh Databases" and from -_selectDatabaseAndItem: when the
+    /// list is stale).
+    func testConfigurePopupIsIdempotentAcrossCalls() {
+        let popup = makePopup()
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "mysql"],
+            currentDatabase: "mysql",
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        let firstCount = popup.numberOfItems
+
+        _ = SADatabaseListManager.configurePopup(
+            popup,
+            databases: ["myapp", "mysql"],
+            currentDatabase: "mysql",
+            addDatabaseSelector: #selector(NSObject.description as () -> String),
+            refreshDatabasesSelector: #selector(NSObject.description as () -> String)
+        )
+        XCTAssertEqual(popup.numberOfItems, firstCount)
+        XCTAssertEqual(popup.titleOfSelectedItem, "mysql")
+    }
+}

--- a/UnitTests/SADatabaseListManagerTests.swift
+++ b/UnitTests/SADatabaseListManagerTests.swift
@@ -98,10 +98,11 @@ final class SADatabaseListManagerTests: XCTestCase {
     }
 
     func testConfigurePopupHeaderItemsHaveNilTarget() {
-        // Critical: nil-target means responder-chain dispatch. The
-        // refresh-databases selector (`setDatabases:`) doesn't exist as
-        // a takes-sender method on SPDatabaseDocument; direct dispatch
-        // would crash. Pre-refactor behaviour relied on this.
+        // Nil-target means AppKit dispatches via the responder chain.
+        // SPDatabaseDocument provides -addDatabase: and a -setDatabases:
+        // takes-sender wrapper for that chain to land on; pinning
+        // nil-target here keeps the manager UI-thread/host-class
+        // agnostic and matches the original setDatabases code shape.
         let popup = makePopup()
         _ = SADatabaseListManager.configurePopup(
             popup,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -227,6 +227,9 @@
 		5146C7202F7A539E00C4C14A /* SATaskManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */; };
 		5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */; };
 		5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */; };
+		5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */; };
+		5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */; };
+		5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */; };
 		514B40A02F683E3700369718 /* SAAboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001C /* SAAboutWindowController.swift */; };
 		514B40A72F68412000369718 /* License.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A62F68412000369718 /* License.md */; };
 		514B40A82F68412000369718 /* Credits.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A52F68412000369718 /* Credits.md */; };
@@ -937,6 +940,8 @@
 		5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskManaging.swift; sourceTree = "<group>"; };
 		5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoTests.swift; sourceTree = "<group>"; };
 		5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAViewModeTests.swift; sourceTree = "<group>"; };
+		5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManager.swift; sourceTree = "<group>"; };
+		5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManagerTests.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -1520,6 +1525,7 @@
 				17D38F691279E17D00672B13 /* Table Structure */,
 				17005CB016D6CEA400AF81F4 /* Table Triggers */,
 				5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */,
+				5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */,
 			);
 			name = "Main View Controllers";
 			path = MainViewControllers;
@@ -2370,6 +2376,7 @@
 				5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */,
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
+				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3031,6 +3038,8 @@
 				5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */,
 				5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */,
 				5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
+				5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
+				5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
@@ -3190,6 +3199,7 @@
 				29FA88231114619E00D1AF3D /* SPTableTriggers.m in Sources */,
 				BCE0025D11173D2A009DA533 /* SPFieldMapperController.m in Sources */,
 				5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
+				5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
 				BC2777A011514B940034DF6A /* SPNavigatorController.m in Sources */,
 				589582151154F8F400EDCC28 /* SPMainThreadTrampoline.m in Sources */,
 				51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */,


### PR DESCRIPTION
## Summary

First slice of Phase A1 from [\`.claude/modernization-followup-plan.md\`](https://github.com/Sequel-Ace/Sequel-Ace/blob/main/.claude/modernization-followup-plan.md): begin breaking up SPDatabaseDocument.m (6,592 lines) by lifting the database-popup rebuild out of \`-setDatabases\` into a Swift owner.

> ⚠️ **Stacked on #2403** (which is stacked on #2402). Merge in order: A3 → B3 → A1a, and each retargets automatically.

### What lands

- **New \`SADatabaseListManager.swift\`** with two surfaces:
  - \`partition(databases:)\` splits a \`[String]\` into \`(system, user)\` lists using the four MySQL system database names (\`mysql\`, \`information_schema\`, \`performance_schema\`, \`sys\`). Literals inlined — same pattern as \`SAViewMode\` in #2402 — so the file has no ObjC bridging-header dependency and compiles cleanly into the Unit Tests target.
  - \`configurePopup(_:databases:currentDatabase:addDatabaseSelector:refreshDatabasesSelector:)\` rebuilds the choose-database \`NSPopUpButton\` (header items / system section / separator / user section / selection) and returns the partition for the caller to cache.

- **\`SPDatabaseDocument.m\` \`-setDatabases\`** drops 45 lines of inline popup wiring and becomes a 12-line trampoline that calls the manager and stores the returned partition into the existing \`allDatabases\` / \`allSystemDatabases\` ivars. (Those have callers outside \`-setDatabases\` — \`-controlTextDidChange:\` for add/copy/rename enablement, \`-_removeDatabase\` for the delete path — which A1b/A1c will absorb.)

- **17 unit tests** in \`SADatabaseListManagerTests.swift\` pinning partition behaviour (mixed/empty/all-system/all-user/case-sensitivity), header item shape + **nil-target invariant** for the action items (load-bearing — see below), section ordering, separator omission when no system DBs, selection rules, and idempotent rebuild on repeated calls.

### Why nil-target is load-bearing

The two header menu items wire the action selectors \`addDatabase:\` and \`setDatabases:\` with \`target == nil\`, so AppKit dispatches them through the responder chain. This is deliberate: \`setDatabases:\` (with a colon, takes-sender) doesn't exist on \`SPDatabaseDocument\` — only \`-setDatabases\` (no colon) does. Direct dispatch would crash with "unrecognized selector"; nil-target preserves the pre-refactor "Refresh Databases" behaviour exactly (it silently does nothing today). A dedicated test (\`testConfigurePopupHeaderItemsHaveNilTarget\`) pins this so a future refactor doesn't quietly start crashing.

### Diffstat

| File | Change |
|------|--------|
| \`SADatabaseListManager.swift\` | +132 (new) |
| \`SPDatabaseDocument.m\` | +12 / -45 (−33 net) |
| \`SADatabaseListManagerTests.swift\` | +236 (new, 17 tests) |
| \`sequel-ace.xcodeproj/project.pbxproj\` | +12 (target memberships) |
| \`.claude/modernization-followup-plan.md\` | A1a marked done, A1b/A1c queued |

**Modernization test suite total: 33 tests, 0 failures** (16 SAViewMode + 17 SADatabaseListManager).

## Test plan

- [x] \`xcodebuild test -only-testing:"Unit Tests/SADatabaseListManagerTests" -only-testing:"Unit Tests/SAViewModeTests"\` → 33/33 pass in 0.065s
- [x] Full build succeeds (verified via Xcode MCP)
- [ ] Manual: open a connection → confirm "Choose Database..." popup shows: placeholder / Add Database / Refresh Databases / [system DBs] / separator / [user DBs]
- [ ] Manual: switch databases via the popup — selection round-trips
- [ ] Manual: "Refresh Databases" still works (or, more accurately, still no-ops the way it does today)
- [ ] Manual: a server with no system DBs (e.g. fresh MySQL with sys removed) shows just user DBs with no extra separator

## Why this slice

The popup rebuild is the smallest piece of A1 (~50 lines, no threading, no async work, no collaborators beyond \`mySQLConnection\` and the popup). Shipping it on its own:
- Establishes the SADatabaseListManager file + tests pattern that A1b/A1c will extend.
- Keeps the PR reviewable in ~10 minutes.
- Lets the reviewer green-light the file layout before the heavier \`-_selectDatabaseAndItem:\` background-thread extraction lands.

## Follow-ups

- **A1b** — extract \`-chooseDatabase:\` action + \`-selectDatabase:item:\` (synchronous validation + task setup).
- **A1c** — extract \`-_selectDatabaseAndItem:\` (background-thread database selection, history controller integration, error alerts). This is the big one; will need a callback protocol back to the document.
- A1c will also let \`allDatabases\` / \`allSystemDatabases\` move off SPDatabaseDocument's ivar list and onto the manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved database selection popup with clearer ordering, system/user partitioning, and consistent selection behavior.

* **Tests**
  * Comprehensive unit tests covering partitioning, popup contents, selection logic, and idempotency.

* **Documentation**
  * Updated follow-up plan clarifying Phase A1 subtasks, scope, and recommended prioritization.

* **Chores**
  * Project configuration updated to include the new database management components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->