### PR TITLE
Isolate per-tab connection loss to avoid app-wide hang (closes #1945)

### DIFF
--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -114,6 +114,38 @@
 
 @end
 
+// Test connection that exercises the real `_silentReconnectAttempt` path,
+// driving the production `_disconnect` → `_connect` state transition that
+// `wasLostInBackground` capture must survive.
+@interface SPMySQLConnectionSilentRecoveryTestConnection : SPMySQLConnection
+@property (nonatomic) BOOL nextConnectResult;
+@end
+
+@implementation SPMySQLConnectionSilentRecoveryTestConnection
+
+- (BOOL)_connect
+{
+	[self _setStateForTesting:self.nextConnectResult ? SPMySQLConnected : SPMySQLDisconnected];
+	return self.nextConnectResult;
+}
+
+- (void)_disconnect
+{
+	// Mirrors production: _disconnect resets a LostInBackground state to Disconnected
+	// before the subsequent _connect tries to come back up. The fix must capture
+	// `wasLostInBackground` BEFORE this transition wipes the marker.
+	[self _setStateForTesting:SPMySQLDisconnected];
+}
+
+- (void)_restoreSessionStateAfterReconnectWithDatabase:(NSString *)databaseName
+                                              encoding:(NSString *)encodingName
+                      encodingUsesLatin1Transport:(BOOL)useLatin1Transport
+                                 timeZoneIdentifier:(NSString *)timeZoneIdentifier
+{
+}
+
+@end
+
 @interface SPMySQLConnectionCancelledReconnectTestConnection : SPMySQLConnection
 @end
 
@@ -697,6 +729,77 @@
 	XCTAssertEqual(delegate.restoredAfterLossCount, 1U,
 		@"Silent worker-thread recovery from Lost-in-Background must fire connectionRestoredAfterLoss: "
 		@"so app-layer observers can clear their backgroundConnectionLost flag.");
+}
+
+// Stronger regression for Codex round-3 review:
+// The hook-based test above only validates the OUTER boolean gate (it bypasses
+// `_silentReconnectAttempt` entirely via the test seam). The production path
+// mutates `state` through `_disconnect` → `_connect`, so this stronger test
+// drives the REAL `_silentReconnectAttempt` through a subclass that performs
+// the actual state transition. If a future refactor moves the `wasLostInBackground`
+// capture after `_silentReconnectAttempt`, this test catches it; the hook-based
+// test would not.
+- (void)testSilentReconnectFromLostInBackgroundFiresRestorationCallbackThroughRealStateTransitions
+{
+	SPMySQLConnectionSilentRecoveryTestConnection *connection = [[SPMySQLConnectionSilentRecoveryTestConnection alloc] init];
+	connection.nextConnectResult = YES;
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+
+	// LostInBackground is what triggers the wasLostInBackground capture; the
+	// real `_silentReconnectAttempt` will then call `_disconnect` which RESETS
+	// state to Disconnected before `_connect` brings it back to Connected.
+	// The fix must capture wasLostInBackground BEFORE that reset wipes it.
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+
+	XCTestExpectation *done = [self expectationWithDescription:@"real silent recovery"];
+	__block BOOL succeeded = NO;
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		succeeded = [connection _reconnectAllowingRetries:YES];
+		[done fulfill];
+	});
+	[self waitForExpectationsWithTimeout:5 handler:nil];
+
+	XCTAssertTrue(succeeded, @"silent reconnect through real state transition should succeed");
+	XCTAssertEqual([connection _stateForTesting], SPMySQLConnected,
+		@"Final state must be Connected after silent recovery through real _disconnect → _connect");
+	XCTAssertEqual(delegate.restoredAfterLossCount, 1U,
+		@"`wasLostInBackground` capture must survive the real `_disconnect` reset inside `_silentReconnectAttempt` "
+		@"and fire `connectionRestoredAfterLoss:` exactly once.");
+}
+
+// Documents the main-thread contract from #2419 PR docstring:
+// when the legacy 1-arg wrapper runs on the main thread AND the silent reconnect
+// attempt fails, the retry/decision branch is forced to default Disconnect rather
+// than blocking the main thread on a delegate sheet. This is the intentional
+// trade-off chosen so #1945's anti-blocking design is preserved. Callers that
+// need an interactive reconnect prompt MUST run on a worker thread.
+- (void)testMainThreadReconnectFailureDefaultsToDisconnectWithoutPrompt
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+
+	// Silent attempt fails; main thread must NOT pop the async delegate sheet
+	// (would re-introduce the #1945 app-wide modal freeze) and instead falls
+	// through to default Disconnect via _delegateDecisionForLostConnection.
+	__block NSUInteger silentAttemptCount = 0;
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		silentAttemptCount++;
+		return NO;
+	}];
+
+	XCTAssertTrue([NSThread isMainThread]);
+	BOOL result = [connection _reconnectAllowingRetries:YES];
+
+	XCTAssertEqual(silentAttemptCount, 1U, @"silent attempt should run once");
+	XCTAssertFalse(result, @"failed reconnect should return NO");
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U,
+		@"async connectionLost:completion: must NOT be invoked from main thread — that would block the UI");
+	XCTAssertEqual(delegate.syncDecisionCount, 0U,
+		@"deprecated sync connectionLost: must NOT be invoked from main thread either");
+	// userTriggeredDisconnect should be set as a side effect of the default Disconnect path.
+	// This documents the contract: silent fail on main → forced disconnect.
 }
 
 @end

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -481,6 +481,32 @@
 	XCTAssertFalse([source containsString:@"performSelectorOnMainThread:@selector(_delegateDecisionForLostConnection)"]);
 }
 
+- (void)testDisconnectFromBackgroundLostStateStillDisconnectsProxy
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestProxy *proxy = [[SPMySQLConnectionLostTestProxy alloc] init];
+	[connection setProxy:proxy];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+
+	[connection _disconnect];
+
+	XCTAssertEqual([connection _stateForTesting], SPMySQLDisconnected);
+	XCTAssertEqual(proxy.disconnectCount, 1U);
+}
+
+- (void)testDisconnectSourceHasNoBlockingProxyMainThreadSelector
+{
+	NSString *testFilePath = [NSString stringWithUTF8String:__FILE__];
+	NSString *sourceRoot = [testFilePath stringByDeletingLastPathComponent];
+	sourceRoot = [sourceRoot stringByDeletingLastPathComponent];
+	NSString *sourcePath = [sourceRoot stringByAppendingPathComponent:@"Source/SPMySQLConnection.m"];
+	NSString *source = [NSString stringWithContentsOfFile:sourcePath encoding:NSUTF8StringEncoding error:nil];
+
+	XCTAssertNotNil(source);
+	XCTAssertFalse([source containsString:@"performSelectorOnMainThread:@selector(disconnect)"]);
+	XCTAssertFalse([source containsString:@"waitUntilDone:YES"]);
+}
+
 - (void)testProxyIdleWithinTwoMinutesSilentReconnectSuccessDoesNotNotifyOrAskDelegate
 {
 	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -49,6 +49,34 @@
 
 @end
 
+@interface SPMySQLConnectionLostDelayedDelegate : NSObject <SPMySQLConnectionDelegate>
+@property (nonatomic) NSUInteger asyncDecisionCount;
+@property (nonatomic) NSTimeInterval firstCompletionDelay;
+@property (nonatomic) SPMySQLConnectionLostDecision firstDecision;
+@property (nonatomic) SPMySQLConnectionLostDecision laterDecision;
+@property (nonatomic, strong) XCTestExpectation *lateCompletionExpectation;
+@end
+
+@implementation SPMySQLConnectionLostDelayedDelegate
+
+- (void)connectionLost:(id)connection completion:(void (^)(SPMySQLConnectionLostDecision decision))completion
+{
+	self.asyncDecisionCount++;
+	NSUInteger decisionNumber = self.asyncDecisionCount;
+
+	if (decisionNumber == 1) {
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.firstCompletionDelay * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+			completion(self.firstDecision);
+			[self.lateCompletionExpectation fulfill];
+		});
+		return;
+	}
+
+	completion(self.laterDecision);
+}
+
+@end
+
 @interface SPMySQLConnectionLostTestProxy : NSObject <SPMySQLConnectionProxy>
 @property (nonatomic) SPMySQLConnectionProxyState state;
 @property (nonatomic) NSUInteger connectCount;
@@ -247,6 +275,38 @@
 
 	XCTAssertEqual(decision, SPMySQLConnectionLostDisconnect);
 	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testAsyncDelegateLateCompletionDoesNotPolluteNextDecision
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostDelayedDelegate *delegate = [[SPMySQLConnectionLostDelayedDelegate alloc] init];
+	delegate.firstCompletionDelay = 0.15;
+	delegate.firstDecision = SPMySQLConnectionLostReconnect;
+	delegate.laterDecision = SPMySQLConnectionLostDisconnect;
+	delegate.lateCompletionExpectation = [self expectationWithDescription:@"late completion"];
+	[connection setDelegate:delegate];
+	[connection _setDelegateDecisionTimeoutForTesting:0.05];
+
+	XCTestExpectation *firstDecisionExpectation = [self expectationWithDescription:@"first decision"];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		SPMySQLConnectionLostDecision decision = [connection _delegateDecisionForLostConnection];
+		XCTAssertEqual(decision, SPMySQLConnectionLostDisconnect);
+		[firstDecisionExpectation fulfill];
+	});
+
+	[self waitForExpectations:@[firstDecisionExpectation] timeout:1];
+	[connection _setDelegateDecisionTimeoutForTesting:1];
+
+	XCTestExpectation *secondDecisionExpectation = [self expectationWithDescription:@"second decision"];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		SPMySQLConnectionLostDecision decision = [connection _delegateDecisionForLostConnection];
+		XCTAssertEqual(decision, SPMySQLConnectionLostDisconnect);
+		[secondDecisionExpectation fulfill];
+	});
+
+	[self waitForExpectations:@[secondDecisionExpectation, delegate.lateCompletionExpectation] timeout:1];
+	XCTAssertEqual(delegate.asyncDecisionCount, 2U);
 }
 
 - (void)testDelegateDecisionSourceHasNoLegacyMainThreadDoWhileWaitBlock

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -798,8 +798,11 @@
 		@"async connectionLost:completion: must NOT be invoked from main thread — that would block the UI");
 	XCTAssertEqual(delegate.syncDecisionCount, 0U,
 		@"deprecated sync connectionLost: must NOT be invoked from main thread either");
-	// userTriggeredDisconnect should be set as a side effect of the default Disconnect path.
-	// This documents the contract: silent fail on main → forced disconnect.
+	// The default Disconnect side effect must actually be applied — distinguishes
+	// "default disconnect happened" from "method returned without doing anything".
+	XCTAssertTrue([connection userTriggeredDisconnect],
+		@"silent fail on main → forced disconnect must set userTriggeredDisconnect, "
+		@"otherwise the contract is silently a no-op.");
 }
 
 @end

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -293,6 +293,42 @@
 	XCTAssertEqual(reconnectCount, 1U);
 }
 
+- (void)testConcurrentReconnectRequestsShareSingleSilentAttempt
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+	__weak SPMySQLConnection *weakConnection = connection;
+
+	dispatch_group_t reconnectGroup = dispatch_group_create();
+	dispatch_semaphore_t firstAttemptStarted = dispatch_semaphore_create(0);
+	dispatch_semaphore_t releaseFirstAttempt = dispatch_semaphore_create(0);
+	__block NSUInteger reconnectCount = 0;
+	__block BOOL firstResult = NO;
+	__block BOOL secondResult = NO;
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		reconnectCount++;
+		dispatch_semaphore_signal(firstAttemptStarted);
+		dispatch_semaphore_wait(releaseFirstAttempt, DISPATCH_TIME_FOREVER);
+		[weakConnection _setStateForTesting:SPMySQLConnected];
+		return YES;
+	}];
+
+	dispatch_group_async(reconnectGroup, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		firstResult = [connection _reconnectAllowingRetries:YES];
+	});
+	dispatch_semaphore_wait(firstAttemptStarted, DISPATCH_TIME_FOREVER);
+	dispatch_group_async(reconnectGroup, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		secondResult = [connection _reconnectAllowingRetries:YES];
+	});
+	dispatch_semaphore_signal(releaseFirstAttempt);
+
+	long waitResult = dispatch_group_wait(reconnectGroup, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)));
+	XCTAssertEqual(waitResult, 0L);
+	XCTAssertTrue(firstResult);
+	XCTAssertTrue(secondResult);
+	XCTAssertEqual(reconnectCount, 1U);
+}
+
 - (void)testSilentReconnectRecapturesRestoreSnapshotAfterFailure
 {
 	SPMySQLConnectionRestoreSnapshotTestConnection *connection = [[SPMySQLConnectionRestoreSnapshotTestConnection alloc] init];

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -311,7 +311,7 @@
 	XCTAssertEqual(reconnectCount, 1U);
 }
 
-// Regression for Codex review on PR #2419:
+// Regression for PR #2419 review:
 // "This branch now returns immediately on the main thread after queueing reconnect
 //  work, but existing synchronous callers (not updated in this commit) still depend
 //  on -_reconnectAllowingRetries: completing before they continue."
@@ -696,7 +696,7 @@
 	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
 }
 
-// Regression for Codex review on PR #2419 P2:
+// Regression for PR #2419 review (P2):
 // "Restoration callbacks are gated on `delegateReconnectDecisionRequested`, so
 //  successful silent reconnects (worker-thread recovery from
 //  SPMySQLConnectionLostInBackground) do not emit `connectionRestoredAfterLoss:`."
@@ -731,7 +731,7 @@
 		@"so app-layer observers can clear their backgroundConnectionLost flag.");
 }
 
-// Stronger regression for Codex round-3 review:
+// Stronger regression for PR #2419 round-3 review:
 // The hook-based test above only validates the OUTER boolean gate (it bypasses
 // `_silentReconnectAttempt` entirely via the test seam). The production path
 // mutates `state` through `_disconnect` → `_connect`, so this stronger test

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -108,6 +108,23 @@
 
 @end
 
+@interface SPMySQLConnectionCancelledReconnectTestConnection : SPMySQLConnection
+@end
+
+@implementation SPMySQLConnectionCancelledReconnectTestConnection
+
+- (void)_disconnect
+{
+}
+
+- (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds
+{
+	[[NSThread currentThread] cancel];
+	return NO;
+}
+
+@end
+
 @interface SPMySQLConnectionLostTestProxy : NSObject <SPMySQLConnectionProxy>
 @property (nonatomic) SPMySQLConnectionProxyState state;
 @property (nonatomic) NSUInteger connectCount;
@@ -327,6 +344,23 @@
 	XCTAssertTrue(firstResult);
 	XCTAssertTrue(secondResult);
 	XCTAssertEqual(reconnectCount, 1U);
+}
+
+- (void)testCancelledSilentReconnectRestoresProxyNotificationFlag
+{
+	SPMySQLConnectionCancelledReconnectTestConnection *connection = [[SPMySQLConnectionCancelledReconnectTestConnection alloc] init];
+	SPMySQLConnectionLostTestProxy *proxy = [[SPMySQLConnectionLostTestProxy alloc] init];
+	[connection setProxy:proxy];
+
+	XCTestExpectation *reconnectExpectation = [self expectationWithDescription:@"cancelled silent reconnect"];
+	NSThread *reconnectThread = [[NSThread alloc] initWithBlock:^{
+		XCTAssertFalse([connection _silentReconnectAttempt]);
+		[reconnectExpectation fulfill];
+	}];
+	[reconnectThread start];
+
+	[self waitForExpectations:@[reconnectExpectation] timeout:1];
+	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
 }
 
 - (void)testSilentReconnectRecapturesRestoreSnapshotAfterFailure

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -195,6 +195,43 @@
 	XCTAssertEqual(delegate.syncDecisionCount, 0U);
 }
 
+- (void)testCheckConnectionIfNecessaryOnMainThreadCoalescesBackgroundLossNotification
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+	__block NSUInteger notificationCount = 0;
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		notificationCount++;
+	}];
+
+	XCTAssertFalse([connection checkConnectionIfNecessary]);
+	XCTAssertFalse([connection checkConnectionIfNecessary]);
+
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertEqual(notificationCount, 1U);
+	XCTAssertEqual(delegate.backgroundDecisionCount, 1U);
+}
+
+- (void)testBackgroundLossNotificationCoalescingResetsAfterStateLeavesLost
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+	__block NSUInteger notificationCount = 0;
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		notificationCount++;
+	}];
+
+	XCTAssertFalse([connection checkConnectionIfNecessary]);
+	[connection _setStateForTesting:SPMySQLConnected];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+	XCTAssertFalse([connection checkConnectionIfNecessary]);
+
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertEqual(notificationCount, 2U);
+}
+
 - (void)testCheckConnectionIfNecessaryOnWorkerThreadRunsReconnectPathForBackgroundLoss
 {
 	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -177,6 +177,26 @@
 	XCTAssertEqual(reconnectCount, 1U);
 }
 
+- (void)testPublicReconnectOnWorkerThreadReturnsReconnectResult
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	XCTestExpectation *reconnectExpectation = [self expectationWithDescription:@"public reconnect"];
+	__block NSUInteger reconnectCount = 0;
+	[connection _setReconnectAttemptForTesting:^BOOL(BOOL canRetry) {
+		reconnectCount++;
+		XCTAssertTrue(canRetry);
+		return YES;
+	}];
+
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		XCTAssertTrue([connection reconnect]);
+		[reconnectExpectation fulfill];
+	});
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(reconnectCount, 1U);
+}
+
 - (void)testKeepAlivePingFailurePostsBackgroundNotificationWithoutDelegateDecision
 {
 	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -77,6 +77,37 @@
 
 @end
 
+@interface SPMySQLConnectionRestoreSnapshotTestConnection : SPMySQLConnection
+@property (nonatomic) BOOL nextConnectResult;
+@property (nonatomic, copy) NSString *restoredDatabase;
+@property (nonatomic, copy) NSString *restoredEncoding;
+@property (nonatomic) BOOL restoredLatin1Transport;
+@end
+
+@implementation SPMySQLConnectionRestoreSnapshotTestConnection
+
+- (BOOL)_connect
+{
+	[self _setStateForTesting:self.nextConnectResult ? SPMySQLConnected : SPMySQLDisconnected];
+	return self.nextConnectResult;
+}
+
+- (void)_disconnect
+{
+}
+
+- (void)_restoreSessionStateAfterReconnectWithDatabase:(NSString *)databaseName
+                                              encoding:(NSString *)encodingName
+                      encodingUsesLatin1Transport:(BOOL)useLatin1Transport
+                                 timeZoneIdentifier:(NSString *)timeZoneIdentifier
+{
+	self.restoredDatabase = databaseName;
+	self.restoredEncoding = encodingName;
+	self.restoredLatin1Transport = useLatin1Transport;
+}
+
+@end
+
 @interface SPMySQLConnectionLostTestProxy : NSObject <SPMySQLConnectionProxy>
 @property (nonatomic) SPMySQLConnectionProxyState state;
 @property (nonatomic) NSUInteger connectCount;
@@ -223,6 +254,27 @@
 
 	[self waitForExpectationsWithTimeout:1 handler:nil];
 	XCTAssertEqual(reconnectCount, 1U);
+}
+
+- (void)testSilentReconnectRecapturesRestoreSnapshotAfterFailure
+{
+	SPMySQLConnectionRestoreSnapshotTestConnection *connection = [[SPMySQLConnectionRestoreSnapshotTestConnection alloc] init];
+	connection.database = @"first";
+	[connection setValue:@"utf8mb4" forKey:@"encoding"];
+	[connection setValue:@NO forKey:@"encodingUsesLatin1Transport"];
+	connection.nextConnectResult = NO;
+
+	XCTAssertFalse([connection _silentReconnectAttempt]);
+
+	connection.database = @"second";
+	[connection setValue:@"latin1" forKey:@"encoding"];
+	[connection setValue:@NO forKey:@"encodingUsesLatin1Transport"];
+	connection.nextConnectResult = YES;
+
+	XCTAssertTrue([connection _silentReconnectAttempt]);
+	XCTAssertEqualObjects(connection.restoredDatabase, @"second");
+	XCTAssertEqualObjects(connection.restoredEncoding, @"latin1");
+	XCTAssertFalse(connection.restoredLatin1Transport);
 }
 
 - (void)testKeepAlivePingFailurePostsBackgroundNotificationWithoutDelegateDecision

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -12,6 +12,7 @@
 @property (nonatomic) NSUInteger asyncDecisionCount;
 @property (nonatomic) NSUInteger syncDecisionCount;
 @property (nonatomic) NSUInteger backgroundDecisionCount;
+@property (nonatomic) NSUInteger restoredAfterLossCount;
 @end
 
 @implementation SPMySQLConnectionLostTestDelegate
@@ -31,6 +32,11 @@
 - (void)connectionLostInBackground:(id)connection
 {
 	self.backgroundDecisionCount++;
+}
+
+- (void)connectionRestoredAfterLoss:(id)connection
+{
+	self.restoredAfterLossCount++;
 }
 
 @end
@@ -344,6 +350,37 @@
 	XCTAssertTrue(firstResult);
 	XCTAssertTrue(secondResult);
 	XCTAssertEqual(reconnectCount, 1U);
+}
+
+- (void)testDelegateDrivenReconnectSuccessNotifiesDelegateAfterRestoration
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	__weak SPMySQLConnection *weakConnection = connection;
+	__block NSUInteger reconnectCount = 0;
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		reconnectCount++;
+		if (reconnectCount == 2) {
+			[weakConnection _setStateForTesting:SPMySQLConnected];
+			return YES;
+		}
+		[weakConnection _setStateForTesting:SPMySQLDisconnected];
+		return NO;
+	}];
+
+	XCTestExpectation *reconnectExpectation = [self expectationWithDescription:@"delegate reconnect completed"];
+	__block BOOL reconnectResult = NO;
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		reconnectResult = [connection _reconnectAllowingRetries:YES];
+		[reconnectExpectation fulfill];
+	});
+
+	[self waitForExpectations:@[reconnectExpectation] timeout:1];
+	XCTAssertTrue(reconnectResult);
+	XCTAssertEqual(delegate.asyncDecisionCount, 1U);
+	XCTAssertEqual(delegate.restoredAfterLossCount, 1U);
+	XCTAssertEqual(reconnectCount, 2U);
 }
 
 - (void)testCancelledSilentReconnectRestoresProxyNotificationFlag

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -1,0 +1,336 @@
+//
+//  SPMySQLConnectionLostTests.m
+//  SPMySQL Unit Tests
+//
+
+#import <XCTest/XCTest.h>
+#import <SPMySQL/SPMySQL.h>
+#import "mysql.h"
+#import "SPMySQL Private APIs.h"
+
+@interface SPMySQLConnectionLostTestDelegate : NSObject <SPMySQLConnectionDelegate>
+@property (nonatomic) NSUInteger asyncDecisionCount;
+@property (nonatomic) NSUInteger syncDecisionCount;
+@property (nonatomic) NSUInteger backgroundDecisionCount;
+@end
+
+@implementation SPMySQLConnectionLostTestDelegate
+
+- (void)connectionLost:(id)connection completion:(void (^)(SPMySQLConnectionLostDecision decision))completion
+{
+	self.asyncDecisionCount++;
+	completion(SPMySQLConnectionLostReconnect);
+}
+
+- (SPMySQLConnectionLostDecision)connectionLost:(id)connection
+{
+	self.syncDecisionCount++;
+	return SPMySQLConnectionLostDisconnect;
+}
+
+- (void)connectionLostInBackground:(id)connection
+{
+	self.backgroundDecisionCount++;
+}
+
+@end
+
+@interface SPMySQLConnectionLostLegacyDelegate : NSObject <SPMySQLConnectionDelegate>
+@property (nonatomic) NSUInteger syncDecisionCount;
+@end
+
+@implementation SPMySQLConnectionLostLegacyDelegate
+
+- (SPMySQLConnectionLostDecision)connectionLost:(id)connection
+{
+	self.syncDecisionCount++;
+	return SPMySQLConnectionLostReconnect;
+}
+
+@end
+
+@interface SPMySQLConnectionLostTestProxy : NSObject <SPMySQLConnectionProxy>
+@property (nonatomic) SPMySQLConnectionProxyState state;
+@property (nonatomic) NSUInteger connectCount;
+@property (nonatomic) NSUInteger disconnectCount;
+@property (nonatomic) NSUInteger localPort;
+@property (nonatomic, weak) id delegate;
+@property (nonatomic) SEL stateChangeSelector;
+- (void)simulateState:(SPMySQLConnectionProxyState)newState;
+@end
+
+@implementation SPMySQLConnectionLostTestProxy
+
+- (instancetype)init
+{
+	if ((self = [super init])) {
+		_state = SPMySQLProxyConnected;
+		_localPort = 3307;
+	}
+	return self;
+}
+
+- (void)connect
+{
+	self.connectCount++;
+	self.state = SPMySQLProxyConnected;
+}
+
+- (void)disconnect
+{
+	self.disconnectCount++;
+	self.state = SPMySQLProxyIdle;
+}
+
+- (BOOL)setConnectionStateChangeSelector:(SEL)theStateChangeSelector delegate:(id)theDelegate
+{
+	self.stateChangeSelector = theStateChangeSelector;
+	self.delegate = theDelegate;
+	return YES;
+}
+
+- (void)simulateState:(SPMySQLConnectionProxyState)newState
+{
+	self.state = newState;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+	[self.delegate performSelector:self.stateChangeSelector withObject:self];
+#pragma clang diagnostic pop
+}
+
+@end
+
+@interface SPMySQLConnectionLostTests : XCTestCase
+@end
+
+@implementation SPMySQLConnectionLostTests
+
+- (void)testIsConnectedWithBackgroundLostStateReturnsNoWithoutDelegateDecision
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+
+	XCTAssertFalse([connection isConnected]);
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testCheckConnectionIfNecessaryOnMainThreadPostsNotificationWithoutDelegateDecision
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+
+	XCTestExpectation *notificationExpectation = [self expectationWithDescription:@"lost notification"];
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		[notificationExpectation fulfill];
+	}];
+
+	XCTAssertFalse([connection checkConnectionIfNecessary]);
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testCheckConnectionIfNecessaryOnWorkerThreadRunsReconnectPathForBackgroundLoss
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+	__weak SPMySQLConnection *weakConnection = connection;
+
+	XCTestExpectation *reconnectExpectation = [self expectationWithDescription:@"worker reconnect"];
+	__block NSUInteger reconnectCount = 0;
+	[connection _setReconnectAttemptForTesting:^BOOL(BOOL canRetry) {
+		reconnectCount++;
+		XCTAssertTrue(canRetry);
+		[weakConnection _setStateForTesting:SPMySQLConnected];
+		[reconnectExpectation fulfill];
+		return YES;
+	}];
+
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		XCTAssertTrue([connection checkConnectionIfNecessary]);
+	});
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(reconnectCount, 1U);
+}
+
+- (void)testReconnectAllowingRetriesOnMainThreadFastReturnsAndDispatchesPrivateQueue
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	XCTestExpectation *queuedReconnectExpectation = [self expectationWithDescription:@"queued reconnect"];
+	__block NSUInteger reconnectCount = 0;
+	[connection _setReconnectAttemptForTesting:^BOOL(BOOL canRetry) {
+		reconnectCount++;
+		[queuedReconnectExpectation fulfill];
+		return YES;
+	}];
+
+	XCTAssertFalse([connection _reconnectAllowingRetries:YES]);
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[connection _drainReconnectQueueForTesting];
+	XCTAssertEqual(reconnectCount, 1U);
+}
+
+- (void)testKeepAlivePingFailurePostsBackgroundNotificationWithoutDelegateDecision
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection _setStateForTesting:SPMySQLConnected];
+	[connection _setKeepAlivePingFailuresForTesting:3];
+
+	XCTestExpectation *notificationExpectation = [self expectationWithDescription:@"keepalive notification"];
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		[notificationExpectation fulfill];
+	}];
+
+	[connection _threadedKeepAlive];
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertEqual([connection _stateForTesting], SPMySQLConnectionLostInBackground);
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+	XCTAssertEqual(delegate.backgroundDecisionCount, 1U);
+}
+
+- (void)testAsyncConnectionLostDelegateIsPreferredOverDeprecatedDelegate
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+
+	XCTestExpectation *decisionExpectation = [self expectationWithDescription:@"async decision"];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		SPMySQLConnectionLostDecision decision = [connection _delegateDecisionForLostConnection];
+		XCTAssertEqual(decision, SPMySQLConnectionLostReconnect);
+		[decisionExpectation fulfill];
+	});
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(delegate.asyncDecisionCount, 1U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testDeprecatedConnectionLostDelegateIsNotCalledOnMainThread
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostLegacyDelegate *delegate = [[SPMySQLConnectionLostLegacyDelegate alloc] init];
+	[connection setDelegate:delegate];
+
+	SPMySQLConnectionLostDecision decision = [connection _delegateDecisionForLostConnection];
+
+	XCTAssertEqual(decision, SPMySQLConnectionLostDisconnect);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testDelegateDecisionSourceHasNoLegacyMainThreadDoWhileWaitBlock
+{
+	NSString *testFilePath = [NSString stringWithUTF8String:__FILE__];
+	NSString *sourceRoot = [testFilePath stringByDeletingLastPathComponent];
+	sourceRoot = [sourceRoot stringByDeletingLastPathComponent];
+	NSString *sourcePath = [sourceRoot stringByAppendingPathComponent:@"Source/SPMySQLConnection Categories/Delegate & Proxy.m"];
+	NSString *source = [NSString stringWithContentsOfFile:sourcePath encoding:NSUTF8StringEncoding error:nil];
+
+	XCTAssertNotNil(source);
+	XCTAssertFalse([source containsString:@"while (0)"]);
+	XCTAssertFalse([source containsString:@"performSelectorOnMainThread:@selector(_delegateDecisionForLostConnection)"]);
+}
+
+- (void)testProxyIdleWithinTwoMinutesSilentReconnectSuccessDoesNotNotifyOrAskDelegate
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestProxy *proxy = [[SPMySQLConnectionLostTestProxy alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection setProxy:proxy];
+	[connection _setStateForTesting:SPMySQLConnected];
+	[connection _setLastConnectionUsedTimeForTestingWithSecondsAgo:120];
+	__weak SPMySQLConnection *weakConnection = connection;
+
+	XCTestExpectation *reconnectExpectation = [self expectationWithDescription:@"silent reconnect"];
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		[weakConnection _setStateForTesting:SPMySQLConnected];
+		[reconnectExpectation fulfill];
+		return YES;
+	}];
+
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		XCTFail(@"silent reconnect success should not post background loss notification");
+	}];
+
+	[proxy simulateState:SPMySQLProxyIdle];
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[connection _drainReconnectQueueForTesting];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+
+	XCTAssertEqual([connection _stateForTesting], SPMySQLConnected);
+	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testProxyIdleWithinFifteenMinutesSilentReconnectFailurePostsOnceAndResetsFlag
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestProxy *proxy = [[SPMySQLConnectionLostTestProxy alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+	[connection setProxy:proxy];
+	[connection _setStateForTesting:SPMySQLConnected];
+	[connection _setLastConnectionUsedTimeForTestingWithSecondsAgo:14 * 60];
+
+	XCTestExpectation *notificationExpectation = [self expectationWithDescription:@"proxy failure notification"];
+	notificationExpectation.expectedFulfillmentCount = 1;
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		[notificationExpectation fulfill];
+	}];
+
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		return NO;
+	}];
+
+	[proxy simulateState:SPMySQLProxyIdle];
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+
+	XCTAssertEqual([connection _stateForTesting], SPMySQLConnectionLostInBackground);
+	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
+	XCTAssertEqual(delegate.asyncDecisionCount, 0U);
+	XCTAssertEqual(delegate.syncDecisionCount, 0U);
+}
+
+- (void)testProxyIdleAfterFifteenMinutesDoesNotSilentReconnectAndPostsNotification
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestProxy *proxy = [[SPMySQLConnectionLostTestProxy alloc] init];
+	[connection setProxy:proxy];
+	[connection _setStateForTesting:SPMySQLConnected];
+	[connection _setLastConnectionUsedTimeForTestingWithSecondsAgo:16 * 60];
+
+	__block NSUInteger silentReconnectCount = 0;
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		silentReconnectCount++;
+		return YES;
+	}];
+
+	XCTestExpectation *notificationExpectation = [self expectationWithDescription:@"old proxy notification"];
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		[notificationExpectation fulfill];
+	}];
+
+	[proxy simulateState:SPMySQLProxyIdle];
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+
+	XCTAssertEqual(silentReconnectCount, 0U);
+	XCTAssertEqual([connection _stateForTesting], SPMySQLConnectionLostInBackground);
+	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
+}
+
+@end

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -279,7 +279,36 @@
 	XCTAssertEqual(reconnectCount, 1U);
 }
 
-- (void)testReconnectAllowingRetriesOnMainThreadFastReturnsAndDispatchesPrivateQueue
+// Regression for Codex review on PR #2419:
+// "This branch now returns immediately on the main thread after queueing reconnect
+//  work, but existing synchronous callers (not updated in this commit) still depend
+//  on -_reconnectAllowingRetries: completing before they continue."
+//
+// The 1-arg `_reconnectAllowingRetries:` wrapper used by cancelCurrentQuery,
+// checkConnectionIfNecessary, etc. must run the reconnect SYNCHRONOUSLY even on
+// the main thread; the unlock → reconnect → lock pattern depends on it.
+// Callers that explicitly want the main-thread fast-return behavior must use the
+// 2-arg form with `dispatchOnMainThread:YES`.
+- (void)testLegacyOneArgReconnectIsSynchronousOnMainThread
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	__block NSUInteger reconnectCount = 0;
+	[connection _setReconnectAttemptForTesting:^BOOL(BOOL canRetry) {
+		reconnectCount++;
+		return YES;
+	}];
+
+	XCTAssertTrue([NSThread isMainThread], @"test runs on the main thread");
+	BOOL result = [connection _reconnectAllowingRetries:YES];
+
+	XCTAssertEqual(reconnectCount, 1U,
+		@"1-arg _reconnectAllowingRetries: must run the reconnect synchronously on main thread.");
+	XCTAssertTrue(result, @"sync reconnect should return the real outcome, not an early NO");
+}
+
+// Companion test: callers that explicitly want main-thread fast-return semantics
+// can still get them via the 2-arg form.
+- (void)testTwoArgReconnectWithDispatchOnMainThreadYesQueuesAndFastReturns
 {
 	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
 	XCTestExpectation *queuedReconnectExpectation = [self expectationWithDescription:@"queued reconnect"];
@@ -290,7 +319,7 @@
 		return YES;
 	}];
 
-	XCTAssertFalse([connection _reconnectAllowingRetries:YES]);
+	XCTAssertFalse([connection _reconnectAllowingRetries:YES dispatchOnMainThread:YES]);
 	[self waitForExpectationsWithTimeout:1 handler:nil];
 	[connection _drainReconnectQueueForTesting];
 	XCTAssertEqual(reconnectCount, 1U);
@@ -633,6 +662,41 @@
 	XCTAssertEqual(silentReconnectCount, 0U);
 	XCTAssertEqual([connection _stateForTesting], SPMySQLConnectionLostInBackground);
 	XCTAssertFalse([connection _proxyStateChangeNotificationsIgnoredForTesting]);
+}
+
+// Regression for Codex review on PR #2419 P2:
+// "Restoration callbacks are gated on `delegateReconnectDecisionRequested`, so
+//  successful silent reconnects (worker-thread recovery from
+//  SPMySQLConnectionLostInBackground) do not emit `connectionRestoredAfterLoss:`."
+//
+// Silent worker-thread recovery from Lost-in-Background MUST notify the delegate
+// so SPDatabaseDocument can clear its backgroundConnectionLost flag.
+- (void)testSilentReconnectFromLostInBackgroundFiresRestorationCallback
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnectionLostTestDelegate *delegate = [[SPMySQLConnectionLostTestDelegate alloc] init];
+	[connection setDelegate:delegate];
+
+	// Set up the lost-in-background state that worker-thread silent reconnect handles.
+	[connection _setStateForTesting:SPMySQLConnectionLostInBackground];
+
+	[connection _setSilentReconnectAttemptForTesting:^BOOL{
+		return YES;
+	}];
+
+	// Run on a worker thread so the main-thread fast-return guard does not apply.
+	XCTestExpectation *done = [self expectationWithDescription:@"silent recovery"];
+	__block BOOL succeeded = NO;
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		succeeded = [connection _reconnectAllowingRetries:YES];
+		[done fulfill];
+	});
+	[self waitForExpectationsWithTimeout:5 handler:nil];
+
+	XCTAssertTrue(succeeded);
+	XCTAssertEqual(delegate.restoredAfterLossCount, 1U,
+		@"Silent worker-thread recovery from Lost-in-Background must fire connectionRestoredAfterLoss: "
+		@"so app-layer observers can clear their backgroundConnectionLost flag.");
 }
 
 @end

--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m
@@ -575,7 +575,18 @@
 	NSString *source = [NSString stringWithContentsOfFile:sourcePath encoding:NSUTF8StringEncoding error:nil];
 
 	XCTAssertNotNil(source);
-	XCTAssertFalse([source containsString:@"while (0)"]);
+	// Reject the legacy do-while wait block ONLY when it appears in the
+	// same neighborhood as `_delegateDecisionForLostConnection` — a bare
+	// `while (0)` elsewhere in the file (e.g. a future `do { ... } while (0)`
+	// macro pattern unrelated to reconnect) must not fail this test.
+	NSRange methodRange = [source rangeOfString:@"_delegateDecisionForLostConnection"];
+	XCTAssertNotEqual(methodRange.location, (NSUInteger)NSNotFound,
+		@"_delegateDecisionForLostConnection symbol must exist in Delegate & Proxy.m");
+	NSUInteger windowStart = (methodRange.location > 1000) ? methodRange.location - 1000 : 0;
+	NSUInteger windowLength = MIN((NSUInteger)2000, [source length] - windowStart);
+	NSString *neighborhood = [source substringWithRange:NSMakeRange(windowStart, windowLength)];
+	XCTAssertFalse([neighborhood containsString:@"while (0)"],
+		@"legacy do-while wait block must not surround _delegateDecisionForLostConnection");
 	XCTAssertFalse([source containsString:@"performSelectorOnMainThread:@selector(_delegateDecisionForLostConnection)"]);
 }
 

--- a/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
+++ b/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF1811BC0C64100104523 /* DataConversion_Tests.m */; };
 		507FF23B1BC0E8CA00104523 /* SPMySQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* SPMySQL.framework */; };
 		507FF23D1BC157B500104523 /* SPMySQLStringAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */; };
+		55ECDDB8FC1D39B782BF6139 /* SPMySQLConnectionLostTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E307CD5A95A82BE1828D95CF /* SPMySQLConnectionLostTests.m */; };
 		580A331E14D75CF7000D6933 /* SPMySQLGeometryData.h in Headers */ = {isa = PBXBuildFile; fileRef = 580A331C14D75CF7000D6933 /* SPMySQLGeometryData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		580A331F14D75CF7000D6933 /* SPMySQLGeometryData.m in Sources */ = {isa = PBXBuildFile; fileRef = 580A331D14D75CF7000D6933 /* SPMySQLGeometryData.m */; };
 		583C734A17A489CC0056B284 /* SPMySQLStreamingResultStoreDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 583C734917A489CC0056B284 /* SPMySQLStreamingResultStoreDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -224,6 +225,7 @@
 		9615D84B2D5EDF530095F55A /* typelib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = typelib.h; sourceTree = "<group>"; };
 		96A5DDB22D63C89A0079105E /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
+		E307CD5A95A82BE1828D95CF /* SPMySQLConnectionLostTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPMySQLConnectionLostTests.m; sourceTree = "<group>"; };
 		FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMySQLGeometryDataTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -262,7 +264,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0867D691FE84028FC02AAC07 /* SPMySQLFramework */ = {
+		0867D691FE84028FC02AAC07 = {
 			isa = PBXGroup;
 			children = (
 				177916A01E88733000EE3043 /* LICENSE */,
@@ -348,6 +350,7 @@
 				507FF1811BC0C64100104523 /* DataConversion_Tests.m */,
 				507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */,
 				FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */,
+				E307CD5A95A82BE1828D95CF /* SPMySQLConnectionLostTests.m */,
 			);
 			name = "Unit Tests";
 			path = "SPMySQL Unit Tests";
@@ -641,7 +644,7 @@
 				en,
 				Base,
 			);
-			mainGroup = 0867D691FE84028FC02AAC07 /* SPMySQLFramework */;
+			mainGroup = 0867D691FE84028FC02AAC07;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -717,6 +720,7 @@
 				507FF23D1BC157B500104523 /* SPMySQLStringAdditions_Tests.m in Sources */,
 				FD4211952918779400941BFE /* SPMySQLGeometryDataTests.m in Sources */,
 				507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */,
+				55ECDDB8FC1D39B782BF6139 /* SPMySQLConnectionLostTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -74,6 +74,7 @@
 - (void)_setReconnectAttemptForTesting:(BOOL (^)(BOOL canRetry))block;
 - (void)_setSilentReconnectAttemptForTesting:(BOOL (^)(void))block;
 - (void)_drainReconnectQueueForTesting;
+- (void)_setDelegateDecisionTimeoutForTesting:(NSTimeInterval)timeoutInterval;
 #endif
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -42,6 +42,7 @@
 - (BOOL)_connect;
 - (MYSQL *)_makeRawMySQLConnectionWithEncoding:(NSString *)encodingName isMasterConnection:(BOOL)isMaster;
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry;
+- (BOOL)_reconnectAllowingRetries:(BOOL)canRetry dispatchOnMainThread:(BOOL)dispatchOnMainThread;
 - (BOOL)_silentReconnectAttempt;
 - (void)_postLostInBackgroundNotification;
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -41,6 +41,7 @@
 
 - (BOOL)_connect;
 - (MYSQL *)_makeRawMySQLConnectionWithEncoding:(NSString *)encodingName isMasterConnection:(BOOL)isMaster;
+- (void)_setConnectionState:(SPMySQLConnectionState)newState;
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry;
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry dispatchOnMainThread:(BOOL)dispatchOnMainThread;
 - (BOOL)_silentReconnectAttempt;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -42,7 +42,7 @@
 - (BOOL)_connect;
 - (MYSQL *)_makeRawMySQLConnectionWithEncoding:(NSString *)encodingName isMasterConnection:(BOOL)isMaster;
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry;
-- (BOOL)_reconnectAfterBackgroundConnectionLoss;
+- (BOOL)_silentReconnectAttempt;
 - (void)_postLostInBackgroundNotification;
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;
 - (void)_disconnect;
@@ -66,6 +66,7 @@
 @interface SPMySQLConnection (Delegate_and_Proxy_Private_API)
 
 - (void)_proxyStateChange:(NSObject <SPMySQLConnectionProxy> *)aProxy;
+- (void)_silentReconnectForProxyLoss;
 - (SPMySQLConnectionLostDecision)_delegateDecisionForLostConnection;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -43,6 +43,7 @@
 - (MYSQL *)_makeRawMySQLConnectionWithEncoding:(NSString *)encodingName isMasterConnection:(BOOL)isMaster;
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry;
 - (BOOL)_reconnectAfterBackgroundConnectionLoss;
+- (void)_postLostInBackgroundNotification;
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;
 - (void)_disconnect;
 - (void)_updateConnectionVariables;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -61,6 +61,20 @@
 + (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
 + (NSString *)_reachabilityProbeHostForHost:(NSString *)host useSocket:(BOOL)useSocket hasProxy:(BOOL)hasProxy;
 
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+- (void)_setStateForTesting:(SPMySQLConnectionState)testState;
+- (SPMySQLConnectionState)_stateForTesting;
+- (void)_setLastConnectionUsedTimeForTesting:(uint64_t)testTime;
+- (void)_setLastConnectionUsedTimeForTestingWithSecondsAgo:(NSTimeInterval)secondsAgo;
+- (void)_setKeepAlivePingFailuresForTesting:(NSUInteger)failures;
+- (void)_setKeepAliveLastPingBlockedForTesting:(BOOL)blocked;
+- (void)_setProxyStateChangeNotificationsIgnoredForTesting:(BOOL)ignored;
+- (BOOL)_proxyStateChangeNotificationsIgnoredForTesting;
+- (void)_setReconnectAttemptForTesting:(BOOL (^)(BOOL canRetry))block;
+- (void)_setSilentReconnectAttemptForTesting:(BOOL (^)(void))block;
+- (void)_drainReconnectQueueForTesting;
+#endif
+
 @end
 
 @interface SPMySQLConnection (Delegate_and_Proxy_Private_API)

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -169,22 +169,36 @@
 
 	if (delegateSupportsConnectionLostAsync) {
 		dispatch_semaphore_t decisionSemaphore = dispatch_semaphore_create(0);
+		__block SPMySQLConnectionLostDecision asyncDecision = SPMySQLConnectionLostDisconnect;
+		__block BOOL decisionExpired = NO;
 
 		[delegate connectionLost:self completion:^(SPMySQLConnectionLostDecision decision) {
 			[self->delegateDecisionLock lock];
-			self->lastDelegateDecisionForLostConnection = decision;
+			if (!decisionExpired) {
+				asyncDecision = decision;
+				self->lastDelegateDecisionForLostConnection = decision;
+			}
 			[self->delegateDecisionLock unlock];
 
 			dispatch_semaphore_signal(decisionSemaphore);
 		}];
 
-		if (dispatch_semaphore_wait(decisionSemaphore, dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC)) != 0) {
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+		NSTimeInterval timeoutInterval = delegateDecisionTimeoutForTesting;
+#else
+		NSTimeInterval timeoutInterval = 60;
+#endif
+
+		if (dispatch_semaphore_wait(decisionSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeoutInterval * NSEC_PER_SEC))) != 0) {
 			SPLog(@"Timed out waiting for async connectionLost:completion: delegate decision; defaulting to disconnect");
+			[delegateDecisionLock lock];
+			decisionExpired = YES;
+			[delegateDecisionLock unlock];
 			return SPMySQLConnectionLostDisconnect;
 		}
 
 		[delegateDecisionLock lock];
-		theDecision = lastDelegateDecisionForLostConnection;
+		theDecision = asyncDecision;
 		[delegateDecisionLock unlock];
 		return theDecision;
 	}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -49,6 +49,7 @@
 	delegateSupportsConnectionLost = [delegate respondsToSelector:@selector(connectionLost:)];
 	delegateSupportsConnectionLostAsync = [delegate respondsToSelector:@selector(connectionLost:completion:)];
 	delegateSupportsConnectionLostBackground = [delegate respondsToSelector:@selector(connectionLostInBackground:)];
+	delegateSupportsConnectionRestoredAfterLoss = [delegate respondsToSelector:@selector(connectionRestoredAfterLoss:)];
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -47,6 +47,8 @@
 	// Cache whether the delegate implements certain delegate methods
 	delegateSupportsWillQueryString = [delegate respondsToSelector:@selector(willQueryString:connection:)];
 	delegateSupportsConnectionLost = [delegate respondsToSelector:@selector(connectionLost:)];
+	delegateSupportsConnectionLostAsync = [delegate respondsToSelector:@selector(connectionLost:completion:)];
+	delegateSupportsConnectionLostBackground = [delegate respondsToSelector:@selector(connectionLostInBackground:)];
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -129,7 +129,7 @@
 		// Otherwise set the state to connection lost for automatic reconnect on next use
 		} else {
             SPLog(@"Otherwise set the state to connection lost for automatic reconnect on next use");
-			state = SPMySQLConnectionLostInBackground;
+			[self _setConnectionState:SPMySQLConnectionLostInBackground];
 			proxyStateChangeNotificationsIgnored = NO;
 			[self _postLostInBackgroundNotification];
 		}
@@ -148,7 +148,7 @@
 		proxyStateChangeNotificationsIgnored = NO;
 
 		if (!reconnectSucceeded) {
-			state = SPMySQLConnectionLostInBackground;
+			[self _setConnectionState:SPMySQLConnectionLostInBackground];
 			[self _postLostInBackgroundNotification];
 		}
 	}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -145,7 +145,13 @@
 	@autoreleasepool {
 		BOOL reconnectSucceeded = [self _silentReconnectAttempt];
 
-		reconnectingThread = NULL;
+		// Release the reconnect ownership claim under the same lock that the
+		// waiter loop in `_reconnectAllowingRetries:` polls — an unsynchronized
+		// write here leaves the waiter without a happens-before edge and can
+		// trap it observing stale ownership indefinitely.
+		@synchronized (self) {
+			reconnectingThread = NULL;
+		}
 		proxyStateChangeNotificationsIgnored = NO;
 
 		if (!reconnectSucceeded) {

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -155,45 +155,48 @@
 }
 
 /**
- * Ask the delegate for the connection lost decision.  This can be called from
- * any thread, and will call itself on the main thread if necessary, updating a global
- * variable which is then returned on the child thread.
+ * Ask the delegate for the connection lost decision. This must be called from
+ * a worker thread; main-thread callers default to disconnect to avoid blocking UI.
  */
 - (SPMySQLConnectionLostDecision)_delegateDecisionForLostConnection
 {
 	SPMySQLConnectionLostDecision theDecision = SPMySQLConnectionLostDisconnect;
 
-	// If on the main thread, ask the delegate directly.
 	if ([NSThread isMainThread]) {
+		SPLog(@"Suppressing connectionLost: delegate decision on main thread; defaulting to disconnect");
+		return SPMySQLConnectionLostDisconnect;
+	}
+
+	if (delegateSupportsConnectionLostAsync) {
+		dispatch_semaphore_t decisionSemaphore = dispatch_semaphore_create(0);
+
+		[delegate connectionLost:self completion:^(SPMySQLConnectionLostDecision decision) {
+			[self->delegateDecisionLock lock];
+			self->lastDelegateDecisionForLostConnection = decision;
+			[self->delegateDecisionLock unlock];
+
+			dispatch_semaphore_signal(decisionSemaphore);
+		}];
+
+		if (dispatch_semaphore_wait(decisionSemaphore, dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC)) != 0) {
+			SPLog(@"Timed out waiting for async connectionLost:completion: delegate decision; defaulting to disconnect");
+			return SPMySQLConnectionLostDisconnect;
+		}
+
+		[delegateDecisionLock lock];
+		theDecision = lastDelegateDecisionForLostConnection;
+		[delegateDecisionLock unlock];
+		return theDecision;
+	}
+
+	if (delegateSupportsConnectionLost) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		[delegateDecisionLock lock];
 		lastDelegateDecisionForLostConnection = [delegate connectionLost:self];
 		theDecision = lastDelegateDecisionForLostConnection;
 		[delegateDecisionLock unlock];
-
-	// Otherwise call ourself on the main thread, waiting until the reply is received.
-	} else {
-
-		// First check whether the application is in a modal state; if so, wait
-        do {
-            NSWindow __block *modalWindow = nil;
-            
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                modalWindow = [NSApp modalWindow];
-            });
-
-            if(modalWindow == nil){
-                break;
-            }
-            else{
-                usleep(100000);
-            }
-
-        } while(0);
-
-		[self performSelectorOnMainThread:@selector(_delegateDecisionForLostConnection) withObject:nil waitUntilDone:YES];
-		[delegateDecisionLock lock];
-		theDecision = lastDelegateDecisionForLostConnection;
-		[delegateDecisionLock unlock];
+#pragma clang diagnostic pop
 	}
 
 	return theDecision;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Delegate & Proxy.m
@@ -119,31 +119,39 @@
 		// Clear the state change selector on the proxy until a connection is re-established
 		proxyStateChangeNotificationsIgnored = YES;
 
-		// Trigger a reconnect depending on connection usage recently.  If the connection has
-		// actively been used in the last couple of minutes, trigger a full reconnection attempt.
-		if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 2) {
-            SPLog(@"If the connection has actively been used in the last couple of minutes, trigger a full reconnection attempt");
-            SPLog(@"create new reconnectionThread");
-			reconnectionThread = [[NSThread alloc] initWithTarget:self selector:@selector(_reconnectAllowingRetries:) object:@YES];
-			[reconnectionThread setName:@"SPMySQL reconnection thread (full)"];
-			[reconnectionThread start];
-
-		// If used within the last fifteen minutes, trigger a background/single reconnection attempt
-		} else if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 15) {
-            SPLog(@"If used within the last fifteen minutes, trigger a background/single reconnection attempt");
-			reconnectionThread = [[NSThread alloc] initWithTarget:self selector:@selector(_reconnectAfterBackgroundConnectionLoss) object:nil];
-			[reconnectionThread setName:@"SPMySQL reconnection thread (limited)"];
+		// If used within the last fifteen minutes, trigger a silent single reconnect attempt.
+		if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 15) {
+            SPLog(@"If used within the last fifteen minutes, trigger a silent background reconnection attempt");
+			reconnectionThread = [[NSThread alloc] initWithTarget:self selector:@selector(_silentReconnectForProxyLoss) object:nil];
+			[reconnectionThread setName:@"SPMySQL silent proxy reconnect"];
 			[reconnectionThread start];
 
 		// Otherwise set the state to connection lost for automatic reconnect on next use
 		} else {
             SPLog(@"Otherwise set the state to connection lost for automatic reconnect on next use");
 			state = SPMySQLConnectionLostInBackground;
+			proxyStateChangeNotificationsIgnored = NO;
+			[self _postLostInBackgroundNotification];
 		}
 	}
 
 	// Update the state record
 	previousProxyState = newState;
+}
+
+- (void)_silentReconnectForProxyLoss
+{
+	@autoreleasepool {
+		BOOL reconnectSucceeded = [self _silentReconnectAttempt];
+
+		reconnectingThread = NULL;
+		proxyStateChangeNotificationsIgnored = NO;
+
+		if (!reconnectSucceeded) {
+			state = SPMySQLConnectionLostInBackground;
+			[self _postLostInBackgroundNotification];
+		}
+	}
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Ping & KeepAlive.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Ping & KeepAlive.m
@@ -70,7 +70,7 @@ typedef struct {
 
 	// If we've had too many ping failures, don't keep trying
 	if (keepAlivePingFailures >= 3) {
-		state = SPMySQLConnectionLostInBackground;
+		[self _setConnectionState:SPMySQLConnectionLostInBackground];
 		[self _postLostInBackgroundNotification];
 		return;
 	}
@@ -105,7 +105,7 @@ typedef struct {
 
 		// If the maximum number of ping failures has been reached, record the background loss.
 		if (keepAliveLastPingBlocked || keepAlivePingFailures >= 3) {
-			state = SPMySQLConnectionLostInBackground;
+			[self _setConnectionState:SPMySQLConnectionLostInBackground];
 			[self _postLostInBackgroundNotification];
 
 			// Return as no further ping action required this cycle.

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Ping & KeepAlive.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Ping & KeepAlive.m
@@ -71,6 +71,7 @@ typedef struct {
 	// If we've had too many ping failures, don't keep trying
 	if (keepAlivePingFailures >= 3) {
 		state = SPMySQLConnectionLostInBackground;
+		[self _postLostInBackgroundNotification];
 		return;
 	}
 
@@ -102,19 +103,10 @@ typedef struct {
 
 		[keepAliveThread setName:[NSString stringWithFormat:@"SPMySQL connection keepalive monitor thread (id=%p)", self]];
 
-		// If the maximum number of ping failures has been reached, determine whether to reconnect.
+		// If the maximum number of ping failures has been reached, record the background loss.
 		if (keepAliveLastPingBlocked || keepAlivePingFailures >= 3) {
-
-			// If the connection has been used within the last fifteen minutes,
-			// attempt a single reconnection in the background
-			if (_timeIntervalSinceMonotonicTime(lastConnectionUsedTime) < 60 * 15) {
-				[self _reconnectAfterBackgroundConnectionLoss];
-			}
-			// Otherwise set the state to connection lost for automatic reconnect on
-			// next use.
-			else {
-				state = SPMySQLConnectionLostInBackground;
-			}
+			state = SPMySQLConnectionLostInBackground;
+			[self _postLostInBackgroundNotification];
 
 			// Return as no further ping action required this cycle.
 			goto end_cleanup;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -77,8 +77,9 @@
 	BOOL proxyStateChangeNotificationsIgnored;
 
 #if DEBUG || SPMYSQL_FOR_UNIT_TESTING
-	BOOL (^reconnectAttemptForTesting)(BOOL canRetry);
-	BOOL (^silentReconnectAttemptForTesting)(void);
+		BOOL (^reconnectAttemptForTesting)(BOOL canRetry);
+		BOOL (^silentReconnectAttemptForTesting)(void);
+		NSTimeInterval delegateDecisionTimeoutForTesting;
 #endif
 
 	// Connection lock to prevent non-thread-safe query misuse

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -38,6 +38,7 @@
 	BOOL delegateSupportsConnectionLost;
 	BOOL delegateSupportsConnectionLostAsync;
 	BOOL delegateSupportsConnectionLostBackground;
+	BOOL delegateSupportsConnectionRestoredAfterLoss;
 	BOOL delegateQueryLogging; // Defaults to YES if protocol implemented
 
 	// Basic connection details

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -67,6 +67,7 @@
 	BOOL connectedWithSSL;
 	BOOL userTriggeredDisconnect;
 	pthread_t reconnectingThread;
+	dispatch_queue_t _reconnectQueue;
 	uint64_t initialConnectTime;
 	unsigned long mysqlConnectionThreadId;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -36,6 +36,8 @@
     __weak NSObject <SPMySQLConnectionDelegate> *delegate;
 	BOOL delegateSupportsWillQueryString;
 	BOOL delegateSupportsConnectionLost;
+	BOOL delegateSupportsConnectionLostAsync;
+	BOOL delegateSupportsConnectionLostBackground;
 	BOOL delegateQueryLogging; // Defaults to YES if protocol implemented
 
 	// Basic connection details

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -86,7 +86,7 @@
 	NSConditionLock *connectionLock;
 
 	// Currently selected database
-	NSString *database, *databaseToRestore;
+	NSString *database;
 
 	// Delegate connection lost decisions
 	NSUInteger reconnectionRetryAttempts;
@@ -106,9 +106,9 @@
 
 	// Encoding details - and also a record of any previous encoding to allow
 	// switching back and forth
-	NSString *encoding, *encodingToRestore;
+	NSString *encoding;
 	NSStringEncoding stringEncoding;
-	BOOL encodingUsesLatin1Transport, encodingUsesLatin1TransportToRestore;
+	BOOL encodingUsesLatin1Transport;
 	NSString *previousEncoding;
 	BOOL previousEncodingUsesLatin1Transport;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -65,6 +65,7 @@
 	struct MYSQL *mySQLConnection;
 	SPMySQLConnectionState state;
 	BOOL connectedWithSSL;
+	BOOL lostInBackgroundNotificationPosted;
 	BOOL userTriggeredDisconnect;
 	pthread_t reconnectingThread;
 	dispatch_queue_t _reconnectQueue;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.h
@@ -76,6 +76,11 @@
 	SPMySQLConnectionProxyState previousProxyState;
 	BOOL proxyStateChangeNotificationsIgnored;
 
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+	BOOL (^reconnectAttemptForTesting)(BOOL canRetry);
+	BOOL (^silentReconnectAttemptForTesting)(void);
+#endif
+
 	// Connection lock to prevent non-thread-safe query misuse
 	NSConditionLock *connectionLock;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -374,6 +374,9 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 		delegate = nil;
 		delegateSupportsWillQueryString = NO;
 		delegateSupportsConnectionLost = NO;
+		delegateSupportsConnectionLostAsync = NO;
+		delegateSupportsConnectionLostBackground = NO;
+		delegateSupportsConnectionRestoredAfterLoss = NO;
 		delegateQueryLogging = YES;
 
 		// Delegate disconnection decisions
@@ -1072,6 +1075,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 #endif
 
 	BOOL reconnectSucceeded = NO;
+	BOOL delegateReconnectDecisionRequested = NO;
 
 	@autoreleasepool {
 		// Check whether a reconnection attempt is already being made - if so, wait
@@ -1135,6 +1139,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 			// If the delegate supports the decision process, ask it how to proceed
 			if (delegateSupportsConnectionLostAsync || delegateSupportsConnectionLost) {
 				connectionLostDecision = [self _delegateDecisionForLostConnection];
+				delegateReconnectDecisionRequested = (connectionLostDecision == SPMySQLConnectionLostReconnect);
 			}
 				// Otherwise default to reconnect, but only a set number of times to prevent a runaway loop
 			else {
@@ -1169,6 +1174,9 @@ asm(".desc ___crashreporter_info__, 0x10");
 		if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
 			reconnectingThread = NULL;
 		}
+	}
+	if (reconnectSucceeded && delegateReconnectDecisionRequested && delegateSupportsConnectionRestoredAfterLoss) {
+		[delegate connectionRestoredAfterLoss:self];
 	}
 	return reconnectSucceeded;
 }

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -382,6 +382,9 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 		reconnectionRetryAttempts = 0;
 		lastDelegateDecisionForLostConnection = SPMySQLConnectionLostDisconnect;
 		delegateDecisionLock = [[NSLock alloc] init];
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+		delegateDecisionTimeoutForTesting = 60;
+#endif
 
 		// Set up the connection lock
 		connectionLock = [[NSConditionLock alloc] initWithCondition:SPMySQLConnectionIdle];
@@ -1347,6 +1350,11 @@ asm(".desc ___crashreporter_info__, 0x10");
 	if (_reconnectQueue && dispatch_get_specific(SPMySQLReconnectQueueKey) != SPMySQLReconnectQueueKey) {
 		dispatch_sync(_reconnectQueue, ^{});
 	}
+}
+
+- (void)_setDelegateDecisionTimeoutForTesting:(NSTimeInterval)timeoutInterval
+{
+	delegateDecisionTimeoutForTesting = timeoutInterval;
 }
 #endif
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1059,6 +1059,12 @@ asm(".desc ___crashreporter_info__, 0x10");
 		return NO;
 	}
 
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+	if (reconnectAttemptForTesting) {
+		return reconnectAttemptForTesting(canRetry);
+	}
+#endif
+
 	BOOL reconnectSucceeded = NO;
 
 	@autoreleasepool {
@@ -1136,6 +1142,12 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 - (BOOL)_silentReconnectAttempt
 {
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+	if (silentReconnectAttemptForTesting) {
+		return silentReconnectAttemptForTesting();
+	}
+#endif
+
 	BOOL reconnectSucceeded = NO;
 	NSString *timeZoneIdentifierToRestore = nil;
 
@@ -1273,6 +1285,65 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	return reconnectSucceeded;
 }
+
+#if DEBUG || SPMYSQL_FOR_UNIT_TESTING
+- (void)_setStateForTesting:(SPMySQLConnectionState)testState
+{
+	state = testState;
+}
+
+- (SPMySQLConnectionState)_stateForTesting
+{
+	return state;
+}
+
+- (void)_setLastConnectionUsedTimeForTesting:(uint64_t)testTime
+{
+	lastConnectionUsedTime = testTime;
+}
+
+- (void)_setLastConnectionUsedTimeForTestingWithSecondsAgo:(NSTimeInterval)secondsAgo
+{
+	lastConnectionUsedTime = _monotonicTime() - (uint64_t)(secondsAgo * 1000000000);
+}
+
+- (void)_setKeepAlivePingFailuresForTesting:(NSUInteger)failures
+{
+	keepAlivePingFailures = failures;
+}
+
+- (void)_setKeepAliveLastPingBlockedForTesting:(BOOL)blocked
+{
+	keepAliveLastPingBlocked = blocked;
+}
+
+- (void)_setProxyStateChangeNotificationsIgnoredForTesting:(BOOL)ignored
+{
+	proxyStateChangeNotificationsIgnored = ignored;
+}
+
+- (BOOL)_proxyStateChangeNotificationsIgnoredForTesting
+{
+	return proxyStateChangeNotificationsIgnored;
+}
+
+- (void)_setReconnectAttemptForTesting:(BOOL (^)(BOOL canRetry))block
+{
+	reconnectAttemptForTesting = [block copy];
+}
+
+- (void)_setSilentReconnectAttemptForTesting:(BOOL (^)(void))block
+{
+	silentReconnectAttemptForTesting = [block copy];
+}
+
+- (void)_drainReconnectQueueForTesting
+{
+	if (_reconnectQueue && dispatch_get_specific(SPMySQLReconnectQueueKey) != SPMySQLReconnectQueueKey) {
+		dispatch_sync(_reconnectQueue, ^{});
+	}
+}
+#endif
 
 - (void)_postLostInBackgroundNotification
 {

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1458,9 +1458,23 @@ asm(".desc ___crashreporter_info__, 0x10");
 {
     SPLog(@"_disconnect");
 
+	void (^disconnectProxy)(void) = ^{
+		NSObject <SPMySQLConnectionProxy> *proxyToDisconnect = self->proxy;
+		if (!proxyToDisconnect) return;
+
+		if ([NSThread isMainThread]) {
+			[proxyToDisconnect disconnect];
+		} else {
+			dispatch_async(dispatch_get_main_queue(), ^{
+				[proxyToDisconnect disconnect];
+			});
+		}
+	};
+
 	// If state is connection lost, set state directly to disconnected.
 	if (state == SPMySQLConnectionLostInBackground) {
 		[self _setConnectionState:SPMySQLDisconnected];
+		disconnectProxy();
 	}
 
 	// Only continue if a connection is active
@@ -1500,9 +1514,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	[self _unlockConnection];
 
 	// If using a connection proxy, disconnect that too
-	if (proxy) {
-		[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
-	}
+	disconnectProxy();
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1050,17 +1050,40 @@ asm(".desc ___crashreporter_info__, 0x10");
  *
  * WARNING: This method may exit early returning NO if the current thread is cancelled!
  *          You MUST check the isCancelled flag before using the result!
+ *
+ * MAIN-THREAD CONTRACT (documented trade-off from #1945 / #2419):
+ *   This wrapper runs synchronously on whatever thread invokes it, INCLUDING the
+ *   main thread, so legacy callers (cancelCurrentQuery, checkConnectionIfNecessary,
+ *   _pingConnectionUsingLoopDelay, Max Packet Size renegotiation) keep their
+ *   `_unlockConnection → reconnect → _lockConnection` sequence intact.
+ *
+ *   However, the broader #1945 design forbids blocking the main thread to ask the
+ *   delegate for a Reconnect/Disconnect decision (that would re-introduce the
+ *   app-wide modal freeze this PR removed). So when this wrapper runs on the
+ *   main thread AND the initial silent reconnect attempt fails, the retry/decision
+ *   branch routes through `_delegateDecisionForLostConnection`, which on the main
+ *   thread is hard-coded to default `SPMySQLConnectionLostDisconnect` (see
+ *   `Delegate & Proxy.m`) — i.e. a failed main-thread reconnect is forced to a
+ *   disconnect rather than prompting the user via a sheet.
+ *
+ *   This is an intentional trade-off:
+ *     - Silent reconnect SUCCESS on main thread → normal recovery, no prompt needed.
+ *     - Silent reconnect FAILURE on main thread → forced disconnect (no prompt).
+ *     - Silent reconnect FAILURE on worker thread → async delegate sheet shown
+ *       on the owning tab's window via `connectionLost:completion:`.
+ *
+ *   Callers that need an interactive reconnect prompt MUST run on a worker
+ *   thread. The application-layer gate `SPDatabaseDocument
+ *   checkForBackgroundConnectionLossThenRun:` already dispatches reconnect work
+ *   to a global queue before calling the public `-reconnect`, so explicit
+ *   user-intent paths get the full delegate experience.
+ *
+ *   Covered by `testLegacyOneArgReconnectIsSynchronousOnMainThread`,
+ *   `testMainThreadReconnectFailureDefaultsToDisconnectWithoutPrompt`, and
+ *   `testSilentReconnectFromLostInBackgroundFiresRestorationCallbackThroughRealStateTransitions`.
  */
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry
 {
-	// Default to synchronous semantics (dispatchOnMainThread:NO) so existing
-	// in-tree callers — cancelCurrentQuery, _pingConnectionUsingLoopDelay,
-	// checkConnectionIfNecessary (worker path), Max Packet Size renegotiation —
-	// keep getting a reconnect that actually completes before returning. They
-	// follow the pattern `_unlockConnection → reconnect → _lockConnection` and
-	// depend on the reset being done before the next line runs. The two-argument
-	// form remains available for callers that explicitly want main-thread
-	// fast-return semantics (none exist in-tree today).
 	return [self _reconnectAllowingRetries:canRetry dispatchOnMainThread:NO];
 }
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -50,6 +50,8 @@ static void *mySQLThreadFlag;
 
 NSString * const SPMySQLConnectionLostInBackgroundNotification = @"SPMySQLConnectionLostInBackgroundNotification";
 
+static void *SPMySQLReconnectQueueKey = &SPMySQLReconnectQueueKey;
+
 static BOOL SPHostIsLoopbackIPv4Address(NSString *normalizedHost)
 {
 	struct in_addr ipv4Address;
@@ -331,6 +333,8 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 		state = SPMySQLDisconnected;
 		userTriggeredDisconnect = NO;
 		reconnectingThread = NULL;
+		_reconnectQueue = dispatch_queue_create("com.sequel-ace.spmysql.reconnect", DISPATCH_QUEUE_SERIAL);
+		dispatch_queue_set_specific(_reconnectQueue, SPMySQLReconnectQueueKey, SPMySQLReconnectQueueKey, NULL);
 		mysqlConnectionThreadId = 0;
 		initialConnectTime = 0;
 
@@ -426,6 +430,10 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 - (void) dealloc
 {
 	userTriggeredDisconnect = YES;
+
+	if (_reconnectQueue && dispatch_get_specific(SPMySQLReconnectQueueKey) != SPMySQLReconnectQueueKey) {
+		dispatch_sync(_reconnectQueue, ^{});
+	}
 
 	// Unset the delegate
 	[self setDelegate:nil];
@@ -1039,6 +1047,13 @@ asm(".desc ___crashreporter_info__, 0x10");
 
     SPLog(@"_reconnectAllowingRetries");
 	if (userTriggeredDisconnect) return NO;
+	if ([NSThread isMainThread]) {
+		dispatch_async(_reconnectQueue, ^{
+			(void)[self _reconnectAllowingRetries:canRetry];
+		});
+		return NO;
+	}
+
 	BOOL reconnectSucceeded = NO;
     NSString *timeZoneIdentifierToRestore = nil;
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -351,7 +351,6 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 
 		// Start with no selected database
 		database = nil;
-		databaseToRestore = nil;
 
 		// Set a timeout of 30 seconds, with keepalive on and acting every sixty seconds
 		timeout = 30;
@@ -367,8 +366,6 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
         encoding = @"utf8mb4";
 		stringEncoding = NSUTF8StringEncoding;
 		encodingUsesLatin1Transport = NO;
-		encodingToRestore = nil;
-		encodingUsesLatin1TransportToRestore = NO;
 		previousEncoding = nil;
 		previousEncodingUsesLatin1Transport = NO;
 
@@ -1157,6 +1154,9 @@ asm(".desc ___crashreporter_info__, 0x10");
 #endif
 
 	BOOL reconnectSucceeded = NO;
+	NSString *databaseToRestoreForAttempt = [database copy];
+	NSString *encodingToRestoreForAttempt = [encoding copy];
+	BOOL encodingUsesLatin1TransportToRestoreForAttempt = encodingUsesLatin1Transport;
 	NSString *timeZoneIdentifierToRestore = nil;
 
 	reconnectingThread = pthread_self();
@@ -1164,11 +1164,6 @@ asm(".desc ___crashreporter_info__, 0x10");
 	// Store certain details about the connection, so that if the reconnection is successful
 	// they can be restored.  This has to be treated separately from _restoreConnectionDetails
 	// as a full connection reinitialises certain values from the server.
-	if (!encodingToRestore) {
-		encodingToRestore = [encoding copy];
-		encodingUsesLatin1TransportToRestore = encodingUsesLatin1Transport;
-		databaseToRestore = [database copy];
-	}
 	// Keep this per-attempt capture aligned with self.timeZoneIdentifier:
 	// reconnect retries re-capture it from the surviving property value, so
 	// revisit this if disconnect teardown ever clears timeZoneIdentifier.
@@ -1281,14 +1276,10 @@ asm(".desc ___crashreporter_info__, 0x10");
 	// If the reconnection succeeded, restore the connection state as appropriate
 	if (state == SPMySQLConnected && ![[NSThread currentThread] isCancelled]) {
 		reconnectSucceeded = YES;
-		[self _restoreSessionStateAfterReconnectWithDatabase:databaseToRestore
-		                                            encoding:encodingToRestore
-		                        encodingUsesLatin1Transport:encodingUsesLatin1TransportToRestore
+		[self _restoreSessionStateAfterReconnectWithDatabase:databaseToRestoreForAttempt
+		                                            encoding:encodingToRestoreForAttempt
+		                        encodingUsesLatin1Transport:encodingUsesLatin1TransportToRestoreForAttempt
 		                              timeZoneIdentifier:timeZoneIdentifierToRestore];
-		// When the connection is restored successfully, reset the relevant variables to prepare for the next time
-		databaseToRestore = nil;
-		encodingToRestore = nil;
-		encodingUsesLatin1TransportToRestore = NO;
 	}
 
 	return reconnectSucceeded;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -492,7 +492,7 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 {
     SPLog(@"reconnect");
 	userTriggeredDisconnect = NO;
-	return [self _reconnectAllowingRetries:YES];
+	return [self _reconnectAllowingRetries:YES dispatchOnMainThread:NO];
 }
 
 /**
@@ -1049,10 +1049,15 @@ asm(".desc ___crashreporter_info__, 0x10");
  */
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry
 {
+	return [self _reconnectAllowingRetries:canRetry dispatchOnMainThread:YES];
+}
+
+- (BOOL)_reconnectAllowingRetries:(BOOL)canRetry dispatchOnMainThread:(BOOL)dispatchOnMainThread
+{
 
     SPLog(@"_reconnectAllowingRetries");
 	if (userTriggeredDisconnect) return NO;
-	if ([NSThread isMainThread]) {
+	if (dispatchOnMainThread && [NSThread isMainThread]) {
 		dispatch_async(_reconnectQueue, ^{
 			(void)[self _reconnectAllowingRetries:canRetry];
 		});
@@ -1131,7 +1136,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 				default:
 					reconnectingThread = NULL;
                     SPLog(@"_reconnectAllowingRetries By default attempt a reconnect");
-					reconnectSucceeded = [self _reconnectAllowingRetries:YES];
+					reconnectSucceeded = [self _reconnectAllowingRetries:YES dispatchOnMainThread:dispatchOnMainThread];
 			}
 		}
 	}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -515,10 +515,9 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
  */
 - (BOOL)isConnected
 {
-	// If the connection has been allowed to drop in the background, restore it if posslbe
 	if (state == SPMySQLConnectionLostInBackground) {
-        SPLog(@"SPMySQLConnectionLostInBackground, reconnecting");
-		[self _reconnectAllowingRetries:YES];
+        SPLog(@"SPMySQLConnectionLostInBackground, returning NO");
+		return NO;
 	}
 
 	return (state == SPMySQLConnected || state == SPMySQLDisconnecting);
@@ -607,7 +606,13 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 	// If the connection has been dropped in the background, trigger a
 	// reconnect and return the success state here
 	if (state == SPMySQLConnectionLostInBackground) {
-        SPLog(@"SPMySQLConnectionLostInBackground, calling _reconnectAllowingRetries");
+		if ([NSThread isMainThread]) {
+	        SPLog(@"SPMySQLConnectionLostInBackground on main thread, posting notification");
+			[self _postLostInBackgroundNotification];
+			return NO;
+		}
+
+        SPLog(@"SPMySQLConnectionLostInBackground on worker thread, calling _reconnectAllowingRetries");
 		return [self _reconnectAllowingRetries:YES];
 	}
 	
@@ -1270,6 +1275,15 @@ asm(".desc ___crashreporter_info__, 0x10");
 	}
 
 	return (state == SPMySQLConnected);
+}
+
+- (void)_postLostInBackgroundNotification
+{
+	[[NSNotificationCenter defaultCenter] postNotificationName:SPMySQLConnectionLostInBackgroundNotification object:self];
+
+	if (delegateSupportsConnectionLostBackground) {
+		[delegate connectionLostInBackground:self];
+	}
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -48,6 +48,8 @@
 static pthread_key_t mySQLThreadInitFlagKey;
 static void *mySQLThreadFlag;
 
+NSString * const SPMySQLConnectionLostInBackgroundNotification = @"SPMySQLConnectionLostInBackgroundNotification";
+
 static BOOL SPHostIsLoopbackIPv4Address(NSString *normalizedHost)
 {
 	struct in_addr ipv4Address;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1060,7 +1060,6 @@ asm(".desc ___crashreporter_info__, 0x10");
 	}
 
 	BOOL reconnectSucceeded = NO;
-    NSString *timeZoneIdentifierToRestore = nil;
 
 	@autoreleasepool {
 		// Check whether a reconnection attempt is already being made - if so, wait
@@ -1093,140 +1092,11 @@ asm(".desc ___crashreporter_info__, 0x10");
 			return NO;
 		}
 
-		reconnectingThread = pthread_self();
+		reconnectSucceeded = [self _silentReconnectAttempt];
 
-		// Store certain details about the connection, so that if the reconnection is successful
-		// they can be restored.  This has to be treated separately from _restoreConnectionDetails
-		// as a full connection reinitialises certain values from the server.
-		if (!encodingToRestore) {
-			encodingToRestore = [encoding copy];
-			encodingUsesLatin1TransportToRestore = encodingUsesLatin1Transport;
-			databaseToRestore = [database copy];
-		}
-        // Keep this per-attempt capture aligned with self.timeZoneIdentifier:
-        // reconnect retries re-capture it from the surviving property value, so
-        // revisit this if disconnect teardown ever clears timeZoneIdentifier.
-        if (!timeZoneIdentifierToRestore && [self.timeZoneIdentifier length]) {
-            timeZoneIdentifierToRestore = [self.timeZoneIdentifier copy];
-        }
-
-		// If there is a connection proxy, temporarily disassociate the state change action
-		if (proxy) proxyStateChangeNotificationsIgnored = YES;
-
-		// Close the connection if it's active
-		[self _disconnect];
-
-		// Lock the connection while waiting for network and proxy
-		[self _lockConnection];
-
-		// If no network is present, wait for a short time for one to become available
-		[self _waitForNetworkConnectionWithTimeout:10];
-
-		if ([[NSThread currentThread] isCancelled]) {
-            SPLog(@"NSThread currentThread] isCancelled, returning");
-
-			[self _unlockConnection];
-			reconnectingThread = NULL;
-			return NO;
-		}
-
-		// If there is a proxy, attempt to reconnect it in blocking fashion
-		if (proxy) {
-
-            SPLog(@"we have a proxy");
-
-			uint64_t loopIterationStart_t, proxyWaitStart_t;
-
-			// If the proxy is not yet idle after requesting a disconnect, wait for a short time
-			// to allow it to disconnect.
-			if ([proxy state] != SPMySQLProxyIdle) {
-
-                SPLog(@"proxy not idle, waiting");
-
-				proxyWaitStart_t = _monotonicTime();
-				while ([proxy state] != SPMySQLProxyIdle) {
-					loopIterationStart_t = _monotonicTime();
-
-					// If the connection timeout has passed, break out of the loop
-					if (_timeIntervalSinceMonotonicTime(proxyWaitStart_t) > timeout) break;
-
-					// Allow events to process for 0.25s, sleeping to completion on early return
-					[[NSRunLoop currentRunLoop] runMode:NSModalPanelRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
-					if (_timeIntervalSinceMonotonicTime(loopIterationStart_t) < 0.25) {
-						usleep(250000 - (useconds_t)(1000000 * _timeIntervalSinceMonotonicTime(loopIterationStart_t)));
-					}
-				}
-			}
-
-			// Request that the proxy re-establishes its connection
-            SPLog(@"Request that the proxy re-establishes its connection, calling proxy connect");
-
-			[proxy connect];
-
-			// Wait while the proxy connects
-			proxyWaitStart_t = _monotonicTime();
-			while (1) {
-				loopIterationStart_t = _monotonicTime();
-
-                SPLog(@"Wait while the proxy connects");
-
-				// If the proxy has connected, record the new local port and break out of the loop
-				if ([proxy state] == SPMySQLProxyConnected) {
-                    SPLog(@"SPMySQLProxyConnected. port: %lu",(unsigned long)[proxy localPort] );
-
-					port = [proxy localPort];
-					break;
-				}
-
-				// If the proxy connection attempt time has exceeded the timeout, break of of the loop.
-				if (_timeIntervalSinceMonotonicTime(proxyWaitStart_t) > (timeout + 1)) {
-                    SPLog(@"proxy connection attempt time has exceeded the timeout, break of of the loop, calling proxy disconnect");
-					[proxy disconnect];
-					break;
-				}
-
-				// Process events for a short time, allowing dialogs to be shown but waiting for
-				// the proxy. Capture how long this interface action took, standardising the
-				// overall time.
-				[[NSRunLoop currentRunLoop] runMode:NSModalPanelRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
-				if (_timeIntervalSinceMonotonicTime(loopIterationStart_t) < 0.25) {
-					usleep((useconds_t)(250000 - (1000000 * _timeIntervalSinceMonotonicTime(loopIterationStart_t))));
-				}
-
-				// Extend the connection timeout by any interface time
-				if ([proxy state] == SPMySQLProxyWaitingForAuth) {
-					proxyWaitStart_t += _monotonicTime() - loopIterationStart_t;
-				}
-			}
-
-			// Having in theory performed the proxy connect, update state
-			previousProxyState = [proxy state];
-			proxyStateChangeNotificationsIgnored = NO;
-		}
-
-		// Unlock the connection
-		[self _unlockConnection];
-
-		// If not using a proxy, or if the proxy successfully connected, trigger a connection
-		if (!proxy || [proxy state] == SPMySQLProxyConnected) {
-			[self _connect];
-		}
-
-		// If the reconnection succeeded, restore the connection state as appropriate
-		if (state == SPMySQLConnected && ![[NSThread currentThread] isCancelled]) {
-			reconnectSucceeded = YES;
-            [self _restoreSessionStateAfterReconnectWithDatabase:databaseToRestore
-                                                        encoding:encodingToRestore
-                                    encodingUsesLatin1Transport:encodingUsesLatin1TransportToRestore
-                                               timeZoneIdentifier:timeZoneIdentifierToRestore];
-            // When the connection is restored successfully, reset the relevant variables to prepare for the next time
-            databaseToRestore = nil;
-            encodingToRestore = nil;
-            encodingUsesLatin1TransportToRestore = NO;
-		}
-			// If the connection failed and the connection is permitted to retry,
-			// then retry the reconnection.
-		else if (canRetry && ![[NSThread currentThread] isCancelled]) {
+		// If the connection failed and the connection is permitted to retry,
+		// then retry the reconnection.
+		if (!reconnectSucceeded && canRetry && ![[NSThread currentThread] isCancelled]) {
 
 			// Default to attempting another reconnect
 			SPMySQLConnectionLostDecision connectionLostDecision = SPMySQLConnectionLostReconnect;
@@ -1264,17 +1134,144 @@ asm(".desc ___crashreporter_info__, 0x10");
 	return reconnectSucceeded;
 }
 
-/**
- * Trigger a single reconnection attempt after losing network in the background,
- * setting the state appropriately for connection on next use if this fails.
- */
-- (BOOL)_reconnectAfterBackgroundConnectionLoss
+- (BOOL)_silentReconnectAttempt
 {
-	if (![self _reconnectAllowingRetries:NO]) {
-		state = SPMySQLConnectionLostInBackground;
+	BOOL reconnectSucceeded = NO;
+	NSString *timeZoneIdentifierToRestore = nil;
+
+	reconnectingThread = pthread_self();
+
+	// Store certain details about the connection, so that if the reconnection is successful
+	// they can be restored.  This has to be treated separately from _restoreConnectionDetails
+	// as a full connection reinitialises certain values from the server.
+	if (!encodingToRestore) {
+		encodingToRestore = [encoding copy];
+		encodingUsesLatin1TransportToRestore = encodingUsesLatin1Transport;
+		databaseToRestore = [database copy];
+	}
+	// Keep this per-attempt capture aligned with self.timeZoneIdentifier:
+	// reconnect retries re-capture it from the surviving property value, so
+	// revisit this if disconnect teardown ever clears timeZoneIdentifier.
+	if (!timeZoneIdentifierToRestore && [self.timeZoneIdentifier length]) {
+		timeZoneIdentifierToRestore = [self.timeZoneIdentifier copy];
 	}
 
-	return (state == SPMySQLConnected);
+	// If there is a connection proxy, temporarily disassociate the state change action
+	if (proxy) proxyStateChangeNotificationsIgnored = YES;
+
+	// Close the connection if it's active
+	[self _disconnect];
+
+	// Lock the connection while waiting for network and proxy
+	[self _lockConnection];
+
+	// If no network is present, wait for a short time for one to become available
+	[self _waitForNetworkConnectionWithTimeout:10];
+
+	if ([[NSThread currentThread] isCancelled]) {
+		SPLog(@"NSThread currentThread] isCancelled, returning");
+
+		[self _unlockConnection];
+		reconnectingThread = NULL;
+		return NO;
+	}
+
+	// If there is a proxy, attempt to reconnect it in blocking fashion
+	if (proxy) {
+
+		SPLog(@"we have a proxy");
+
+		uint64_t loopIterationStart_t, proxyWaitStart_t;
+
+		// If the proxy is not yet idle after requesting a disconnect, wait for a short time
+		// to allow it to disconnect.
+		if ([proxy state] != SPMySQLProxyIdle) {
+
+			SPLog(@"proxy not idle, waiting");
+
+			proxyWaitStart_t = _monotonicTime();
+			while ([proxy state] != SPMySQLProxyIdle) {
+				loopIterationStart_t = _monotonicTime();
+
+				// If the connection timeout has passed, break out of the loop
+				if (_timeIntervalSinceMonotonicTime(proxyWaitStart_t) > timeout) break;
+
+				// Allow events to process for 0.25s, sleeping to completion on early return
+				[[NSRunLoop currentRunLoop] runMode:NSModalPanelRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
+				if (_timeIntervalSinceMonotonicTime(loopIterationStart_t) < 0.25) {
+					usleep(250000 - (useconds_t)(1000000 * _timeIntervalSinceMonotonicTime(loopIterationStart_t)));
+				}
+			}
+		}
+
+		// Request that the proxy re-establishes its connection
+		SPLog(@"Request that the proxy re-establishes its connection, calling proxy connect");
+
+		[proxy connect];
+
+		// Wait while the proxy connects
+		proxyWaitStart_t = _monotonicTime();
+		while (1) {
+			loopIterationStart_t = _monotonicTime();
+
+			SPLog(@"Wait while the proxy connects");
+
+			// If the proxy has connected, record the new local port and break out of the loop
+			if ([proxy state] == SPMySQLProxyConnected) {
+				SPLog(@"SPMySQLProxyConnected. port: %lu",(unsigned long)[proxy localPort] );
+
+				port = [proxy localPort];
+				break;
+			}
+
+			// If the proxy connection attempt time has exceeded the timeout, break of of the loop.
+			if (_timeIntervalSinceMonotonicTime(proxyWaitStart_t) > (timeout + 1)) {
+				SPLog(@"proxy connection attempt time has exceeded the timeout, break of of the loop, calling proxy disconnect");
+				[proxy disconnect];
+				break;
+			}
+
+			// Process events for a short time, allowing dialogs to be shown but waiting for
+			// the proxy. Capture how long this interface action took, standardising the
+			// overall time.
+			[[NSRunLoop currentRunLoop] runMode:NSModalPanelRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
+			if (_timeIntervalSinceMonotonicTime(loopIterationStart_t) < 0.25) {
+				usleep((useconds_t)(250000 - (1000000 * _timeIntervalSinceMonotonicTime(loopIterationStart_t))));
+			}
+
+			// Extend the connection timeout by any interface time
+			if ([proxy state] == SPMySQLProxyWaitingForAuth) {
+				proxyWaitStart_t += _monotonicTime() - loopIterationStart_t;
+			}
+		}
+
+		// Having in theory performed the proxy connect, update state
+		previousProxyState = [proxy state];
+		proxyStateChangeNotificationsIgnored = NO;
+	}
+
+	// Unlock the connection
+	[self _unlockConnection];
+
+	// If not using a proxy, or if the proxy successfully connected, trigger a connection
+	if (!proxy || [proxy state] == SPMySQLProxyConnected) {
+		[self _connect];
+	}
+
+	// If the reconnection succeeded, restore the connection state as appropriate
+	if (state == SPMySQLConnected && ![[NSThread currentThread] isCancelled]) {
+		reconnectSucceeded = YES;
+		[self _restoreSessionStateAfterReconnectWithDatabase:databaseToRestore
+		                                            encoding:encodingToRestore
+		                        encodingUsesLatin1Transport:encodingUsesLatin1TransportToRestore
+		                              timeZoneIdentifier:timeZoneIdentifierToRestore];
+		// When the connection is restored successfully, reset the relevant variables to prepare for the next time
+		databaseToRestore = nil;
+		encodingToRestore = nil;
+		encodingUsesLatin1TransportToRestore = NO;
+	}
+
+	return reconnectSucceeded;
 }
 
 - (void)_postLostInBackgroundNotification

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -331,6 +331,7 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 	if ((self = [super init])) {
 		mySQLConnection = NULL;
 		state = SPMySQLDisconnected;
+		lostInBackgroundNotificationPosted = NO;
 		userTriggeredDisconnect = NO;
 		reconnectingThread = NULL;
 		_reconnectQueue = dispatch_queue_create("com.sequel-ace.spmysql.reconnect", DISPATCH_QUEUE_SERIAL);
@@ -766,7 +767,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		[NSException raise:NSInternalInconsistencyException format:@"Attempted to connect a connection that is not disconnected (SPMySQLConnectionState=%d).", state];
 		return NO;
 	}
-	state = SPMySQLConnecting;
+	[self _setConnectionState:SPMySQLConnecting];
 
 	if (userTriggeredDisconnect) {
 		return NO;
@@ -783,7 +784,7 @@ asm(".desc ___crashreporter_info__, 0x10");
         SPLog(@"!mySQLConnection, unlock");
 
 		[self _unlockConnection];
-		state = SPMySQLDisconnected;
+		[self _setConnectionState:SPMySQLDisconnected];
 		return NO;
 	}
 
@@ -796,7 +797,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	}
 
 	// Successfully connected - record connected state and reset tracking variables
-	state = SPMySQLConnected;
+	[self _setConnectionState:SPMySQLConnected];
 
 	@synchronized (self) {
 		initialConnectTime = _monotonicTime();
@@ -1288,7 +1289,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 #if DEBUG || SPMYSQL_FOR_UNIT_TESTING
 - (void)_setStateForTesting:(SPMySQLConnectionState)testState
 {
-	state = testState;
+	[self _setConnectionState:testState];
 }
 
 - (SPMySQLConnectionState)_stateForTesting
@@ -1351,11 +1352,23 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 - (void)_postLostInBackgroundNotification
 {
+	if (lostInBackgroundNotificationPosted) return;
+
+	lostInBackgroundNotificationPosted = YES;
 	[[NSNotificationCenter defaultCenter] postNotificationName:SPMySQLConnectionLostInBackgroundNotification object:self];
 
 	if (delegateSupportsConnectionLostBackground) {
 		[delegate connectionLostInBackground:self];
 	}
+}
+
+- (void)_setConnectionState:(SPMySQLConnectionState)newState
+{
+	if (state == SPMySQLConnectionLostInBackground && newState != SPMySQLConnectionLostInBackground) {
+		lostInBackgroundNotificationPosted = NO;
+	}
+
+	state = newState;
 }
 
 /**
@@ -1419,7 +1432,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	// If state is connection lost, set state directly to disconnected.
 	if (state == SPMySQLConnectionLostInBackground) {
-		state = SPMySQLDisconnected;
+		[self _setConnectionState:SPMySQLDisconnected];
 	}
 
 	// Only continue if a connection is active
@@ -1430,7 +1443,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	// If a query is active, cancel it
 	[self cancelCurrentQuery];
 
-	state = SPMySQLDisconnecting;
+	[self _setConnectionState:SPMySQLDisconnecting];
 
 	// Allow any pings or cancelled queries  to complete, inside a time limit of ten seconds
 	uint64_t disconnectStartTime_t = _monotonicTime();
@@ -1455,7 +1468,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	}
 	mySQLConnection = NULL;
 	serverVersionNumber = 0;
-	state = SPMySQLDisconnected;
+	[self _setConnectionState:SPMySQLDisconnected];
 	[self _unlockConnection];
 
 	// If using a connection proxy, disconnect that too

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1102,7 +1102,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 			SPMySQLConnectionLostDecision connectionLostDecision = SPMySQLConnectionLostReconnect;
 
 			// If the delegate supports the decision process, ask it how to proceed
-			if (delegateSupportsConnectionLost) {
+			if (delegateSupportsConnectionLostAsync || delegateSupportsConnectionLost) {
 				connectionLostDecision = [self _delegateDecisionForLostConnection];
 			}
 				// Otherwise default to reconnect, but only a set number of times to prevent a runaway loop

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1215,6 +1215,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		SPLog(@"NSThread currentThread] isCancelled, returning");
 
 		[self _unlockConnection];
+		if (proxy) proxyStateChangeNotificationsIgnored = NO;
 		reconnectingThread = NULL;
 		return NO;
 	}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -52,6 +52,14 @@ NSString * const SPMySQLConnectionLostInBackgroundNotification = @"SPMySQLConnec
 
 static void *SPMySQLReconnectQueueKey = &SPMySQLReconnectQueueKey;
 
+// Per-thread recursion depth for `_reconnectAllowingRetries:dispatchOnMainThread:`.
+// The method releases `reconnectingThread` before recursing into itself for a
+// delegate-driven retry, so an instance-wide counter could misclassify an
+// unrelated overlapping recovery as an inner frame. A thread-local counter
+// only counts true self-recursion, so each thread's outermost call is
+// independently identified and emits `connectionRestoredAfterLoss:` once.
+static __thread NSUInteger SPMySQLReconnectFrameDepthTLS = 0;
+
 static BOOL SPHostIsLoopbackIPv4Address(NSString *normalizedHost)
 {
 	struct in_addr ipv4Address;
@@ -1108,6 +1116,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 	BOOL reconnectSucceeded = NO;
 	BOOL delegateReconnectDecisionRequested = NO;
 	BOOL wasLostInBackground = NO;
+	BOOL isOuterReconnectFrame = NO;
 
 	@autoreleasepool {
 		// Check whether a reconnection attempt is already being made - if so, wait
@@ -1176,52 +1185,72 @@ asm(".desc ___crashreporter_info__, 0x10");
 		// the lost-state flag stays set and the next user action shows an
 		// unnecessary reconnect/disconnect sheet.
 		wasLostInBackground = (state == SPMySQLConnectionLostInBackground);
-		reconnectSucceeded = [self _silentReconnectAttempt];
 
-		// If the connection failed and the connection is permitted to retry,
-		// then retry the reconnection.
-		if (!reconnectSucceeded && canRetry && ![[NSThread currentThread] isCancelled]) {
+		// Thread-local recursion depth ensures the restoration callback fires
+		// exactly once per overall recovery on a given thread, even when a
+		// delegate-driven retry recurses into this method. Two unrelated
+		// recoveries on different threads each see depth 1 and stay independent
+		// because TLS storage is per-thread.
+		SPMySQLReconnectFrameDepthTLS++;
+		isOuterReconnectFrame = (SPMySQLReconnectFrameDepthTLS == 1);
 
-			// Default to attempting another reconnect
-			SPMySQLConnectionLostDecision connectionLostDecision = SPMySQLConnectionLostReconnect;
+		// `@try/@finally` guarantees the TLS depth decrement and
+		// `reconnectingThread` release run on every exit path including any
+		// Objective-C exception propagating out of `_silentReconnectAttempt`
+		// or the delegate decision callback. The restoration callback itself
+		// is fired AFTER the finally block so the cleanup runs first.
+		@try {
+			reconnectSucceeded = [self _silentReconnectAttempt];
 
-			// If the delegate supports the decision process, ask it how to proceed
-			if (delegateSupportsConnectionLostAsync || delegateSupportsConnectionLost) {
-				connectionLostDecision = [self _delegateDecisionForLostConnection];
-				delegateReconnectDecisionRequested = (connectionLostDecision == SPMySQLConnectionLostReconnect);
-			}
-				// Otherwise default to reconnect, but only a set number of times to prevent a runaway loop
-			else {
-				if (reconnectionRetryAttempts < 5) {
-					connectionLostDecision = SPMySQLConnectionLostReconnect;
-				} else {
-					connectionLostDecision = SPMySQLConnectionLostDisconnect;
+			// If the connection failed and the connection is permitted to retry,
+			// then retry the reconnection.
+			if (!reconnectSucceeded && canRetry && ![[NSThread currentThread] isCancelled]) {
+
+				// Default to attempting another reconnect
+				SPMySQLConnectionLostDecision connectionLostDecision = SPMySQLConnectionLostReconnect;
+
+				// If the delegate supports the decision process, ask it how to proceed
+				if (delegateSupportsConnectionLostAsync || delegateSupportsConnectionLost) {
+					connectionLostDecision = [self _delegateDecisionForLostConnection];
+					delegateReconnectDecisionRequested = (connectionLostDecision == SPMySQLConnectionLostReconnect);
 				}
-				reconnectionRetryAttempts++;
-			}
-
-			switch (connectionLostDecision) {
-				case SPMySQLConnectionLostDisconnect:
-					[self _updateLastErrorMessage:NSLocalizedString(@"User triggered disconnection", @"User triggered disconnection")];
-					userTriggeredDisconnect = YES;
-					break;
-
-					// By default attempt a reconnect
-				default:
-					@synchronized (self) {
-						if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
-							reconnectingThread = NULL;
-						}
+					// Otherwise default to reconnect, but only a set number of times to prevent a runaway loop
+				else {
+					if (reconnectionRetryAttempts < 5) {
+						connectionLostDecision = SPMySQLConnectionLostReconnect;
+					} else {
+						connectionLostDecision = SPMySQLConnectionLostDisconnect;
 					}
-                    SPLog(@"_reconnectAllowingRetries By default attempt a reconnect");
-					reconnectSucceeded = [self _reconnectAllowingRetries:YES dispatchOnMainThread:dispatchOnMainThread];
+					reconnectionRetryAttempts++;
+				}
+
+				switch (connectionLostDecision) {
+					case SPMySQLConnectionLostDisconnect:
+						[self _updateLastErrorMessage:NSLocalizedString(@"User triggered disconnection", @"User triggered disconnection")];
+						userTriggeredDisconnect = YES;
+						break;
+
+						// By default attempt a reconnect
+					default:
+						@synchronized (self) {
+							if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
+								reconnectingThread = NULL;
+							}
+						}
+	                    SPLog(@"_reconnectAllowingRetries By default attempt a reconnect");
+						reconnectSucceeded = [self _reconnectAllowingRetries:YES dispatchOnMainThread:dispatchOnMainThread];
+				}
 			}
 		}
-	}
-
-	@synchronized (self) {
-		if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
-			reconnectingThread = NULL;
+		@finally {
+			@synchronized (self) {
+				if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
+					reconnectingThread = NULL;
+				}
+			}
+			if (SPMySQLReconnectFrameDepthTLS > 0) {
+				SPMySQLReconnectFrameDepthTLS--;
+			}
 		}
 	}
 	// Fire the restoration callback when EITHER:
@@ -1231,7 +1260,10 @@ asm(".desc ___crashreporter_info__, 0x10");
 	// Case (b) is needed so observers like SPDatabaseDocument can clear their
 	// own backgroundConnectionLost flag instead of waiting for a delegate path
 	// that silent recovery never triggers.
-	if (reconnectSucceeded
+	// Restricted to the outermost frame so a recursive delegate-driven retry
+	// emits the callback once for the whole recovery rather than once per depth.
+	if (isOuterReconnectFrame
+	    && reconnectSucceeded
 	    && (delegateReconnectDecisionRequested || wasLostInBackground)
 	    && delegateSupportsConnectionRestoredAfterLoss) {
 		[delegate connectionRestoredAfterLoss:self];

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1053,7 +1053,15 @@ asm(".desc ___crashreporter_info__, 0x10");
  */
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry
 {
-	return [self _reconnectAllowingRetries:canRetry dispatchOnMainThread:YES];
+	// Default to synchronous semantics (dispatchOnMainThread:NO) so existing
+	// in-tree callers — cancelCurrentQuery, _pingConnectionUsingLoopDelay,
+	// checkConnectionIfNecessary (worker path), Max Packet Size renegotiation —
+	// keep getting a reconnect that actually completes before returning. They
+	// follow the pattern `_unlockConnection → reconnect → _lockConnection` and
+	// depend on the reset being done before the next line runs. The two-argument
+	// form remains available for callers that explicitly want main-thread
+	// fast-return semantics (none exist in-tree today).
+	return [self _reconnectAllowingRetries:canRetry dispatchOnMainThread:NO];
 }
 
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry dispatchOnMainThread:(BOOL)dispatchOnMainThread
@@ -1076,6 +1084,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	BOOL reconnectSucceeded = NO;
 	BOOL delegateReconnectDecisionRequested = NO;
+	BOOL wasLostInBackground = NO;
 
 	@autoreleasepool {
 		// Check whether a reconnection attempt is already being made - if so, wait
@@ -1127,6 +1136,14 @@ asm(".desc ___crashreporter_info__, 0x10");
 			return NO;
 		}
 
+		// Capture whether we are recovering from a background-loss state BEFORE
+		// the silent attempt resets it. App-layer observers (e.g.
+		// SPDatabaseDocument.backgroundConnectionLost) need a restoration
+		// callback even when the silent worker-thread reconnect succeeds on
+		// its own (without ever asking the delegate for a decision), otherwise
+		// the lost-state flag stays set and the next user action shows an
+		// unnecessary reconnect/disconnect sheet.
+		wasLostInBackground = (state == SPMySQLConnectionLostInBackground);
 		reconnectSucceeded = [self _silentReconnectAttempt];
 
 		// If the connection failed and the connection is permitted to retry,
@@ -1175,7 +1192,16 @@ asm(".desc ___crashreporter_info__, 0x10");
 			reconnectingThread = NULL;
 		}
 	}
-	if (reconnectSucceeded && delegateReconnectDecisionRequested && delegateSupportsConnectionRestoredAfterLoss) {
+	// Fire the restoration callback when EITHER:
+	// (a) the delegate was asked for a decision and chose Reconnect (existing),
+	// (b) the silent worker-thread attempt recovered from a prior
+	//     SPMySQLConnectionLostInBackground state (no delegate was asked).
+	// Case (b) is needed so observers like SPDatabaseDocument can clear their
+	// own backgroundConnectionLost flag instead of waiting for a delegate path
+	// that silent recovery never triggers.
+	if (reconnectSucceeded
+	    && (delegateReconnectDecisionRequested || wasLostInBackground)
+	    && delegateSupportsConnectionRestoredAfterLoss) {
 		[delegate connectionRestoredAfterLoss:self];
 	}
 	return reconnectSucceeded;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1125,7 +1125,16 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 			// Loop in a panel runloop mode until the reconnection has processed; if an iteration
 			// takes less than the requested 0.1s, sleep instead.
-			while (reconnectingThread) {
+			// Re-check `reconnectingThread` under the same lock that protects all
+			// writes (the claim/release in this method and in `_silentReconnectAttempt`)
+			// so the waiter cannot observe stale ownership and spin forever.
+			while (1) {
+				BOOL reconnectInFlight = NO;
+				@synchronized (self) {
+					reconnectInFlight = (reconnectingThread != NULL);
+				}
+				if (!reconnectInFlight) break;
+
                 SPLog(@"a reconnection attempt is already being made, waiting");
 
 				uint64_t loopIterationStart_t = _monotonicTime();
@@ -1244,7 +1253,14 @@ asm(".desc ___crashreporter_info__, 0x10");
 	BOOL encodingUsesLatin1TransportToRestoreForAttempt = encodingUsesLatin1Transport;
 	NSString *timeZoneIdentifierToRestore = nil;
 
-	reconnectingThread = pthread_self();
+	// All writes to `reconnectingThread` must go through `@synchronized (self)`
+	// — the waiter loop in `_reconnectAllowingRetries:` polls this variable to
+	// detect an in-flight reconnect attempt and decide when to stop spinning.
+	// An unsynchronized write here lets the waiter observe stale ownership and
+	// spin indefinitely.
+	@synchronized (self) {
+		reconnectingThread = pthread_self();
+	}
 
 	// Store certain details about the connection, so that if the reconnection is successful
 	// they can be restored.  This has to be treated separately from _restoreConnectionDetails
@@ -1273,7 +1289,11 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 		[self _unlockConnection];
 		if (proxy) proxyStateChangeNotificationsIgnored = NO;
-		reconnectingThread = NULL;
+		// Pair with the synchronized claim above so the waiter observes the
+		// release without spinning on stale ownership.
+		@synchronized (self) {
+			reconnectingThread = NULL;
+		}
 		return NO;
 	}
 
@@ -1437,9 +1457,23 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 - (void)_postLostInBackgroundNotification
 {
-	if (lostInBackgroundNotificationPosted) return;
+	// Check-and-set the coalescing flag atomically. Multiple background sources
+	// (keepalive ping, SSH proxy state change) can race into this method, and
+	// `_setConnectionState:` can concurrently clear the flag on a worker-thread
+	// reconnect path. Without the lock, two callers could both observe NO and
+	// both post; or a clear could land between the check and the set and we'd
+	// miss the next legitimate post.
+	// Notification + delegate dispatch happen OUTSIDE the lock so observers
+	// that take other locks cannot deadlock against us.
+	BOOL shouldPost = NO;
+	@synchronized (self) {
+		if (!lostInBackgroundNotificationPosted) {
+			lostInBackgroundNotificationPosted = YES;
+			shouldPost = YES;
+		}
+	}
+	if (!shouldPost) return;
 
-	lostInBackgroundNotificationPosted = YES;
 	[[NSNotificationCenter defaultCenter] postNotificationName:SPMySQLConnectionLostInBackgroundNotification object:self];
 
 	if (delegateSupportsConnectionLostBackground) {
@@ -1449,11 +1483,17 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 - (void)_setConnectionState:(SPMySQLConnectionState)newState
 {
-	if (state == SPMySQLConnectionLostInBackground && newState != SPMySQLConnectionLostInBackground) {
-		lostInBackgroundNotificationPosted = NO;
-	}
+	// Mutate `state` and the coalescing flag under one lock so an interleaving
+	// `_postLostInBackgroundNotification` cannot see the flag cleared with
+	// state still reading as LostInBackground (or vice versa). Same lock as
+	// `_postLostInBackgroundNotification`.
+	@synchronized (self) {
+		if (state == SPMySQLConnectionLostInBackground && newState != SPMySQLConnectionLostInBackground) {
+			lostInBackgroundNotificationPosted = NO;
+		}
 
-	state = newState;
+		state = newState;
+	}
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1077,7 +1077,15 @@ asm(".desc ___crashreporter_info__, 0x10");
 		// Check whether a reconnection attempt is already being made - if so, wait
 		// and return the status of that reconnection attempt.  This improves threaded
 		// use of the connection by preventing reconnect races.
-		if (reconnectingThread && !pthread_equal(reconnectingThread, pthread_self())) {
+		BOOL shouldWaitForReconnect = NO;
+		@synchronized (self) {
+			shouldWaitForReconnect = (reconnectingThread && !pthread_equal(reconnectingThread, pthread_self()));
+			if (!reconnectingThread) {
+				reconnectingThread = pthread_self();
+			}
+		}
+
+		if (shouldWaitForReconnect) {
 
 			// Loop in a panel runloop mode until the reconnection has processed; if an iteration
 			// takes less than the requested 0.1s, sleep instead.
@@ -1096,11 +1104,22 @@ asm(".desc ___crashreporter_info__, 0x10");
 			if (!(state == SPMySQLConnectionLostInBackground && canRetry)) {
 				return (state == SPMySQLConnected);
 			}
+
+			@synchronized (self) {
+				if (!reconnectingThread) {
+					reconnectingThread = pthread_self();
+				}
+			}
 		}
 
 		if ([[NSThread currentThread] isCancelled]) {
             SPLog(@"NSThread currentThread] isCancelled, returning");
 
+			@synchronized (self) {
+				if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
+					reconnectingThread = NULL;
+				}
+			}
 			return NO;
 		}
 
@@ -1135,14 +1154,22 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 					// By default attempt a reconnect
 				default:
-					reconnectingThread = NULL;
+					@synchronized (self) {
+						if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
+							reconnectingThread = NULL;
+						}
+					}
                     SPLog(@"_reconnectAllowingRetries By default attempt a reconnect");
 					reconnectSucceeded = [self _reconnectAllowingRetries:YES dispatchOnMainThread:dispatchOnMainThread];
 			}
 		}
 	}
 
-	reconnectingThread = NULL;
+	@synchronized (self) {
+		if (reconnectingThread && pthread_equal(reconnectingThread, pthread_self())) {
+			reconnectingThread = NULL;
+		}
+	}
 	return reconnectSucceeded;
 }
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionDelegate.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionDelegate.h
@@ -95,12 +95,30 @@
 
 /**
  * Notifies the delegate that the connection has been temporarily lost,
- * and asks the delegate for guidance on how to proceed.  If the delegate
- * does not implement this method, reconnections will automatically be
- * attempted - up to a small limit of attempts.
+ * and asks the delegate for guidance on how to proceed. This synchronous
+ * callback is deprecated and is only used as a worker-thread fallback.
  *
  * @param connection The connection instance that requires a decision on how to proceed
  */
-- (SPMySQLConnectionLostDecision)connectionLost:(id)connection;
+- (SPMySQLConnectionLostDecision)connectionLost:(id)connection
+	DEPRECATED_MSG_ATTRIBUTE("Use connectionLost:completion: instead. Old API is no longer called from the main thread.");
+
+/**
+ * Notifies the delegate that the connection has been temporarily lost and asks
+ * asynchronously for guidance on how to proceed. The completion may be called
+ * from any thread.
+ *
+ * @param connection The connection instance that requires a decision on how to proceed
+ * @param completion The completion block to call with the selected decision
+ */
+- (void)connectionLost:(id)connection completion:(void (^)(SPMySQLConnectionLostDecision decision))completion;
+
+/**
+ * Notifies the delegate that a background-only connection loss was detected.
+ * This callback is informational and must not request a reconnect decision.
+ *
+ * @param connection The connection instance which lost the connection in the background
+ */
+- (void)connectionLostInBackground:(id)connection;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionDelegate.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionDelegate.h
@@ -114,6 +114,14 @@
 - (void)connectionLost:(id)connection completion:(void (^)(SPMySQLConnectionLostDecision decision))completion;
 
 /**
+ * Notifies the delegate that a previously lost connection has been restored
+ * after the lost-connection decision flow completed with a reconnect.
+ *
+ * @param connection The connection instance which restored the connection
+ */
+- (void)connectionRestoredAfterLoss:(id)connection;
+
+/**
  * Notifies the delegate that a background-only connection loss was detected.
  * This callback is informational and must not request a reconnect decision.
  *

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConstants.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConstants.h
@@ -50,6 +50,10 @@ typedef enum {
 	SPMySQLConnectionLostReconnect  = 1
 } SPMySQLConnectionLostDecision;
 
+// Posted with the SPMySQLConnection instance as the object when a background-only
+// connection loss is detected without asking the delegate for a reconnect decision.
+extern NSString * const SPMySQLConnectionLostInBackgroundNotification;
+
 // Result set row types
 typedef enum {
 	SPMySQLResultRowAsDefault    = 0,

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConstants.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConstants.h
@@ -28,6 +28,8 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
+#import <Foundation/Foundation.h>
+
 // Connection state
 typedef enum {
 	SPMySQLDisconnected               = 0,

--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -1077,6 +1077,27 @@
 /* description for disconnected notification */
 "Disconnected from %@" = "Disconnected from %@";
 
+/* connection lost alert title */
+"Connection Lost" = "Connection Lost";
+
+/* connection lost alert message */
+"This tab's connection to the database was lost. Reconnect to continue?" = "This tab's connection to the database was lost. Reconnect to continue?";
+
+/* connection lost reconnect button */
+"Reconnect" = "Reconnect";
+
+/* connection lost disconnect button */
+"Disconnect" = "Disconnect";
+
+/* connection lost reconnect failure alert title */
+"Reconnect Failed" = "Reconnect Failed";
+
+/* connection lost reconnect failure alert message */
+"Sequel Ace could not reconnect this tab's database connection." = "Sequel Ace could not reconnect this tab's database connection.";
+
+/* connection lost retry button */
+"Retry" = "Retry";
+
 /* do update operator tooltip */
 "Do UPDATE where field contents match" = "Do UPDATE where field contents match";
 

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setBackgroundConnectionLostForGate:(BOOL)lost;
 - (BOOL)showConnectionLostSheetAllowingCancelForGate:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion;
 - (BOOL)reconnectConnectionForGate;
+- (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion;
 - (void)closeAndDisconnectForGate;
 
 @end

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
@@ -1,0 +1,27 @@
+//
+//  SAMultiTabConnectionLostGate.h
+//  sequel-ace
+//
+
+#import <Foundation/Foundation.h>
+#import <SPMySQL/SPMySQL.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SAMultiTabConnectionLostGateHandler <NSObject>
+
+- (BOOL)backgroundConnectionLostForGate;
+- (void)setBackgroundConnectionLostForGate:(BOOL)lost;
+- (BOOL)showConnectionLostSheetAllowingCancelForGate:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion;
+- (BOOL)reconnectConnectionForGate;
+- (void)closeAndDisconnectForGate;
+
+@end
+
+@interface SAMultiTabConnectionLostGate : NSObject
+
++ (void)runAction:(void (^ _Nullable)(void))action forHandler:(id<SAMultiTabConnectionLostGateHandler>)handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.h
@@ -14,6 +14,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setBackgroundConnectionLostForGate:(BOOL)lost;
 - (BOOL)showConnectionLostSheetAllowingCancelForGate:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion;
 - (BOOL)reconnectConnectionForGate;
+
+/// YES iff the user clicked the Disconnect button in the framework's
+/// lost-connection sheet during the just-finished `reconnectConnectionForGate`
+/// attempt. Implementations MUST distinguish a genuine button-click from the
+/// non-user defaults the framework also maps to its Disconnect enum (timeout,
+/// no-window fallback, main-thread suppression, retry exhaustion).
+///
+/// Implementations that report YES MUST have already performed the close
+/// (typically inside the framework's `-connectionLost:completion:` handler).
+/// The gate uses this signal to skip a redundant Retry/Disconnect prompt AND
+/// to avoid calling `closeAndDisconnectForGate` a second time, so the close
+/// flow runs exactly once per user click.
+- (BOOL)connectionGateUserChoseDisconnect;
+
 - (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion;
 - (void)closeAndDisconnectForGate;
 

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
@@ -25,6 +25,18 @@
 					if (reconnected) {
 						[handler setBackgroundConnectionLostForGate:NO];
 						if (action) action();
+					} else {
+						BOOL failureShown = [handler presentReconnectFailureAllowingRetryForGate:^(BOOL retry) {
+							if (retry) {
+								[self runAction:action forHandler:handler];
+							} else {
+								[handler closeAndDisconnectForGate];
+							}
+						}];
+
+						if (!failureShown) {
+							[handler closeAndDisconnectForGate];
+						}
 					}
 				});
 			});

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
@@ -14,7 +14,7 @@
 		return;
 	}
 
-	[handler showConnectionLostSheetAllowingCancelForGate:YES completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
+	BOOL sheetShown = [handler showConnectionLostSheetAllowingCancelForGate:YES completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
 		if (cancelled) return;
 
 		if (decision == SPMySQLConnectionLostReconnect) {
@@ -32,6 +32,10 @@
 			[handler closeAndDisconnectForGate];
 		}
 	}];
+
+	if (!sheetShown) {
+		[handler closeAndDisconnectForGate];
+	}
 }
 
 @end

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
@@ -1,0 +1,37 @@
+//
+//  SAMultiTabConnectionLostGate.m
+//  sequel-ace
+//
+
+#import "SAMultiTabConnectionLostGate.h"
+
+@implementation SAMultiTabConnectionLostGate
+
++ (void)runAction:(void (^ _Nullable)(void))action forHandler:(id<SAMultiTabConnectionLostGateHandler>)handler
+{
+	if (![handler backgroundConnectionLostForGate]) {
+		if (action) action();
+		return;
+	}
+
+	[handler showConnectionLostSheetAllowingCancelForGate:YES completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
+		if (cancelled) return;
+
+		if (decision == SPMySQLConnectionLostReconnect) {
+			dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+				BOOL reconnected = [handler reconnectConnectionForGate];
+
+				dispatch_async(dispatch_get_main_queue(), ^{
+					if (reconnected) {
+						[handler setBackgroundConnectionLostForGate:NO];
+						if (action) action();
+					}
+				});
+			});
+		} else if (decision == SPMySQLConnectionLostDisconnect) {
+			[handler closeAndDisconnectForGate];
+		}
+	}];
+}
+
+@end

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
@@ -41,6 +41,20 @@
 				return;
 			}
 
+			// Honor a Disconnect already chosen by the user inside the framework's
+			// async lost-connection sheet (which the underlying `-reconnect` ran
+			// on the worker thread). The handler's own delegate path
+			// (`-connectionLost:completion:`) already closes the document on the
+			// user's Disconnect click, so do NOT call `closeAndDisconnectForGate`
+			// here — that would invoke `-closeAndDisconnect` a second time, which
+			// is non-idempotent (window close is rescheduled, query history is
+			// re-persisted, and the `wasConnected` branch flips). Showing another
+			// Retry/Disconnect prompt would also contradict the user's choice
+			// and even let them "retry" past it.
+			if ([handler connectionGateUserChoseDisconnect]) {
+				return;
+			}
+
 			BOOL failureShown = [handler presentReconnectFailureAllowingRetryForGate:^(BOOL retry) {
 				if (retry) {
 					[self _attemptReconnectForAction:action handler:handler];

--- a/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
+++ b/Source/Controllers/MainViewControllers/SAMultiTabConnectionLostGate.m
@@ -18,28 +18,7 @@
 		if (cancelled) return;
 
 		if (decision == SPMySQLConnectionLostReconnect) {
-			dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-				BOOL reconnected = [handler reconnectConnectionForGate];
-
-				dispatch_async(dispatch_get_main_queue(), ^{
-					if (reconnected) {
-						[handler setBackgroundConnectionLostForGate:NO];
-						if (action) action();
-					} else {
-						BOOL failureShown = [handler presentReconnectFailureAllowingRetryForGate:^(BOOL retry) {
-							if (retry) {
-								[self runAction:action forHandler:handler];
-							} else {
-								[handler closeAndDisconnectForGate];
-							}
-						}];
-
-						if (!failureShown) {
-							[handler closeAndDisconnectForGate];
-						}
-					}
-				});
-			});
+			[self _attemptReconnectForAction:action handler:handler];
 		} else if (decision == SPMySQLConnectionLostDisconnect) {
 			[handler closeAndDisconnectForGate];
 		}
@@ -48,6 +27,33 @@
 	if (!sheetShown) {
 		[handler closeAndDisconnectForGate];
 	}
+}
+
++ (void)_attemptReconnectForAction:(void (^ _Nullable)(void))action handler:(id<SAMultiTabConnectionLostGateHandler>)handler
+{
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		BOOL reconnected = [handler reconnectConnectionForGate];
+
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (reconnected) {
+				[handler setBackgroundConnectionLostForGate:NO];
+				if (action) action();
+				return;
+			}
+
+			BOOL failureShown = [handler presentReconnectFailureAllowingRetryForGate:^(BOOL retry) {
+				if (retry) {
+					[self _attemptReconnectForAction:action handler:handler];
+				} else {
+					[handler closeAndDisconnectForGate];
+				}
+			}];
+
+			if (!failureShown) {
+				[handler closeAndDisconnectForGate];
+			}
+		});
+	});
 }
 
 @end

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -183,6 +183,13 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
  */
 - (IBAction)runAllQueries:(id)sender
 {
+    [tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+        [self _runAllQueriesAfterConnectionCheck:sender];
+    }];
+}
+
+- (void)_runAllQueriesAfterConnectionCheck:(id)sender
+{
     SPSQLParser *queryParser;
     NSArray		*queries;
     
@@ -227,6 +234,13 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
  * at a single point within the text view), or run the selected text (if a text range is selected).
  */
 - (IBAction)runSelectedQueries:(id)sender
+{
+    [tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+        [self _runSelectedQueriesAfterConnectionCheck:sender];
+    }];
+}
+
+- (void)_runSelectedQueriesAfterConnectionCheck:(id)sender
 {
     NSArray *queries;
     NSRange selectedRange = [textView selectedRange];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -180,6 +180,7 @@
 	NSMenu *selectEncodingMenu;
 	BOOL _supportsEncoding;
 	BOOL _isConnected;
+	BOOL backgroundConnectionLost;
 	NSInteger _isWorkingLevel;
 	BOOL _mainNibLoaded;
 	BOOL databaseListIsSelectable;
@@ -277,6 +278,7 @@
 // Connection callback and methods
 - (void)setConnection:(SPMySQLConnection *)theConnection;
 - (SPMySQLConnection *)getConnection;
+- (void)checkForBackgroundConnectionLossThenRun:(void (^ _Nullable)(void))action;
 
 // Database methods
 - (IBAction)chooseDatabase:(id)sender;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -136,6 +136,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 - (NSString *)keychainPasswordForSSHConnection:(SPMySQLConnection *)connection;
 - (void)_mysqlConnectionLostInBackground:(NSNotification *)notification;
 - (BOOL)_showConnectionLostSheetAllowingCancel:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion;
+- (BOOL)_showReconnectFailureSheetWithCompletion:(void (^)(BOOL retry))completion;
 
 @end
 
@@ -6118,6 +6119,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     return [mySQLConnection reconnect];
 }
 
+- (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion
+{
+    return [self _showReconnectFailureSheetWithCompletion:completion];
+}
+
 - (void)closeAndDisconnectForGate
 {
     [self closeAndDisconnect];
@@ -6160,6 +6166,32 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             : SPMySQLConnectionLostDisconnect;
 
         if (completion) completion(decision, NO);
+    }];
+
+    return YES;
+}
+
+- (BOOL)_showReconnectFailureSheetWithCompletion:(void (^)(BOOL retry))completion
+{
+    NSWindow *parentWindow = [self.parentWindowController window];
+
+    if (!parentWindow || ![parentWindow isVisible] || appIsTerminating) {
+        return NO;
+    }
+
+    if ([parentWindow isMiniaturized]) {
+        [parentWindow deminiaturize:self];
+    }
+    [[self parentWindowControllerWindow] orderWindow:NSWindowAbove relativeTo:0];
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:NSLocalizedString(@"Reconnect Failed", @"connection lost reconnect failure alert title")];
+    [alert setInformativeText:NSLocalizedString(@"Sequel Ace could not reconnect this tab's database connection.", @"connection lost reconnect failure alert message")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Retry", @"connection lost retry button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Disconnect", @"connection lost disconnect button")];
+
+    [alert beginSheetModalForWindow:parentWindow completionHandler:^(NSModalResponse returnCode) {
+        if (completion) completion(returnCode == NSAlertFirstButtonReturn);
     }];
 
     return YES;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -108,6 +108,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 @property (nonatomic, strong) NSImage *textAndCommandMacwindowImage API_AVAILABLE(macos(11.0));
 @property (nonatomic, weak, readwrite) SPWindowController *parentWindowController;
 @property (assign) BOOL appIsTerminating;
+@property (atomic, assign) BOOL backgroundConnectionLost;
 
 @property (readwrite, nonatomic, strong) NSToolbar *mainToolbar;
 
@@ -132,6 +133,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 - (NSString *)keychainPasswordForConnection:(SPMySQLConnection *)connection;
 - (NSString *)keychainPasswordForSSHConnection:(SPMySQLConnection *)connection;
+- (void)_mysqlConnectionLostInBackground:(NSNotification *)notification;
+- (BOOL)_showConnectionLostSheetAllowingCancel:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion;
 
 @end
 
@@ -156,6 +159,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 @synthesize textAndCommandMacwindowImage;
 @synthesize appIsTerminating;
 @synthesize multipleLineEditingButton;
+@synthesize backgroundConnectionLost;
 
 #pragma mark -
 
@@ -170,6 +174,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
         _mainNibLoaded = NO;
         _isConnected = NO;
+        backgroundConnectionLost = NO;
         _isWorkingLevel = 0;
         _isSavedInBundle = NO;
         _supportsEncoding = NO;
@@ -409,7 +414,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     _isConnected = YES;
+    self.backgroundConnectionLost = NO;
     mySQLConnection = theConnection;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:SPMySQLConnectionLostInBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_mysqlConnectionLostInBackground:)
+                                                 name:SPMySQLConnectionLostInBackgroundNotification
+                                               object:mySQLConnection];
 
     // Now that we have a connection, determine what functionality the database supports.
     // Note that this must be done before anything else as it's used by nearly all of the main controllers.
@@ -6047,40 +6058,103 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 /**
  * Invoked when the connection fails and the framework needs to know how to proceed.
  */
-- (SPMySQLConnectionLostDecision)connectionLost:(id)connection
+- (void)connectionLost:(id)connection completion:(void (^)(SPMySQLConnectionLostDecision decision))completion
 {
-
     SPLog(@"connectionLost");
 
-    SPMySQLConnectionLostDecision connectionErrorCode = SPMySQLConnectionLostDisconnect;
-
-    // Only display the reconnect dialog if the window is visible
-    // and we are not terminating
-    if ([self.parentWindowController window] && [[self.parentWindowController window] isVisible] && appIsTerminating == NO) {
-
-        SPLog(@"not terminating, parentWindow isVisible, showing connectionErrorDialog");
-        // Ensure the window isn't miniaturized
-        if ([[self.parentWindowController window] isMiniaturized]) {
-            [[self.parentWindowController window] deminiaturize:self];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (![self _showConnectionLostSheetAllowingCancel:NO completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
+            if (decision == SPMySQLConnectionLostDisconnect) {
+                [self closeAndDisconnect];
+            }
+            if (completion) completion(decision);
+        }]) {
+            if (completion) completion(SPMySQLConnectionLostDisconnect);
         }
-        [[self parentWindowControllerWindow] orderWindow:NSWindowAbove relativeTo:0];
+    });
+}
 
-        // Display the connection error dialog and wait for the return code
-        [[self.parentWindowController window] beginSheet:connectionErrorDialog completionHandler:nil];
-        connectionErrorCode = (SPMySQLConnectionLostDecision)[NSApp runModalForWindow:connectionErrorDialog];
+- (void)connectionLostInBackground:(id)connection
+{
+    if (connection != mySQLConnection) return;
 
-        [NSApp endSheet:connectionErrorDialog];
-        [connectionErrorDialog orderOut:nil];
+    self.backgroundConnectionLost = YES;
+}
 
-        queryStartDate = [[NSDate alloc] init];
+- (void)_mysqlConnectionLostInBackground:(NSNotification *)notification
+{
+    if ([notification object] != mySQLConnection) return;
 
-        // If 'disconnect' was selected, trigger a window close.
-        if (connectionErrorCode == SPMySQLConnectionLostDisconnect) {
-            [self performSelectorOnMainThread:@selector(closeAndDisconnect) withObject:nil waitUntilDone:YES];
-        }
+    self.backgroundConnectionLost = YES;
+}
+
+- (void)checkForBackgroundConnectionLossThenRun:(void (^ _Nullable)(void))action
+{
+    if (!self.backgroundConnectionLost) {
+        if (action) action();
+        return;
     }
 
-    return connectionErrorCode;
+    [self _showConnectionLostSheetAllowingCancel:YES completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
+        if (cancelled) return;
+
+        if (decision == SPMySQLConnectionLostReconnect) {
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+                BOOL reconnected = [self->mySQLConnection reconnect];
+
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (reconnected) {
+                        self.backgroundConnectionLost = NO;
+                        if (action) action();
+                    }
+                });
+            });
+        } else if (decision == SPMySQLConnectionLostDisconnect) {
+            [self closeAndDisconnect];
+        }
+    }];
+}
+
+- (BOOL)_showConnectionLostSheetAllowingCancel:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion
+{
+    NSWindow *parentWindow = [self.parentWindowController window];
+
+    // Only display the reconnect dialog if the window is visible and we are not terminating.
+    if (!parentWindow || ![parentWindow isVisible] || appIsTerminating) {
+        return NO;
+    }
+
+    SPLog(@"not terminating, parentWindow isVisible, showing connectionErrorDialog");
+    if ([parentWindow isMiniaturized]) {
+        [parentWindow deminiaturize:self];
+    }
+    [[self parentWindowControllerWindow] orderWindow:NSWindowAbove relativeTo:0];
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:NSLocalizedString(@"Connection Lost", @"connection lost alert title")];
+    [alert setInformativeText:NSLocalizedString(@"This tab's connection to the database was lost. Reconnect to continue?", @"connection lost alert message")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Reconnect", @"connection lost reconnect button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Disconnect", @"connection lost disconnect button")];
+    if (allowCancel) {
+        [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"connection lost cancel button")];
+    }
+
+    [alert beginSheetModalForWindow:parentWindow completionHandler:^(NSModalResponse returnCode) {
+        self->queryStartDate = [[NSDate alloc] init];
+
+        if (allowCancel && returnCode == NSAlertThirdButtonReturn) {
+            if (completion) completion(SPMySQLConnectionLostDisconnect, YES);
+            return;
+        }
+
+        SPMySQLConnectionLostDecision decision = (returnCode == NSAlertFirstButtonReturn)
+            ? SPMySQLConnectionLostReconnect
+            : SPMySQLConnectionLostDisconnect;
+
+        if (completion) completion(decision, NO);
+    }];
+
+    return YES;
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -907,7 +907,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Refreshes the tables list by calling SPTablesList's updateTables.
  */
 - (void)refreshTables {
-    [tablesListInstance updateTables:self];
+    [self checkForBackgroundConnectionLossThenRun:^{
+        [self->tablesListInstance updateTables:self];
+    }];
 }
 
 /**
@@ -2280,8 +2282,10 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Passes query to tablesListInstance
  */
 - (void)doPerformQueryService:(NSString *)query {
-    [self viewQuery];
-    [customQueryInstance doPerformQueryService:query];
+    [self checkForBackgroundConnectionLossThenRun:^{
+        [self viewQuery];
+        [self->customQueryInstance doPerformQueryService:query];
+    }];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -110,6 +110,14 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 @property (nonatomic, weak, readwrite) SPWindowController *parentWindowController;
 @property (assign) BOOL appIsTerminating;
 @property (atomic, assign) BOOL backgroundConnectionLost;
+// YES iff the user explicitly clicked the Disconnect button in the most
+// recently shown framework lost-connection sheet. Set from main thread inside
+// the sheet completion handler, reset from the multi-tab gate worker thread
+// at the start of every fresh `reconnectConnectionForGate` attempt. Atomic
+// so both read and write are torn-free; the narrow scope is "since the last
+// reconnect attempt started, did the user pick Disconnect in the framework's
+// sheet that just appeared?".
+@property (atomic, assign) BOOL userExplicitlyChoseDisconnectInLostSheet;
 
 @property (readwrite, nonatomic, strong) NSToolbar *mainToolbar;
 
@@ -6123,7 +6131,22 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 - (BOOL)reconnectConnectionForGate
 {
+    // Reset the sheet-level signal so it can only become YES via this attempt's
+    // own sheet completion. Without this reset, a leftover YES from a previous
+    // recovery would let the gate skip the failure sheet on an unrelated retry.
+    self.userExplicitlyChoseDisconnectInLostSheet = NO;
     return [mySQLConnection reconnect];
+}
+
+- (BOOL)connectionGateUserChoseDisconnect
+{
+    // Read the sheet-level signal that is only set when the user actually
+    // clicked the Disconnect button in the framework's lost-connection sheet.
+    // Non-user defaults (timeout, no-window fallback, main-thread suppression,
+    // retry exhaustion) all map to SPMySQLConnectionLostDisconnect inside the
+    // framework but never touch this flag, so the gate now distinguishes a
+    // real user choice from those silent defaults.
+    return self.userExplicitlyChoseDisconnectInLostSheet;
 }
 
 - (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion
@@ -6171,6 +6194,16 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         SPMySQLConnectionLostDecision decision = (returnCode == NSAlertFirstButtonReturn)
             ? SPMySQLConnectionLostReconnect
             : SPMySQLConnectionLostDisconnect;
+
+        // Record an explicit user-click only when this sheet's Disconnect button
+        // is the actual return code. Non-user defaults that map to Disconnect
+        // (sheet could not be shown, async timeout, main-thread suppression,
+        // retry exhaustion) never reach this completion block and therefore
+        // never set the flag, so the gate's "did the user just click Disconnect"
+        // check stays accurate.
+        if (decision == SPMySQLConnectionLostDisconnect) {
+            self.userExplicitlyChoseDisconnectInLostSheet = YES;
+        }
 
         if (completion) completion(decision, NO);
     }];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -6229,6 +6229,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void)closeAndDisconnect {
 
+    BOOL wasConnected = _isConnected;
     _isConnected = NO;
 
     [self.parentWindowControllerWindow orderOut:self];
@@ -6254,7 +6255,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                                                    object:nil];
     }
 
-    if (_isConnected) {
+    if (wasConnected) {
         [self closeConnection];
     } else {
         [connectionController cancelConnection:self];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -83,6 +83,7 @@
 #import "SPHelpViewerController.h"
 #import "SPPrintUtility.h"
 #import "SPBundleManager.h"
+#import "SAMultiTabConnectionLostGate.h"
 
 #import "sequel-ace-Swift.h"
 
@@ -97,7 +98,7 @@ static NSString *SPNewDatabaseCopyContent = @"SPNewDatabaseCopyContent";
 
 static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
-@interface SPDatabaseDocument () <SADatabaseSelectionDelegate>
+@interface SPDatabaseDocument () <SADatabaseSelectionDelegate, SAMultiTabConnectionLostGateHandler>
 
 // Privately redeclare as read/write to get the synthesized setter
 @property (readwrite, assign) BOOL allowSplitViewResizing;
@@ -6094,29 +6095,32 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
 - (void)checkForBackgroundConnectionLossThenRun:(void (^ _Nullable)(void))action
 {
-    if (!self.backgroundConnectionLost) {
-        if (action) action();
-        return;
-    }
+    [SAMultiTabConnectionLostGate runAction:action forHandler:self];
+}
 
-    [self _showConnectionLostSheetAllowingCancel:YES completion:^(SPMySQLConnectionLostDecision decision, BOOL cancelled) {
-        if (cancelled) return;
+- (BOOL)backgroundConnectionLostForGate
+{
+    return self.backgroundConnectionLost;
+}
 
-        if (decision == SPMySQLConnectionLostReconnect) {
-            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-                BOOL reconnected = [self->mySQLConnection reconnect];
+- (void)setBackgroundConnectionLostForGate:(BOOL)lost
+{
+    self.backgroundConnectionLost = lost;
+}
 
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    if (reconnected) {
-                        self.backgroundConnectionLost = NO;
-                        if (action) action();
-                    }
-                });
-            });
-        } else if (decision == SPMySQLConnectionLostDisconnect) {
-            [self closeAndDisconnect];
-        }
-    }];
+- (BOOL)showConnectionLostSheetAllowingCancelForGate:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion
+{
+    return [self _showConnectionLostSheetAllowingCancel:allowCancel completion:completion];
+}
+
+- (BOOL)reconnectConnectionForGate
+{
+    return [mySQLConnection reconnect];
+}
+
+- (void)closeAndDisconnectForGate
+{
+    [self closeAndDisconnect];
 }
 
 - (BOOL)_showConnectionLostSheetAllowingCancel:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -6087,6 +6087,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     self.backgroundConnectionLost = YES;
 }
 
+- (void)connectionRestoredAfterLoss:(id)connection
+{
+    if (connection != mySQLConnection) return;
+
+    self.backgroundConnectionLost = NO;
+}
+
 - (void)_mysqlConnectionLostInBackground:(NSNotification *)notification
 {
     if ([notification object] != mySQLConnection) return;

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -102,11 +102,13 @@ static NSString *SPMySQLCommentField          = @"Comment";
  */
 - (IBAction)reloadTable:(id)sender
 {
-	// Reset the table data's cache
-	[tableDataInstance resetAllData];
+	[tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+		// Reset the table data's cache
+		[self->tableDataInstance resetAllData];
 
-	// Load the new table info
-	[self loadTable:selectedTable];
+		// Load the new table info
+		[self loadTable:self->selectedTable];
+	}];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1253,6 +1253,13 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
  */
 - (IBAction)reloadTable:(id)sender
 {
+	[tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+		[self _reloadTableAfterConnectionCheck:sender];
+	}];
+}
+
+- (void)_reloadTableAfterConnectionCheck:(id)sender
+{
 	[tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Reloading data...", @"Reloading data task description")];
 
 	if ([NSThread isMainThread]) {

--- a/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
+++ b/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
@@ -325,7 +325,9 @@ static NSString *SPRelationOnDeleteKey   = @"on_delete";
  */
 - (IBAction)refreshRelations:(id)sender
 {
-	[self _refreshRelationDataForcingCacheRefresh:YES];
+	[tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+		[self _refreshRelationDataForcingCacheRefresh:YES];
+	}];
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1836,6 +1836,13 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
  */
 - (IBAction)reloadTable:(id)sender
 {
+	[tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+		[self _reloadTableAfterConnectionCheck:sender];
+	}];
+}
+
+- (void)_reloadTableAfterConnectionCheck:(id)sender
+{
 	// Check whether a save of the current row is required
 	if (![[self onMainThread] saveRowOnDeselect]) return;
 

--- a/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
+++ b/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
@@ -338,7 +338,9 @@ static SPTriggerEventTag TagForEvent(NSString *mysql);
  */
 - (IBAction)refreshTriggers:(id)sender
 {
-	[self _refreshTriggerDataForcingCacheRefresh:YES];
+	[tableDocumentInstance checkForBackgroundConnectionLossThenRun:^{
+		[self _refreshTriggerDataForcingCacheRefresh:YES];
+	}];
 }
 
 #pragma mark -

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -17,6 +17,7 @@
 @property (nonatomic) NSUInteger reconnectCount;
 @property (nonatomic) NSUInteger reconnectFailurePresentationCount;
 @property (nonatomic) NSUInteger closeAndDisconnectCount;
+@property (nonatomic, strong) NSMutableArray<NSNumber *> *queuedReconnectResults;
 @property (nonatomic, strong) XCTestExpectation *reconnectExpectation;
 @property (nonatomic, strong) XCTestExpectation *reconnectFailureExpectation;
 @property (nonatomic, copy) void (^capturedCompletion)(SPMySQLConnectionLostDecision decision, BOOL cancelled);
@@ -57,6 +58,11 @@
 {
 	self.reconnectCount++;
 	[self.reconnectExpectation fulfill];
+	if ([self.queuedReconnectResults count]) {
+		BOOL nextResult = [[self.queuedReconnectResults firstObject] boolValue];
+		[self.queuedReconnectResults removeObjectAtIndex:0];
+		return nextResult;
+	}
 	return self.reconnectResult;
 }
 
@@ -225,27 +231,60 @@
 	XCTAssertTrue(handler.backgroundConnectionLost);
 }
 
-- (void)testReconnectFailureRetryReentersGate
+- (void)testReconnectFailureRetryReconnectsDirectlyAndRunsAction
 {
 	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
 	handler.backgroundConnectionLost = YES;
-	handler.reconnectResult = NO;
+	handler.queuedReconnectResults = [@[@NO, @YES] mutableCopy];
 	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
 	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presented"];
-	__block NSUInteger actionCount = 0;
+	XCTestExpectation *actionExpectation = [self expectationWithDescription:@"action invoked"];
 
 	[SAMultiTabConnectionLostGate runAction:^{
-		actionCount++;
+		[actionExpectation fulfill];
 	} forHandler:handler];
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
-	[self waitForExpectationsWithTimeout:1 handler:nil];
+	[self waitForExpectations:@[handler.reconnectExpectation, handler.reconnectFailureExpectation] timeout:1];
 	handler.sheetShown = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"retry reconnect invoked"];
+	handler.reconnectFailureExpectation = nil;
 	handler.capturedReconnectFailureCompletion(YES);
 
-	XCTAssertTrue(handler.sheetShown);
-	XCTAssertEqual(actionCount, 0U);
+	[self waitForExpectations:@[handler.reconnectExpectation, actionExpectation] timeout:1];
+
+	XCTAssertFalse(handler.sheetShown);
+	XCTAssertEqual(handler.reconnectCount, 2U);
 	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+	XCTAssertFalse(handler.backgroundConnectionLost);
+}
+
+- (void)testReconnectFailureRetryDoesNotShowInitialSheet
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.queuedReconnectResults = [@[@NO, @YES] mutableCopy];
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presented"];
+	XCTestExpectation *actionExpectation = [self expectationWithDescription:@"action invoked"];
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		[actionExpectation fulfill];
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectations:@[handler.reconnectExpectation, handler.reconnectFailureExpectation] timeout:1];
+	handler.sheetShown = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"retry reconnect invoked"];
+	handler.reconnectFailureExpectation = nil;
+	handler.capturedReconnectFailureCompletion(YES);
+
+	[self waitForExpectations:@[handler.reconnectExpectation, actionExpectation] timeout:1];
+
+	XCTAssertFalse(handler.sheetShown);
+	XCTAssertEqual(handler.reconnectCount, 2U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+	XCTAssertFalse(handler.backgroundConnectionLost);
 }
 
 - (void)testReconnectFailureDisconnectCloses

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -1,0 +1,175 @@
+//
+//  SAMultiTabConnectionLostTests.m
+//  Unit Tests
+//
+
+#import <XCTest/XCTest.h>
+#import <SPMySQL/SPMySQL.h>
+#import "SAMultiTabConnectionLostGate.h"
+
+@interface SATestConnectionLostGateHandler : NSObject <SAMultiTabConnectionLostGateHandler>
+@property (nonatomic) BOOL backgroundConnectionLost;
+@property (nonatomic) BOOL sheetShown;
+@property (nonatomic) BOOL lastAllowCancel;
+@property (nonatomic) BOOL reconnectResult;
+@property (nonatomic) NSUInteger reconnectCount;
+@property (nonatomic) NSUInteger closeAndDisconnectCount;
+@property (nonatomic, strong) XCTestExpectation *reconnectExpectation;
+@property (nonatomic, copy) void (^capturedCompletion)(SPMySQLConnectionLostDecision decision, BOOL cancelled);
+- (void)observeBackgroundLossNotification:(NSNotification *)notification;
+@end
+
+@implementation SATestConnectionLostGateHandler
+
+- (BOOL)backgroundConnectionLostForGate
+{
+	return self.backgroundConnectionLost;
+}
+
+- (void)setBackgroundConnectionLostForGate:(BOOL)lost
+{
+	self.backgroundConnectionLost = lost;
+}
+
+- (BOOL)showConnectionLostSheetAllowingCancelForGate:(BOOL)allowCancel completion:(void (^)(SPMySQLConnectionLostDecision decision, BOOL cancelled))completion
+{
+	self.sheetShown = YES;
+	self.lastAllowCancel = allowCancel;
+	self.capturedCompletion = completion;
+	return YES;
+}
+
+- (BOOL)reconnectConnectionForGate
+{
+	self.reconnectCount++;
+	[self.reconnectExpectation fulfill];
+	return self.reconnectResult;
+}
+
+- (void)closeAndDisconnectForGate
+{
+	self.closeAndDisconnectCount++;
+}
+
+- (void)observeBackgroundLossNotification:(NSNotification *)notification
+{
+	self.backgroundConnectionLost = YES;
+}
+
+@end
+
+@interface SAMultiTabConnectionLostTests : XCTestCase
+@end
+
+@implementation SAMultiTabConnectionLostTests
+
+- (void)testFrameworkNotificationForOwnConnectionSetsBackgroundLossFlag
+{
+	SPMySQLConnection *connection = [[SPMySQLConnection alloc] init];
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:connection queue:nil usingBlock:^(NSNotification *note) {
+		[handler observeBackgroundLossNotification:note];
+	}];
+
+	[[NSNotificationCenter defaultCenter] postNotificationName:SPMySQLConnectionLostInBackgroundNotification object:connection];
+
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
+- (void)testFrameworkNotificationForOtherConnectionDoesNotSetBackgroundLossFlag
+{
+	SPMySQLConnection *ownConnection = [[SPMySQLConnection alloc] init];
+	SPMySQLConnection *otherConnection = [[SPMySQLConnection alloc] init];
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	id token = [[NSNotificationCenter defaultCenter] addObserverForName:SPMySQLConnectionLostInBackgroundNotification object:ownConnection queue:nil usingBlock:^(NSNotification *note) {
+		[handler observeBackgroundLossNotification:note];
+	}];
+
+	[[NSNotificationCenter defaultCenter] postNotificationName:SPMySQLConnectionLostInBackgroundNotification object:otherConnection];
+
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+	XCTAssertFalse(handler.backgroundConnectionLost);
+}
+
+- (void)testGateFastPathRunsActionSynchronouslyWithoutSheet
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+
+	XCTAssertEqual(actionCount, 1U);
+	XCTAssertFalse(handler.sheetShown);
+}
+
+- (void)testGateSlowPathShowsCancellableSheetAndDoesNotRunActionImmediately
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+
+	XCTAssertTrue(handler.sheetShown);
+	XCTAssertTrue(handler.lastAllowCancel);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertNotNil(handler.capturedCompletion);
+}
+
+- (void)testReconnectCompletionClearsFlagAndRunsAction
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = YES;
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	XCTestExpectation *actionExpectation = [self expectationWithDescription:@"action invoked"];
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		[actionExpectation fulfill];
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(handler.reconnectCount, 1U);
+	XCTAssertFalse(handler.backgroundConnectionLost);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+}
+
+- (void)testDisconnectCompletionClosesWithoutRunningAction
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostDisconnect, NO);
+
+	XCTAssertEqual(handler.closeAndDisconnectCount, 1U);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
+- (void)testCancelCompletionDoesNotRunActionAndLeavesFlagSet
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostDisconnect, YES);
+
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
+@end

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -202,6 +202,29 @@
 	XCTAssertTrue(handler.backgroundConnectionLost);
 }
 
+- (void)testReconnectFailureClosesWhenFailureSheetCannotBePresented
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = NO;
+	handler.reconnectFailurePresentationResult = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presentation attempted"];
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(handler.reconnectCount, 1U);
+	XCTAssertEqual(handler.reconnectFailurePresentationCount, 1U);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 1U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
 - (void)testReconnectFailureRetryReentersGate
 {
 	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -195,6 +195,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		[actionExpectation fulfill];
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectationsWithTimeout:1 handler:nil];
@@ -215,6 +216,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectationsWithTimeout:1 handler:nil];
@@ -239,6 +241,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectationsWithTimeout:1 handler:nil];
@@ -261,15 +264,25 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		[actionExpectation fulfill];
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectations:@[handler.reconnectExpectation, handler.reconnectFailureExpectation] timeout:1];
 	handler.sheetShown = NO;
 	handler.reconnectExpectation = [self expectationWithDescription:@"retry reconnect invoked"];
 	handler.reconnectFailureExpectation = nil;
+	XCTAssertNotNil(handler.capturedReconnectFailureCompletion);
 	handler.capturedReconnectFailureCompletion(YES);
 
 	[self waitForExpectations:@[handler.reconnectExpectation, actionExpectation] timeout:1];
+
+	// Drain one main-queue turn so any pending sheet-presentation dispatch on
+	// the gate's re-entry path settles before asserting it did NOT happen.
+	// Without this, a stale dispatch_async could land after the assertion runs
+	// and produce a flaky XCTAssertFalse on `handler.sheetShown`.
+	XCTestExpectation *settleTurn = [self expectationWithDescription:@"main-queue turn settled"];
+	dispatch_async(dispatch_get_main_queue(), ^{ [settleTurn fulfill]; });
+	[self waitForExpectations:@[settleTurn] timeout:1];
 
 	XCTAssertFalse(handler.sheetShown);
 	XCTAssertEqual(handler.reconnectCount, 2U);
@@ -289,15 +302,23 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		[actionExpectation fulfill];
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectations:@[handler.reconnectExpectation, handler.reconnectFailureExpectation] timeout:1];
 	handler.sheetShown = NO;
 	handler.reconnectExpectation = [self expectationWithDescription:@"retry reconnect invoked"];
 	handler.reconnectFailureExpectation = nil;
+	XCTAssertNotNil(handler.capturedReconnectFailureCompletion);
 	handler.capturedReconnectFailureCompletion(YES);
 
 	[self waitForExpectations:@[handler.reconnectExpectation, actionExpectation] timeout:1];
+
+	// Drain one main-queue turn so any pending sheet-presentation dispatch on
+	// the gate's re-entry path settles before asserting it did NOT happen.
+	XCTestExpectation *settleTurn = [self expectationWithDescription:@"main-queue turn settled"];
+	dispatch_async(dispatch_get_main_queue(), ^{ [settleTurn fulfill]; });
+	[self waitForExpectations:@[settleTurn] timeout:1];
 
 	XCTAssertFalse(handler.sheetShown);
 	XCTAssertEqual(handler.reconnectCount, 2U);
@@ -317,9 +338,11 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 
 	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertNotNil(handler.capturedReconnectFailureCompletion);
 	handler.capturedReconnectFailureCompletion(NO);
 
 	XCTAssertEqual(actionCount, 0U);
@@ -336,6 +359,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostDisconnect, NO);
 
 	XCTAssertEqual(handler.closeAndDisconnectCount, 1U);
@@ -352,6 +376,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostDisconnect, YES);
 
 	XCTAssertEqual(actionCount, 0U);
@@ -382,6 +407,7 @@
 	[SAMultiTabConnectionLostGate runAction:^{
 		actionCount++;
 	} forHandler:handler];
+	XCTAssertNotNil(handler.capturedCompletion);
 	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
 	[self waitForExpectationsWithTimeout:1 handler:nil];
 

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -10,6 +10,7 @@
 @interface SATestConnectionLostGateHandler : NSObject <SAMultiTabConnectionLostGateHandler>
 @property (nonatomic) BOOL backgroundConnectionLost;
 @property (nonatomic) BOOL sheetShown;
+@property (nonatomic) BOOL sheetPresentationResult;
 @property (nonatomic) BOOL lastAllowCancel;
 @property (nonatomic) BOOL reconnectResult;
 @property (nonatomic) NSUInteger reconnectCount;
@@ -20,6 +21,14 @@
 @end
 
 @implementation SATestConnectionLostGateHandler
+
+- (instancetype)init
+{
+	if ((self = [super init])) {
+		_sheetPresentationResult = YES;
+	}
+	return self;
+}
 
 - (BOOL)backgroundConnectionLostForGate
 {
@@ -36,7 +45,7 @@
 	self.sheetShown = YES;
 	self.lastAllowCancel = allowCancel;
 	self.capturedCompletion = completion;
-	return YES;
+	return self.sheetPresentationResult;
 }
 
 - (BOOL)reconnectConnectionForGate
@@ -119,6 +128,23 @@
 	XCTAssertTrue(handler.lastAllowCancel);
 	XCTAssertEqual(actionCount, 0U);
 	XCTAssertNotNil(handler.capturedCompletion);
+}
+
+- (void)testGateClosesWithoutRunningActionWhenSheetCannotBePresented
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.sheetPresentationResult = NO;
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+
+	XCTAssertTrue(handler.sheetShown);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 1U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
 }
 
 - (void)testReconnectCompletionClearsFlagAndRunsAction

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -11,12 +11,16 @@
 @property (nonatomic) BOOL backgroundConnectionLost;
 @property (nonatomic) BOOL sheetShown;
 @property (nonatomic) BOOL sheetPresentationResult;
+@property (nonatomic) BOOL reconnectFailurePresentationResult;
 @property (nonatomic) BOOL lastAllowCancel;
 @property (nonatomic) BOOL reconnectResult;
 @property (nonatomic) NSUInteger reconnectCount;
+@property (nonatomic) NSUInteger reconnectFailurePresentationCount;
 @property (nonatomic) NSUInteger closeAndDisconnectCount;
 @property (nonatomic, strong) XCTestExpectation *reconnectExpectation;
+@property (nonatomic, strong) XCTestExpectation *reconnectFailureExpectation;
 @property (nonatomic, copy) void (^capturedCompletion)(SPMySQLConnectionLostDecision decision, BOOL cancelled);
+@property (nonatomic, copy) void (^capturedReconnectFailureCompletion)(BOOL retry);
 - (void)observeBackgroundLossNotification:(NSNotification *)notification;
 @end
 
@@ -26,6 +30,7 @@
 {
 	if ((self = [super init])) {
 		_sheetPresentationResult = YES;
+		_reconnectFailurePresentationResult = YES;
 	}
 	return self;
 }
@@ -53,6 +58,14 @@
 	self.reconnectCount++;
 	[self.reconnectExpectation fulfill];
 	return self.reconnectResult;
+}
+
+- (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion
+{
+	self.reconnectFailurePresentationCount++;
+	self.capturedReconnectFailureCompletion = completion;
+	[self.reconnectFailureExpectation fulfill];
+	return self.reconnectFailurePresentationResult;
 }
 
 - (void)closeAndDisconnectForGate
@@ -164,6 +177,74 @@
 	XCTAssertEqual(handler.reconnectCount, 1U);
 	XCTAssertFalse(handler.backgroundConnectionLost);
 	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+}
+
+- (void)testReconnectFailurePresentsFailureHandlingWithoutRunningAction
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presented"];
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	XCTAssertEqual(handler.reconnectCount, 1U);
+	XCTAssertEqual(handler.reconnectFailurePresentationCount, 1U);
+	XCTAssertNotNil(handler.capturedReconnectFailureCompletion);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
+- (void)testReconnectFailureRetryReentersGate
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presented"];
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	handler.sheetShown = NO;
+	handler.capturedReconnectFailureCompletion(YES);
+
+	XCTAssertTrue(handler.sheetShown);
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
+}
+
+- (void)testReconnectFailureDisconnectCloses
+{
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = NO;
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect invoked"];
+	handler.reconnectFailureExpectation = [self expectationWithDescription:@"reconnect failure presented"];
+	__block NSUInteger actionCount = 0;
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+	handler.capturedReconnectFailureCompletion(NO);
+
+	XCTAssertEqual(actionCount, 0U);
+	XCTAssertEqual(handler.closeAndDisconnectCount, 1U);
+	XCTAssertTrue(handler.backgroundConnectionLost);
 }
 
 - (void)testDisconnectCompletionClosesWithoutRunningAction

--- a/UnitTests/SAMultiTabConnectionLostTests.m
+++ b/UnitTests/SAMultiTabConnectionLostTests.m
@@ -14,6 +14,14 @@
 @property (nonatomic) BOOL reconnectFailurePresentationResult;
 @property (nonatomic) BOOL lastAllowCancel;
 @property (nonatomic) BOOL reconnectResult;
+@property (nonatomic) BOOL userChoseDisconnect;
+// Models SPDatabaseDocument's real behavior: its `connectionLost:completion:`
+// path calls `closeAndDisconnect` itself on a user Disconnect click before
+// the worker-thread `-reconnect` returns. Setting this to YES makes the fake
+// handler increment `closeAndDisconnectCount` from inside
+// `reconnectConnectionForGate`, so tests can assert the gate does NOT close
+// a second time on the same user choice.
+@property (nonatomic) BOOL handlerClosesInsideReconnect;
 @property (nonatomic) NSUInteger reconnectCount;
 @property (nonatomic) NSUInteger reconnectFailurePresentationCount;
 @property (nonatomic) NSUInteger closeAndDisconnectCount;
@@ -57,6 +65,11 @@
 - (BOOL)reconnectConnectionForGate
 {
 	self.reconnectCount++;
+	if (self.handlerClosesInsideReconnect) {
+		// Mirror SPDatabaseDocument's connectionLost:completion: closing the
+		// document itself on a user-clicked Disconnect before -reconnect returns.
+		[self closeAndDisconnectForGate];
+	}
 	[self.reconnectExpectation fulfill];
 	if ([self.queuedReconnectResults count]) {
 		BOOL nextResult = [[self.queuedReconnectResults firstObject] boolValue];
@@ -64,6 +77,11 @@
 		return nextResult;
 	}
 	return self.reconnectResult;
+}
+
+- (BOOL)connectionGateUserChoseDisconnect
+{
+	return self.userChoseDisconnect;
 }
 
 - (BOOL)presentReconnectFailureAllowingRetryForGate:(void (^)(BOOL retry))completion
@@ -339,6 +357,45 @@
 	XCTAssertEqual(actionCount, 0U);
 	XCTAssertEqual(handler.closeAndDisconnectCount, 0U);
 	XCTAssertTrue(handler.backgroundConnectionLost);
+}
+
+// When the underlying `-reconnect` already ran the framework's async lost-
+// connection sheet and the user picked Disconnect, SPDatabaseDocument's
+// `connectionLost:completion:` already calls `-closeAndDisconnect` for that
+// click. `-reconnect` then returns NO and `connectionGateUserChoseDisconnect`
+// reports YES via the sheet-level flag. The gate MUST:
+//   (1) skip the second Retry/Disconnect failure sheet, AND
+//   (2) NOT call `closeAndDisconnectForGate` a second time —
+// otherwise `-closeAndDisconnect` runs twice (non-idempotent: window close is
+// re-scheduled, query history is re-persisted, the `wasConnected` branch
+// flips, observers are removed again).
+- (void)testReconnectFailureWithUserChosenDisconnectDoesNotDoubleClose
+{
+	__block NSUInteger actionCount = 0;
+	SATestConnectionLostGateHandler *handler = [[SATestConnectionLostGateHandler alloc] init];
+	handler.backgroundConnectionLost = YES;
+	handler.reconnectResult = NO;                 // reconnect fails
+	handler.userChoseDisconnect = YES;            // user picked Disconnect inside the framework sheet
+	handler.handlerClosesInsideReconnect = YES;   // mirrors SPDatabaseDocument's first close
+	handler.reconnectExpectation = [self expectationWithDescription:@"reconnect attempted"];
+
+	[SAMultiTabConnectionLostGate runAction:^{
+		actionCount++;
+	} forHandler:handler];
+	handler.capturedCompletion(SPMySQLConnectionLostReconnect, NO);
+	[self waitForExpectationsWithTimeout:1 handler:nil];
+
+	// Wait one main-queue turn so the failure-path branch can run on main.
+	XCTestExpectation *mainTurn = [self expectationWithDescription:@"main turn"];
+	dispatch_async(dispatch_get_main_queue(), ^{ [mainTurn fulfill]; });
+	[self waitForExpectations:@[mainTurn] timeout:1];
+
+	XCTAssertEqual(handler.reconnectCount, 1U, @"only one reconnect attempt should have run");
+	XCTAssertEqual(handler.reconnectFailurePresentationCount, 0U,
+		@"Retry/Disconnect failure sheet must NOT appear once user already chose Disconnect");
+	XCTAssertEqual(handler.closeAndDisconnectCount, 1U,
+		@"close must run exactly once (from SPDatabaseDocument's own delegate path), not twice");
+	XCTAssertEqual(actionCount, 0U, @"original action must not run");
 }
 
 @end

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -65,10 +65,6 @@
 		17E0937E114AE154007FC1B4 /* SPTableInfoPrintTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = 17E0937D114AE154007FC1B4 /* SPTableInfoPrintTemplate.html */; };
 		17E641460EF01EB5001BC333 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641440EF01EB5001BC333 /* main.m */; };
 		17E641560EF01EF6001BC333 /* SPCustomQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641490EF01EF6001BC333 /* SPCustomQuery.m */; };
-		C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */; };
-		C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
-		C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
-		C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */; };
 		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
@@ -108,9 +104,6 @@
 		17F5B39C1049B96A00FC794F /* SPSQLExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F5B39B1049B96A00FC794F /* SPSQLExporter.m */; };
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
-		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
-		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
-		DD00DD00DD00DD00DD000005 /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
 		CF0000182F8C000600C4C14A /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
 		CF0000192F8C000600C4C14A /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
 		CF0000202F8C000600C4C14A /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B193CCBD925ECB4BA86FAD7 /* SAMultiTabConnectionLostGate.m in Sources */ = {isa = PBXBuildFile; fileRef = DF13DCABF712577C6E747E7F /* SAMultiTabConnectionLostGate.m */; };
 		1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
 		1198F5B31174EDD500670590 /* SPDatabaseCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1198F5B21174EDD500670590 /* SPDatabaseCopy.m */; };
 		11B55BFE1189E3B2009EF465 /* SPDatabaseAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 11B55BFD1189E3B2009EF465 /* SPDatabaseAction.m */; };
@@ -64,10 +65,6 @@
 		17E0937E114AE154007FC1B4 /* SPTableInfoPrintTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = 17E0937D114AE154007FC1B4 /* SPTableInfoPrintTemplate.html */; };
 		17E641460EF01EB5001BC333 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641440EF01EB5001BC333 /* main.m */; };
 		17E641560EF01EF6001BC333 /* SPCustomQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641490EF01EF6001BC333 /* SPCustomQuery.m */; };
-		C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */; };
-		C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
-		C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
-		C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */; };
 		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
 		17E641590EF01EF6001BC333 /* SPTableContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414F0EF01EF6001BC333 /* SPTableContent.m */; };
 		17E6415A0EF01EF6001BC333 /* SPDatabaseDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641510EF01EF6001BC333 /* SPDatabaseDocument.m */; };
@@ -90,9 +87,6 @@
 		17F5B39C1049B96A00FC794F /* SPSQLExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F5B39B1049B96A00FC794F /* SPSQLExporter.m */; };
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
-		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
-		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
-		DD00DD00DD00DD00DD000005 /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
 		1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
 		1A11E50425A327F1001CB721 /* SPPanelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A11E50325A327F1001CB721 /* SPPanelOptions.m */; };
@@ -384,6 +378,7 @@
 		6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */; };
 		6F0EA9242734ABE200514FF1 /* SABundleRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA9232734ABE200514FF1 /* SABundleRunner.m */; };
 		73F70A961E4E547500636550 /* SPJSONFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73F70A951E4E547500636550 /* SPJSONFormatter.m */; };
+		7DD8588CED67AEB460161D12 /* SAMultiTabConnectionLostGate.m in Sources */ = {isa = PBXBuildFile; fileRef = DF13DCABF712577C6E747E7F /* SAMultiTabConnectionLostGate.m */; };
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		8831EFA8224011B700D10172 /* button_addTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFA5224011B700D10172 /* button_addTemplate.pdf */; };
 		8831EFAA2240128700D10172 /* button_removeTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFA92240128600D10172 /* button_removeTemplate.pdf */; };
@@ -477,6 +472,10 @@
 		C0F17A1A2B3C4D5E6F708091 /* SPTableContentColumnFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */; };
 		C2E7A3B52E5E1A1A00D22990 /* SPDatabaseData.m in Sources */ = {isa = PBXBuildFile; fileRef = 1740FABA0FC4372F00CF3699 /* SPDatabaseData.m */; };
 		C2E7A3B62E5E1B3A00D22990 /* NSAlertExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */; };
+		C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */; };
+		C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
+		C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
+		C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */; };
 		C812F06F0D4A95968C1B0154 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		C9AD7C781676138000234EEE /* database-small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9AD7C771676138000234EEE /* database-small@2x.png */; };
 		C9AD7C7B1676158C00234EEE /* toolbar-switch-to-sql.png in Resources */ = {isa = PBXBuildFile; fileRef = C9AD7C791676158C00234EEE /* toolbar-switch-to-sql.png */; };
@@ -490,6 +489,10 @@
 		C9F92712162D39E60051CB2E /* toolbar-switch-to-browse.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */; };
 		C9F92714162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */; };
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
+		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
+		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
+		DD00DD00DD00DD00DD000005 /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
+		E77BF562D3ED5BC08688967F /* SAMultiTabConnectionLostTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C30B263436A97FB4A518886E /* SAMultiTabConnectionLostTests.m */; };
 		F3A4B8C191E14E7094C9A111 /* AWSCredentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */; };
 		F3A4B8C191E14E7094C9A112 /* RDSIAMAuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */; };
 		F3A4B8C191E14E7094C9A113 /* AWSDirectoryBookmarkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A103 /* AWSDirectoryBookmarkManagerTests.swift */; };
@@ -756,9 +759,6 @@
 		17E641450EF01EB5001BC333 /* Sequel-Ace.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Sequel-Ace.pch"; sourceTree = "<group>"; };
 		17E641480EF01EF6001BC333 /* SPCustomQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPCustomQuery.h; sourceTree = "<group>"; };
 		17E641490EF01EF6001BC333 /* SPCustomQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPCustomQuery.m; sourceTree = "<group>"; };
-		AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPCustomQuery+Explain.swift"; sourceTree = "<group>"; };
-		AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifier.swift; sourceTree = "<group>"; };
-		AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifierTests.swift; sourceTree = "<group>"; };
 		17E6414A0EF01EF6001BC333 /* SPAppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPAppController.h; sourceTree = "<group>"; };
 		17E6414B0EF01EF6001BC333 /* SPAppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPAppController.m; sourceTree = "<group>"; };
 		17E6414E0EF01EF6001BC333 /* SPTableContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTableContent.h; sourceTree = "<group>"; };
@@ -798,9 +798,6 @@
 		17F90E471210B42700274C98 /* SPExportFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPExportFile.m; sourceTree = "<group>"; };
 		17FDB04A1280778B00DBBBC2 /* SPFontPreviewTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFontPreviewTextField.h; sourceTree = "<group>"; };
 		17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFontPreviewTextField.m; sourceTree = "<group>"; };
-		DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleTextField.swift; sourceTree = "<group>"; };
-		DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleEditor.swift; sourceTree = "<group>"; };
-		DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPRuleFilterDropBox.swift; sourceTree = "<group>"; };
 		1A071B8B254D983700246912 /* SPNSMutableDictionaryAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPNSMutableDictionaryAdditions.h; sourceTree = "<group>"; };
 		1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPNSMutableDictionaryAdditions.m; sourceTree = "<group>"; };
 		1A0751DF25EAF37700FFDF6B /* ReportExceptionApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReportExceptionApplication.m; sourceTree = "<group>"; };
@@ -890,6 +887,7 @@
 		29FA88221114619E00D1AF3D /* SPTableTriggers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableTriggers.m; sourceTree = "<group>"; };
 		2A37F4C4FDCFA73011CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		2A37F4C5FDCFA73011CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		3243DC1E334C26BC97F13AE1 /* SAMultiTabConnectionLostGate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SAMultiTabConnectionLostGate.h; sourceTree = "<group>"; };
 		380F4ED90FC0B50500B0BFD7 /* Unit Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Unit Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPStringAdditionsTests.m; sourceTree = "<group>"; };
 		384582C30FB95FF800DDACB6 /* func-small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "func-small.png"; sourceTree = "<group>"; };
@@ -970,6 +968,7 @@
 		5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDetailsValidatorTests.swift; sourceTree = "<group>"; };
 		5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormHelpers.swift; sourceTree = "<group>"; };
 		5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormHelpersTests.swift; sourceTree = "<group>"; };
+		5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchTreeWalker.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -1034,7 +1033,6 @@
 		51CD0BDB258D06D8009E2484 /* BundleHTMLOutput.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BundleHTMLOutput.xib; sourceTree = "<group>"; };
 		51F41FB625F56A5900594BA5 /* MainWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		51F4AFBD24B26665006144D5 /* Sequel-Ace-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sequel-Ace-Bridging-Header.h"; sourceTree = "<group>"; };
-		5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchTreeWalker.swift; sourceTree = "<group>"; };
 		51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
 		5806B76211A991EC00813A88 /* SPDocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDocumentController.h; sourceTree = "<group>"; };
 		5806B76311A991EC00813A88 /* SPDocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDocumentController.m; sourceTree = "<group>"; };
@@ -1190,6 +1188,9 @@
 		9BE76F9BF9BDA2921CDD05AF /* SPFilterTableController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFilterTableController.h; sourceTree = "<group>"; };
 		AA000001000000000000001A /* SAAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutView.swift; sourceTree = "<group>"; };
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
+		AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPCustomQuery+Explain.swift"; sourceTree = "<group>"; };
+		AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifier.swift; sourceTree = "<group>"; };
+		AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifierTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -1265,6 +1266,7 @@
 		BCE0025B11173D2A009DA533 /* SPFieldMapperController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFieldMapperController.h; sourceTree = "<group>"; };
 		BCE0025C11173D2A009DA533 /* SPFieldMapperController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFieldMapperController.m; sourceTree = "<group>"; };
 		C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPTableContentColumnFilterTests.swift; sourceTree = "<group>"; };
+		C30B263436A97FB4A518886E /* SAMultiTabConnectionLostTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SAMultiTabConnectionLostTests.m; sourceTree = "<group>"; };
 		C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBundleManagerAdditionsTests.swift; sourceTree = "<group>"; };
 		C9AD7C771676138000234EEE /* database-small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "database-small@2x.png"; sourceTree = "<group>"; };
 		C9AD7C791676158C00234EEE /* toolbar-switch-to-sql.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-sql.png"; sourceTree = "<group>"; };
@@ -1278,6 +1280,10 @@
 		C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse.png"; sourceTree = "<group>"; };
 		C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse@2x.png"; sourceTree = "<group>"; };
 		D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowTabAccessory.swift; sourceTree = "<group>"; };
+		DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleTextField.swift; sourceTree = "<group>"; };
+		DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleEditor.swift; sourceTree = "<group>"; };
+		DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPRuleFilterDropBox.swift; sourceTree = "<group>"; };
+		DF13DCABF712577C6E747E7F /* SAMultiTabConnectionLostGate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SAMultiTabConnectionLostGate.m; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCredentialsTests.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RDSIAMAuthenticationTests.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A103 /* AWSDirectoryBookmarkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDirectoryBookmarkManagerTests.swift; sourceTree = "<group>"; };
@@ -1557,6 +1563,8 @@
 				17005CB016D6CEA400AF81F4 /* Table Triggers */,
 				5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */,
 				5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */,
+				3243DC1E334C26BC97F13AE1 /* SAMultiTabConnectionLostGate.h */,
+				DF13DCABF712577C6E747E7F /* SAMultiTabConnectionLostGate.m */,
 			);
 			name = "Main View Controllers";
 			path = MainViewControllers;
@@ -2326,7 +2334,7 @@
 			path = MGTemplateEngine;
 			sourceTree = "<group>";
 		};
-		2A37F4AAFDCFA73011CA2CEA /* sequel-pro */ = {
+		2A37F4AAFDCFA73011CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				518E02F227B91FBC007973E3 /* Entitlements */,
@@ -2418,6 +2426,7 @@
 				5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */,
 				5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */,
 				5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */,
+				C30B263436A97FB4A518886E /* SAMultiTabConnectionLostTests.m */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -2759,7 +2768,7 @@
 				cs,
 				eo,
 			);
-			mainGroup = 2A37F4AAFDCFA73011CA2CEA /* sequel-pro */;
+			mainGroup = 2A37F4AAFDCFA73011CA2CEA;
 			packageReferences = (
 				51D9527425AE2B5300574BEB /* XCRemoteSwiftPackageReference "fmdb" */,
 				51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */,
@@ -3096,6 +3105,8 @@
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
 				1A9A40D525875EC9009F0E71 /* NSMutableArray-MultipleSort.m in Sources */,
 				8AEACED018AABDD8CBB42877 /* TableSortHelperTests.swift in Sources */,
+				E77BF562D3ED5BC08688967F /* SAMultiTabConnectionLostTests.m in Sources */,
+				7DD8588CED67AEB460161D12 /* SAMultiTabConnectionLostGate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3359,6 +3370,7 @@
 				9BE765682376A00C82FB93AA /* SPHelpViewerClient.m in Sources */,
 				8AEAC27B5C5B866575ECDB62 /* TableSortHelper.swift in Sources */,
 				44011FFBC7DF57126761313F /* SQLitePinnedTableManager.swift in Sources */,
+				0B193CCBD925ECB4BA86FAD7 /* SAMultiTabConnectionLostGate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

- Removes the synchronous main-thread modal that previously froze the entire app when any single tab's connection (or SSH proxy) hit an error. Background `keepAlive` failure and proxy-disconnect now stay tab-local and post `SPMySQLConnectionLostInBackgroundNotification` instead of cascading into a global `runModalForWindow:` sheet.
- Introduces an app-layer gate (`SAMultiTabConnectionLostGate` + `SPDatabaseDocument.checkForBackgroundConnectionLossThenRun:`) so explicit user actions (Run Query / Reload / Refresh) on a Lost tab present a window-scoped `beginSheetModalForWindow:completionHandler:` sheet only on that tab's window, with Reconnect / Disconnect / Cancel choices and proper Retry/Disconnect handling when reconnect itself fails.
- Adds new async `connectionLost:completion:` and notification-only `connectionLostInBackground:` delegate methods (old sync `connectionLost:` kept as deprecated worker-thread fallback). Public `-reconnect` keeps its synchronous BOOL contract; only internal callers opt into main-thread fast-return via a new `dispatchOnMainThread:` parameter on `_reconnectAllowingRetries:`.

## What changed (root cause path neutralized)

| Path before | Symptom | Path now |
|-------------|---------|---------|
| keepAlive 3x ping fail on background tab | App-modal sheet froze every tab for 30-60s | Tab-local state + notification; UI only shown on explicit user action via the gate |
| SSH proxy idle after recently used | Same modal freeze through proxy reconnect thread | `_silentReconnectForProxyLoss` performs one silent attempt then sets Lost state; no delegate decision dispatch |
| `_delegateDecisionForLostConnection` `performSelectorOnMainThread:waitUntilDone:YES` + `runModalForWindow:` | Background thread blocked on main; main blocked in modal mode | Removed; new async delegate uses worker-side `dispatch_semaphore` with `__block` expired guard to drop late completions |
| `isConnected` / `checkConnectionIfNecessary` cascading reconnect on Lost from main thread | Implicit triggers (table data, navigator, menu validation) caused freezes outside user intent | Side-effect-free on main thread for Lost state; explicit foreground reconnect goes through the gate |
| 30+ `queryString:` callers | Each one could hit the freeze | Protected at framework convergence point; no per-caller migration needed |

## Independent audit summary

Phase A code was re-reviewed by an independent adversary pass (separate session, given only the diff, not the plan history). It surfaced 5 P1 + 2 P2 issues that are all addressed in this PR:

- **P1** gate-sheet-fail — gate now disconnects when sheet can't be presented (window not visible / app terminating)
- **P1** reconnect-failure-silent — Reconnect failure now presents a window-scoped Retry/Disconnect follow-up sheet
- **P1** public-reconnect-broken-contract — public `-reconnect` restored to synchronous BOOL; new `dispatchOnMainThread:` param keeps internal main-thread fast-return semantics
- **P1** shared-mutable-state-race — async delegate path uses `__block` local state + `decisionExpired` flag under `delegateDecisionLock`; late completions are dropped
- **P1** stale-restore-snapshot — `_silentReconnectAttempt` captures DB / encoding / latin1-transport state per attempt; failure paths no longer leak stale snapshots
- **P2** notification-spam — `SPMySQLConnectionLostInBackgroundNotification` coalesced per Lost transition; resets when state leaves Lost
- **P2** i18n-missing — new sheet keys added to `Resources/Localization/en.lproj/Localizable.strings` (existing `Cancel` key reused)

A subsequent verify-audit confirmed all 7 fixes hold; one P3 test-gap (failure-sheet-presentation-failure branch) was added in the final commit.

## Compatibility

- Framework public API is additive only (new optional `connectionLost:completion:` and `connectionLostInBackground:` protocol methods, new `SPMySQLConnectionLostInBackgroundNotification` constant).
- Old sync `connectionLost:` is marked `DEPRECATED_MSG_ATTRIBUTE` but kept for third-party forks. Framework now only calls it from a worker thread; main-thread invocation defaults to `SPMySQLConnectionLostDisconnect` with a one-shot log so a UI-bound third-party delegate cannot reintroduce the freeze.
- No new dependencies, no minimum-macOS bump.

## Tests

- New: `Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SPMySQLConnectionLostTests.m` — 16 tests covering side-effect-free `isConnected` / `checkConnectionIfNecessary`, main-thread `_reconnectAllowingRetries:` fast-return, keepAlive notification path, async-vs-deprecated delegate preference, deprecated delegate main-thread suppression, do-while-zero regression guard, SSH proxy silent reconnect (success / fail / >15min branches), late-completion race, stale-restore-snapshot regression, and notification coalescing.
- New: `UnitTests/SAMultiTabConnectionLostTests.m` — 12 tests covering notification observer + object filter, multi-doc isolation, gate fast-path / slow-path, sheet completion Reconnect / Disconnect / Cancel routing, sheet-presentation-failure handling, reconnect-failure Retry / Disconnect / sheet-fail-to-present handling.
- Both targeted test bundles run clean with `xcodebuild test`.
- Release build verified locally.

## Test plan

- [ ] Open multiple tabs against distinct databases (mix local + remote)
- [ ] Disconnect VPN / block a remote IP / kill SSH tunnel for one tab; verify other tabs stay responsive (no app-wide freeze)
- [ ] Activate the affected tab → trigger Reload / Refresh / Run Query → window-scoped sheet appears only on that tab's window
- [ ] On the sheet, choose Reconnect — successful path resumes the original action
- [ ] On the sheet, choose Reconnect with reconnect actually failing — Retry / Disconnect follow-up sheet appears
- [ ] On the sheet, choose Disconnect — tab closes; other tabs unaffected
- [ ] On the sheet, choose Cancel — flag preserved; no action runs; next IBAction re-prompts
- [ ] Sleep / wake laptop with multiple tabs — no app-modal freeze
- [ ] App relaunch with multiple saved tabs (some unreachable) — no startup freeze

Closes #1945.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and handle connections lost in background with a coalesced background-loss notification, async reconnect decision API, multi-tab reconnect UI gate, and silent automatic reconnects via a dedicated reconnect queue.

* **Bug Fixes**
  * Keep‑alive failures and disconnects now consistently transition to background‑loss and trigger appropriate UI/cleanup behavior.

* **Tests**
  * Extensive unit tests for background‑loss, coalescing, reconnect paths, delegate selection, and multi‑tab gate flows.

* **Localization**
  * Added strings for connection‑lost alerts, actions, retries, and failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->