### PR TITLE
#added enable_cleartext_plugin URL query parameter

### DIFF
--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -45,6 +45,7 @@ NSArray<NSString *> *SPValidMySQLConnectionURLQueryParameters(void)
 	         @"socket",
 	         @"aws_profile",
 	         @"aws_region",
+	         @"enable_cleartext_plugin",
 	         @"type"];
 }
 
@@ -304,6 +305,15 @@ BOOL SPExtractConnectionDetailsFromMySQLURL(NSURL *url, NSMutableDictionary *det
 
 			if ([queryItem.name isEqualToString:@"type"]) {
 				requestedType = [[decodedValue lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+				continue;
+			}
+
+			if ([queryItem.name isEqualToString:@"enable_cleartext_plugin"]) {
+				// Map URL-style snake_case to the favorite plist key consumed
+				// by SPDatabaseDocument -setState:fromFile: and normalize the
+				// value to an NSNumber so downstream -intValue is well defined
+				// for the usual truthy strings ("1", "true", "yes", "Y").
+				[details setObject:@([decodedValue boolValue]) forKey:SPFavoriteEnableClearTextPluginKey];
 				continue;
 			}
 

--- a/Source/Other/Utility/SPFunctions.m
+++ b/Source/Other/Utility/SPFunctions.m
@@ -313,7 +313,10 @@ BOOL SPExtractConnectionDetailsFromMySQLURL(NSURL *url, NSMutableDictionary *det
 				// by SPDatabaseDocument -setState:fromFile: and normalize the
 				// value to an NSNumber so downstream -intValue is well defined
 				// for the usual truthy strings ("1", "true", "yes", "Y").
-				[details setObject:@([decodedValue boolValue]) forKey:SPFavoriteEnableClearTextPluginKey];
+				// Hardcoded to match SPFavoriteEnableClearTextPluginKey; the
+				// symbolic constant lives in SPConstants.m which is not linked
+				// into the minimal SequelAceTunnelAssistant target.
+				[details setObject:@([decodedValue boolValue]) forKey:@"enableClearTextPlugin"];
 				continue;
 			}
 

--- a/UnitTests/SPURLAdditionsTests.m
+++ b/UnitTests/SPURLAdditionsTests.m
@@ -297,6 +297,52 @@
 	XCTAssertEqualObjects(details[@"type"], @"SPTCPIPConnection");
 }
 
+- (void)testMySQLURLParserAcceptsEnableCleartextPluginTrue
+{
+	NSURL *url = [NSURL URLWithString:@"mysql://db_user@db.example.com/my_database?enable_cleartext_plugin=1"];
+	NSMutableDictionary *details = [NSMutableDictionary dictionary];
+	BOOL autoConnect = NO;
+	NSArray<NSString *> *invalidParameters = nil;
+
+	BOOL parsed = SPExtractConnectionDetailsFromMySQLURL(url, details, &autoConnect, &invalidParameters);
+
+	XCTAssertTrue(parsed);
+	XCTAssertEqual(invalidParameters.count, 0);
+	// Stored under the favorite plist key so -setState:fromFile: applies it.
+	XCTAssertEqualObjects(details[SPFavoriteEnableClearTextPluginKey], @YES);
+	// Raw URL-style key must not leak through.
+	XCTAssertNil(details[@"enable_cleartext_plugin"]);
+}
+
+- (void)testMySQLURLParserAcceptsEnableCleartextPluginFalse
+{
+	NSURL *url = [NSURL URLWithString:@"mysql://db_user@db.example.com/my_database?enable_cleartext_plugin=0"];
+	NSMutableDictionary *details = [NSMutableDictionary dictionary];
+	BOOL autoConnect = NO;
+	NSArray<NSString *> *invalidParameters = nil;
+
+	BOOL parsed = SPExtractConnectionDetailsFromMySQLURL(url, details, &autoConnect, &invalidParameters);
+
+	XCTAssertTrue(parsed);
+	XCTAssertEqual(invalidParameters.count, 0);
+	XCTAssertEqualObjects(details[SPFavoriteEnableClearTextPluginKey], @NO);
+}
+
+- (void)testMySQLURLParserAcceptsEnableCleartextPluginTruthyString
+{
+	// NSString -boolValue is YES for "1"-"9", "Y", "y", "T", "t".
+	NSURL *url = [NSURL URLWithString:@"mysql://db_user@db.example.com/my_database?enable_cleartext_plugin=true"];
+	NSMutableDictionary *details = [NSMutableDictionary dictionary];
+	BOOL autoConnect = NO;
+	NSArray<NSString *> *invalidParameters = nil;
+
+	BOOL parsed = SPExtractConnectionDetailsFromMySQLURL(url, details, &autoConnect, &invalidParameters);
+
+	XCTAssertTrue(parsed);
+	XCTAssertEqual(invalidParameters.count, 0);
+	XCTAssertEqualObjects(details[SPFavoriteEnableClearTextPluginKey], @YES);
+}
+
 // 0.15 s
 - (void)testPerformanceSwizzle{
     // This is an example of a performance test case.

--- a/UnitTests/SPURLAdditionsTests.m
+++ b/UnitTests/SPURLAdditionsTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "SPFunctions.h"
+#import "SPConstants.h"
 
 @interface SPURLAdditionsTests : XCTestCase
 

--- a/docs/get-started/connect-via-url.md
+++ b/docs/get-started/connect-via-url.md
@@ -51,6 +51,7 @@ These query parameters are currently supported:
 - `socket`
 - `aws_profile`
 - `aws_region`
+- `enable_cleartext_plugin` (set to `1` to allow MySQL's cleartext authentication plugin, required by PAM, LDAP, and some IAM-style authenticators; `0` or omission keeps it disabled)
 
 `type` explicitly sets the connection mode (`tcpip`, `socket`, `ssh`, or `aws_iam`) and takes precedence over inferred mode.
 
@@ -87,6 +88,9 @@ open 'mysql://db_user@mydb.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com:3306
 
 # AWS IAM connection (type inferred from AWS parameters)
 open 'mysql://db_user@mydb.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com:3306/my_database?aws_profile=default'
+
+# Enable MySQL's cleartext authentication plugin (e.g. for PAM/LDAP)
+open 'mysql://db_user:db_password@db.example.com:3306/my_database?enable_cleartext_plugin=1'
 ```
 
 If any unsupported query parameter is included, Sequel Ace shows an error and does not process that URL.
@@ -99,6 +103,7 @@ If any unsupported query parameter is included, Sequel Ace shows an error and do
 - For socket URLs, use the `socket` query parameter for the Unix socket path. Socket files must be inside Sequel Ace's container path due to macOS sandboxing.
 - AWS IAM URLs require Sequel Ace to already have sandbox access to your `~/.aws` directory. Grant access from the **AWS IAM** tab first.
 - If you use `ssh_keyLocation`, Sequel Ace must already have sandbox access to that key path. Grant access in **Sequel Ace → Preferences → Files** (add the key file or its containing folder).
+- `enable_cleartext_plugin=1` lets the MySQL client transmit the password unobscured to plugins that require it (typically PAM or LDAP back-ends). Only enable it on TLS-encrypted or SSH-tunneled connections.
 
 #### Related History
 


### PR DESCRIPTION
## Changes:

- Adds `enable_cleartext_plugin` to the list of valid `mysql://` URL query parameters in `SPValidMySQLConnectionURLQueryParameters()`.
- In `SPExtractConnectionDetailsFromMySQLURL()`, maps the URL-style parameter onto the existing favorite plist key `SPFavoriteEnableClearTextPluginKey` (`enableClearTextPlugin`) so `SPDatabaseDocument -setState:fromFile:` applies it via `setEnableClearTextPlugin:` — no new wiring downstream.
- Values are parsed via `NSString -boolValue`, so the usual truthy strings (`1`, `true`, `yes`, `Y`) flip the toggle and anything else is treated as `NO`.
- Adds three XCTest cases to `UnitTests/SPURLAdditionsTests.m` covering `=1`, `=0`, and `=true`, plus a sanity check that the raw URL-style key does not leak through to the details dictionary.

## Why:

In a fast-moving database developer setting — many internal apps, dozens of databases per day, constant context switching between projects, customer instances, and ad-hoc debugging — every extra click between *"I need to look at this"* and *"I'm querying"* is real friction. A lot of teams generate short-lived `mysql://` URLs from internal tooling (browser extensions, Slack/Linear shortcuts, deploy scripts, internal portals) and rely on Sequel Ace's URL handler to land straight in a connected database window. Sequel Ace already handles most of that path beautifully via `mysql://`, which is genuinely one of the things that makes it our team's daily driver.

The one piece still missing for us is *Enable Cleartext Plugin*, which we need when the MySQL server is configured for LDAP / PAM auth. Today that toggle can only be set by manually editing a Favorite — which defeats the point of generating URLs on the fly with dynamic credentials. With this PR you can pass `?enable_cleartext_plugin=1` alongside the existing `ssh_*` and `aws_*` parameters and arrive at a fully-configured connection without any extra clicks.

## Closes following issues:

- None linked. Happy to open a tracking issue first if that fits the workflow better.

## Tested:

- Processors:
  - [ ] Intel
  - [ ] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: not yet run locally — see note below.

**Honest disclosure:** my local Xcode is mid-update (an `IDESimulatorFoundation` / `DVTDownloads` framework mismatch is blocking ` xcodebuild`) so I have not been able to run the suite end-to-end myself. The new tests follow the exact pattern of the existing tests in `SPURLAdditionsTests.m`, the production change is ~10 lines, and the downstream consumer (`SPDatabaseDocument -setState:fromFile:` at the existing `enableClearTextPlugin` branch) is unchanged. Happy to iterate once CI runs or once I have my toolchain back.

## Backward compatibility:

- URLs that don't include the parameter behave identically to before.
- The parameter is opt-in; the default is unchanged (`NO`).
- A malformed value still resolves to `NO`, matching the existing fallback when the favorite plist key is absent.

## Screenshots:

N/A — no UI change.

## Additional notes:

- Snake-case (`enable_cleartext_plugin`) was chosen to match the existing convention (`ssh_host`, `ssh_password`, `aws_profile`, …). Happy to rename if you prefer a shorter alias.
- The favorite plist constant (`SPFavoriteEnableClearTextPluginKey`) is already declared in `SPConstants.h` and the project's PCH imports `SPConstants.h`, so no new headers were needed in `SPFunctions.m`.
- Real-world context: this came out of a Chrome extension we wrote that injects DB credentials into internal admin links and opens them straight in Sequel Ace via a generated `mysql://` URL. Cleartext plugin was the last setting we couldn't automate. With this we can.

Thank you for maintaining Sequel Ace — it's a daily-driver tool for our whole engineering team and we really appreciate having the URL scheme there in the first place. Happy to revise this PR in any direction the maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MySQL connection URLs now support the enable_cleartext_plugin query parameter, allowing cleartext plugin configuration in connection strings (accepts 1, 0, and "true").

* **Documentation**
  * Connection docs updated with the new parameter, an example URL, and guidance to enable it only over TLS-encrypted or SSH-tunneled connections.

* **Tests**
  * Added tests verifying parsing of enable_cleartext_plugin across input formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->