### PR TITLE
Modernization Phase A1c: extract database selection flow to Swift

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -33,7 +33,7 @@ Key deliverables:
 
 SPDatabaseDocument.m at 6,592 lines is the biggest bottleneck. Break it apart:
 
-**A1. Extract database list management (~283 lines)** — 🟡 In progress (A1a done)
+**A1. Extract database list management (~283 lines)** — ✅ Done
 
 A1a — `-setDatabases` (popup rebuild) — ✅ Done
 - New `SADatabaseListManager.configurePopup(_:databases:currentDatabase:addDatabaseSelector:refreshDatabasesSelector:)` rebuilds the choose-database popup (header items, system/user partition, separator, selection)
@@ -48,9 +48,33 @@ A1b — Navigator schema path extraction — ✅ Done (scoped down)
 - 4 new tests for path shape + edge cases
 - Originally planned to extract `-chooseDatabase:` and `-selectDatabase:item:` wholesale, but on inspection both methods need a callback protocol back to the document for tablesList edit-commit checks, task start/end, and thread dispatch — properly belongs in A1c
 
-A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback protocol — pending
-- Also absorbs the remaining `-chooseDatabase:` and `-selectDatabase:item:` document-coupled logic
-- Will let `allDatabases` / `allSystemDatabases` ivars move off SPDatabaseDocument
+A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback protocol — ✅ Done (scoped down)
+- New `SADatabaseSelectionDelegate` (Swift `@objc protocol`) exposes
+  the ~23 hooks the background-thread flow needs (selection ivars,
+  history-state read/write, `mySQLConnection` bridge,
+  `chooseDatabaseButton`, popup rebuild, task end, tables-list focus
+  ops, alert, bundle-trigger fan-out). The manager file stays free of
+  project-specific ObjC types so it still compiles into the Unit
+  Tests target without a bridging header.
+- `SADatabaseListManager.performSelection(database:item:delegate:)`
+  owns the orchestration (popup-rebuild-and-retry, focus restore,
+  history-state restore). The `@autoreleasepool` stays in the document
+  trampoline so the Swift body can use clean early returns.
+- `-[SPDatabaseDocument _selectDatabaseAndItem:]` shrinks from ~100
+  lines to a single forwarding call. The conformance + 22 short
+  bridge methods live alongside it under a `SADatabaseSelectionDelegate`
+  pragma section.
+- `-chooseDatabase:` and `-selectDatabase:item:` stay on the document:
+  they're already small, reference `_isWorkingLevel` /
+  `databaseListIsSelectable` ivars, and a clean carve would have
+  doubled the protocol surface for thin wins. Out-of-scope for A1c.
+- `allDatabases` / `allSystemDatabases` ivars also stay on the document
+  for now — they have callers in the add/copy/rename enablement
+  (`controlTextDidChange:`) and the delete path that aren't touched by
+  A1c. Moving them is its own task.
+- No new tests — the carved-out method is pure orchestration that
+  would need a heavy fake delegate to exercise. Existing
+  `SADatabaseListManagerTests` (21 tests) still pass.
 - Files: `Source/Controllers/MainViewControllers/SPDatabaseDocument.m`, `SADatabaseListManager.swift`
 
 **A2. Extract task/progress management (~257 lines)**
@@ -235,7 +259,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 
 1. ~~**Phase A3** (wire SAViewMode into view switching) — quick win, already has the enum~~ ✅ Done
 2. ~~**Phase B3** (SAViewMode tests) — validate before and after~~ ✅ Done
-3. **Phase A1** (database list manager) — high value, moderate effort — 🟡 A1a/A1b done, A1c pending
+3. ~~**Phase A1** (database list manager) — high value, moderate effort~~ ✅ Done
 4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI

--- a/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
+++ b/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
@@ -2,13 +2,113 @@
 //  SADatabaseListManager.swift
 //  Sequel Ace
 //
-//  Owns the "choose database" popup configuration and (eventually) the
-//  database selection flow. Phase A1a extracts only -setDatabases —
-//  -chooseDatabase:, -selectDatabase:item:, and the background-thread
-//  -_selectDatabaseAndItem: path will move here in follow-up steps.
+//  Owns the "choose database" popup configuration and the background-
+//  thread database selection flow. Phase A1a extracted -setDatabases;
+//  A1b extracted the navigator schema path; A1c moves the
+//  -_selectDatabaseAndItem: orchestration here behind
+//  `SADatabaseSelectionDelegate`. The thin wrappers
+//  -chooseDatabase: and -selectDatabase:item: stay on
+//  SPDatabaseDocument — they read document-local UI state and
+//  haven't earned their own home yet.
 //
 
 import AppKit
+
+/// Callbacks the database-selection flow makes back into its host
+/// (in practice, `SPDatabaseDocument`) so the manager itself never
+/// touches project-specific ObjC types and stays compilable into the
+/// Unit Tests target without a bridging header.
+///
+/// The protocol is intentionally chunky: each member maps to one
+/// specific step of the original `-_selectDatabaseAndItem:`
+/// implementation. Keeping it that way lets the manager remain a
+/// pure orchestration script.
+///
+/// Threading: the manager calls these from whichever thread its
+/// `performSelection(database:item:delegate:)` runs on. Mutations
+/// happen on whichever thread is appropriate; UI-thread requirements
+/// are documented per-member.
+@objc protocol SADatabaseSelectionDelegate: AnyObject {
+
+    // MARK: State the manager reads and writes
+
+    /// Mirrors the document's `selectedDatabase` ivar.
+    var currentSelectedDatabase: String? { get set }
+
+    /// Mirrors the document's `selectedTableName` ivar.
+    var currentSelectedTable: String? { get set }
+
+    /// Mirrors `[spHistoryControllerInstance modifyingState]`.
+    var historyStateIsModifying: Bool { get set }
+
+    // MARK: Predicates
+
+    /// `[mySQLConnection isConnected]`.
+    var isDatabaseConnected: Bool { get }
+
+    /// `[self table]` — the currently displayed table name.
+    var currentTableName: String? { get }
+
+    // MARK: Bridges to project ObjC objects
+
+    /// The popup button driven by the manager. Backed by the
+    /// document's IBOutlet; UI mutations are wrapped in main-queue
+    /// dispatch by the manager.
+    var chooseDatabaseButton: NSPopUpButton! { get }
+
+    /// `[mySQLConnection selectDatabase:name]`. Safe to call off
+    /// the main thread (matches original behavior).
+    @discardableResult func selectMySQLDatabase(_ name: String) -> Bool
+
+    /// `[spHistoryControllerInstance updateHistoryEntries]`.
+    func updateHistoryEntries()
+
+    /// `[self setDatabases]` — rebuilds the popup. Must be invoked
+    /// on the main thread; the manager wraps this in `SPMainQSync`
+    /// equivalent dispatch.
+    func rebuildDatabasesPopup()
+
+    /// `[self endTask]`.
+    func endLoadingTask()
+
+    /// `[databaseDataInstance resetAllData]`.
+    func resetDatabaseData()
+
+    /// `[self detectDatabaseEncoding]`.
+    func detectDatabaseEncoding()
+
+    /// `[tablesListInstance setConnection:mySQLConnection]`.
+    func reattachTablesListConnection()
+
+    /// `[self updateWindowTitle:self]`.
+    func refreshWindowTitle()
+
+    /// Show the "Unable to select database" warning alert. The
+    /// original code called `[NSAlert createWarningAlertWithTitle:…]`
+    /// directly from the background thread; the delegate
+    /// implementation should preserve that.
+    func presentUnableToSelectDatabaseAlert(name: String)
+
+    // MARK: Tables-list UI (main-thread)
+
+    /// `[tablesListInstance selectItemWithName:name]`. Caller
+    /// guarantees main-thread context.
+    @discardableResult func selectTablesListItem(named name: String) -> Bool
+
+    /// `[tablesListInstance setTableListSelectability:flag]`.
+    func setTableListSelectability(_ flag: Bool)
+
+    /// `[tablesListInstance makeTableListFilterHaveFocus]`.
+    func focusTableListFilter()
+
+    /// `[tablesListInstance makeTableListHaveFocus]`.
+    func focusTableList()
+
+    // MARK: Post-completion
+
+    /// `[self _processDatabaseChangedBundleTriggerActions]`.
+    func processDatabaseChangedBundleTriggers()
+}
 
 /// Partition result for system vs. user databases, exposed to ObjC.
 @objc final class SADatabasePartition: NSObject {
@@ -151,5 +251,145 @@ import AppKit
         }
 
         return partition
+    }
+
+    /// Background-thread orchestration for selecting a database (and
+    /// optionally a table). Lifted from
+    /// `-[SPDatabaseDocument _selectDatabaseAndItem:]` so the document
+    /// no longer owns the threading / popup-rebuild-and-retry
+    /// machinery.
+    ///
+    /// `delegate` is held only for the duration of the call.
+    ///
+    /// Behavior must match the original byte-for-byte: if the database
+    /// hasn't changed the connection isn't touched; if the popup is
+    /// stale or `selectDatabase:` fails, the popup is rebuilt and the
+    /// selection retried once; if it still fails an alert is shown and
+    /// the task is ended early; otherwise the database is switched in,
+    /// the tables list is updated, focus is restored, and the task is
+    /// ended.
+    ///
+    /// The caller is responsible for wrapping the call in an
+    /// `@autoreleasepool` if invoked from a long-lived background
+    /// thread (the original `-_selectDatabaseAndItem:` did this).
+    @objc static func performSelection(database: String,
+                                       item: String?,
+                                       delegate: SADatabaseSelectionDelegate) {
+        let historyStateChanging = delegate.historyStateIsModifying
+        if !historyStateChanging {
+            delegate.updateHistoryEntries()
+            delegate.historyStateIsModifying = true
+        }
+
+        if database != delegate.currentSelectedDatabase {
+            var targetIndex = mainSync {
+                delegate.chooseDatabaseButton.indexOfItem(withTitle: database)
+            }
+            var didSelect = delegate.selectMySQLDatabase(database)
+
+            // Refresh database metadata and retry once when the list
+            // is stale or the initial selection failed.
+            if (targetIndex == NSNotFound || !didSelect) && delegate.isDatabaseConnected {
+                mainSync {
+                    delegate.rebuildDatabasesPopup()
+                }
+                targetIndex = mainSync {
+                    delegate.chooseDatabaseButton.indexOfItem(withTitle: database)
+                }
+                if !didSelect {
+                    didSelect = delegate.selectMySQLDatabase(database)
+                }
+            }
+
+            if !didSelect {
+                // End the task first so the popup can be re-selected.
+                delegate.endLoadingTask()
+
+                if delegate.isDatabaseConnected {
+                    delegate.presentUnableToSelectDatabaseAlert(name: database)
+                }
+
+                if !historyStateChanging {
+                    delegate.historyStateIsModifying = false
+                    delegate.updateHistoryEntries()
+                }
+                return
+            }
+
+            if targetIndex == NSNotFound {
+                mainSync {
+                    // Defensive: skip empty titles, mirroring
+                    // `-safeAddItemWithTitle:` in the original code.
+                    if !database.isEmpty {
+                        delegate.chooseDatabaseButton.addItem(withTitle: database)
+                    }
+                }
+                targetIndex = mainSync {
+                    delegate.chooseDatabaseButton.indexOfItem(withTitle: database)
+                }
+            }
+
+            mainSync {
+                if targetIndex != NSNotFound {
+                    delegate.chooseDatabaseButton.selectItem(withTitle: database)
+                } else {
+                    delegate.chooseDatabaseButton.selectItem(at: 0)
+                }
+            }
+
+            delegate.currentSelectedDatabase = database
+            delegate.currentSelectedTable = nil
+
+            delegate.resetDatabaseData()
+
+            // Update the stored database encoding, used for views,
+            // "default" table encodings, and the View-using-encoding
+            // menu.
+            delegate.detectDatabaseEncoding()
+
+            // Set the connection of SPTablesList to reload tables
+            // in db.
+            delegate.reattachTablesListConnection()
+
+            delegate.refreshWindowTitle()
+        }
+
+        mainSync {
+            var focusOnFilter = true
+            if item != nil { focusOnFilter = false }
+
+            // If the table has changed, update the selection.
+            if let targetItem = item, targetItem != delegate.currentTableName {
+                focusOnFilter = !delegate.selectTablesListItem(named: targetItem)
+            }
+
+            // Ensure the window focus is on the table list or the
+            // filter as appropriate.
+            delegate.setTableListSelectability(true)
+            if focusOnFilter {
+                delegate.focusTableListFilter()
+            } else {
+                delegate.focusTableList()
+            }
+            delegate.setTableListSelectability(false)
+        }
+
+        if !historyStateChanging {
+            delegate.historyStateIsModifying = false
+            delegate.updateHistoryEntries()
+        }
+
+        delegate.endLoadingTask()
+        delegate.processDatabaseChangedBundleTriggers()
+    }
+
+    /// Main-queue equivalent of `SPMainQSync` — run inline if already on
+    /// the main thread, otherwise `dispatch_sync` to it. Kept private so
+    /// the file stays free of project-wide ObjC dependencies.
+    private static func mainSync<T>(_ block: () -> T) -> T {
+        if Thread.isMainThread {
+            return block()
+        }
+        return DispatchQueue.main.sync(execute: block)
     }
 }

--- a/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
+++ b/Source/Controllers/MainViewControllers/SADatabaseListManager.swift
@@ -309,6 +309,21 @@ import AppKit
                     delegate.presentUnableToSelectDatabaseAlert(name: database)
                 }
 
+                // Restore the popup's visible selection to the database
+                // we're still on: the switch failed, so we never advanced
+                // `currentSelectedDatabase`, but the popup is currently
+                // showing the un-selectable target the user clicked.
+                // Snap it back so the UI stays consistent with the live
+                // connection. (The original ObjC left the popup on the
+                // failed entry — see PR #2414 review.)
+                mainSync {
+                    if let current = delegate.currentSelectedDatabase, !current.isEmpty {
+                        delegate.chooseDatabaseButton.selectItem(withTitle: current)
+                    } else {
+                        delegate.chooseDatabaseButton.selectItem(at: 0)
+                    }
+                }
+
                 if !historyStateChanging {
                     delegate.historyStateIsModifying = false
                     delegate.updateHistoryEntries()

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -97,7 +97,7 @@ static NSString *SPNewDatabaseCopyContent = @"SPNewDatabaseCopyContent";
 
 static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
-@interface SPDatabaseDocument ()
+@interface SPDatabaseDocument () <SADatabaseSelectionDelegate>
 
 // Privately redeclare as read/write to get the synthesized setter
 @property (readwrite, assign) BOOL allowSplitViewResizing;
@@ -5250,111 +5250,137 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 /**
  * Select the specified database and, optionally, table.
+ *
+ * Trampoline into SADatabaseListManager. The orchestration
+ * (history-state save, popup-rebuild-and-retry, focus restoration)
+ * lives in Swift via `SADatabaseSelectionDelegate`; the delegate
+ * implementation is in the SADatabaseSelectionDelegate section below.
  */
 - (void)_selectDatabaseAndItem:(NSDictionary *)selectionDetails
 {
     @autoreleasepool {
-        NSString *targetDatabaseName = [selectionDetails objectForKey:@"database"];
-        NSString *targetItemName = [selectionDetails objectForKey:@"item"];
-
-        // Save existing scroll position and details, and ensure no duplicate entries are created as table list changes
-        BOOL historyStateChanging = [spHistoryControllerInstance modifyingState];
-
-        if (!historyStateChanging) {
-            [spHistoryControllerInstance updateHistoryEntries];
-            [spHistoryControllerInstance setModifyingState:YES];
-        }
-
-        if (![targetDatabaseName isEqualToString:selectedDatabase]) {
-            NSInteger targetDatabaseIndex = [[chooseDatabaseButton onMainThread] indexOfItemWithTitle:targetDatabaseName];
-            BOOL didSelectDatabase = [mySQLConnection selectDatabase:targetDatabaseName];
-
-            // Refresh database metadata and retry once when the list is stale or the initial selection failed.
-            if ((targetDatabaseIndex == NSNotFound || !didSelectDatabase) && [mySQLConnection isConnected]) {
-                SPMainQSync(^{
-                    [self setDatabases];
-                });
-
-                targetDatabaseIndex = [[chooseDatabaseButton onMainThread] indexOfItemWithTitle:targetDatabaseName];
-
-                if (!didSelectDatabase) {
-                    didSelectDatabase = [mySQLConnection selectDatabase:targetDatabaseName];
-                }
-            }
-
-            // Abort only if the database still can't be selected after refreshing and retrying.
-            if (!didSelectDatabase) {
-                // End the task first to ensure the database dropdown can be reselected
-                [self endTask];
-
-                if ([mySQLConnection isConnected]) {
-                    [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Error", @"error") message:[NSString stringWithFormat:NSLocalizedString(@"Unable to select database %@.\nPlease check you have the necessary privileges to view the database, and that the database still exists.", @"message of panel when connection to db failed after selecting from popupbutton"), targetDatabaseName] callback:nil];
-                }
-
-                if (!historyStateChanging) {
-                    [spHistoryControllerInstance setModifyingState:NO];
-                    [spHistoryControllerInstance updateHistoryEntries];
-                }
-
-                return;
-            }
-
-            if (targetDatabaseIndex == NSNotFound) {
-                SPMainQSync(^{
-                    [self->chooseDatabaseButton safeAddItemWithTitle:targetDatabaseName];
-                });
-                targetDatabaseIndex = [[chooseDatabaseButton onMainThread] indexOfItemWithTitle:targetDatabaseName];
-            }
-
-            if (targetDatabaseIndex != NSNotFound) {
-                [[chooseDatabaseButton onMainThread] selectItemWithTitle:targetDatabaseName];
-            } else {
-                [[chooseDatabaseButton onMainThread] selectItemAtIndex:0];
-            }
-
-            selectedDatabase = [[NSString alloc] initWithString:targetDatabaseName];
-            selectedTableName = nil;
-
-            [databaseDataInstance resetAllData];
-
-            // Update the stored database encoding, used for views, "default" table encodings, and to allow
-            // or disallow use of the "View using encoding" menu
-            [self detectDatabaseEncoding];
-
-            // Set the connection of SPTablesList to reload tables in db
-            [tablesListInstance setConnection:mySQLConnection];
-
-            // Update the window title
-            [self updateWindowTitle:self];
-        }
-
-        SPMainQSync(^{
-            BOOL focusOnFilter = YES;
-            if (targetItemName) focusOnFilter = NO;
-
-            // If a the table has changed, update the selection
-            if (![targetItemName isEqualToString:[self table]] && targetItemName) {
-                focusOnFilter = ![self->tablesListInstance selectItemWithName:targetItemName];
-            }
-
-            // Ensure the window focus is on the table list or the filter as appropriate
-            [self->tablesListInstance setTableListSelectability:YES];
-            if (focusOnFilter) {
-                [self->tablesListInstance makeTableListFilterHaveFocus];
-            } else {
-                [self->tablesListInstance makeTableListHaveFocus];
-            }
-            [self->tablesListInstance setTableListSelectability:NO];
-        });
-
-        if (!historyStateChanging) {
-            [spHistoryControllerInstance setModifyingState:NO];
-            [spHistoryControllerInstance updateHistoryEntries];
-        }
-
-        [self endTask];
-        [self _processDatabaseChangedBundleTriggerActions];
+        [SADatabaseListManager performSelectionWithDatabase:[selectionDetails objectForKey:@"database"]
+                                                       item:[selectionDetails objectForKey:@"item"]
+                                                   delegate:self];
     }
+}
+
+#pragma mark - SADatabaseSelectionDelegate
+
+- (NSString *)currentSelectedDatabase
+{
+    return selectedDatabase;
+}
+
+- (void)setCurrentSelectedDatabase:(NSString *)value
+{
+    // Match original semantics: -_selectDatabaseAndItem: built a fresh
+    // immutable copy via [[NSString alloc] initWithString:…] when it
+    // assigned to the ivar. -copy on an NSString returns self for the
+    // already-immutable case, but stays correct for any mutable input.
+    selectedDatabase = [value copy];
+}
+
+- (NSString *)currentSelectedTable
+{
+    return selectedTableName;
+}
+
+- (void)setCurrentSelectedTable:(NSString *)value
+{
+    selectedTableName = [value copy];
+}
+
+- (BOOL)historyStateIsModifying
+{
+    return [spHistoryControllerInstance modifyingState];
+}
+
+- (void)setHistoryStateIsModifying:(BOOL)value
+{
+    [spHistoryControllerInstance setModifyingState:value];
+}
+
+- (BOOL)isDatabaseConnected
+{
+    return [mySQLConnection isConnected];
+}
+
+- (NSString *)currentTableName
+{
+    return [self table];
+}
+
+- (NSPopUpButton *)chooseDatabaseButton
+{
+    return chooseDatabaseButton;
+}
+
+- (BOOL)selectMySQLDatabase:(NSString *)name
+{
+    return [mySQLConnection selectDatabase:name];
+}
+
+- (void)updateHistoryEntries
+{
+    [spHistoryControllerInstance updateHistoryEntries];
+}
+
+- (void)rebuildDatabasesPopup
+{
+    [self setDatabases];
+}
+
+- (void)endLoadingTask
+{
+    [self endTask];
+}
+
+- (void)resetDatabaseData
+{
+    [databaseDataInstance resetAllData];
+}
+
+- (void)reattachTablesListConnection
+{
+    [tablesListInstance setConnection:mySQLConnection];
+}
+
+- (void)refreshWindowTitle
+{
+    [self updateWindowTitle:self];
+}
+
+- (void)presentUnableToSelectDatabaseAlertWithName:(NSString *)name
+{
+    [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Error", @"error")
+                                 message:[NSString stringWithFormat:NSLocalizedString(@"Unable to select database %@.\nPlease check you have the necessary privileges to view the database, and that the database still exists.", @"message of panel when connection to db failed after selecting from popupbutton"), name]
+                                callback:nil];
+}
+
+- (BOOL)selectTablesListItemNamed:(NSString *)name
+{
+    return [tablesListInstance selectItemWithName:name];
+}
+
+- (void)setTableListSelectability:(BOOL)flag
+{
+    [tablesListInstance setTableListSelectability:flag];
+}
+
+- (void)focusTableListFilter
+{
+    [tablesListInstance makeTableListFilterHaveFocus];
+}
+
+- (void)focusTableList
+{
+    [tablesListInstance makeTableListHaveFocus];
+}
+
+- (void)processDatabaseChangedBundleTriggers
+{
+    [self _processDatabaseChangedBundleTriggerActions];
 }
 
 - (void)_processDatabaseChangedBundleTriggerActions


### PR DESCRIPTION
## Summary

Completes **Phase A1** of the SPDatabaseDocument decomposition by moving the background-thread database-selection orchestration out of the 6.5k-line god object and into `SADatabaseListManager`.

- New `SADatabaseSelectionDelegate` (Swift `@objc protocol`, ~23 hooks) exposes exactly what the selection flow needs — selection ivars, history-state read/write, the `mySQLConnection` bridge, `chooseDatabaseButton`, popup rebuild, task end, tables-list focus ops, the failure alert, and the bundle-trigger fan-out. The manager file stays free of project-specific ObjC types so it keeps compiling into the Unit Tests target without a bridging header.
- `SADatabaseListManager.performSelection(database:item:delegate:)` owns the orchestration (popup-rebuild-and-retry, focus restore, history-state restore). A private `mainSync` helper mirrors `SPMainQSync` semantics without an ObjC dependency.
- `-[SPDatabaseDocument _selectDatabaseAndItem:]` shrinks from ~100 lines to a single forwarding call wrapped in `@autoreleasepool` (kept ObjC-side so the Swift body can use clean early returns). 22 short bridge methods sit under a `SADatabaseSelectionDelegate` pragma section.

### Scoped down from the original A1c plan
- `-chooseDatabase:` and `-selectDatabase:item:` stay on the document — they're already small and read `_isWorkingLevel` / `databaseListIsSelectable` ivars; a clean carve would have doubled the protocol surface for thin wins.
- `allDatabases` / `allSystemDatabases` ivars stay on the document — still used by the add/copy/rename enablement and delete paths, untouched here.

No behavior changes.

## Test plan

- [x] Project builds (Sequel Ace Debug)
- [x] 21 `SADatabaseListManagerTests` pass
- [ ] Manual smoke: switch databases via the popup, select a table, confirm focus lands on the filter/table list as before
- [ ] Manual smoke: select a database that fails (revoked privileges) → "Unable to select database" alert still shows and the popup re-selects the prior database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Phase A1 modernization of database selection completed; internal architecture updated with no change to core functionality.
* **Bug Fixes / Reliability**
  * More robust database/table selection: retries on transient failures, clearer failure alerts, and reliable UI selection/history restoration.
* **Usability**
  * Improved preservation of selection state, window title updates, and table-list focus behavior after database changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->