### PR TITLE
#fixed Add a small vertical inset to the query editor

### DIFF
--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -3702,6 +3702,9 @@ static NSString * const SPDashStyleCommentMarker = @"-- ";
     [queryInfoPaneSplitView setCollapsibleSubviewIndex:1];
     [queryInfoPaneSplitView setCollapsibleSubviewCollapsed:YES animate:NO];
     
+    // Give the editor a small vertical inset so text is not flush against the top and bottom edges (#2236)
+    [textView setTextContainerInset:NSMakeSize(0.0f, 2.0f)];
+
     // Set the structure and index view's vertical gridlines if required
     [customQueryView setGridStyleMask:([prefs boolForKey:SPDisplayTableViewVerticalGridlines]) ? NSTableViewSolidVerticalGridLineMask : NSTableViewGridNone];
     

--- a/Source/ThirdParty/Views/NoodleLineNumberView.m
+++ b/Source/ThirdParty/Views/NoodleLineNumberView.m
@@ -213,6 +213,8 @@ typedef NSRange (*RangeOfLineIMP)(id object, SEL selector, NSRange range);
 	
 	if ([view isKindOfClass:[NSTextView class]])
 	{
+		// Account for the textContainerInset the drawing path adds, so a gutter click maps to the line drawn there (#2236)
+		location -= [(NSTextView *)view textContainerInset].height;
 
 		nullRange = NSMakeRange(NSNotFound, 0);
 		count = [lines count];


### PR DESCRIPTION
## Changes:
- The query editor used the default `NSTextView` `textContainerInset` of `(0,0)`, so the first line's text sat flush against the top edge with no gap (#2236). I set a small vertical inset on it.
- That inset also has to be accounted for in `NoodleLineNumberView`. The label drawing path already adds `textContainerInset.height`, but the click-to-line hit test did not, so a click in the line-number ruler would select a line off by the inset until this is matched.

## Closes following issues:
- Closes: #2236

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.5

## Screenshots:
Before:
<img width="500" height="200" alt="before" src="https://github.com/user-attachments/assets/82c907b8-bc16-487d-9ec0-efe9f560060d" />

After:
<img width="501" height="200" alt="after" src="https://github.com/user-attachments/assets/79631bbf-a135-47a0-b89f-631c6354de42" />


## Additional notes:
The line-number change is a no-op for the other text views, whose inset stays `(0,0)`. It only keeps the query editor's line numbers aligned now that it has an inset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed text display spacing by adding proper inset to prevent content from appearing flush against view edges
* Fixed line number gutter clicks to accurately correspond to the correct line

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->