### PR TITLE
Modernization Phase C1a: wrap favorites list in NSViewRepresentable

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -211,8 +211,12 @@ C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select
   tree of `.quickConnect` / `.group` / `.favorite` nodes. Pure — no
   AppKit / project ObjC types — so it compiles into the Unit Tests
   target (same constraint as `SAFavoriteSearchMatcher`). Carries a
-  stable `id` (kind-prefixed) plus the real `favoriteID` so a
-  selection resolves back to the underlying favorite.
+  stable `id` plus the real `favoriteID` so a selection resolves back
+  to the underlying favorite. Ids come from the persistent
+  `SPTreeNode` instance address (favorites prefer their `favoriteID`),
+  so identity is stable + unique across sibling reorder/insert/remove
+  — index-path ids would shift and clear SwiftUI's selection (Codex,
+  PR #2416).
 - `SAFavoriteItem.filtered(using:)` + `[SAFavoriteItem].filtered(query:)`
   reuse `SAFavoriteSearchMatcher` and reproduce the AppKit walker
   semantics exactly: Quick Connect always kept, favorites matched on

--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -206,7 +206,39 @@ C1a — `NSViewRepresentable` wrap — ✅ Done
   already covered by `SAFavoriteSearchMatcherTests`.
 - Files: new `Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift`
 
-C1b — iterate toward a pure SwiftUI `List` / `OutlineGroup` — pending
+C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select; reorder+rename deferred)
+- New `SAFavoriteItem` (Swift value model, Identifiable/Hashable) is a
+  tree of `.quickConnect` / `.group` / `.favorite` nodes. Pure — no
+  AppKit / project ObjC types — so it compiles into the Unit Tests
+  target (same constraint as `SAFavoriteSearchMatcher`). Carries a
+  stable `id` (kind-prefixed) plus the real `favoriteID` so a
+  selection resolves back to the underlying favorite.
+- `SAFavoriteItem.filtered(using:)` + `[SAFavoriteItem].filtered(query:)`
+  reuse `SAFavoriteSearchMatcher` and reproduce the AppKit walker
+  semantics exactly: Quick Connect always kept, favorites matched on
+  name+host, groups kept only when a descendant favorite matches
+  (group name itself not matched), empty groups pruned under an active
+  query. Plus `flattened()` / `first(byID:)` lookups.
+- `SAFavoriteItem+Tree.swift` (app-target only) builds the model from
+  the live `SPTreeNode` tree via the `SPFavorite*Key` constants —
+  isolated here so the model file stays test-eligible. (Builder itself
+  is untested: constructing `SPTreeNode` from the test target hits the
+  B2b sharp edge.)
+- `SAFavoritesList` (SwiftUI) renders `List(selection:)` +
+  `OutlineGroup(children:)` with `.sidebar` style, per-row icons
+  (quick-connect / folder / database-small) and color-tinted favorite
+  labels via `SPFavoriteColorSupport`, live search filtering, and
+  double-click-to-connect on leaves (mirrors `-nodeDoubleClicked:`).
+- 13 unit tests in `UnitTests/SAFavoriteItemTests.swift` covering
+  flatten/lookup, inactive-query passthrough, name/host matching,
+  group keep/prune rules, group-name-not-matched, quick-connect
+  survival, and multi-token AND.
+- Still deferred before this can replace the C1a wrap: drag & drop
+  reordering, inline rename, and expand/collapse persistence (all
+  still in the AppKit data source). Nothing hosts this view yet
+  (Phase C3).
+- Files: new `SAFavoriteItem.swift`, `SAFavoriteItem+Tree.swift`,
+  `SAFavoritesList.swift`, `UnitTests/SAFavoriteItemTests.swift`
 
 **C2. SwiftUI ConnectionFormView**
 - The 55 IBOutlets in ConnectionView.xib are the target
@@ -286,7 +318,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 3. ~~**Phase A1** (database list manager) — high value, moderate effort~~ ✅ Done
 4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
-6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a done (NSViewRepresentable wrap), C1b pending (pure SwiftUI list)
+6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a + C1b done (wrap + pure SwiftUI list); reorder/rename/persistence + hosting (C3) still pending before it replaces the AppKit list
 7. **Phase A2** (task controller) — large but impactful
 8. **Phase D1-D3** (SPConnectionController cleanup) — ongoing
 9. **Phase C2-C3** (SwiftUI connection form) — bigger effort

--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -178,11 +178,35 @@ backlog.
 
 ### Phase C: SwiftUI migration starts
 
-**C1. SwiftUI FavoritesListView**
-- Wrap the existing `SAFavoritesListDataSource` in an `NSViewRepresentable` first
-- Then iterate toward a pure SwiftUI `List` with `OutlineGroup`
-- This is the first visible SwiftUI in the app
-- Files: new `SAFavoritesListView.swift`
+**C1. SwiftUI FavoritesListView** — 🟡 In progress (NSViewRepresentable wrap done)
+
+C1a — `NSViewRepresentable` wrap — ✅ Done
+- New `SAFavoritesListView` (Swift, SwiftUI) wraps an
+  `SPFavoritesOutlineView` driven by the existing
+  `SAFavoritesListDataSource` inside an `NSScrollView`. It applies the
+  same column / font / row-height / source-list config that
+  `-[SPConnectionController setUpFavoritesOutlineView]` applies, and
+  keeps the data source's `searchQuery` / `delegate` in sync across
+  `updateNSView`.
+- The delegate is captured as a `() -> SAFavoritesListDelegate?`
+  closure over a `weak` local rather than a stored property, since
+  `NSViewRepresentable` is a value type that SwiftUI keeps alive for
+  the view's lifetime (avoids a retain cycle once C3 hosts it inside
+  its owner).
+- A `Coordinator` (NSObject) holds the data source + outline view
+  across SwiftUI view-value churn and forwards the cell-based
+  double-click to the delegate (mirrors
+  `-[SPConnectionController nodeDoubleClicked:]`: ignore Quick
+  Connect, edit groups, connect on leaf).
+- App-target only (wired into pbxproj by hand, mirroring
+  `SAFavoritesListDataSource.swift`); not yet hosted anywhere —
+  Phase C3 (standalone connection window) is the intended host.
+- No tests: the wrapper is AppKit plumbing that needs a live
+  `NSOutlineView`; the filtering / data-source logic it drives is
+  already covered by `SAFavoriteSearchMatcherTests`.
+- Files: new `Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift`
+
+C1b — iterate toward a pure SwiftUI `List` / `OutlineGroup` — pending
 
 **C2. SwiftUI ConnectionFormView**
 - The 55 IBOutlets in ConnectionView.xib are the target
@@ -262,7 +286,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 3. ~~**Phase A1** (database list manager) — high value, moderate effort~~ ✅ Done
 4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
-6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI
+6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a done (NSViewRepresentable wrap), C1b pending (pure SwiftUI list)
 7. **Phase A2** (task controller) — large but impactful
 8. **Phase D1-D3** (SPConnectionController cleanup) — ongoing
 9. **Phase C2-C3** (SwiftUI connection form) — bigger effort

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
@@ -35,27 +35,33 @@ extension SAFavoriteItem {
         }
 
         let topLevel = (root.children ?? []).compactMap { $0 as? SPTreeNode }
-        for (index, node) in topLevel.enumerated() {
-            items.append(build(node, path: "\(index)"))
+        for node in topLevel {
+            items.append(build(node))
         }
         return items
     }
 
-    /// Recursively convert one `SPTreeNode`. `path` is the dotted
-    /// index-path from the root, used as a stable fallback id for
-    /// groups (which have no persistent identifier) and for favorites
-    /// missing an ID.
-    private static func build(_ node: SPTreeNode, path: String) -> SAFavoriteItem {
+    /// Recursively convert one `SPTreeNode`.
+    ///
+    /// Identity comes from the underlying `SPTreeNode` instance, not a
+    /// positional index path: the favorites tree owns persistent
+    /// `SPTreeNode` objects for the lifetime of the session, so the
+    /// address is stable across model rebuilds *and* unique per node —
+    /// reordering, inserting, or removing siblings doesn't change a
+    /// surviving node's id, so SwiftUI `List(selection:)` keeps the
+    /// right row selected. (Favorites still prefer their persistent
+    /// `favoriteID`, which is nicer for resolving a selection back to
+    /// the favorite dictionary; the node-address id is the fallback.)
+    private static func build(_ node: SPTreeNode) -> SAFavoriteItem {
+        let nodeAddress = UInt(bitPattern: Unmanaged.passUnretained(node).toOpaque())
+
         if node.isGroup {
             let group = node.representedObject as? SPGroupNode
             let children = (node.children ?? [])
                 .compactMap { $0 as? SPTreeNode }
-                .enumerated()
-                .map { offset, child in
-                    build(child, path: "\(path).\(offset)")
-                }
+                .map { build($0) }
             return SAFavoriteItem(
-                id: "grp:\(path)",
+                id: "grp:\(nodeAddress)",
                 kind: .group,
                 name: group?.nodeName ?? "",
                 children: children
@@ -69,7 +75,7 @@ extension SAFavoriteItem {
         let colorIndex = favorite?[SPFavoriteColorIndexKey] as? Int
 
         return SAFavoriteItem(
-            id: favoriteID.map { "fav:\($0)" } ?? "fav:\(path)",
+            id: favoriteID.map { "fav:\($0)" } ?? "node:\(nodeAddress)",
             kind: .favorite,
             name: name,
             host: host,

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
@@ -1,0 +1,90 @@
+//
+//  SAFavoriteItem+Tree.swift
+//  Sequel Ace
+//
+//  Phase C1b: bridges the AppKit favorites tree (`SPTreeNode` of
+//  `SPGroupNode` / `SPFavoriteNode`) into the value-type
+//  `SAFavoriteItem` model that the SwiftUI list consumes.
+//
+//  Kept separate from `SAFavoriteItem.swift` because it touches
+//  project-specific ObjC types and the `SPFavorite*Key` extern
+//  constants (bridging-header dependency) — so this file is
+//  app-target only, while the pure model + filter stays testable.
+//
+
+import AppKit
+
+extension SAFavoriteItem {
+
+    /// Build the SwiftUI model forest from the live favorites tree.
+    ///
+    /// - Parameters:
+    ///   - root: the favorites tree root (`SPFavoritesController.favoritesTree`).
+    ///   - includeQuickConnect: when `true` (default), a virtual
+    ///     Quick Connect item is prepended, mirroring
+    ///     `SAFavoritesListDataSource`.
+    static func tree(from root: SPTreeNode, includeQuickConnect: Bool = true) -> [SAFavoriteItem] {
+        var items: [SAFavoriteItem] = []
+
+        if includeQuickConnect {
+            items.append(SAFavoriteItem(
+                id: "quickConnect",
+                kind: .quickConnect,
+                name: NSLocalizedString("Quick Connect", comment: "Quick connect item label").uppercased()
+            ))
+        }
+
+        let topLevel = (root.children ?? []).compactMap { $0 as? SPTreeNode }
+        for (index, node) in topLevel.enumerated() {
+            items.append(build(node, path: "\(index)"))
+        }
+        return items
+    }
+
+    /// Recursively convert one `SPTreeNode`. `path` is the dotted
+    /// index-path from the root, used as a stable fallback id for
+    /// groups (which have no persistent identifier) and for favorites
+    /// missing an ID.
+    private static func build(_ node: SPTreeNode, path: String) -> SAFavoriteItem {
+        if node.isGroup {
+            let group = node.representedObject as? SPGroupNode
+            let children = (node.children ?? [])
+                .compactMap { $0 as? SPTreeNode }
+                .enumerated()
+                .map { offset, child in
+                    build(child, path: "\(path).\(offset)")
+                }
+            return SAFavoriteItem(
+                id: "grp:\(path)",
+                kind: .group,
+                name: group?.nodeName ?? "",
+                children: children
+            )
+        }
+
+        let favorite = (node.representedObject as? SPFavoriteNode)?.nodeFavorite
+        let favoriteID = Self.string(favorite?[SPFavoriteIDKey])
+        let name = favorite?[SPFavoriteNameKey] as? String ?? ""
+        let host = favorite?[SPFavoriteHostKey] as? String ?? ""
+        let colorIndex = favorite?[SPFavoriteColorIndexKey] as? Int
+
+        return SAFavoriteItem(
+            id: favoriteID.map { "fav:\($0)" } ?? "fav:\(path)",
+            kind: .favorite,
+            name: name,
+            host: host,
+            colorIndex: colorIndex,
+            favoriteID: favoriteID
+        )
+    }
+
+    /// Normalize a favorite-dictionary value (often an `NSNumber`)
+    /// to a string ID.
+    private static func string(_ value: Any?) -> String? {
+        switch value {
+        case let number as NSNumber: return number.stringValue
+        case let string as String where !string.isEmpty: return string
+        default: return nil
+        }
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem.swift
@@ -1,0 +1,136 @@
+//
+//  SAFavoriteItem.swift
+//  Sequel Ace
+//
+//  Phase C1b of the SwiftUI migration: a value-type model of the
+//  favorites tree, suitable for a SwiftUI `List` / `OutlineGroup`.
+//
+//  This file is intentionally free of any project-specific ObjC type
+//  (no `SPTreeNode`, no AppKit) so it compiles into the Unit Tests
+//  target without a bridging header — the same constraint that keeps
+//  `SAFavoriteSearchMatcher` testable. The bridge that builds this
+//  model from the live `SPTreeNode` tree lives in
+//  `SAFavoriteItem+Tree.swift` (app target only).
+//
+
+import Foundation
+
+/// One node in the SwiftUI favorites list.
+///
+/// Reference identity (`SPTreeNode`) is replaced by a stable `id`
+/// string so SwiftUI selection / diffing behaves. Favorites carry
+/// their real `favoriteID` separately so a selection can be mapped
+/// back to the underlying favorite.
+struct SAFavoriteItem: Identifiable, Hashable {
+
+    enum Kind: Hashable {
+        /// The virtual "Quick Connect" row pinned to the top.
+        case quickConnect
+        /// A folder grouping other items.
+        case group
+        /// A leaf connection favorite.
+        case favorite
+    }
+
+    /// Stable, unique identity for SwiftUI. Prefixed by kind so a
+    /// group and a favorite can never collide.
+    let id: String
+
+    let kind: Kind
+    let name: String
+
+    /// Host string (favorites only; empty otherwise). Used by search.
+    let host: String
+
+    /// Favorite color tag index, if any (favorites only).
+    let colorIndex: Int?
+
+    /// The underlying favorite's ID (favorites only). Lets a selection
+    /// be resolved back to the real favorite dictionary.
+    let favoriteID: String?
+
+    /// `nil` for leaves; an array (possibly empty) for groups.
+    var children: [SAFavoriteItem]?
+
+    init(id: String,
+         kind: Kind,
+         name: String,
+         host: String = "",
+         colorIndex: Int? = nil,
+         favoriteID: String? = nil,
+         children: [SAFavoriteItem]? = nil) {
+        self.id = id
+        self.kind = kind
+        self.name = name
+        self.host = host
+        self.colorIndex = colorIndex
+        self.favoriteID = favoriteID
+        self.children = children
+    }
+}
+
+// MARK: - Filtering
+
+extension SAFavoriteItem {
+
+    /// Returns a copy of this item pruned to the search results, or
+    /// `nil` if it should be hidden entirely.
+    ///
+    /// Mirrors the AppKit filter semantics
+    /// (`SAFavoriteSearchTreeWalker` + `SAFavoriteSearchMatcher`):
+    ///   - Quick Connect is always kept.
+    ///   - A favorite is kept iff its name/host matches every token.
+    ///   - A group is kept iff at least one descendant favorite is
+    ///     kept (the group's own name is *not* matched, matching the
+    ///     original behavior), and its children are pruned to the
+    ///     surviving set.
+    func filtered(using matcher: SAFavoriteSearchMatcher) -> SAFavoriteItem? {
+        guard matcher.isActive else { return self }
+
+        switch kind {
+        case .quickConnect:
+            return self
+
+        case .favorite:
+            return matcher.matches(name: name, host: host) ? self : nil
+
+        case .group:
+            let keptChildren = (children ?? []).compactMap { $0.filtered(using: matcher) }
+            guard !keptChildren.isEmpty else { return nil }
+            var copy = self
+            copy.children = keptChildren
+            return copy
+        }
+    }
+}
+
+// MARK: - Convenience
+
+extension Array where Element == SAFavoriteItem {
+
+    /// Apply a search query, returning the visible top-level items.
+    /// An inactive (empty/whitespace) query returns `self` unchanged.
+    func filtered(query: String) -> [SAFavoriteItem] {
+        let matcher = SAFavoriteSearchMatcher(query: query)
+        guard matcher.isActive else { return self }
+        return compactMap { $0.filtered(using: matcher) }
+    }
+
+    /// Depth-first flattening of the whole forest (groups included),
+    /// handy for tests and for resolving a selection id to its item.
+    func flattened() -> [SAFavoriteItem] {
+        var out: [SAFavoriteItem] = []
+        for item in self {
+            out.append(item)
+            if let kids = item.children {
+                out.append(contentsOf: kids.flattened())
+            }
+        }
+        return out
+    }
+
+    /// Find an item anywhere in the forest by its `id`.
+    func first(byID id: SAFavoriteItem.ID) -> SAFavoriteItem? {
+        flattened().first { $0.id == id }
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesList.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesList.swift
@@ -1,0 +1,101 @@
+//
+//  SAFavoritesList.swift
+//  Sequel Ace
+//
+//  Phase C1b of the SwiftUI migration: a pure SwiftUI `List` /
+//  `OutlineGroup` rendering of the favorites sidebar, replacing the
+//  AppKit outline view used by the `NSViewRepresentable` wrap
+//  (`SAFavoritesListView`, C1a).
+//
+//  This is the SwiftUI-native path. It currently covers display,
+//  search filtering, selection, and double-click-to-connect. Drag &
+//  drop reordering, inline rename, and expand/collapse persistence
+//  still live in the AppKit data source and are follow-up work before
+//  this can fully replace the wrap (tracked in the modernization
+//  plan). Nothing hosts this view yet — Phase C3 is the intended host.
+//
+
+import SwiftUI
+
+/// SwiftUI favorites sidebar built over the value-type
+/// `SAFavoriteItem` model.
+struct SAFavoritesList: View {
+
+    /// The full (unfiltered) model forest, e.g. from
+    /// `SAFavoriteItem.tree(from:)`.
+    let items: [SAFavoriteItem]
+
+    /// Live search query. An empty/whitespace query shows everything.
+    var searchQuery: String = ""
+
+    /// Currently selected row id.
+    @Binding var selection: SAFavoriteItem.ID?
+
+    /// Invoked when a favorite (leaf) row is double-clicked — the host
+    /// should initiate a connection. Groups and Quick Connect are
+    /// ignored here (matching `-[SPConnectionController nodeDoubleClicked:]`).
+    var onConnect: (SAFavoriteItem) -> Void = { _ in }
+
+    private var visibleItems: [SAFavoriteItem] {
+        items.filtered(query: searchQuery)
+    }
+
+    var body: some View {
+        List(selection: $selection) {
+            ForEach(visibleItems) { item in
+                OutlineGroup(item, children: \.children) { node in
+                    SAFavoriteRow(item: node)
+                        .tag(node.id)
+                        .contentShape(Rectangle())
+                        .onTapGesture(count: 2) {
+                            if node.kind == .favorite {
+                                onConnect(node)
+                            }
+                        }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+    }
+}
+
+/// A single favorites row: icon + (color-tinted) name.
+struct SAFavoriteRow: View {
+
+    let item: SAFavoriteItem
+
+    var body: some View {
+        Label {
+            Text(item.name)
+                .foregroundColor(labelColor)
+        } icon: {
+            icon
+        }
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        switch item.kind {
+        case .quickConnect:
+            Image("quick-connect-icon")
+                .renderingMode(.template)
+        case .group:
+            Image(nsImage: NSWorkspace.shared.icon(forFileType: NSFileTypeForHFSTypeCode(OSType(kGenericFolderIcon))))
+                .resizable()
+                .frame(width: 16, height: 16)
+        case .favorite:
+            Image("database-small")
+        }
+    }
+
+    /// Favorites with a color tag get a tinted label, mirroring
+    /// `-[SAFavoritesListDataSource outlineView:willDisplayCell:…]`.
+    private var labelColor: Color? {
+        guard item.kind == .favorite,
+              let index = item.colorIndex,
+              let nsColor = SPFavoriteColorSupport.sharedInstance().color(for: index) else {
+            return nil
+        }
+        return Color(nsColor: nsColor)
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
@@ -1,0 +1,168 @@
+//
+//  SAFavoritesListView.swift
+//  Sequel Ace
+//
+//  Phase C1 of the SwiftUI migration: the first SwiftUI-hostable view
+//  in the app. This is the *wrap* step — it embeds the existing
+//  AppKit favorites sidebar (an `SPFavoritesOutlineView` driven by
+//  `SAFavoritesListDataSource`) inside an `NSViewRepresentable` so the
+//  list can be dropped into a SwiftUI hierarchy unchanged. A later
+//  step iterates toward a pure SwiftUI `List` / `OutlineGroup`.
+//
+//  Nothing wires this into the running app yet (that's Phase C3, the
+//  standalone connection window). Until then it exists as a reusable
+//  building block.
+//
+
+import SwiftUI
+import AppKit
+
+/// SwiftUI wrapper around the AppKit favorites outline view.
+///
+/// The heavy lifting still lives in `SAFavoritesListDataSource` (the
+/// outline view's data source + delegate). This type only owns the
+/// AppKit plumbing: building the scroll view + outline view, applying
+/// the same column / font / row-height configuration that
+/// `-[SPConnectionController setUpFavoritesOutlineView]` applies, and
+/// keeping the data source's `searchQuery` / `delegate` in sync with
+/// SwiftUI state across `updateNSView`.
+struct SAFavoritesListView: NSViewRepresentable {
+
+    /// Root of the favorites tree (from `SPFavoritesController`).
+    let favoritesRoot: SPTreeNode
+
+    /// Backing favorites controller used for save operations.
+    let favoritesController: SPFavoritesController
+
+    /// Active search query. Changing it re-filters the list.
+    var searchQuery: String
+
+    /// Provides the (weakly-held) callback delegate. Captured as a
+    /// closure rather than a stored `weak var` because
+    /// `NSViewRepresentable` is a value type — SwiftUI keeps the most
+    /// recent struct value alive for the view's lifetime, so a strong
+    /// stored delegate could outlive its owner and form a retain cycle
+    /// once this view is hosted inside that owner (Phase C3).
+    private let delegateProvider: () -> SAFavoritesListDelegate?
+
+    init(favoritesRoot: SPTreeNode,
+         favoritesController: SPFavoritesController,
+         searchQuery: String = "",
+         delegate: SAFavoritesListDelegate?) {
+        self.favoritesRoot = favoritesRoot
+        self.favoritesController = favoritesController
+        self.searchQuery = searchQuery
+        weak var weakDelegate = delegate
+        self.delegateProvider = { weakDelegate }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        let dataSource = SAFavoritesListDataSource(favoritesRoot: favoritesRoot,
+                                                   favoritesController: favoritesController)
+        dataSource.delegate = delegateProvider()
+        return Coordinator(dataSource: dataSource, delegateProvider: delegateProvider)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let outlineView = SPFavoritesOutlineView()
+        outlineView.selectionHighlightStyle = .sourceList
+        outlineView.headerView = nil
+        outlineView.focusRingType = .none
+        outlineView.allowsEmptySelection = true
+        outlineView.allowsMultipleSelection = true
+        outlineView.indentationPerLevel = 14
+
+        // Single column, cell-based — matches the XIB outline view.
+        // `SAFavoritesListDataSource` returns `SPFavoriteTextFieldCell`
+        // instances from its `dataCellFor:` delegate method, so the
+        // column's data cell must be one too.
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "favorites"))
+        column.isEditable = true
+        column.resizingMask = .autoresizingMask
+        let cell = SPFavoriteTextFieldCell()
+        column.dataCell = cell
+        outlineView.addTableColumn(column)
+        outlineView.outlineTableColumn = column
+
+        // Font + row height mirror -[SPConnectionController setUpFavoritesOutlineView].
+        let font = UserDefaults.getFont()
+        outlineView.font = font
+        cell.font = font
+        let probeHeight = ("{ǞṶḹÜ∑zgyf" as NSString)
+            .size(withAttributes: [.font: font]).height
+        outlineView.rowHeight = 4.0 + probeHeight
+
+        // Data source / delegate / drag types are installed by -attach(to:).
+        context.coordinator.dataSource.attach(to: outlineView)
+
+        // Double click → connect (mirrors -[SPConnectionController nodeDoubleClicked:]).
+        outlineView.target = context.coordinator
+        outlineView.doubleAction = #selector(Coordinator.nodeDoubleClicked(_:))
+
+        context.coordinator.outlineView = outlineView
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = outlineView
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+
+        // Initial population + restore saved expand/collapse state.
+        context.coordinator.dataSource.searchQuery = searchQuery
+        context.coordinator.dataSource.reloadData(in: outlineView)
+        context.coordinator.dataSource.restoreOutlineViewState(favoritesRoot, in: outlineView)
+
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let outlineView = context.coordinator.outlineView else { return }
+        let dataSource = context.coordinator.dataSource
+
+        // Keep the (weak) delegate fresh in case SwiftUI handed us a
+        // new closure capturing a different owner.
+        dataSource.delegate = delegateProvider()
+
+        // Re-filter only when the query actually changed — setting
+        // `searchQuery` rebuilds the visible-node set on every assign.
+        if dataSource.searchQuery != searchQuery {
+            dataSource.searchQuery = searchQuery
+            dataSource.reloadData(in: outlineView)
+        }
+    }
+
+    // MARK: - Coordinator
+
+    /// Holds the AppKit objects across SwiftUI view-value churn and
+    /// forwards the cell-based double-click action to the delegate.
+    final class Coordinator: NSObject {
+        let dataSource: SAFavoritesListDataSource
+        weak var outlineView: SPFavoritesOutlineView?
+        private let delegateProvider: () -> SAFavoritesListDelegate?
+
+        init(dataSource: SAFavoritesListDataSource,
+             delegateProvider: @escaping () -> SAFavoritesListDelegate?) {
+            self.dataSource = dataSource
+            self.delegateProvider = delegateProvider
+        }
+
+        @objc func nodeDoubleClicked(_ sender: Any?) {
+            guard let outlineView = outlineView,
+                  let node = outlineView.itemForDoubleAction as? SPTreeNode else { return }
+
+            // Ignore the Quick Connect row.
+            if node === dataSource.quickConnectItem { return }
+
+            if node.isGroup {
+                // Begin editing the group name (matches the controller).
+                let row = outlineView.selectedRow
+                if row >= 0 {
+                    outlineView.editColumn(0, row: row, with: nil, select: true)
+                }
+            } else {
+                delegateProvider()?.favoritesListNodeDoubleClicked(node)
+            }
+        }
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
@@ -124,11 +124,34 @@ struct SAFavoritesListView: NSViewRepresentable {
         // new closure capturing a different owner.
         dataSource.delegate = delegateProvider()
 
+        // Reconcile the backing tree: the data source was built once in
+        // makeCoordinator() from the then-current values, but the host
+        // can hand us a different `favoritesRoot` / `favoritesController`
+        // later — e.g. `-[SPFavoritesController reloadFavoritesWithSave:]`
+        // assigns a brand-new tree root. Re-point and reload so the
+        // outline never renders a stale tree.
+        if dataSource.favoritesController !== favoritesController {
+            dataSource.favoritesController = favoritesController
+        }
+        let rootChanged = dataSource.favoritesRoot !== favoritesRoot
+        if rootChanged {
+            dataSource.favoritesRoot = favoritesRoot
+        }
+
         // Re-filter only when the query actually changed — setting
         // `searchQuery` rebuilds the visible-node set on every assign.
-        if dataSource.searchQuery != searchQuery {
+        let queryChanged = dataSource.searchQuery != searchQuery
+        if queryChanged {
             dataSource.searchQuery = searchQuery
+        }
+
+        if rootChanged || queryChanged {
             dataSource.reloadData(in: outlineView)
+        }
+        // A fresh tree needs its saved expand/collapse state restored,
+        // same as the initial load in makeNSView.
+        if rootChanged {
+            dataSource.restoreOutlineViewState(favoritesRoot, in: outlineView)
         }
     }
 
@@ -152,8 +175,11 @@ struct SAFavoritesListView: NSViewRepresentable {
             if node === dataSource.quickConnectItem { return }
 
             if node.isGroup {
-                // Begin editing the group name (matches the controller).
-                let row = outlineView.selectedRow
+                // Begin editing the group name. Use the row of the node
+                // we resolved via `itemForDoubleAction` rather than
+                // `selectedRow`, so the edit always targets the
+                // double-clicked group even if the selection diverges.
+                let row = outlineView.row(forItem: node)
                 if row >= 0 {
                     outlineView.editColumn(0, row: row, with: nil, select: true)
                 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListView.swift
@@ -60,7 +60,7 @@ struct SAFavoritesListView: NSViewRepresentable {
         let dataSource = SAFavoritesListDataSource(favoritesRoot: favoritesRoot,
                                                    favoritesController: favoritesController)
         dataSource.delegate = delegateProvider()
-        return Coordinator(dataSource: dataSource, delegateProvider: delegateProvider)
+        return Coordinator(dataSource: dataSource)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -139,12 +139,9 @@ struct SAFavoritesListView: NSViewRepresentable {
     final class Coordinator: NSObject {
         let dataSource: SAFavoritesListDataSource
         weak var outlineView: SPFavoritesOutlineView?
-        private let delegateProvider: () -> SAFavoritesListDelegate?
 
-        init(dataSource: SAFavoritesListDataSource,
-             delegateProvider: @escaping () -> SAFavoritesListDelegate?) {
+        init(dataSource: SAFavoritesListDataSource) {
             self.dataSource = dataSource
-            self.delegateProvider = delegateProvider
         }
 
         @objc func nodeDoubleClicked(_ sender: Any?) {
@@ -161,7 +158,12 @@ struct SAFavoritesListView: NSViewRepresentable {
                     outlineView.editColumn(0, row: row, with: nil, select: true)
                 }
             } else {
-                delegateProvider()?.favoritesListNodeDoubleClicked(node)
+                // Route through the data source's delegate rather than a
+                // separately-captured closure: `updateNSView` refreshes
+                // `dataSource.delegate` when SwiftUI recreates the view
+                // with a new owner, so selection and double-click always
+                // target the same (current) delegate.
+                dataSource.delegate?.favoritesListNodeDoubleClicked(node)
             }
         }
     }

--- a/UnitTests/SAFavoriteItemTests.swift
+++ b/UnitTests/SAFavoriteItemTests.swift
@@ -1,0 +1,126 @@
+//
+//  SAFavoriteItemTests.swift
+//  Unit Tests
+//
+//  Covers the pure value-model layer of the SwiftUI favorites list
+//  (Phase C1b): search filtering and the flatten / lookup helpers.
+//  The `SPTreeNode` → `SAFavoriteItem` builder (`SAFavoriteItem+Tree`)
+//  is *not* covered here — constructing `SPTreeNode` from the test
+//  target hits the known bridging-header sharp edge (see B2b in the
+//  modernization plan). End-to-end matching semantics are pinned by
+//  `SAFavoriteSearchMatcherTests`.
+//
+
+import XCTest
+
+final class SAFavoriteItemTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// quickConnect
+    /// fav: "Local" @ 127.0.0.1
+    /// group "Prod"
+    ///   fav: "Web" @ db.example.com
+    ///   fav: "Cache" @ redis.example.com
+    /// group "Empty"
+    ///   (no children)
+    private func sampleForest() -> [SAFavoriteItem] {
+        [
+            SAFavoriteItem(id: "quickConnect", kind: .quickConnect, name: "QUICK CONNECT"),
+            SAFavoriteItem(id: "fav:1", kind: .favorite, name: "Local", host: "127.0.0.1", favoriteID: "1"),
+            SAFavoriteItem(id: "grp:0", kind: .group, name: "Prod", children: [
+                SAFavoriteItem(id: "fav:2", kind: .favorite, name: "Web", host: "db.example.com", favoriteID: "2"),
+                SAFavoriteItem(id: "fav:3", kind: .favorite, name: "Cache", host: "redis.example.com", favoriteID: "3"),
+            ]),
+            SAFavoriteItem(id: "grp:1", kind: .group, name: "Empty", children: []),
+        ]
+    }
+
+    // MARK: - Identity / Hashable
+
+    func testIdentifiableUsesIDField() {
+        let item = SAFavoriteItem(id: "fav:42", kind: .favorite, name: "x")
+        XCTAssertEqual(item.id, "fav:42")
+    }
+
+    // MARK: - Flatten / lookup
+
+    func testFlattenedVisitsEveryNodeDepthFirst() {
+        let ids = sampleForest().flattened().map(\.id)
+        XCTAssertEqual(ids, ["quickConnect", "fav:1", "grp:0", "fav:2", "fav:3", "grp:1"])
+    }
+
+    func testFirstByIDFindsNestedFavorite() {
+        let found = sampleForest().first(byID: "fav:3")
+        XCTAssertEqual(found?.name, "Cache")
+    }
+
+    func testFirstByIDReturnsNilForUnknown() {
+        XCTAssertNil(sampleForest().first(byID: "nope"))
+    }
+
+    // MARK: - Filtering: inactive query
+
+    func testInactiveQueryReturnsEverythingUnchanged() {
+        let forest = sampleForest()
+        XCTAssertEqual(forest.filtered(query: "").map(\.id), forest.map(\.id))
+        XCTAssertEqual(forest.filtered(query: "   ").map(\.id), forest.map(\.id))
+    }
+
+    // MARK: - Filtering: favorites
+
+    func testFilterKeepsMatchingFavoriteByName() {
+        let result = sampleForest().filtered(query: "local")
+        // "Local" leaf kept; Quick Connect always kept; groups have no
+        // matching descendants so they drop.
+        XCTAssertEqual(result.map(\.id), ["quickConnect", "fav:1"])
+    }
+
+    func testFilterMatchesOnHost() {
+        let result = sampleForest().filtered(query: "redis")
+        // Only the Cache favorite (host redis.example.com), inside Prod.
+        XCTAssertEqual(result.map(\.id), ["quickConnect", "grp:0"])
+        let prod = result.first { $0.id == "grp:0" }
+        XCTAssertEqual(prod?.children?.map(\.id), ["fav:3"])
+    }
+
+    // MARK: - Filtering: groups
+
+    func testGroupKeptOnlyWhenADescendantMatches() {
+        let result = sampleForest().filtered(query: "web")
+        XCTAssertEqual(result.map(\.id), ["quickConnect", "grp:0"])
+        XCTAssertEqual(result.first { $0.id == "grp:0" }?.children?.map(\.id), ["fav:2"])
+    }
+
+    func testGroupNameItselfIsNotMatched() {
+        // "Prod" is a group name; matching it must NOT surface the
+        // group (mirrors the AppKit walker's leaf-only rule).
+        let result = sampleForest().filtered(query: "prod")
+        XCTAssertEqual(result.map(\.id), ["quickConnect"])
+    }
+
+    func testEmptyGroupIsAlwaysPrunedUnderActiveQuery() {
+        let result = sampleForest().filtered(query: "example")
+        XCTAssertFalse(result.contains { $0.id == "grp:1" })
+    }
+
+    // MARK: - Filtering: quick connect
+
+    func testQuickConnectSurvivesEvenWhenNothingMatches() {
+        let result = sampleForest().filtered(query: "zzzzz-no-match")
+        XCTAssertEqual(result.map(\.id), ["quickConnect"])
+    }
+
+    // MARK: - Filtering: multi-token AND
+
+    func testMultiTokenMatchesAcrossNameAndHost() {
+        // "cache" (name) + "redis" (host) both match the same leaf.
+        let result = sampleForest().filtered(query: "cache redis")
+        XCTAssertEqual(result.first { $0.id == "grp:0" }?.children?.map(\.id), ["fav:3"])
+    }
+
+    func testMultiTokenWithUnsatisfiedTokenDropsLeaf() {
+        let result = sampleForest().filtered(query: "cache nope")
+        XCTAssertEqual(result.map(\.id), ["quickConnect"])
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -222,6 +222,11 @@
 		5146ADF02F79B16900C4C14A /* SAFavoritesListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */; };
 		5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */; };
 		5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C1000000000000000001 /* SAFavoritesListView.swift */; };
+		5AF0C2000000000000000002 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
+		5AF0C2000000000000000003 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
+		5AF0C2000000000000000012 /* SAFavoriteItem+Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */; };
+		5AF0C2000000000000000022 /* SAFavoritesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000021 /* SAFavoritesList.swift */; };
+		5AF0C2000000000000000032 /* SAFavoriteItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */; };
 		5146ADF92F79B9EF00C4C14A /* SAConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */; };
 		5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
 		5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
@@ -950,6 +955,10 @@
 		5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDelegate.swift; sourceTree = "<group>"; };
 		5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDataSource.swift; sourceTree = "<group>"; };
 		5AF0C1000000000000000001 /* SAFavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListView.swift; sourceTree = "<group>"; };
+		5AF0C2000000000000000001 /* SAFavoriteItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteItem.swift; sourceTree = "<group>"; };
+		5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAFavoriteItem+Tree.swift"; sourceTree = "<group>"; };
+		5AF0C2000000000000000021 /* SAFavoritesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesList.swift; sourceTree = "<group>"; };
+		5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteItemTests.swift; sourceTree = "<group>"; };
 		5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionService.swift; sourceTree = "<group>"; };
 		5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPDatabaseDocument+ViewMode.swift"; sourceTree = "<group>"; };
 		5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskManaging.swift; sourceTree = "<group>"; };
@@ -1762,6 +1771,9 @@
 				5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */,
 				5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */,
 				5AF0C1000000000000000001 /* SAFavoritesListView.swift */,
+				5AF0C2000000000000000001 /* SAFavoriteItem.swift */,
+				5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */,
+				5AF0C2000000000000000021 /* SAFavoritesList.swift */,
 				5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */,
 				5147B00B2F8C000300C4C14A /* SAConnectionDetailsValidator.swift */,
 				5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */,
@@ -2409,6 +2421,7 @@
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
 				5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */,
+				5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */,
 				5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */,
 				5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */,
 			);
@@ -3078,6 +3091,8 @@
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */,
+				5AF0C2000000000000000003 /* SAFavoriteItem.swift in Sources */,
+				5AF0C2000000000000000032 /* SAFavoriteItemTests.swift in Sources */,
 				5147B00D2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
 				5147B00F2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift in Sources */,
 				5147B0122F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */,
@@ -3196,6 +3211,9 @@
 				51BB391C25F82B060048CA69 /* SPAppController.swift in Sources */,
 				5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */,
 				5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */,
+				5AF0C2000000000000000002 /* SAFavoriteItem.swift in Sources */,
+				5AF0C2000000000000000012 /* SAFavoriteItem+Tree.swift in Sources */,
+				5AF0C2000000000000000022 /* SAFavoritesList.swift in Sources */,
 				5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00C2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
 				5147B0112F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		513C8CE12BBC4132001CCE3A /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = 513C8CE02BBC4132001CCE3A /* OCMock */; };
 		5146ADF02F79B16900C4C14A /* SAFavoritesListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */; };
 		5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */; };
+		5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C1000000000000000001 /* SAFavoritesListView.swift */; };
 		5146ADF92F79B9EF00C4C14A /* SAConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */; };
 		5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
 		5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */; };
@@ -948,6 +949,7 @@
 		51384AC12903461000FEC501 /* NSDictionaryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSDictionaryExtension.swift; sourceTree = "<group>"; };
 		5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDelegate.swift; sourceTree = "<group>"; };
 		5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDataSource.swift; sourceTree = "<group>"; };
+		5AF0C1000000000000000001 /* SAFavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListView.swift; sourceTree = "<group>"; };
 		5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionService.swift; sourceTree = "<group>"; };
 		5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPDatabaseDocument+ViewMode.swift"; sourceTree = "<group>"; };
 		5146C71F2F7A539E00C4C14A /* SATaskManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskManaging.swift; sourceTree = "<group>"; };
@@ -1759,6 +1761,7 @@
 				51B09FEB2F7696C7003BAFFF /* SAConnectionWindowController.swift */,
 				5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */,
 				5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */,
+				5AF0C1000000000000000001 /* SAFavoritesListView.swift */,
 				5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */,
 				5147B00B2F8C000300C4C14A /* SAConnectionDetailsValidator.swift */,
 				5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */,
@@ -3192,6 +3195,7 @@
 				BC8C8532100E0A8000D7A129 /* SPTableView.m in Sources */,
 				51BB391C25F82B060048CA69 /* SPAppController.swift in Sources */,
 				5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */,
+				5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */,
 				5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00C2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
 				5147B0112F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */,


### PR DESCRIPTION
## Summary

First SwiftUI-hostable view in the app, and the opening step of **Phase C1**. `SAFavoritesListView` wraps the existing AppKit favorites sidebar — an `SPFavoritesOutlineView` driven by `SAFavoritesListDataSource` — inside an `NSViewRepresentable`, so the list can be dropped into a SwiftUI hierarchy unchanged. A later step (C1b) iterates toward a pure SwiftUI `List` / `OutlineGroup`.

This is the **wrap** step only: no behavior change, and nothing hosts the view yet (Phase C3, the standalone connection window, is the intended host). Until then it's a reusable building block.

### Details
- Builds the scroll view + outline view and applies the same column / font / row-height / source-list configuration as `-[SPConnectionController setUpFavoritesOutlineView]`.
- Keeps the data source's `searchQuery` / `delegate` in sync with SwiftUI state across `updateNSView`.
- The delegate is captured as a `() -> SAFavoritesListDelegate?` closure over a `weak` local rather than a stored property — `NSViewRepresentable` is a value type SwiftUI keeps alive for the view's lifetime, so a stored strong delegate could form a retain cycle once C3 hosts this inside its owner.
- A `Coordinator` (NSObject) holds the data source + outline view across SwiftUI view-value churn and forwards the cell-based double-click to the delegate, mirroring `-[SPConnectionController nodeDoubleClicked:]` (ignore Quick Connect, edit groups, connect on leaf).
- App-target only; wired into the pbxproj by hand, mirroring `SAFavoritesListDataSource.swift`.

## Test plan
- [x] Project builds (Sequel Ace Debug)
- [x] No existing tests affected (the filtering logic the wrapper drives is already covered by `SAFavoriteSearchMatcherTests`)
- [ ] No new tests: the wrapper is AppKit plumbing that needs a live `NSOutlineView`; meaningful coverage arrives with the pure-SwiftUI rewrite (C1b) / once it's hosted (C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pure SwiftUI favorites list and value-model tree with filtering, selection binding, icons, and double-tap connect for leaf items.
* **Refactor**
  * Added a SwiftUI wrapper that embeds the existing outline, preserves view state across updates, restores expansion/collapse, and syncs search/selection.
* **Tests**
  * Unit tests covering model identity, traversal, lookup, and filtering semantics.
* **Chores**
  * Modernization plan updated: Phase C1a and C1b marked completed; remaining replacement work pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->