### PR TITLE
Modernization Phase A4 + B2a: Window title & favorites search extraction

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -66,10 +66,13 @@ A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback
 - View-specific extras (focus change for query, table load + focus for status) stay in the per-mode wrappers
 - Files: `SPDatabaseDocument.m`, `SPDatabaseDocument+ViewMode.swift`
 
-**A4. Extract window title management (~57 lines)**
-- `updateWindowTitle:`, `displayName`
-- Move to SPWindowController (where it logically belongs)
-- Files: `SPDatabaseDocument.m`, `SPWindowController.swift`
+**A4. Extract window title management (~57 lines)** — ✅ Done
+- New `SAWindowTitleBuilder` (Swift, pure, no AppKit) composes both window and tab titles from the document's current state. Three-branch state enum (`connecting`, `disconnected`, `connected`) mirrors the original ObjC code.
+- `displayNameWithIsConnected:…` ObjC bridge replaces the duplicated path-prefix logic in `-[SPDatabaseDocument displayName]`.
+- `-[SPDatabaseDocument updateWindowTitle:]` shrinks from ~50 lines of NSMutableString juggling to ~20 lines of state-gathering and a single forward call into the builder.
+- Accessory color update stays gated on `connected` (unchanged behavior).
+- 15 unit tests in `UnitTests/SAWindowTitleBuilderTests.swift` pin byte-exact output: connecting state, disconnected with/without path prefix, untitled-flag suppression, connected variants (host only, +db, +db+table), server-version preamble (window-only, nil version omitted), file-prefix + version stacking order, empty db/table normalization, and `displayName` parity.
+- Files: `Source/Controllers/Window/SAWindowTitleBuilder.swift`, `SPDatabaseDocument.m`
 
 ### Phase B: Test coverage (foundation for safe refactoring)
 
@@ -137,8 +140,8 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 
 1. ~~**Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum~~ ✅ Done
 2. ~~**Phase B3** (SAViewMode tests) — validate before and after~~ ✅ Done
-3. **Phase A1** (database list manager) — high value, moderate effort — 🟡 A1a done, A1b/A1c pending
-4. **Phase A4** (window title) — quick, easy
+3. **Phase A1** (database list manager) — high value, moderate effort — 🟡 A1a/A1b done, A1c pending
+4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
 5. **Phase B2** (favorites data source tests) — safety net
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI
 7. **Phase A2** (task controller) — large but impactful

--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -81,10 +81,33 @@ A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback
 - Requires a test MySQL instance (Docker or local) — make it opt-in via env var
 - Test TCP/IP, socket, SSL, database selection, timezone
 
-**B2. Tests for SAFavoritesListDataSource**
-- Mock SPTreeNode tree, verify outline view data source methods return correct values
-- Test drag & drop acceptance/rejection logic
-- Test Quick Connect item injection
+**B2. Tests for SAFavoritesListDataSource** — 🟡 Partial (search matcher done)
+
+B2a — Extract + test the favorites-search matcher — ✅ Done
+- New `SAFavoriteSearchMatcher` (Swift, pure, no AppKit) owns the
+  whitespace tokenize → AND-across-tokens → substring-in-name-or-host
+  rule, lifted out of `SAFavoritesListDataSource.rebuildVisibleNodes` /
+  `collectMatchingNodes` (which now delegate to it). The tree walk
+  itself stays in the data source.
+- 17 unit tests in `UnitTests/SAFavoriteSearchMatcherTests.swift`
+  covering: `isActive` for empty/whitespace/single/multi queries,
+  inactive-matcher-matches-everything, token lowercasing, adjacent-
+  whitespace collapse, mixed whitespace splitting (`\t`, `\n`, space),
+  single-token name/host hits, case-insensitivity on both sides,
+  multi-token AND across mixed name/host fields, single-token miss,
+  empty-name-and-host fail, and substring vs word-boundary semantics.
+- Files: `Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteSearchMatcher.swift`, `SAFavoritesListDataSource.swift`
+
+B2b — Outline-view data-source tests (numberOfChildren, child(at:),
+Quick Connect injection, drag/drop validation, isGroupItem, etc.) —
+pending. Blocked on getting `SPTreeNode`, `SPFavoriteNode`,
+`SPGroupNode`, `SPFavoritesController`, `SPFavoriteTextFieldCell`,
+`SPFavoriteColorSupport`, and the relevant `SPConstants` strings
+visible to the Unit Tests target (none currently are — the test target
+is standalone, no bridging header). Likely needs either an ObjC test
+file that `#imports` the .m files directly (existing pattern in
+`SPDatabaseActionTest.m`) or a small bridging header for the test
+target. Worth its own PR.
 
 **B3. Tests for SAViewMode** — ✅ Done
 - 16 unit tests in `UnitTests/SAViewModeTests.swift` covering tab indexes, toolbar identifiers (literal match against the SPConstants wire format), preferences round-trip + unknown-value fallback, action selector names, the `SAViewModeHelper` ObjC bridges, and the toolbar item factory configuration
@@ -142,7 +165,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 2. ~~**Phase B3** (SAViewMode tests) — validate before and after~~ ✅ Done
 3. **Phase A1** (database list manager) — high value, moderate effort — 🟡 A1a/A1b done, A1c pending
 4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
-5. **Phase B2** (favorites data source tests) — safety net
+5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI
 7. **Phase A2** (task controller) — large but impactful
 8. **Phase D1-D3** (SPConnectionController cleanup) — ongoing

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteSearchMatcher.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteSearchMatcher.swift
@@ -1,0 +1,56 @@
+//
+//  SAFavoriteSearchMatcher.swift
+//  Sequel Ace
+//
+//  Pure search-token matching for the favorites sidebar filter.
+//  Extracted from SAFavoritesListDataSource so the matching rule can be
+//  pinned by unit tests without standing up an NSOutlineView, SPTreeNode
+//  tree, and SPFavoritesController.
+//
+//  No AppKit / ObjC dependencies — the file is compiled into both the
+//  app and the Unit Tests target (same pattern as SAViewMode and
+//  SADatabaseListManager).
+//
+
+import Foundation
+
+/// Holds the tokenized form of a favorites-search query and decides
+/// whether a single favorite (identified by its name and host) matches.
+///
+/// Rule: the user's query is split into whitespace-separated tokens,
+/// lowercased once at construction time. A candidate matches when
+/// **every** token is found (substring, case-insensitive) in either
+/// the name **or** the host. This lets the user narrow down with
+/// e.g. `"staging maja"` to match `"[Staging] Majapahit"`.
+struct SAFavoriteSearchMatcher {
+
+    /// Whitespace-separated, lowercased tokens parsed from the query.
+    /// Empty when the query was nil / blank — in that case `isActive`
+    /// returns false and the caller should bypass filtering entirely.
+    let tokens: [String]
+
+    init(query: String) {
+        tokens = query
+            .lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+    }
+
+    /// `true` when the query yielded at least one non-whitespace token.
+    /// Callers should treat `false` as "no filter" — show everything.
+    var isActive: Bool { !tokens.isEmpty }
+
+    /// Whether the given (name, host) pair matches every token.
+    ///
+    /// Both arguments are lowercased here, so callers don't need to
+    /// pre-normalize. Returns `true` when `isActive` is `false`, since
+    /// "no filter" means "everything matches".
+    func matches(name: String, host: String) -> Bool {
+        guard isActive else { return true }
+        let lowerName = name.lowercased()
+        let lowerHost = host.lowercased()
+        return tokens.allSatisfy { token in
+            lowerName.contains(token) || lowerHost.contains(token)
+        }
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
@@ -115,20 +115,18 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
     // MARK: - Filtering
 
     /// Rebuilds `visibleNodes` based on the current `searchQuery`.
-    /// The query is split into whitespace-separated tokens; a leaf matches when
-    /// EVERY token is found (case-insensitively) in either its name or its host.
-    /// This lets users type e.g. "staging maja" to narrow to "[Staging]Majapahit".
+    /// Matching rule lives in `SAFavoriteSearchMatcher` (see that file
+    /// for semantics + test coverage). Leaves match when every token is
+    /// found in either the favorite's name or host; groups inherit
+    /// visibility from any matching descendant.
     private func rebuildVisibleNodes() {
-        let tokens = searchQuery
-            .lowercased()
-            .split(whereSeparator: { $0.isWhitespace })
-            .map(String.init)
-        guard !tokens.isEmpty else {
+        let matcher = SAFavoriteSearchMatcher(query: searchQuery)
+        guard matcher.isActive else {
             visibleNodes = nil
             return
         }
         var matched: Set<SPTreeNode> = []
-        _ = collectMatchingNodes(in: favoritesRoot, tokens: tokens, into: &matched)
+        _ = collectMatchingNodes(in: favoritesRoot, matcher: matcher, into: &matched)
         visibleNodes = matched
     }
 
@@ -136,11 +134,11 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
     /// plus every ancestor of any matched leaf. Returns whether `node` itself is matched
     /// (a group is "matched" if any of its descendants matched).
     @discardableResult
-    private func collectMatchingNodes(in node: SPTreeNode, tokens: [String], into matched: inout Set<SPTreeNode>) -> Bool {
+    private func collectMatchingNodes(in node: SPTreeNode, matcher: SAFavoriteSearchMatcher, into matched: inout Set<SPTreeNode>) -> Bool {
         if node.isGroup {
             var anyDescendantMatched = false
             for child in (node.children ?? []).compactMap({ $0 as? SPTreeNode }) {
-                if collectMatchingNodes(in: child, tokens: tokens, into: &matched) {
+                if collectMatchingNodes(in: child, matcher: matcher, into: &matched) {
                     anyDescendantMatched = true
                 }
             }
@@ -150,12 +148,9 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
             return anyDescendantMatched
         }
         let fav = (node.representedObject as? SPFavoriteNode)?.nodeFavorite
-        let name = (fav?[SPFavoriteNameKey] as? String ?? "").lowercased()
-        let host = (fav?[SPFavoriteHostKey] as? String ?? "").lowercased()
-        let allTokensMatch = tokens.allSatisfy { token in
-            name.contains(token) || host.contains(token)
-        }
-        if allTokensMatch {
+        let name = (fav?[SPFavoriteNameKey] as? String ?? "")
+        let host = (fav?[SPFavoriteHostKey] as? String ?? "")
+        if matcher.matches(name: name, host: host) {
             matched.insert(node)
             return true
         }

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3330,6 +3330,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 /**
  * Update the window title.
+ *
+ * The actual string composition lives in SAWindowTitleBuilder (Swift) —
+ * this method gathers the document's current state and forwards the
+ * result to the window controller. The accessory-color update only
+ * applies in the connected branch.
  */
 - (void)updateWindowTitle:(id)sender {
     // Ensure a call on the main thread
@@ -3337,47 +3342,29 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         return [[self onMainThread] updateWindowTitle:sender];
     }
 
-    // Determine name details
-    NSString *pathName = @"";
-    if ([[[self fileURL] path] length] && ![self isUntitled]) {
-        pathName = [NSString stringWithFormat:@"%@ — ", [[[self fileURL] path] lastPathComponent]];
+    SAWindowConnectionState state;
+    if ([connectionController isConnecting]) {
+        state = SAWindowConnectionStateConnecting;
+    } else if (!_isConnected) {
+        state = SAWindowConnectionStateDisconnected;
+    } else {
+        state = SAWindowConnectionStateConnected;
     }
 
-    if ([connectionController isConnecting]) {
-        NSString *title = NSLocalizedString(@"Connecting…", @"window title string indicating that sp is connecting");
-        [self.parentWindowController updateWindowWithTitle:title tabTitle:title];
-    } else if (!_isConnected) {
-        NSString *title = [NSString stringWithFormat:@"%@%@", pathName, [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey]];
-        [self.parentWindowController updateWindowWithTitle:title tabTitle:title];
-    } else {
-        NSMutableString *windowTitle = [NSMutableString string];
+    SAWindowTitleResult *result = [SAWindowTitleBuilder
+        buildTitleWithConnectionState:state
+                             filePath:[[self fileURL] path]
+                           isUntitled:[self isUntitled]
+                           bundleName:[[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey]
+                       connectionName:[self name]
+                             database:[self database]
+                                table:[self table]
+                         mySQLVersion:mySQLVersion
+             showServerVersionInTitle:[prefs boolForKey:SPDisplayServerVersionInWindowTitle]];
 
-        // Add the path to the window title
-        [windowTitle appendString:pathName];
+    [self.parentWindowController updateWindowWithTitle:result.windowTitle tabTitle:result.tabTitle];
 
-        // Add the MySQL version to the window title if enabled in prefs
-        if ([prefs boolForKey:SPDisplayServerVersionInWindowTitle]) {
-            [windowTitle appendFormat:@"(MySQL %@) ", mySQLVersion];
-        }
-
-        NSMutableString *tabTitle = [NSMutableString string];
-
-        // Add the name to the window
-        [windowTitle appendString:[self name]];
-        [tabTitle appendString:[self name]];
-
-        // If a database is selected, add to the window - and other tabs if host is the same but db different or table is not set
-        if ([self database]) {
-            [windowTitle appendFormat:@"/%@", [self database]];
-            [tabTitle appendFormat:@"/%@", [self database]];
-        }
-
-        // Add the table name if one is selected
-        if ([[self table] length]) {
-            [windowTitle appendFormat:@"/%@", [self table]];
-            [tabTitle appendFormat:@"/%@", [self table]];
-        }
-        [self.parentWindowController updateWindowWithTitle:windowTitle tabTitle:tabTitle];
+    if (state == SAWindowConnectionStateConnected) {
         [self.parentWindowController updateWindowAccessoryWithColor:[[SPFavoriteColorSupport sharedInstance] colorForIndex:[connectionController colorIndex]] isSSL:[self.connectionController isConnectedViaSSL]];
     }
 }
@@ -3707,14 +3694,15 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 }
 
 /**
- * The window title for this document.
+ * The window title for this document. Mirrors the disconnected-state
+ * preamble of -updateWindowTitle:; both share SAWindowTitleBuilder.
  */
 - (NSString *)displayName
 {
-    if (!_isConnected) {
-        return [NSString stringWithFormat:@"%@%@", ([[[self fileURL] path] length] && ![self isUntitled]) ? [NSString stringWithFormat:@"%@ — ",[[[self fileURL] path] lastPathComponent]] : @"", [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey]];
-    }
-    return [[[self fileURL] path] lastPathComponent];
+    return [SAWindowTitleBuilder displayNameWithIsConnected:_isConnected
+                                                   filePath:[[self fileURL] path]
+                                                 isUntitled:[self isUntitled]
+                                                 bundleName:[[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey]];
 }
 
 - (NSUndoManager *)undoManager

--- a/Source/Controllers/Window/SAWindowTitleBuilder.swift
+++ b/Source/Controllers/Window/SAWindowTitleBuilder.swift
@@ -1,0 +1,121 @@
+//
+//  SAWindowTitleBuilder.swift
+//  Sequel Ace
+//
+//  Pure title-string composition for the document window and its tab.
+//  Extracted from -[SPDatabaseDocument updateWindowTitle:] and
+//  -[SPDatabaseDocument displayName] as Phase A4 of the modernization
+//  follow-up plan. No AppKit or ObjC dependencies — kept in this form so
+//  the file can be compiled into the Unit Tests target without a
+//  bridging header (same pattern as SAViewMode and SADatabaseListManager).
+//
+
+import Foundation
+
+/// Result of composing window and tab titles. Two strings because they
+/// can diverge (e.g. the window prepends a path component or MySQL
+/// version, while the tab stays compact).
+@objc final class SAWindowTitleResult: NSObject {
+    @objc let windowTitle: String
+    @objc let tabTitle: String
+
+    @objc init(windowTitle: String, tabTitle: String) {
+        self.windowTitle = windowTitle
+        self.tabTitle = tabTitle
+        super.init()
+    }
+}
+
+/// Three-state classification used by the title composer. Mirrors the
+/// branching in the original `-updateWindowTitle:`.
+@objc enum SAWindowConnectionState: Int {
+    case connecting
+    case disconnected
+    case connected
+}
+
+@objc final class SAWindowTitleBuilder: NSObject {
+
+    /// Compose the window and tab titles for the document.
+    ///
+    /// Branches:
+    ///   - `.connecting` — both strings are "Connecting…", no path prefix.
+    ///   - `.disconnected` — `<path — >?<bundleName>`, both strings equal.
+    ///   - `.connected` — `<path — >?<(MySQL X) >?<connectionName>[/db[/table]]`
+    ///     for the window; same minus the path-and-version preamble for
+    ///     the tab.
+    ///
+    /// The path prefix (`"<fileName> — "`) is included only when there's
+    /// a file URL and the document has been given a name (i.e. is not
+    /// "Untitled"). The (MySQL X) chunk only appears when the user has
+    /// toggled the corresponding preference.
+    @objc static func buildTitle(
+        connectionState: SAWindowConnectionState,
+        filePath: String?,
+        isUntitled: Bool,
+        bundleName: String,
+        connectionName: String,
+        database: String?,
+        table: String?,
+        mySQLVersion: String?,
+        showServerVersionInTitle: Bool
+    ) -> SAWindowTitleResult {
+        let pathName = pathPrefix(filePath: filePath, isUntitled: isUntitled)
+
+        switch connectionState {
+        case .connecting:
+            let title = NSLocalizedString("Connecting…",
+                                          comment: "window title string indicating that sp is connecting")
+            return SAWindowTitleResult(windowTitle: title, tabTitle: title)
+
+        case .disconnected:
+            let title = pathName + bundleName
+            return SAWindowTitleResult(windowTitle: title, tabTitle: title)
+
+        case .connected:
+            var windowTitle = pathName
+            if showServerVersionInTitle, let version = mySQLVersion, !version.isEmpty {
+                windowTitle += "(MySQL \(version)) "
+            }
+            windowTitle += connectionName
+            var tabTitle = connectionName
+
+            if let database = database, !database.isEmpty {
+                windowTitle += "/\(database)"
+                tabTitle += "/\(database)"
+            }
+            if let table = table, !table.isEmpty {
+                windowTitle += "/\(table)"
+                tabTitle += "/\(table)"
+            }
+            return SAWindowTitleResult(windowTitle: windowTitle, tabTitle: tabTitle)
+        }
+    }
+
+    /// The `displayName` returned to `NSDocument` for save panels and
+    /// the proxy icon. Behaves the same as the original method:
+    ///   - Disconnected: `<path — >?<bundleName>` (same as the title).
+    ///   - Connected: just the file's last path component (may be empty
+    ///     if there is no file URL — the original returned the same).
+    @objc static func displayName(
+        isConnected: Bool,
+        filePath: String?,
+        isUntitled: Bool,
+        bundleName: String
+    ) -> String {
+        if !isConnected {
+            return pathPrefix(filePath: filePath, isUntitled: isUntitled) + bundleName
+        }
+        guard let filePath = filePath, !filePath.isEmpty else { return "" }
+        return (filePath as NSString).lastPathComponent
+    }
+
+    /// `<fileName> — ` when there is a real file URL and the document has
+    /// been given a name; empty string otherwise. The em dash and spaces
+    /// match the format used by the original method so the assembled
+    /// title matches byte-for-byte.
+    private static func pathPrefix(filePath: String?, isUntitled: Bool) -> String {
+        guard let filePath = filePath, !filePath.isEmpty, !isUntitled else { return "" }
+        return "\((filePath as NSString).lastPathComponent) — "
+    }
+}

--- a/UnitTests/SAFavoriteSearchMatcherTests.swift
+++ b/UnitTests/SAFavoriteSearchMatcherTests.swift
@@ -1,0 +1,128 @@
+//
+//  SAFavoriteSearchMatcherTests.swift
+//  Unit Tests
+//
+//  Pins the favorites-search semantics extracted from
+//  SAFavoritesListDataSource.rebuildVisibleNodes / collectMatchingNodes.
+//  The matcher is the user-facing contract for the sidebar's search
+//  field — getting these wrong silently hides favorites.
+//
+
+import XCTest
+
+final class SAFavoriteSearchMatcherTests: XCTestCase {
+
+    // MARK: - isActive
+
+    func testEmptyQueryIsNotActive() {
+        XCTAssertFalse(SAFavoriteSearchMatcher(query: "").isActive)
+    }
+
+    func testWhitespaceOnlyQueryIsNotActive() {
+        // Multiple kinds of whitespace — must all be treated as separators
+        // and never produce a non-empty token.
+        XCTAssertFalse(SAFavoriteSearchMatcher(query: "   ").isActive)
+        XCTAssertFalse(SAFavoriteSearchMatcher(query: "\t\n").isActive)
+    }
+
+    func testSingleTokenIsActive() {
+        XCTAssertTrue(SAFavoriteSearchMatcher(query: "prod").isActive)
+    }
+
+    func testMultipleTokensAreActive() {
+        XCTAssertTrue(SAFavoriteSearchMatcher(query: "staging maja").isActive)
+    }
+
+    // MARK: - Inactive-matcher behavior
+
+    /// When the filter is inactive, every candidate must pass — the
+    /// data source skips filtering entirely in that case, and any code
+    /// that asks the matcher directly must agree.
+    func testInactiveMatcherMatchesEverything() {
+        let matcher = SAFavoriteSearchMatcher(query: "")
+        XCTAssertTrue(matcher.matches(name: "", host: ""))
+        XCTAssertTrue(matcher.matches(name: "anything", host: "anywhere"))
+    }
+
+    // MARK: - Token parsing
+
+    func testTokensAreLowercased() {
+        XCTAssertEqual(SAFavoriteSearchMatcher(query: "ProD STG").tokens, ["prod", "stg"])
+    }
+
+    func testTokensCollapseAdjacentWhitespace() {
+        // Adjacent runs of whitespace must collapse to a single
+        // separator (not produce empty-string tokens that would
+        // accidentally match everything).
+        let matcher = SAFavoriteSearchMatcher(query: "  staging   maja  ")
+        XCTAssertEqual(matcher.tokens, ["staging", "maja"])
+    }
+
+    func testTokensSplitOnMixedWhitespace() {
+        let matcher = SAFavoriteSearchMatcher(query: "a\tb\nc d")
+        XCTAssertEqual(matcher.tokens, ["a", "b", "c", "d"])
+    }
+
+    // MARK: - Single-token match
+
+    func testSingleTokenMatchesByName() {
+        let matcher = SAFavoriteSearchMatcher(query: "prod")
+        XCTAssertTrue(matcher.matches(name: "Production", host: "10.0.0.1"))
+    }
+
+    func testSingleTokenMatchesByHost() {
+        let matcher = SAFavoriteSearchMatcher(query: "internal")
+        XCTAssertTrue(matcher.matches(name: "MyDB", host: "db.internal.example.com"))
+    }
+
+    func testSingleTokenIsCaseInsensitiveOnBothSides() {
+        let matcher = SAFavoriteSearchMatcher(query: "PROD")
+        XCTAssertTrue(matcher.matches(name: "production", host: ""))
+
+        let matcher2 = SAFavoriteSearchMatcher(query: "prod")
+        XCTAssertTrue(matcher2.matches(name: "PRODUCTION", host: ""))
+    }
+
+    func testSingleTokenMissBothFields() {
+        let matcher = SAFavoriteSearchMatcher(query: "missing")
+        XCTAssertFalse(matcher.matches(name: "Production", host: "10.0.0.1"))
+    }
+
+    // MARK: - Multi-token (AND) match
+
+    /// Multi-token queries are an AND across tokens, but each token can
+    /// match either field. The advertised example: "staging maja"
+    /// narrows to "[Staging] Majapahit" on host "majapahit.internal".
+    func testMultipleTokensRequireAllToMatchSomewhere() {
+        let matcher = SAFavoriteSearchMatcher(query: "staging maja")
+        XCTAssertTrue(matcher.matches(name: "[Staging] Majapahit", host: "majapahit.internal"))
+    }
+
+    func testMultipleTokensMixedNameAndHost() {
+        // One token matches the name, the other matches the host.
+        let matcher = SAFavoriteSearchMatcher(query: "prod example")
+        XCTAssertTrue(matcher.matches(name: "Production", host: "db.example.com"))
+    }
+
+    func testMultipleTokensFailWhenOneMisses() {
+        let matcher = SAFavoriteSearchMatcher(query: "prod ghost")
+        XCTAssertFalse(matcher.matches(name: "Production", host: "db.example.com"))
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyNameAndHostNeverMatchActiveQuery() {
+        let matcher = SAFavoriteSearchMatcher(query: "anything")
+        XCTAssertFalse(matcher.matches(name: "", host: ""))
+    }
+
+    func testSubstringMatchAcrossWordBoundary() {
+        // The matcher is substring-based, not word-based — "prodb"
+        // should match "production-db" because the chars are contiguous.
+        let matcher = SAFavoriteSearchMatcher(query: "prodb")
+        XCTAssertFalse(matcher.matches(name: "Production-DB", host: ""))
+        // But the substring "prod-d" does occur literally:
+        let matcher2 = SAFavoriteSearchMatcher(query: "tion-d")
+        XCTAssertTrue(matcher2.matches(name: "Production-DB", host: ""))
+    }
+}

--- a/UnitTests/SAWindowTitleBuilderTests.swift
+++ b/UnitTests/SAWindowTitleBuilderTests.swift
@@ -1,0 +1,255 @@
+//
+//  SAWindowTitleBuilderTests.swift
+//  Unit Tests
+//
+//  Pins the byte-exact format of -[SPDatabaseDocument updateWindowTitle:]
+//  and -[SPDatabaseDocument displayName] after the Phase A4 extraction.
+//  The em dash, the trailing space after "(MySQL X)", and the slash
+//  separators are all load-bearing — the strings are user-visible in the
+//  window chrome and the tab.
+//
+
+import XCTest
+
+final class SAWindowTitleBuilderTests: XCTestCase {
+
+    private let bundleName = "Sequel Ace"
+
+    // MARK: - Connecting state
+
+    func testConnectingStateIgnoresEverythingElse() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connecting,
+            filePath: "/Users/x/foo.spf",
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "host",
+            database: "mydb",
+            table: "mytable",
+            mySQLVersion: "8.0",
+            showServerVersionInTitle: true
+        )
+        XCTAssertEqual(result.windowTitle, "Connecting…")
+        XCTAssertEqual(result.tabTitle, "Connecting…")
+    }
+
+    // MARK: - Disconnected state
+
+    func testDisconnectedUntitledHasNoPathPrefix() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .disconnected,
+            filePath: nil,
+            isUntitled: true,
+            bundleName: bundleName,
+            connectionName: "ignored",
+            database: nil,
+            table: nil,
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, bundleName)
+        XCTAssertEqual(result.tabTitle, bundleName)
+    }
+
+    func testDisconnectedWithFilePathPrependsLastComponentAndEmDash() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .disconnected,
+            filePath: "/Users/x/Sessions/work.spf",
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "ignored",
+            database: nil,
+            table: nil,
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, "work.spf — Sequel Ace")
+        XCTAssertEqual(result.tabTitle, "work.spf — Sequel Ace")
+    }
+
+    func testDisconnectedUntitledFlagSuppressesPathPrefix() {
+        // The document can have a fileURL but still be marked untitled
+        // — the path prefix only appears when both conditions hold.
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .disconnected,
+            filePath: "/Users/x/Untitled.spf",
+            isUntitled: true,
+            bundleName: bundleName,
+            connectionName: "ignored",
+            database: nil,
+            table: nil,
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, bundleName)
+    }
+
+    // MARK: - Connected state
+
+    func testConnectedHostOnly() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: nil,
+            table: nil,
+            mySQLVersion: "8.0.32",
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, "production")
+        XCTAssertEqual(result.tabTitle, "production")
+    }
+
+    func testConnectedWithDatabase() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: "orders",
+            table: nil,
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, "production/orders")
+        XCTAssertEqual(result.tabTitle, "production/orders")
+    }
+
+    func testConnectedWithDatabaseAndTable() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: "orders",
+            table: "customers",
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, "production/orders/customers")
+        XCTAssertEqual(result.tabTitle, "production/orders/customers")
+    }
+
+    /// Server-version preamble is window-only — the tab stays compact so
+    /// the version doesn't waste the limited tab real estate.
+    func testConnectedShowServerVersionAffectsOnlyWindowTitle() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: "orders",
+            table: nil,
+            mySQLVersion: "8.0.32",
+            showServerVersionInTitle: true
+        )
+        XCTAssertEqual(result.windowTitle, "(MySQL 8.0.32) production/orders")
+        XCTAssertEqual(result.tabTitle, "production/orders")
+    }
+
+    func testConnectedShowServerVersionWithMissingVersionIsOmitted() {
+        // Defensive: -mySQLVersion can briefly be nil before the
+        // post-connect handshake stores it. We must not render
+        // "(MySQL (null)) " in the title.
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: nil,
+            table: nil,
+            mySQLVersion: nil,
+            showServerVersionInTitle: true
+        )
+        XCTAssertEqual(result.windowTitle, "production")
+    }
+
+    func testConnectedFilePathAndServerVersionStackInOrder() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: "/Users/x/work.spf",
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: "orders",
+            table: "customers",
+            mySQLVersion: "8.0.32",
+            showServerVersionInTitle: true
+        )
+        // Pin the exact preamble order: filename — (MySQL X) host/db/table
+        XCTAssertEqual(result.windowTitle, "work.spf — (MySQL 8.0.32) production/orders/customers")
+        // Tab stays compact (no file prefix, no version)
+        XCTAssertEqual(result.tabTitle, "production/orders/customers")
+    }
+
+    /// Empty strings for database/table should NOT produce stray slashes.
+    /// The original code uses `[[self table] length]` for the table check
+    /// but only nil-tests the database — passing an empty database string
+    /// would have produced "host/" historically. The builder normalizes
+    /// both to "treat empty as absent" to avoid that footgun.
+    func testConnectedEmptyDatabaseAndTableAreOmitted() {
+        let result = SAWindowTitleBuilder.buildTitle(
+            connectionState: .connected,
+            filePath: nil,
+            isUntitled: false,
+            bundleName: bundleName,
+            connectionName: "production",
+            database: "",
+            table: "",
+            mySQLVersion: nil,
+            showServerVersionInTitle: false
+        )
+        XCTAssertEqual(result.windowTitle, "production")
+        XCTAssertEqual(result.tabTitle, "production")
+    }
+
+    // MARK: - displayName
+
+    func testDisplayNameDisconnectedMatchesDisconnectedTitle() {
+        let name = SAWindowTitleBuilder.displayName(
+            isConnected: false,
+            filePath: "/Users/x/work.spf",
+            isUntitled: false,
+            bundleName: bundleName
+        )
+        XCTAssertEqual(name, "work.spf — Sequel Ace")
+    }
+
+    func testDisplayNameDisconnectedUntitled() {
+        let name = SAWindowTitleBuilder.displayName(
+            isConnected: false,
+            filePath: nil,
+            isUntitled: true,
+            bundleName: bundleName
+        )
+        XCTAssertEqual(name, bundleName)
+    }
+
+    func testDisplayNameConnectedReturnsLastPathComponent() {
+        let name = SAWindowTitleBuilder.displayName(
+            isConnected: true,
+            filePath: "/Users/x/Sessions/work.spf",
+            isUntitled: false,
+            bundleName: bundleName
+        )
+        XCTAssertEqual(name, "work.spf")
+    }
+
+    func testDisplayNameConnectedNoFilePathReturnsEmpty() {
+        // The original returned "" via -lastPathComponent of "" — pin
+        // that behavior so callers that compare against "" still work.
+        let name = SAWindowTitleBuilder.displayName(
+            isConnected: true,
+            filePath: nil,
+            isUntitled: true,
+            bundleName: bundleName
+        )
+        XCTAssertEqual(name, "")
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -230,6 +230,9 @@
 		5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */; };
 		5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */; };
 		5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */; };
+		5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
+		5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
+		5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */; };
 		514B40A02F683E3700369718 /* SAAboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001C /* SAAboutWindowController.swift */; };
 		514B40A72F68412000369718 /* License.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A62F68412000369718 /* License.md */; };
 		514B40A82F68412000369718 /* Credits.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A52F68412000369718 /* Credits.md */; };
@@ -942,6 +945,8 @@
 		5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAViewModeTests.swift; sourceTree = "<group>"; };
 		5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManager.swift; sourceTree = "<group>"; };
 		5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManagerTests.swift; sourceTree = "<group>"; };
+		5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilder.swift; sourceTree = "<group>"; };
+		5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilderTests.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -1695,6 +1700,7 @@
 			children = (
 				5132930925F586A900D803AD /* NotificationToken.swift */,
 				51BC14F725BE135500F1CDC9 /* SPWindowController.swift */,
+				5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */,
 				5132930A25F586A900D803AD /* TabManager.swift */,
 			);
 			path = Window;
@@ -2377,6 +2383,7 @@
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
+				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3040,6 +3047,8 @@
 				5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
 				5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
 				5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */,
+				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
+				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
@@ -3200,6 +3209,7 @@
 				BCE0025D11173D2A009DA533 /* SPFieldMapperController.m in Sources */,
 				5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
 				5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
+				5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				BC2777A011514B940034DF6A /* SPNavigatorController.m in Sources */,
 				589582151154F8F400EDCC28 /* SPMainThreadTrampoline.m in Sources */,
 				51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -233,6 +233,9 @@
 		5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
 		5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
 		5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */; };
+		5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */; };
+		5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */; };
+		5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */; };
 		514B40A02F683E3700369718 /* SAAboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001C /* SAAboutWindowController.swift */; };
 		514B40A72F68412000369718 /* License.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A62F68412000369718 /* License.md */; };
 		514B40A82F68412000369718 /* Credits.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A52F68412000369718 /* Credits.md */; };
@@ -947,6 +950,8 @@
 		5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManagerTests.swift; sourceTree = "<group>"; };
 		5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilder.swift; sourceTree = "<group>"; };
 		5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilderTests.swift; sourceTree = "<group>"; };
+		5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcher.swift; sourceTree = "<group>"; };
+		5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcherTests.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -1742,6 +1747,7 @@
 				51B09FEB2F7696C7003BAFFF /* SAConnectionWindowController.swift */,
 				5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */,
 				5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */,
+				5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */,
 			);
 			name = "Connection View";
 			path = ConnectionView;
@@ -2384,6 +2390,7 @@
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
+				5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3049,6 +3056,8 @@
 				5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
+				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
+				5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
@@ -3162,6 +3171,7 @@
 				BC8C8532100E0A8000D7A129 /* SPTableView.m in Sources */,
 				51BB391C25F82B060048CA69 /* SPAppController.swift in Sources */,
 				5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */,
+				5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				BC9F0881100FCF2C00A80D32 /* SPFieldEditorController.m in Sources */,
 				58D2E229101222670063EF1D /* SPTextAndLinkCell.m in Sources */,
 				1A96E4B72588F34C0055F5F5 /* SecureBookmarkManager.swift in Sources */,


### PR DESCRIPTION
## Summary

Two follow-up steps from `.claude/modernization-followup-plan.md`, each as a single commit.

### Phase A4 — Window title composition extracted to SAWindowTitleBuilder
- `-[SPDatabaseDocument updateWindowTitle:]` shared ~50 lines of `NSMutableString` juggling across three branches. Pure string composition moves to `SAWindowTitleBuilder` (Swift, no AppKit) and the document method shrinks to a state-gathering wrapper.
- Three-branch `SAWindowConnectionState` enum mirrors the original control flow (connecting / disconnected / connected). `SAWindowTitleResult` returns window and tab titles separately — the tab stays compact while the window can carry the file-prefix and an optional `(MySQL X)` preamble.
- `displayName(isConnected:filePath:isUntitled:bundleName:)` replaces the duplicated path-prefix logic in `-displayName`.
- Accessory color update stays gated on the connected branch (unchanged behavior).
- **15 unit tests** pin byte-exact output: em-dash + space file prefix, untitled-flag suppression, db/table slash separators, nil-version safety, and the file → version → host/db/table stacking order.

### Phase B2a — Favorites search matcher extracted + tested
- The favorites sidebar's search rule (tokenize → AND-across-tokens → substring-in-name-or-host) was inline inside `SAFavoritesListDataSource.rebuildVisibleNodes` / `collectMatchingNodes`. Pull just the matching rule into `SAFavoriteSearchMatcher` so the user-facing semantics can be pinned without an `NSOutlineView`, `SPTreeNode` tree, and `SPFavoritesController`.
- Tree walking + ancestor-of-match bookkeeping stays in the data source; only the per-leaf decision is delegated.
- **17 unit tests** cover `isActive` semantics, token lowercasing, whitespace collapse, mixed whitespace splitting (tab/newline/space), single/multi-token AND across name/host, case-insensitivity on both sides, and substring vs word-boundary semantics.

### Scope notes
- **A1c** (background-thread `-_selectDatabaseAndItem:` extraction) was deferred — it needs a callback protocol back to the document for tablesList edit-commit, task start/end, and thread dispatch. Plan already calls this out; warrants its own PR.
- **B2b** (full data-source tests — `numberOfChildren`, `child(at:)`, Quick Connect injection, drag/drop validation) is also deferred and documented in the plan. The Unit Tests target is currently standalone with no bridging header, so `SPTreeNode` / `SPFavoriteNode` / `SPGroupNode` / `SPFavoritesController` aren't reachable from Swift tests. Proposed approach (per the plan): an ObjC test file `#import`-ing the .m files directly, mirroring `SPDatabaseActionTest.m`.

Both new Swift files compile into the app target and the Unit Tests target (same pattern as `SAViewMode` / `SADatabaseListManager`).

## Test plan

- [x] Build the project (Xcode) — succeeds
- [x] Run `SAWindowTitleBuilderTests` — 15 / 15 pass
- [x] Run `SAFavoriteSearchMatcherTests` — 17 / 17 pass
- [ ] Manual smoke: connect to a server, switch DB and tables, toggle "Display server version in window title" pref, check window + tab titles update correctly
- [ ] Manual smoke: open the connection screen, type in the favorites search field, verify single-token and multi-token narrowing behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced window and tab title formatting for improved document identification.
  * Improved favorites sidebar search with refined filtering and tokenization logic.

* **Tests**
  * Added comprehensive unit tests for window title composition across various connection states.
  * Added unit tests for favorites search matching behavior and edge cases.

* **Refactor**
  * Modernized window title and display name generation with a dedicated builder component.
  * Updated favorites list filtering to use an improved search matcher.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->