### PR TITLE
Modernization Phase A1b: Extract navigator schema path into SADatabaseListManager

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -42,8 +42,15 @@ A1a — `-setDatabases` (popup rebuild) — ✅ Done
 - System database name literals inlined (mysql, information_schema, performance_schema, sys) so the file compiles into the Unit Tests target without a bridging header (same pattern as SAViewMode)
 - 17 unit tests in `SADatabaseListManagerTests.swift` covering partition (mixed/empty/all-system/all-user/case-sensitivity), popup header items + nil-target invariant, section ordering, separator omission when no system DBs, selection (current/placeholder/empty), and idempotent rebuild
 
-A1b — `-chooseDatabase:` and `-selectDatabase:item:` — pending
-A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) — pending
+A1b — Navigator schema path extraction — ✅ Done (scoped down)
+- `SADatabaseListManager.navigatorSchemaPath(connectionID:selectedDatabaseTitle:)` + `schemaPathDelimiter` constant (U+FFF8, mirroring `SPUniqueSchemaDelimiter` in SPConstants.m)
+- `-[SPDatabaseDocument selectDatabase:item:]` shrinks by 7 lines of NSMutableString juggling
+- 4 new tests for path shape + edge cases
+- Originally planned to extract `-chooseDatabase:` and `-selectDatabase:item:` wholesale, but on inspection both methods need a callback protocol back to the document for tablesList edit-commit checks, task start/end, and thread dispatch — properly belongs in A1c
+
+A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback protocol — pending
+- Also absorbs the remaining `-chooseDatabase:` and `-selectDatabase:item:` document-coupled logic
+- Will let `allDatabases` / `allSystemDatabases` ivars move off SPDatabaseDocument
 - Files: `Source/Controllers/MainViewControllers/SPDatabaseDocument.m`, `SADatabaseListManager.swift`
 
 **A2. Extract task/progress management (~257 lines)**

--- a/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
+++ b/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
@@ -24,6 +24,31 @@ import AppKit
 
 @objc final class SADatabaseListManager: NSObject {
 
+    /// Separator placed between connectionID and database name in
+    /// SPNavigatorController schema paths. Matches the value of
+    /// `SPUniqueSchemaDelimiter` in SPConstants.m (U+FFF8). Inlined for
+    /// the same reason as `systemDatabaseNames` — keeps this file free
+    /// of an ObjC bridging-header dependency so the Unit Tests target
+    /// can compile it.
+    @objc static let schemaPathDelimiter: String = "\u{FFF8}"
+
+    /// Build the path that `SPNavigatorController` uses to highlight
+    /// the currently selected database in the schema browser.
+    ///
+    /// Shape: `<connectionID>` if the popup has no selected title or
+    /// it's empty; otherwise `<connectionID><U+FFF8><databaseTitle>`.
+    ///
+    /// Pulled out of -[SPDatabaseDocument selectDatabase:item:] so it
+    /// can be tested without a live NSPopUpButton or
+    /// SPNavigatorController.
+    @objc static func navigatorSchemaPath(connectionID: String,
+                                          selectedDatabaseTitle: String?) -> String {
+        guard let title = selectedDatabaseTitle, !title.isEmpty else {
+            return connectionID
+        }
+        return connectionID + schemaPathDelimiter + title
+    }
+
     /// The four built-in databases that get pulled into a separate
     /// "system" section of the popup.
     ///

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -653,15 +653,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     // If Navigator runs in syncMode let it follow the selection
     if ([[[SPNavigatorController sharedNavigatorController] onMainThread] syncMode]) {
-        NSMutableString *schemaPath = [NSMutableString string];
-
-        [schemaPath setString:[self connectionID]];
-
-        if([chooseDatabaseButton titleOfSelectedItem] && [[chooseDatabaseButton titleOfSelectedItem] length]) {
-            [schemaPath appendString:SPUniqueSchemaDelimiter];
-            [schemaPath appendString:[chooseDatabaseButton titleOfSelectedItem]];
-        }
-
+        NSString *schemaPath = [SADatabaseListManager navigatorSchemaPathWithConnectionID:[self connectionID]
+                                                                   selectedDatabaseTitle:[chooseDatabaseButton titleOfSelectedItem]];
         [[SPNavigatorController sharedNavigatorController] selectPath:schemaPath];
     }
 

--- a/UnitTests/SADatabaseListManagerTests.swift
+++ b/UnitTests/SADatabaseListManagerTests.swift
@@ -209,6 +209,68 @@ final class SADatabaseListManagerTests: XCTestCase {
         XCTAssertEqual(partition.userDatabases,   ["myapp", "analytics"])
     }
 
+    // MARK: - Navigator schema path
+
+    /// Locks the SPNavigatorController separator wire format. Matches
+    /// SPUniqueSchemaDelimiter in SPConstants.m (U+FFF8).
+    func testSchemaPathDelimiter() {
+        XCTAssertEqual(SADatabaseListManager.schemaPathDelimiter, "\u{FFF8}")
+    }
+
+    func testNavigatorSchemaPathWithDatabase() {
+        XCTAssertEqual(
+            SADatabaseListManager.navigatorSchemaPath(
+                connectionID: "conn-42",
+                selectedDatabaseTitle: "analytics"
+            ),
+            "conn-42\u{FFF8}analytics"
+        )
+    }
+
+    /// When no database is selected in the popup, the navigator should
+    /// just see the connection root — no trailing separator. This is
+    /// what the pre-refactor SPMutableString-based code did when
+    /// titleOfSelectedItem was nil or empty.
+    func testNavigatorSchemaPathWithoutDatabase() {
+        XCTAssertEqual(
+            SADatabaseListManager.navigatorSchemaPath(
+                connectionID: "conn-42",
+                selectedDatabaseTitle: nil
+            ),
+            "conn-42"
+        )
+        XCTAssertEqual(
+            SADatabaseListManager.navigatorSchemaPath(
+                connectionID: "conn-42",
+                selectedDatabaseTitle: ""
+            ),
+            "conn-42"
+        )
+    }
+
+    /// Even an empty connectionID stays empty + no separator — defensive
+    /// behaviour because callers (the popup placeholder, connection
+    /// startup) sometimes hand us a stub ID before the connection
+    /// completes.
+    func testNavigatorSchemaPathWithEmptyConnectionID() {
+        XCTAssertEqual(
+            SADatabaseListManager.navigatorSchemaPath(
+                connectionID: "",
+                selectedDatabaseTitle: nil
+            ),
+            ""
+        )
+        XCTAssertEqual(
+            SADatabaseListManager.navigatorSchemaPath(
+                connectionID: "",
+                selectedDatabaseTitle: "analytics"
+            ),
+            "\u{FFF8}analytics"
+        )
+    }
+
+    // MARK: - Popup rebuild idempotency
+
     /// Calling configurePopup twice must produce the same result on the
     /// second call — i.e. the popup is fully rebuilt, not appended to.
     /// The original setDatabases relied on this (it's called from


### PR DESCRIPTION
## Summary

Small second slice of Phase A1. Lifts the SPNavigatorController schema-path construction out of \`-[SPDatabaseDocument selectDatabase:item:]\` into a pure helper on \`SADatabaseListManager\`.

> ⚠️ **Stacked on #2404** (which is stacked on #2403 / #2402). Merge order: A3 → B3 → A1a → A1b.

### Honest scoping note

I originally pitched A1b as "extract \`-chooseDatabase:\` and \`-selectDatabase:item:\` wholesale". After actually reading the methods carefully, both need a callback protocol back to the document — \`tablesListInstance selectionShouldChangeInTableView:\`, \`startTaskWithDescription:\`, \`NSThread detachNewThreadWithName:target:...\` — that properly belongs in the A1c PR with the threaded \`_selectDatabaseAndItem:\` extraction.

So A1b shrinks to one concrete win: the pure-string helper for the SPNavigatorController path. Small but real, fully testable, and queues A1c cleanly.

### What lands

- **\`SADatabaseListManager.navigatorSchemaPath(connectionID:selectedDatabaseTitle:)\`** — replaces 7 lines of NSMutableString juggling. Returns \`connectionID\` when no database is selected, \`connectionID + U+FFF8 + databaseTitle\` otherwise.
- **\`SADatabaseListManager.schemaPathDelimiter\`** — exposes U+FFF8 as a Swift constant, mirroring \`SPUniqueSchemaDelimiter\` in SPConstants.m. Inlined per the same no-bridging-header rule as \`systemDatabaseNames\`.
- **4 new tests** pinning: delimiter constant, the with-database branch, the without-database branches (nil + empty string), and the defensive empty-connectionID edge.

### Diffstat

| File | Change |
|------|--------|
| \`SADatabaseListManager.swift\` | +24 (helper + constant) |
| \`SPDatabaseDocument.m\` | +3 / -9 (−6 net) |
| \`SADatabaseListManagerTests.swift\` | +62 (4 new tests) |
| \`.claude/modernization-followup-plan.md\` | A1b done, A1c scope documented |

**Modernization test suite total: 37 tests, 0 failures** (16 SAViewMode + 21 SADatabaseListManager).

## Test plan

- [x] \`xcodebuild test -only-testing:"Unit Tests/SADatabaseListManagerTests"\` → 21/21 pass in 0.040s
- [ ] Manual: with the Navigator window open in sync mode, switch databases via the choose-database popup and confirm the schema browser highlights the right database (i.e. the path still resolves correctly server-side).

## Follow-ups

- **A1c** (now bigger) — \`SADatabaseListManagerDelegate\` protocol covering edit-commit check, task lifecycle, and detached-thread dispatch; extract \`-chooseDatabase:\`, \`-selectDatabase:item:\`, and \`-_selectDatabaseAndItem:\`; move \`allDatabases\` / \`allSystemDatabases\` ownership off SPDatabaseDocument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)