### PR TITLE
Filter by Selected Value: context menu on Table Content cells

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3432,3 +3432,6 @@
 
 /* Vault save-favorite validation: credentials path field is empty */
 "A Vault credentials path is required to save a Vault favorite." = "A Vault credentials path is required to save a Vault favorite.";
+
+/* Cell context menu filter submenu title */
+"Filter by Selected Value" = "Filter by Selected Value";

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterAction.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterAction.swift
@@ -8,13 +8,41 @@
 
 import Foundation
 
+/// Retains the data needed by one "Filter by Selected Value" menu item
+/// and applies it back to the owning table-content controller.
+///
+/// `NSMenuItem` keeps its target weakly, so each item stores an instance
+/// of this wrapper as its represented object. The wrapper keeps only a
+/// weak reference to `SPTableContent`, matching menu lifetime rather than
+/// extending the document/controller lifetime.
 @objcMembers public final class SACellFilterAction: NSObject {
     private weak var tableContent: SPTableContent?
+
+    /// Schema column name to filter, not the visible table-column title.
     public let columnName: String
+
+    /// Serialized rule-filter operator name understood by `SPRuleFilterController`.
     public let operatorName: String
+
+    /// Argument values to pass to the rule-filter serializer.
+    ///
+    /// Zero-argument operators such as `IS NULL` use an empty array.
     public let values: [String]
+
+    /// Whether the selected cell should be serialized through the NULL path.
+    ///
+    /// When true, `SPTableContent` ignores `values` and writes
+    /// `filterValues: []` so the rule editor restores a zero-argument rule.
     public let isNull: Bool
 
+    /// Creates an action object for one menu item.
+    ///
+    /// - Parameters:
+    ///   - tableContent: Table-content controller that owns the rule filter.
+    ///   - columnName: Schema column name to filter.
+    ///   - operatorName: Serialized operator name for the rule-filter controller.
+    ///   - values: Operator arguments captured from the clicked cell.
+    ///   - isNull: Whether the rule should be applied as a SQL NULL comparison.
     public init(tableContent: SPTableContent, columnName: String, operatorName: String, values: [String], isNull: Bool) {
         self.tableContent = tableContent
         self.columnName = columnName
@@ -24,6 +52,10 @@ import Foundation
         super.init()
     }
 
+    /// Applies the captured filter to the owning table-content controller.
+    ///
+    /// The sender is intentionally unused; AppKit supplies it when invoking
+    /// the menu-item target action.
     @objc public func apply(_ sender: Any?) {
         tableContent?.applyCellFilter(forColumn: columnName, operator: operatorName, values: values, isNull: isNull)
     }

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterAction.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterAction.swift
@@ -1,0 +1,30 @@
+//
+//  SACellFilterAction.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+@objcMembers public final class SACellFilterAction: NSObject {
+    private weak var tableContent: SPTableContent?
+    public let columnName: String
+    public let operatorName: String
+    public let values: [String]
+    public let isNull: Bool
+
+    public init(tableContent: SPTableContent, columnName: String, operatorName: String, values: [String], isNull: Bool) {
+        self.tableContent = tableContent
+        self.columnName = columnName
+        self.operatorName = operatorName
+        self.values = values
+        self.isNull = isNull
+        super.init()
+    }
+
+    @objc public func apply(_ sender: Any?) {
+        tableContent?.applyCellFilter(forColumn: columnName, operator: operatorName, values: values, isNull: isNull)
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterColumnIdentifier.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterColumnIdentifier.swift
@@ -8,8 +8,23 @@
 
 import AppKit
 
+/// Normalizes `NSTableColumn.identifier` values into storage-column indexes.
+///
+/// Table-content columns use numeric identifiers that map visible columns back
+/// to the backing `SPDataStorage` column. AppKit allows arbitrary identifier
+/// objects, so the cell-filter context-menu path validates the shape before
+/// treating an identifier as an array index.
 @objcMembers public final class SACellFilterColumnIdentifier: NSObject {
 
+    /// Parses a table-column identifier into a storage index.
+    ///
+    /// Accepts `NSUserInterfaceItemIdentifier`, `String`, and `NSNumber`
+    /// values that contain only decimal digits. Non-integer identifiers are
+    /// rejected instead of being coerced with Objective-C's permissive
+    /// `integerValue`, which would turn values such as `"abc"` into `0`.
+    ///
+    /// - Parameter identifier: Identifier object read from an `NSTableColumn`.
+    /// - Returns: The storage index, or `nil` when the identifier is not a pure integer.
     @objc(storageIndexFromIdentifier:)
     public static func storageIndex(from identifier: Any?) -> NSNumber? {
         guard let rawValue = rawValue(from: identifier),

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterColumnIdentifier.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterColumnIdentifier.swift
@@ -1,0 +1,37 @@
+//
+//  SACellFilterColumnIdentifier.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objcMembers public final class SACellFilterColumnIdentifier: NSObject {
+
+    @objc(storageIndexFromIdentifier:)
+    public static func storageIndex(from identifier: Any?) -> NSNumber? {
+        guard let rawValue = rawValue(from: identifier),
+              rawValue.isNotEmpty,
+              rawValue.allSatisfy(\.isNumber),
+              let index = Int(rawValue) else {
+            return nil
+        }
+
+        return NSNumber(value: index)
+    }
+
+    private static func rawValue(from identifier: Any?) -> String? {
+        switch identifier {
+        case let identifier as NSUserInterfaceItemIdentifier:
+            return identifier.rawValue
+        case let identifier as String:
+            return identifier
+        case let identifier as NSNumber:
+            return identifier.stringValue
+        default:
+            return identifier.map { String(describing: $0) }
+        }
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
@@ -1,0 +1,75 @@
+//
+//  SACellFilterMenuBuilder.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objcMembers public final class SACellFilterMenuItemDescriptor: NSObject {
+
+    public let title: String
+    public let columnName: String
+    public let operatorName: String
+    public let values: [String]
+    public let isNull: Bool
+
+    public init(title: String, columnName: String, operatorName: String, values: [String], isNull: Bool) {
+        self.title = title
+        self.columnName = columnName
+        self.operatorName = operatorName
+        self.values = values
+        self.isNull = isNull
+    }
+}
+
+@objcMembers public final class SACellFilterMenuBuilder: NSObject {
+
+    public static func filterMenu(column: [String: Any], value: String?, isNull: Bool) -> NSMenu? {
+        let descriptors = menuItemDescriptors(column: column, value: value, isNull: isNull)
+        guard !descriptors.isEmpty else {
+            return nil
+        }
+
+        let menu = NSMenu()
+        for descriptor in descriptors {
+            menu.addItem(NSMenuItem(title: descriptor.title, action: nil, keyEquivalent: ""))
+        }
+
+        return menu
+    }
+
+    public static func menuItemDescriptors(column: [String: Any], value: String?, isNull: Bool) -> [SACellFilterMenuItemDescriptor] {
+        guard let columnName = column["name"] as? String,
+              let typeGrouping = column["typegrouping"] as? String else {
+            return []
+        }
+
+        return menuItemDescriptors(columnName: columnName, typeGrouping: typeGrouping, value: value, isNull: isNull)
+    }
+
+    @objc(menuItemDescriptorsWithColumnName:typeGrouping:value:isNull:)
+    public static func menuItemDescriptors(columnName: String?, typeGrouping: String?, value: String?, isNull: Bool) -> [SACellFilterMenuItemDescriptor] {
+        guard let columnName,
+              let typeGrouping else {
+            return []
+        }
+
+        let operators = SACellFilterOperator.operators(for: typeGrouping, cellIsNull: isNull)
+        guard !operators.isEmpty else {
+            return []
+        }
+
+        return operators.map { op in
+            SACellFilterMenuItemDescriptor(
+                title: op.menuTitle,
+                columnName: columnName,
+                operatorName: op.serializedName,
+                values: op.valueCount == 0 ? [] : [value ?? ""],
+                isNull: isNull
+            )
+        }
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
@@ -57,7 +57,15 @@ import AppKit
             return []
         }
 
-        let operators = SACellFilterOperator.operators(for: typeGrouping, cellIsNull: isNull)
+        // Treat an empty-string cell value the same as a NULL cell for menu purposes:
+        // SPRuleFilterController's starter detection collapses any expression whose
+        // filterValues are all empty strings into a placeholder (see SerIsUntouchedStarterRule
+        // at SPRuleFilterController.m:1814-1829), so a value-bearing operator with `[""]`
+        // cannot be persisted via the rule editor. Restrict the menu to NULL operators
+        // for empty strings so the cell-filter feature never produces non-persistent rules.
+        let effectiveIsNull = isNull || (value?.isEmpty ?? false)
+
+        let operators = SACellFilterOperator.operators(for: typeGrouping, cellIsNull: effectiveIsNull)
         guard !operators.isEmpty else {
             return []
         }
@@ -68,7 +76,7 @@ import AppKit
                 columnName: columnName,
                 operatorName: op.serializedName,
                 values: op.valueCount == 0 ? [] : [value ?? ""],
-                isNull: isNull
+                isNull: effectiveIsNull
             )
         }
     }

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
@@ -8,14 +8,38 @@
 
 import AppKit
 
+/// Description of one item in the "Filter by Selected Value" submenu.
+///
+/// The descriptor is deliberately UI-light: Objective-C code in `SPCopyTable`
+/// uses it both to build the visible `NSMenuItem` and to create the
+/// `SACellFilterAction` that applies the selected rule.
 @objcMembers public final class SACellFilterMenuItemDescriptor: NSObject {
 
+    /// Menu title displayed to the user.
     public let title: String
+
+    /// Schema column name passed to `SPRuleFilterController`.
     public let columnName: String
+
+    /// Serialized operator name that matches an entry in `ContentFilters.plist`.
     public let operatorName: String
+
+    /// Operator argument payload captured from the clicked cell.
+    ///
+    /// Empty for zero-argument NULL operators.
     public let values: [String]
+
+    /// Whether the descriptor should serialize through the SQL NULL path.
     public let isNull: Bool
 
+    /// Creates a descriptor for one menu item and its apply action.
+    ///
+    /// - Parameters:
+    ///   - title: Visible menu title.
+    ///   - columnName: Schema column name to filter.
+    ///   - operatorName: Serialized operator name for the rule-filter controller.
+    ///   - values: Operator argument values.
+    ///   - isNull: Whether this descriptor represents a SQL NULL comparison.
     public init(title: String, columnName: String, operatorName: String, values: [String], isNull: Bool) {
         self.title = title
         self.columnName = columnName
@@ -25,8 +49,23 @@ import AppKit
     }
 }
 
+/// Builds the filter submenu and its serializable item descriptors.
+///
+/// This class keeps the type/operator matrix in Swift while exposing an
+/// Objective-C-friendly API for `SPCopyTable.m`.
 @objcMembers public final class SACellFilterMenuBuilder: NSObject {
 
+    /// Builds a display-only submenu for a table cell.
+    ///
+    /// Used by tests and by callers that only need menu titles. The actual
+    /// context-menu hook uses `menuItemDescriptors(...)` so each item can carry
+    /// the payload needed by `SACellFilterAction`.
+    ///
+    /// - Parameters:
+    ///   - column: Column definition dictionary containing `name` and `typegrouping`.
+    ///   - value: Display string for the clicked cell.
+    ///   - isNull: Whether the raw clicked cell is SQL NULL.
+    /// - Returns: A menu populated with supported operators, or `nil` when none apply.
     public static func filterMenu(column: [String: Any], value: String?, isNull: Bool) -> NSMenu? {
         let descriptors = menuItemDescriptors(column: column, value: value, isNull: isNull)
         guard !descriptors.isEmpty else {
@@ -41,6 +80,13 @@ import AppKit
         return menu
     }
 
+    /// Builds item descriptors from a table-content column definition.
+    ///
+    /// - Parameters:
+    ///   - column: Column definition dictionary containing `name` and `typegrouping`.
+    ///   - value: Display string for the clicked cell.
+    ///   - isNull: Whether the raw clicked cell is SQL NULL.
+    /// - Returns: Descriptors for every operator the selected column/value can use.
     public static func menuItemDescriptors(column: [String: Any], value: String?, isNull: Bool) -> [SACellFilterMenuItemDescriptor] {
         guard let columnName = column["name"] as? String,
               let typeGrouping = column["typegrouping"] as? String else {
@@ -50,6 +96,18 @@ import AppKit
         return menuItemDescriptors(columnName: columnName, typeGrouping: typeGrouping, value: value, isNull: isNull)
     }
 
+    /// Builds item descriptors from normalized column metadata.
+    ///
+    /// Empty-string and nil display values are routed to NULL operators because
+    /// value-bearing empty-string rules serialize with `filterValues: [""]`,
+    /// the same shape the rule editor uses for half-touched placeholder rows.
+    ///
+    /// - Parameters:
+    ///   - columnName: Schema column name to filter.
+    ///   - typeGrouping: Sequel Ace type grouping from `SPTableDataColumnDefinition`.
+    ///   - value: Display string for the clicked cell.
+    ///   - isNull: Whether the raw clicked cell is SQL NULL.
+    /// - Returns: Descriptors for every supported operator, or an empty array.
     @objc(menuItemDescriptorsWithColumnName:typeGrouping:value:isNull:)
     public static func menuItemDescriptors(columnName: String?, typeGrouping: String?, value: String?, isNull: Bool) -> [SACellFilterMenuItemDescriptor] {
         guard let columnName,

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMenuBuilder.swift
@@ -57,13 +57,15 @@ import AppKit
             return []
         }
 
-        // Treat an empty-string cell value the same as a NULL cell for menu purposes:
+        // Treat an empty-string OR nil cell value the same as a NULL cell for menu purposes:
         // SPRuleFilterController's starter detection collapses any expression whose
         // filterValues are all empty strings into a placeholder (see SerIsUntouchedStarterRule
         // at SPRuleFilterController.m:1814-1829), so a value-bearing operator with `[""]`
         // cannot be persisted via the rule editor. Restrict the menu to NULL operators
-        // for empty strings so the cell-filter feature never produces non-persistent rules.
-        let effectiveIsNull = isNull || (value?.isEmpty ?? false)
+        // for these cases so the cell-filter feature never produces non-persistent rules.
+        // `SPCopyTable.displayStringForRow` may return nil for stale or out-of-range
+        // cells (see SPCopyTable.h:112-115), which would otherwise fall through here.
+        let effectiveIsNull = isNull || value == nil || value?.isEmpty == true
 
         let operators = SACellFilterOperator.operators(for: typeGrouping, cellIsNull: effectiveIsNull)
         guard !operators.isEmpty else {

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
@@ -45,7 +45,10 @@ import Foundation
             return false
         }
 
-        guard let values = filter["filterValues"] as? [Any] else {
+        guard let column = filter["column"] as? String,
+              column.isEmpty,
+              let values = filter["filterValues"] as? [Any],
+              !values.isEmpty else {
             return false
         }
 

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
@@ -1,0 +1,72 @@
+//
+//  SACellFilterMerge.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+@objcMembers public final class SACellFilterMerge: NSObject {
+
+    public static func mergedFilter(currentFilter: [String: Any]?, newFilter: [String: Any]) -> [String: Any] {
+        guard let currentFilter, !isEmpty(filter: currentFilter), !isUntouchedStarter(filter: currentFilter) else {
+            return newFilter
+        }
+
+        if isConjunctionGroup(filter: currentFilter), var children = currentFilter["children"] as? [[String: Any]] {
+            children.append(newFilter)
+            return andGroup(children: children)
+        }
+
+        return andGroup(children: [currentFilter, newFilter])
+    }
+
+    public static func isEmpty(filter: [String: Any]?) -> Bool {
+        guard let filter else {
+            return true
+        }
+
+        if filter["filterClass"] as? String == "groupNode" {
+            let children = filter["children"] as? [Any]
+            return children?.isEmpty ?? true
+        }
+
+        if filter["filterClass"] as? String == "expressionNode" {
+            return (filter["column"] as? String)?.isEmpty ?? true
+        }
+
+        return true
+    }
+
+    public static func isUntouchedStarter(filter: [String: Any]?) -> Bool {
+        guard let filter, filter["filterClass"] as? String == "expressionNode" else {
+            return false
+        }
+
+        guard let values = filter["filterValues"] as? [Any] else {
+            return false
+        }
+
+        for value in values {
+            guard let string = value as? String, string.isEmpty else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private static func isConjunctionGroup(filter: [String: Any]) -> Bool {
+        return filter["filterClass"] as? String == "groupNode" && filter["isConjunction"] as? Bool == true
+    }
+
+    private static func andGroup(children: [[String: Any]]) -> [String: Any] {
+        return [
+            "filterClass": "groupNode",
+            "isConjunction": true,
+            "children": children,
+        ]
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
@@ -15,9 +15,14 @@ import Foundation
             return newFilter
         }
 
-        if isConjunctionGroup(filter: currentFilter), var children = currentFilter["children"] as? [[String: Any]] {
-            children.append(newFilter)
-            return andGroup(children: children)
+        if isConjunctionGroup(filter: currentFilter), let children = currentFilter["children"] as? [[String: Any]] {
+            // Strip placeholder children (empty starter or value-empty half-touched rows) before appending
+            var realChildren = children.filter { !isEmpty(filter: $0) && !isUntouchedStarter(filter: $0) }
+            realChildren.append(newFilter)
+            if realChildren.count == 1 {
+                return realChildren[0]
+            }
+            return andGroup(children: realChildren)
         }
 
         return andGroup(children: [currentFilter, newFilter])
@@ -40,15 +45,21 @@ import Foundation
         return true
     }
 
+    /// A "starter" or "half-touched placeholder" row that the user added to the rule editor
+    /// but never filled in. Two shapes are recognized:
+    ///   - Original starter: empty column + empty filterValues entries.
+    ///   - Half-touched: column was picked but every filterValues entry is still an empty string.
+    /// In both cases the row contributes nothing to the query and should be stripped during merge
+    /// so that AND-appending a new cell filter does not produce an impossible WHERE clause.
+    ///
+    /// Zero-argument real operators (IS NULL / IS NOT NULL) serialize with `filterValues: []`
+    /// (count == 0) so the `!values.isEmpty` guard keeps them out of the placeholder bucket.
     public static func isUntouchedStarter(filter: [String: Any]?) -> Bool {
         guard let filter, filter["filterClass"] as? String == "expressionNode" else {
             return false
         }
 
-        guard let column = filter["column"] as? String,
-              column.isEmpty,
-              let values = filter["filterValues"] as? [Any],
-              !values.isEmpty else {
+        guard let values = filter["filterValues"] as? [Any], !values.isEmpty else {
             return false
         }
 

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterMerge.swift
@@ -8,8 +8,25 @@
 
 import Foundation
 
+/// Merges a newly requested cell filter into the rule-filter tree already
+/// shown in the rule editor.
+///
+/// The helper understands the serialized dictionary shape produced by
+/// `SPRuleFilterController` and keeps the merge logic testable outside the
+/// Objective-C controller.
 @objcMembers public final class SACellFilterMerge: NSObject {
 
+    /// Appends a new filter rule while removing rule-editor placeholder rows.
+    ///
+    /// Existing real filters are combined with the new rule under an AND group.
+    /// Empty starter rows and half-touched rows are dropped so right-clicking a
+    /// cell after choosing a column in the rule editor does not produce an
+    /// impossible `column = "" AND column = value` expression.
+    ///
+    /// - Parameters:
+    ///   - currentFilter: Serialized filter currently restored in the rule editor.
+    ///   - newFilter: Serialized filter created from the clicked cell.
+    /// - Returns: A serialized filter tree ready for `restoreSerializedFilters:`.
     public static func mergedFilter(currentFilter: [String: Any]?, newFilter: [String: Any]) -> [String: Any] {
         guard let currentFilter, !isEmpty(filter: currentFilter), !isUntouchedStarter(filter: currentFilter) else {
             return newFilter
@@ -28,6 +45,14 @@ import Foundation
         return andGroup(children: [currentFilter, newFilter])
     }
 
+    /// Whether a serialized filter contributes no usable rule content.
+    ///
+    /// Empty AND groups and expression rows without a selected column are
+    /// treated as empty. Unknown filter classes are considered empty so callers
+    /// fail closed rather than preserving malformed state.
+    ///
+    /// - Parameter filter: Serialized filter dictionary to inspect.
+    /// - Returns: `true` when the filter should be replaced by the new rule.
     public static func isEmpty(filter: [String: Any]?) -> Bool {
         guard let filter else {
             return true
@@ -54,6 +79,9 @@ import Foundation
     ///
     /// Zero-argument real operators (IS NULL / IS NOT NULL) serialize with `filterValues: []`
     /// (count == 0) so the `!values.isEmpty` guard keeps them out of the placeholder bucket.
+    ///
+    /// - Parameter filter: Serialized expression-node dictionary to inspect.
+    /// - Returns: `true` when every stored argument is an empty string.
     public static func isUntouchedStarter(filter: [String: Any]?) -> Bool {
         guard let filter, filter["filterClass"] as? String == "expressionNode" else {
             return false

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
@@ -8,12 +8,32 @@
 
 import Foundation
 
+/// One operator advertised by the cell-filter context menu.
+///
+/// The serialized name must match `ContentFilters.plist` exactly because the
+/// descriptor is later restored through `SPRuleFilterController`.
 @objcMembers public final class SACellFilterOperator: NSObject {
+    /// Menu title shown in the "Filter by Selected Value" submenu.
     public let menuTitle: String
+
+    /// Operator name stored in the serialized rule-filter dictionary.
     public let serializedName: String
+
+    /// Number of argument values this operator expects.
+    ///
+    /// `IS NULL` and `IS NOT NULL` use zero; value-bearing operators use one.
     public let valueCount: Int
+
+    /// Type groupings for which this operator is valid.
     public let typeGroupings: Set<String>
 
+    /// Creates an operator catalog entry.
+    ///
+    /// - Parameters:
+    ///   - menuTitle: Visible menu title.
+    ///   - serializedName: Rule-filter operator name.
+    ///   - valueCount: Number of argument values the operator requires.
+    ///   - typeGroupings: Supported Sequel Ace column type groupings.
     public init(menuTitle: String, serializedName: String, valueCount: Int, typeGroupings: Set<String>) {
         self.menuTitle = menuTitle
         self.serializedName = serializedName
@@ -22,6 +42,13 @@ import Foundation
         super.init()
     }
 
+    /// Returns all operators supported for a type grouping.
+    ///
+    /// Unknown, nil, or empty type groupings intentionally return no operators
+    /// so the context menu does not offer a filter it cannot restore.
+    ///
+    /// - Parameter typeGrouping: Type grouping from the table-content column definition.
+    /// - Returns: Catalog entries valid for that grouping.
     @objc(operatorsForTypeGrouping:)
     public static func operators(for typeGrouping: String?) -> [SACellFilterOperator] {
         guard let typeGrouping, typeGrouping.isNotEmpty else {
@@ -31,6 +58,15 @@ import Foundation
         return catalog.filter { $0.typeGroupings.contains(typeGrouping) }
     }
 
+    /// Returns operators appropriate for the selected cell value.
+    ///
+    /// NULL cells can only use zero-argument NULL operators. Non-NULL cells use
+    /// value-bearing operators so the selected value can become the rule argument.
+    ///
+    /// - Parameters:
+    ///   - typeGrouping: Type grouping from the table-content column definition.
+    ///   - cellIsNull: Whether the selected raw cell value is SQL NULL.
+    /// - Returns: Operators suitable for the current value state.
     @objc(operatorsForTypeGrouping:cellIsNull:)
     public static func operators(for typeGrouping: String?, cellIsNull: Bool) -> [SACellFilterOperator] {
         let operators = operators(for: typeGrouping)
@@ -41,6 +77,13 @@ import Foundation
         return operators.filter { $0.valueCount > 0 }
     }
 
+    /// Enumerates every advertised `(typeGrouping, operator)` pair for tests.
+    ///
+    /// Round-trip tests use this to verify each advertised operator exists in
+    /// `ContentFilters.plist` and survives restore/serialize through the real
+    /// rule-filter controller.
+    ///
+    /// - Returns: All supported type/operator combinations.
     public static func allAdvertisedPairs() -> [SACellFilterOperatorPair] {
         var pairs: [SACellFilterOperatorPair] = []
         for typeGrouping in supportedTypeGroupings {
@@ -96,7 +139,11 @@ import Foundation
     ] + nullOperators
 }
 
+/// Test-only pairing of a type grouping with one advertised operator.
 public struct SACellFilterOperatorPair {
+    /// Type grouping used to select a rule-filter operator list.
     public let typeGrouping: String
+
+    /// Operator advertised for the type grouping.
     public let op: SACellFilterOperator
 }

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
@@ -52,7 +52,7 @@ import Foundation
     }
 
     private static let numberTypeGroupings: Set<String> = ["bit", "integer", "float"]
-    private static let stringTypeGroupings: Set<String> = ["string", "binary", "textdata", "blobdata", "enum"]
+    private static let stringTypeGroupings: Set<String> = ["string", "textdata", "enum"]
 
     private static let supportedTypeGroupings = [
         "bit",
@@ -60,8 +60,8 @@ import Foundation
         "float",
         "date",
         "string",
-        "binary",
         "textdata",
+        "binary",
         "blobdata",
         "enum",
         "geometry",

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
@@ -71,10 +71,20 @@ import Foundation
     public static func operators(for typeGrouping: String?, cellIsNull: Bool) -> [SACellFilterOperator] {
         let operators = operators(for: typeGrouping)
         if cellIsNull {
+            // NULL cell: only the zero-argument NULL operators make sense.
             return operators.filter { $0.valueCount == 0 }
         }
 
-        return operators.filter { $0.valueCount > 0 }
+        // Non-NULL cell: keep value operators AND zero-argument NULL operators.
+        // Dropping NULL operators here would make the Filter submenu disappear
+        // entirely for type groupings whose catalog is NULL-only
+        // (binary / blobdata / geometry) — even though `IS NOT NULL` is a
+        // valid and useful filter on a non-NULL cell of those types. For
+        // value-bearing types (string / number / date) the user also gets
+        // `IS NULL` / `IS NOT NULL` alongside the value operators, letting
+        // them pivot to "find other rows where this column is empty/non-empty"
+        // from the same context menu without re-clicking the rule editor.
+        return operators
     }
 
     /// Enumerates every advertised `(typeGrouping, operator)` pair for tests.

--- a/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
+++ b/Source/Controllers/MainViewControllers/TableContent/SACellFilterOperator.swift
@@ -1,0 +1,102 @@
+//
+//  SACellFilterOperator.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+@objcMembers public final class SACellFilterOperator: NSObject {
+    public let menuTitle: String
+    public let serializedName: String
+    public let valueCount: Int
+    public let typeGroupings: Set<String>
+
+    public init(menuTitle: String, serializedName: String, valueCount: Int, typeGroupings: Set<String>) {
+        self.menuTitle = menuTitle
+        self.serializedName = serializedName
+        self.valueCount = valueCount
+        self.typeGroupings = typeGroupings
+        super.init()
+    }
+
+    @objc(operatorsForTypeGrouping:)
+    public static func operators(for typeGrouping: String?) -> [SACellFilterOperator] {
+        guard let typeGrouping, typeGrouping.isNotEmpty else {
+            return []
+        }
+
+        return catalog.filter { $0.typeGroupings.contains(typeGrouping) }
+    }
+
+    @objc(operatorsForTypeGrouping:cellIsNull:)
+    public static func operators(for typeGrouping: String?, cellIsNull: Bool) -> [SACellFilterOperator] {
+        let operators = operators(for: typeGrouping)
+        if cellIsNull {
+            return operators.filter { $0.valueCount == 0 }
+        }
+
+        return operators.filter { $0.valueCount > 0 }
+    }
+
+    public static func allAdvertisedPairs() -> [SACellFilterOperatorPair] {
+        var pairs: [SACellFilterOperatorPair] = []
+        for typeGrouping in supportedTypeGroupings {
+            for op in operators(for: typeGrouping) {
+                pairs.append(SACellFilterOperatorPair(typeGrouping: typeGrouping, op: op))
+            }
+        }
+        return pairs
+    }
+
+    private static let numberTypeGroupings: Set<String> = ["bit", "integer", "float"]
+    private static let stringTypeGroupings: Set<String> = ["string", "binary", "textdata", "blobdata", "enum"]
+
+    private static let supportedTypeGroupings = [
+        "bit",
+        "integer",
+        "float",
+        "date",
+        "string",
+        "binary",
+        "textdata",
+        "blobdata",
+        "enum",
+        "geometry",
+    ]
+
+    private static let nullOperators = [
+        SACellFilterOperator(menuTitle: "IS NULL", serializedName: "IS NULL", valueCount: 0, typeGroupings: Set(supportedTypeGroupings)),
+        SACellFilterOperator(menuTitle: "IS NOT NULL", serializedName: "IS NOT NULL", valueCount: 0, typeGroupings: Set(supportedTypeGroupings)),
+    ]
+
+    private static let catalog: [SACellFilterOperator] = [
+        SACellFilterOperator(menuTitle: "=", serializedName: "=", valueCount: 1, typeGroupings: numberTypeGroupings),
+        SACellFilterOperator(menuTitle: "≠", serializedName: "≠", valueCount: 1, typeGroupings: numberTypeGroupings),
+        SACellFilterOperator(menuTitle: ">", serializedName: ">", valueCount: 1, typeGroupings: numberTypeGroupings),
+        SACellFilterOperator(menuTitle: "<", serializedName: "<", valueCount: 1, typeGroupings: numberTypeGroupings),
+        SACellFilterOperator(menuTitle: "≥", serializedName: "≥", valueCount: 1, typeGroupings: numberTypeGroupings),
+        SACellFilterOperator(menuTitle: "≤", serializedName: "≤", valueCount: 1, typeGroupings: numberTypeGroupings),
+
+        SACellFilterOperator(menuTitle: "=", serializedName: "=", valueCount: 1, typeGroupings: ["date"]),
+        SACellFilterOperator(menuTitle: "≠", serializedName: "≠", valueCount: 1, typeGroupings: ["date"]),
+        SACellFilterOperator(menuTitle: "is after", serializedName: "is after", valueCount: 1, typeGroupings: ["date"]),
+        SACellFilterOperator(menuTitle: "is before", serializedName: "is before", valueCount: 1, typeGroupings: ["date"]),
+        SACellFilterOperator(menuTitle: "is after or equal to", serializedName: "is after or equal to", valueCount: 1, typeGroupings: ["date"]),
+        SACellFilterOperator(menuTitle: "is before or equal to", serializedName: "is before or equal to", valueCount: 1, typeGroupings: ["date"]),
+
+        SACellFilterOperator(menuTitle: "=", serializedName: "=", valueCount: 1, typeGroupings: stringTypeGroupings),
+        SACellFilterOperator(menuTitle: "≠", serializedName: "≠", valueCount: 1, typeGroupings: stringTypeGroupings),
+        SACellFilterOperator(menuTitle: "LIKE", serializedName: "LIKE", valueCount: 1, typeGroupings: stringTypeGroupings),
+        SACellFilterOperator(menuTitle: "NOT LIKE", serializedName: "NOT LIKE", valueCount: 1, typeGroupings: stringTypeGroupings),
+        SACellFilterOperator(menuTitle: "contains", serializedName: "contains", valueCount: 1, typeGroupings: stringTypeGroupings),
+        SACellFilterOperator(menuTitle: "does not contain", serializedName: "does not contain", valueCount: 1, typeGroupings: stringTypeGroupings),
+    ] + nullOperators
+}
+
+public struct SACellFilterOperatorPair {
+    public let typeGrouping: String
+    public let op: SACellFilterOperator
+}

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -185,6 +185,7 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 - (void)reloadTableTask;
 - (IBAction)filterTable:(id)sender;
 - (IBAction)toggleRuleEditorVisible:(id)sender;
+- (void)applyCellFilterForColumn:(NSString *)columnName operator:(NSString *)operatorName values:(NSArray *)values isNull:(BOOL)isNull;
 - (void)filterTableTask;
 - (void)setUsedQuery:(NSString *)query;
 - (NSString *)selectedTable;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1506,6 +1506,19 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	}
 }
 
+- (void)applyCellFilterForColumn:(NSString *)columnName operator:(NSString *)operatorName values:(NSArray *)values isNull:(BOOL)isNull
+{
+	NSDictionary *newFilter = [SPRuleFilterController makeSerializedFilterForColumn:columnName
+																		   operator:operatorName
+																			 values:(isNull ? @[] : (values ?: @[]))];
+	NSDictionary *mergedFilter = [SACellFilterMerge mergedFilterWithCurrentFilter:[ruleFilterController serializedFilter] newFilter:newFilter];
+
+	[ruleFilterController restoreSerializedFilters:mergedFilter];
+	activeFilter = SPTableContentFilterSourceRuleFilter;
+	[self setRuleEditorVisible:YES animate:YES];
+	[self performSelectorOnMainThread:@selector(filterTable:) withObject:ruleFilterController waitUntilDone:NO];
+}
+
 #pragma mark -
 #pragma mark Pagination
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1508,6 +1508,13 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 - (void)applyCellFilterForColumn:(NSString *)columnName operator:(NSString *)operatorName values:(NSArray *)values isNull:(BOOL)isNull
 {
+	if (![NSThread isMainThread]) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self applyCellFilterForColumn:columnName operator:operatorName values:values isNull:isNull];
+		});
+		return;
+	}
+
 	NSDictionary *newFilter = [SPRuleFilterController makeSerializedFilterForColumn:columnName
 																		   operator:operatorName
 																			 values:(isNull ? @[] : (values ?: @[]))];

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1817,10 +1817,16 @@ static BOOL SerIsUntouchedStarterRule(NSDictionary *dict)
 	if (![SerFilterClassExpression isEqual:[dict objectForKey:SerFilterClass]]) return NO;
 	NSArray *values = [dict objectForKey:SerFilterExprValues];
 	if (![values isKindOfClass:[NSArray class]]) return NO;
-	// A row counts as "untouched starter" only if every argument is an
-	// empty NSString. Anything else (NSData, NSNull, NSNumber, or a
-	// non-empty string) is real data the user or a restore path put
-	// there – merging, not replacing, is the correct behavior.
+	// A row counts as "untouched starter" only if at least one argument
+	// is present AND every argument is an empty NSString. Zero-argument
+	// operators such as IS NULL / IS NOT NULL serialize with an empty
+	// values array (count == 0); without the count guard they would be
+	// misclassified as starter and replaced on the next append/drop,
+	// silently dropping the user's NULL filter.
+	// Anything else (NSData, NSNull, NSNumber, or a non-empty string)
+	// is real data the user or a restore path put there – merging, not
+	// replacing, is the correct behavior.
+	if ([values count] == 0) return NO;
 	for (id v in values) {
 		if (![v isKindOfClass:[NSString class]]) return NO;
 		if ([(NSString *)v length]) return NO;

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -290,10 +290,21 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		numberOfDefaultFilters = [[NSMutableDictionary alloc] init];
 
 		NSError *readError = nil;
-		NSString *filePath = [NSBundle pathForResource:@"ContentFilters.plist" ofType:nil inDirectory:[[NSBundle mainBundle] bundlePath]];
-		NSData *defaultFilterData = [NSData dataWithContentsOfFile:filePath
-		                                                   options:NSMappedRead
-		                                                     error:&readError];
+		NSString *filePath = [[NSBundle mainBundle] pathForResource:@"ContentFilters" ofType:@"plist"];
+		if (!filePath) {
+			filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"ContentFilters" ofType:@"plist"];
+		}
+		NSData *defaultFilterData = nil;
+		if(filePath) {
+			defaultFilterData = [NSData dataWithContentsOfFile:filePath
+			                                           options:NSMappedRead
+			                                             error:&readError];
+		}
+		else {
+			readError = [NSError errorWithDomain:NSCocoaErrorDomain
+			                                code:NSFileNoSuchFileError
+			                            userInfo:@{NSFilePathErrorKey: @"ContentFilters.plist"}];
+		}
 
 		if(defaultFilterData && !readError) {
 			NSDictionary *defaultFilterDict = [NSPropertyListSerialization propertyListWithData:defaultFilterData

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -33,6 +33,7 @@
 #import "SPSQLParser.h"
 #import "SPStringAdditions.h"
 #import "SPDatabaseDocument.h"
+#import "SPTableContent.h"
 #import "SPProcessListController.h"
 #import "SPBundleManager.h"
 #import "SPWindow.h"

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -100,7 +100,8 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 	if(visibleColumn < 0 || visibleColumn >= (NSInteger)[[self tableColumns] count]) return NSNotFound;
 
 	NSTableColumn *tableColumn = [[self tableColumns] objectAtIndex:visibleColumn];
-	return [[tableColumn identifier] integerValue];
+	NSNumber *storageColumn = [SACellFilterColumnIdentifier storageIndexFromIdentifier:[tableColumn identifier]];
+	return storageColumn ? [storageColumn integerValue] : NSNotFound;
 }
 
 - (void)_appendCellFilterMenuToMenu:(NSMenu *)menu forEvent:(NSEvent *)event

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -64,6 +64,7 @@ static const NSInteger kBlobExclude     = 1;
 static const NSInteger kBlobInclude     = 2;
 static const NSInteger kBlobAsFile      = 3;
 static const NSInteger kBlobAsImageFile = 4;
+static const NSInteger SACellFilterMenuTag = 1945001;
 
 NSString *kColType    = @"TYPE";
 NSString *kColMapping = @"MAPPING";
@@ -79,6 +80,75 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
  */
 @synthesize fieldEditorSelectedRange;
 @synthesize tmpBlobFileDirectory;
+
+- (void)_removeCellFilterMenuItemFromMenu:(NSMenu *)menu
+{
+	NSMenuItem *item = [menu itemWithTag:SACellFilterMenuTag];
+	if(!item) return;
+
+	NSInteger index = [menu indexOfItem:item];
+	if(index > 0 && [[menu itemAtIndex:index - 1] isSeparatorItem]) {
+		[menu removeItemAtIndex:index - 1];
+		index--;
+	}
+
+	[menu removeItem:item];
+}
+
+- (NSInteger)_storageColumnIndexForVisibleColumn:(NSInteger)visibleColumn
+{
+	if(visibleColumn < 0 || visibleColumn >= (NSInteger)[[self tableColumns] count]) return NSNotFound;
+
+	NSTableColumn *tableColumn = [[self tableColumns] objectAtIndex:visibleColumn];
+	return [[tableColumn identifier] integerValue];
+}
+
+- (void)_appendCellFilterMenuToMenu:(NSMenu *)menu forEvent:(NSEvent *)event
+{
+	if(![[self delegate] isKindOfClass:[SPTableContent class]]) return;
+
+	NSPoint point = [self convertPoint:[event locationInWindow] fromView:nil];
+	NSInteger row = [self rowAtPoint:point];
+	NSInteger visibleColumn = [self columnAtPoint:point];
+	if(row < 0 || visibleColumn < 0) return;
+
+	NSInteger storageColumn = [self _storageColumnIndexForVisibleColumn:visibleColumn];
+	if(storageColumn == NSNotFound) return;
+
+	NSArray *columnDefinitions = [(id <SPDatabaseContentViewDelegate>)[self delegate] dataColumnDefinitions];
+	if(storageColumn < 0 || storageColumn >= (NSInteger)[columnDefinitions count]) return;
+
+	NSDictionary *columnDefinition = [columnDefinitions objectAtIndex:storageColumn];
+	NSString *columnName = [columnDefinition objectForKey:@"name"];
+	NSString *typeGrouping = [columnDefinition objectForKey:@"typegrouping"];
+	NSArray<SACellFilterMenuItemDescriptor *> *descriptors = [SACellFilterMenuBuilder menuItemDescriptorsWithColumnName:columnName
+		typeGrouping:typeGrouping
+		value:[self displayStringForRow:row column:visibleColumn]
+		isNull:[self isNullAtRow:row column:visibleColumn]];
+
+	if(![descriptors count]) return;
+
+	NSMenu *filterMenu = [[NSMenu alloc] init];
+	SPTableContent *tableContent = (SPTableContent *)[self delegate];
+	for(SACellFilterMenuItemDescriptor *descriptor in descriptors) {
+		SACellFilterAction *action = [[SACellFilterAction alloc] initWithTableContent:tableContent
+			columnName:[descriptor columnName]
+			operatorName:[descriptor operatorName]
+			values:[descriptor values]
+			isNull:[descriptor isNull]];
+		NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:[descriptor title] action:@selector(apply:) keyEquivalent:@""];
+		[item setTarget:action];
+		[item setRepresentedObject:action];
+		[filterMenu addItem:item];
+	}
+
+	[menu addItem:[NSMenuItem separatorItem]];
+
+	NSMenuItem *filterMenuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Filter by Selected Value", @"Cell context menu filter submenu title") action:nil keyEquivalent:@""];
+	[filterMenuItem setTag:SACellFilterMenuTag];
+	[menu addItem:filterMenuItem];
+	[menu setSubmenu:filterMenu forItem:filterMenuItem];
+}
 
 /**
  * Cell editing in SPCustomQuery or for views in SPTableContent
@@ -1053,6 +1123,7 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 	NSMenu *menu = [self menu];
 
 	if(![[self delegate] isKindOfClass:[SPCustomQuery class]] && ![[self delegate] isKindOfClass:[SPTableContent class]]) return menu;
+	[self _removeCellFilterMenuItemFromMenu:menu];
 
 	[SPBundleManager.shared reloadBundles:self];
 
@@ -1115,6 +1186,8 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
 			}
 		}
 	}
+
+	[self _appendCellFilterMenuToMenu:menu forEvent:event];
 
 	return menu;
 

--- a/UnitTests/SACellFilterColumnIdentifierTests.swift
+++ b/UnitTests/SACellFilterColumnIdentifierTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 final class SACellFilterColumnIdentifierTests: XCTestCase {
 
+    /// Verifies integer-like identifiers resolve to storage column indexes.
     func testPureIntegerIdentifiersResolveStorageIndex() {
         XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: "0")?.intValue, 0)
         XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: "12")?.intValue, 12)
@@ -17,6 +18,7 @@ final class SACellFilterColumnIdentifierTests: XCTestCase {
         XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: NSUserInterfaceItemIdentifier("4"))?.intValue, 4)
     }
 
+    /// Verifies nil, empty, mixed, whitespace, and negative identifiers are rejected.
     func testNonIntegerIdentifiersAreRejected() {
         XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: nil))
         XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: ""))

--- a/UnitTests/SACellFilterColumnIdentifierTests.swift
+++ b/UnitTests/SACellFilterColumnIdentifierTests.swift
@@ -1,0 +1,28 @@
+//
+//  SACellFilterColumnIdentifierTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SACellFilterColumnIdentifierTests: XCTestCase {
+
+    func testPureIntegerIdentifiersResolveStorageIndex() {
+        XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: "0")?.intValue, 0)
+        XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: "12")?.intValue, 12)
+        XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: NSNumber(value: 7))?.intValue, 7)
+        XCTAssertEqual(SACellFilterColumnIdentifier.storageIndex(from: NSUserInterfaceItemIdentifier("4"))?.intValue, 4)
+    }
+
+    func testNonIntegerIdentifiersAreRejected() {
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: nil))
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: ""))
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: "abc"))
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: "12abc"))
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: " 12"))
+        XCTAssertNil(SACellFilterColumnIdentifier.storageIndex(from: "-1"))
+    }
+}

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -115,4 +115,36 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(descriptors.map(\.values), [[], []])
         XCTAssertEqual(descriptors.map(\.isNull), [true, true])
     }
+
+    func testEmptyStringDescriptorsAreMarkedAsNullPayload() throws {
+        // Empty-string cells must produce zero-argument NULL descriptors so the
+        // downstream applyCellFilter path serializes filterValues:[] (not [""]).
+        let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
+            columnName: "payload",
+            typeGrouping: "string",
+            value: "",
+            isNull: false
+        )
+
+        XCTAssertEqual(descriptors.map(\.title), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(descriptors.map(\.values), [[], []])
+        XCTAssertEqual(descriptors.map(\.isNull), [true, true])
+    }
+
+    func testNilNonNullValueProducesNullDescriptorsNotEmptyValueRules() throws {
+        // SPCopyTable.displayStringForRow may return nil for stale / out-of-range
+        // cells (see SPCopyTable.h:112-115). The menu builder must NOT fall through
+        // to value operators with `[""]`; it must route to NULL operators with
+        // filterValues:[] like the empty-string case.
+        let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
+            columnName: "payload",
+            typeGrouping: "string",
+            value: nil,
+            isNull: false
+        )
+
+        XCTAssertEqual(descriptors.map(\.title), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(descriptors.map(\.values), [[], []])
+        XCTAssertEqual(descriptors.map(\.isNull), [true, true])
+    }
 }

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 final class SACellFilterMenuBuilderTests: XCTestCase {
 
+    /// Verifies unknown type groupings do not produce a cell-filter menu.
     func testUnknownTypeGroupingReturnsNoMenu() {
         let menu = SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "unknown_type_group"],
@@ -20,6 +21,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertNil(menu)
     }
 
+    /// Verifies NULL cell values only expose NULL and NOT NULL menu items.
     func testNullValueOnlyShowsNullOperators() throws {
         let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "string"],
@@ -30,6 +32,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies non-empty string cells expose the advertised string operators.
     func testStringValueMenuUsesAdvertisedOperators() throws {
         let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "string"],
@@ -40,6 +43,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain"])
     }
 
+    /// Verifies empty string cells are limited to NULL operators to avoid placeholder filters.
     func testEmptyStringValueOnlyShowsNullOperators() throws {
         // An empty-string cell value cannot be persisted as a value-bearing rule because
         // SPRuleFilterController's starter detection treats filterValues=[""] as a
@@ -54,6 +58,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies empty numeric cells are also limited to NULL operators.
     func testEmptyStringValueOnNumberColumnOnlyShowsNullOperators() throws {
         // Same reasoning as the string case — applies across all type groupings.
         let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
@@ -65,6 +70,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies non-NULL binary and blob values do not produce unsupported value menus.
     func testBinaryAndBlobNonNullValuesReturnNoMenu() {
         XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "binary"],
@@ -78,6 +84,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         ))
     }
 
+    /// Verifies NULL binary values still expose NULL-safe menu items.
     func testBinaryNullValueOnlyShowsNullOperators() throws {
         let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "binary"],
@@ -88,6 +95,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies non-NULL descriptors carry the selected column, operator, and value.
     func testDescriptorsCarryFilterPayload() throws {
         let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
             columnName: "payload",
@@ -104,6 +112,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertFalse(first.isNull)
     }
 
+    /// Verifies NULL descriptors do not carry the selected display value.
     func testNullDescriptorsDoNotCarrySelectedValue() throws {
         let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
             columnName: "payload",
@@ -116,6 +125,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(descriptors.map(\.isNull), [true, true])
     }
 
+    /// Verifies empty string descriptors serialize as zero-argument NULL payloads.
     func testEmptyStringDescriptorsAreMarkedAsNullPayload() throws {
         // Empty-string cells must produce zero-argument NULL descriptors so the
         // downstream applyCellFilter path serializes filterValues:[] (not [""]).
@@ -131,6 +141,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(descriptors.map(\.isNull), [true, true])
     }
 
+    /// Verifies nil non-NULL values route to NULL descriptors instead of empty value rules.
     func testNilNonNullValueProducesNullDescriptorsNotEmptyValueRules() throws {
         // SPCopyTable.displayStringForRow may return nil for stale / out-of-range
         // cells (see SPCopyTable.h:112-115). The menu builder must NOT fall through

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -40,6 +40,29 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain"])
     }
 
+    func testBinaryAndBlobNonNullValuesReturnNoMenu() {
+        XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "binary"],
+            value: "0xdeadbeef",
+            isNull: false
+        ))
+        XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "blobdata"],
+            value: "0xdeadbeef",
+            isNull: false
+        ))
+    }
+
+    func testBinaryNullValueOnlyShowsNullOperators() throws {
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "binary"],
+            value: "NULL",
+            isNull: true
+        ))
+
+        XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+    }
+
     func testDescriptorsCarryFilterPayload() throws {
         let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
             columnName: "payload",

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -1,0 +1,70 @@
+//
+//  SACellFilterMenuBuilderTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SACellFilterMenuBuilderTests: XCTestCase {
+
+    func testUnknownTypeGroupingReturnsNoMenu() {
+        let menu = SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "unknown_type_group"],
+            value: "abc",
+            isNull: false
+        )
+
+        XCTAssertNil(menu)
+    }
+
+    func testNullValueOnlyShowsNullOperators() throws {
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "string"],
+            value: "NULL",
+            isNull: true
+        ))
+
+        XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+    }
+
+    func testStringValueMenuUsesAdvertisedOperators() throws {
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "string"],
+            value: "abc",
+            isNull: false
+        ))
+
+        XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain"])
+    }
+
+    func testDescriptorsCarryFilterPayload() throws {
+        let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
+            columnName: "payload",
+            typeGrouping: "string",
+            value: "abc",
+            isNull: false
+        )
+
+        let first = try XCTUnwrap(descriptors.first)
+        XCTAssertEqual(first.title, "=")
+        XCTAssertEqual(first.columnName, "payload")
+        XCTAssertEqual(first.operatorName, "=")
+        XCTAssertEqual(first.values, ["abc"])
+        XCTAssertFalse(first.isNull)
+    }
+
+    func testNullDescriptorsDoNotCarrySelectedValue() throws {
+        let descriptors = SACellFilterMenuBuilder.menuItemDescriptors(
+            columnName: "payload",
+            typeGrouping: "string",
+            value: "NULL",
+            isNull: true
+        )
+
+        XCTAssertEqual(descriptors.map(\.values), [[], []])
+        XCTAssertEqual(descriptors.map(\.isNull), [true, true])
+    }
+}

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -32,7 +32,7 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
-    /// Verifies non-empty string cells expose the advertised string operators.
+    /// Verifies non-empty string cells expose the advertised string operators plus NULL operators.
     func testStringValueMenuUsesAdvertisedOperators() throws {
         let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "string"],
@@ -40,7 +40,10 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
             isNull: false
         ))
 
-        XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain"])
+        // Non-NULL cells keep IS NULL / IS NOT NULL alongside value operators so
+        // the user can pivot to "find other rows where this column is empty" from
+        // the same context menu without re-opening the rule editor.
+        XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain", "IS NULL", "IS NOT NULL"])
     }
 
     /// Verifies empty string cells are limited to NULL operators to avoid placeholder filters.
@@ -70,18 +73,37 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
-    /// Verifies non-NULL binary and blob values do not produce unsupported value menus.
-    func testBinaryAndBlobNonNullValuesReturnNoMenu() {
-        XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
+    /// Verifies non-NULL binary and blob values still expose NULL operators (the
+    /// only operators their catalog advertises) instead of returning no menu at all.
+    func testBinaryAndBlobNonNullValuesShowNullOperators() throws {
+        // The catalog for binary / blobdata / geometry is NULL-only on purpose
+        // (hex/empty value handling for `=` is unsafe). Before this fix, the
+        // menu was empty for non-NULL cells of these types, hiding the still-
+        // valid IS NULL / IS NOT NULL filter. Now they remain available so the
+        // feature is usable on these columns.
+        let binaryMenu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "binary"],
             value: "0xdeadbeef",
             isNull: false
         ))
-        XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
+        XCTAssertEqual(binaryMenu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+
+        let blobMenu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "blobdata"],
             value: "0xdeadbeef",
             isNull: false
         ))
+        XCTAssertEqual(blobMenu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+    }
+
+    /// Verifies non-NULL geometry cells also expose IS NULL / IS NOT NULL.
+    func testGeometryNonNullValueShowsNullOperators() throws {
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "shape", "typegrouping": "geometry"],
+            value: "POINT(1 1)",
+            isNull: false
+        ))
+        XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
     }
 
     /// Verifies NULL binary values still expose NULL-safe menu items.

--- a/UnitTests/SACellFilterMenuBuilderTests.swift
+++ b/UnitTests/SACellFilterMenuBuilderTests.swift
@@ -40,6 +40,31 @@ final class SACellFilterMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items.map(\.title), ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain"])
     }
 
+    func testEmptyStringValueOnlyShowsNullOperators() throws {
+        // An empty-string cell value cannot be persisted as a value-bearing rule because
+        // SPRuleFilterController's starter detection treats filterValues=[""] as a
+        // disposable placeholder. Cell-filter therefore restricts the menu to NULL
+        // operators for empty strings, matching the NULL-cell handling.
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "payload", "typegrouping": "string"],
+            value: "",
+            isNull: false
+        ))
+
+        XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+    }
+
+    func testEmptyStringValueOnNumberColumnOnlyShowsNullOperators() throws {
+        // Same reasoning as the string case — applies across all type groupings.
+        let menu = try XCTUnwrap(SACellFilterMenuBuilder.filterMenu(
+            column: ["name": "qty", "typegrouping": "integer"],
+            value: "",
+            isNull: false
+        ))
+
+        XCTAssertEqual(menu.items.map(\.title), ["IS NULL", "IS NOT NULL"])
+    }
+
     func testBinaryAndBlobNonNullValuesReturnNoMenu() {
         XCTAssertNil(SACellFilterMenuBuilder.filterMenu(
             column: ["name": "payload", "typegrouping": "binary"],

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -28,10 +28,21 @@ final class SACellFilterMergeTests: XCTestCase {
     }
 
     func testUntouchedStarterExpressionUsesNewFilter() {
-        let starter = filter(column: "id", comparison: "=", values: [""])
+        let starter = filter(column: "", comparison: "=", values: [""])
         let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
 
         XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: starter, newFilter: newFilter)), filterDictionary(newFilter))
+    }
+
+    func testExistingZeroArgumentNullRuleIsPreserved() {
+        let existing = filter(column: "deleted_at", comparison: "IS NULL", values: [])
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged["filterClass"] as? String, "groupNode")
+        XCTAssertEqual(merged["isConjunction"] as? Bool, true)
+        XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
     }
 
     func testRealExpressionWrapsInAndGroup() {

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -10,12 +10,14 @@ import XCTest
 
 final class SACellFilterMergeTests: XCTestCase {
 
+    /// Verifies a missing current filter is replaced by the new cell filter.
     func testNilCurrentFilterUsesNewFilter() {
         let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
 
         XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: nil, newFilter: newFilter)), filterDictionary(newFilter))
     }
 
+    /// Verifies an empty AND group collapses to the new cell filter.
     func testEmptyAndGroupUsesNewFilter() {
         let emptyGroup: [String: Any] = [
             "filterClass": "groupNode",
@@ -27,6 +29,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: emptyGroup, newFilter: newFilter)), filterDictionary(newFilter))
     }
 
+    /// Verifies an untouched starter expression is replaced by the new cell filter.
     func testUntouchedStarterExpressionUsesNewFilter() {
         let starter = filter(column: "", comparison: "=", values: [""])
         let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
@@ -34,6 +37,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: starter, newFilter: newFilter)), filterDictionary(newFilter))
     }
 
+    /// Verifies existing zero-argument NULL rules are preserved during merges.
     func testExistingZeroArgumentNullRuleIsPreserved() {
         let existing = filter(column: "deleted_at", comparison: "IS NULL", values: [])
         let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
@@ -45,6 +49,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
     }
 
+    /// Verifies a real expression and a new filter are wrapped in an AND group.
     func testRealExpressionWrapsInAndGroup() {
         let existing = filter(column: "id", comparison: "=", values: ["42"])
         let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
@@ -56,6 +61,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
     }
 
+    /// Verifies an existing AND group appends the new cell filter as another child.
     func testExistingAndGroupAppendsNewFilter() {
         let first = filter(column: "id", comparison: "=", values: ["42"])
         let second = filter(column: "state", comparison: "=", values: ["active"])
@@ -73,6 +79,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(first), filterDictionary(second), filterDictionary(newFilter)])
     }
 
+    /// Verifies an existing OR group is preserved as one child of a new AND group.
     func testExistingOrGroupIsWrappedAsOneAndChild() {
         let first = filter(column: "id", comparison: "=", values: ["42"])
         let second = filter(column: "state", comparison: "=", values: ["active"])
@@ -90,6 +97,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
     }
 
+    /// Verifies a half-touched single expression is treated as a placeholder.
     func testHalfTouchedSingleExpressionIsTreatedAsPlaceholder() {
         // User picked a column in the rule editor but never filled in a value.
         // Serialized as `Host = ""`. Merging a real cell filter must REPLACE
@@ -102,6 +110,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(merged as NSDictionary, newFilter as NSDictionary)
     }
 
+    /// Verifies half-touched placeholder children are stripped before AND merges.
     func testAndGroupStripsHalfTouchedChildrenWhenMerging() {
         let halfTouched = filter(column: "Host", comparison: "=", values: [""])
         let real = filter(column: "id", comparison: "=", values: ["42"])
@@ -120,6 +129,7 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(real), filterDictionary(newFilter)])
     }
 
+    /// Verifies an AND group containing only placeholders collapses to the new filter.
     func testAndGroupOfOnlyPlaceholdersCollapsesToNewFilter() {
         // All existing rules are unfilled placeholders → strip them all,
         // leaving only the new cell filter as a single leaf (not a group).

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -1,0 +1,99 @@
+//
+//  SACellFilterMergeTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SACellFilterMergeTests: XCTestCase {
+
+    func testNilCurrentFilterUsesNewFilter() {
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+
+        XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: nil, newFilter: newFilter)), filterDictionary(newFilter))
+    }
+
+    func testEmptyAndGroupUsesNewFilter() {
+        let emptyGroup: [String: Any] = [
+            "filterClass": "groupNode",
+            "isConjunction": true,
+            "children": [],
+        ]
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+
+        XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: emptyGroup, newFilter: newFilter)), filterDictionary(newFilter))
+    }
+
+    func testUntouchedStarterExpressionUsesNewFilter() {
+        let starter = filter(column: "id", comparison: "=", values: [""])
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+
+        XCTAssertEqual(filterDictionary(SACellFilterMerge.mergedFilter(currentFilter: starter, newFilter: newFilter)), filterDictionary(newFilter))
+    }
+
+    func testRealExpressionWrapsInAndGroup() {
+        let existing = filter(column: "id", comparison: "=", values: ["42"])
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged["filterClass"] as? String, "groupNode")
+        XCTAssertEqual(merged["isConjunction"] as? Bool, true)
+        XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
+    }
+
+    func testExistingAndGroupAppendsNewFilter() {
+        let first = filter(column: "id", comparison: "=", values: ["42"])
+        let second = filter(column: "state", comparison: "=", values: ["active"])
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+        let existing: [String: Any] = [
+            "filterClass": "groupNode",
+            "isConjunction": true,
+            "children": [first, second],
+        ]
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged["filterClass"] as? String, "groupNode")
+        XCTAssertEqual(merged["isConjunction"] as? Bool, true)
+        XCTAssertEqual(filterChildren(from: merged), [filterDictionary(first), filterDictionary(second), filterDictionary(newFilter)])
+    }
+
+    func testExistingOrGroupIsWrappedAsOneAndChild() {
+        let first = filter(column: "id", comparison: "=", values: ["42"])
+        let second = filter(column: "state", comparison: "=", values: ["active"])
+        let newFilter = filter(column: "name", comparison: "=", values: ["Alice"])
+        let existing: [String: Any] = [
+            "filterClass": "groupNode",
+            "isConjunction": false,
+            "children": [first, second],
+        ]
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged["filterClass"] as? String, "groupNode")
+        XCTAssertEqual(merged["isConjunction"] as? Bool, true)
+        XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
+    }
+
+    private func filter(column: String, comparison: String, values: [String]) -> [String: AnyHashable] {
+        return [
+            "filterClass": "expressionNode",
+            "column": column,
+            "filterComparison": comparison,
+            "filterValues": values,
+            "enabled": true,
+        ]
+    }
+
+    private func filterDictionary(_ filter: [String: Any]) -> NSDictionary {
+        return filter as NSDictionary
+    }
+
+    private func filterChildren(from filter: [String: Any]) -> [NSDictionary]? {
+        return (filter["children"] as? [[String: Any]])?.map { $0 as NSDictionary }
+    }
+}

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -90,6 +90,53 @@ final class SACellFilterMergeTests: XCTestCase {
         XCTAssertEqual(filterChildren(from: merged), [filterDictionary(existing), filterDictionary(newFilter)])
     }
 
+    func testHalfTouchedSingleExpressionIsTreatedAsPlaceholder() {
+        // User picked a column in the rule editor but never filled in a value.
+        // Serialized as `Host = ""`. Merging a real cell filter must REPLACE
+        // (not AND-append) so the result is not the impossible `Host="" AND Host="localhost"`.
+        let halfTouched = filter(column: "Host", comparison: "=", values: [""])
+        let newFilter = filter(column: "Host", comparison: "=", values: ["localhost"])
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: halfTouched, newFilter: newFilter)
+
+        XCTAssertEqual(merged as NSDictionary, newFilter as NSDictionary)
+    }
+
+    func testAndGroupStripsHalfTouchedChildrenWhenMerging() {
+        let halfTouched = filter(column: "Host", comparison: "=", values: [""])
+        let real = filter(column: "id", comparison: "=", values: ["42"])
+        let newFilter = filter(column: "Host", comparison: "=", values: ["localhost"])
+        let existing: [String: Any] = [
+            "filterClass": "groupNode",
+            "isConjunction": true,
+            "children": [halfTouched, real],
+        ]
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged["filterClass"] as? String, "groupNode")
+        XCTAssertEqual(merged["isConjunction"] as? Bool, true)
+        // halfTouched stripped; real kept; newFilter appended → [real, newFilter]
+        XCTAssertEqual(filterChildren(from: merged), [filterDictionary(real), filterDictionary(newFilter)])
+    }
+
+    func testAndGroupOfOnlyPlaceholdersCollapsesToNewFilter() {
+        // All existing rules are unfilled placeholders → strip them all,
+        // leaving only the new cell filter as a single leaf (not a group).
+        let placeholder1 = filter(column: "Host", comparison: "=", values: [""])
+        let placeholder2 = filter(column: "User", comparison: "=", values: [""])
+        let newFilter = filter(column: "Host", comparison: "=", values: ["localhost"])
+        let existing: [String: Any] = [
+            "filterClass": "groupNode",
+            "isConjunction": true,
+            "children": [placeholder1, placeholder2],
+        ]
+
+        let merged = SACellFilterMerge.mergedFilter(currentFilter: existing, newFilter: newFilter)
+
+        XCTAssertEqual(merged as NSDictionary, newFilter as NSDictionary)
+    }
+
     private func filter(column: String, comparison: String, values: [String]) -> [String: AnyHashable] {
         return [
             "filterClass": "expressionNode",

--- a/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
+++ b/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
@@ -16,6 +16,7 @@
 - (void)restoreSerializedFilters:(NSDictionary *)serialized;
 - (NSDictionary *)serializedFilter;
 - (void)setColumns:(NSArray *)dataColumns;
+- (BOOL)appendFilterForColumn:(NSString *)columnName value:(NSString *)value isNull:(BOOL)isNull;
 @end
 
 @interface SACellFilterOperatorRoundTripControllerTests : XCTestCase
@@ -92,6 +93,36 @@
 		[values addObject:[NSString stringWithFormat:@"sample%ld", (long)i]];
 	}
 	return values;
+}
+
+// Regression for the SerIsUntouchedStarterRule zero-value guard.
+// Before the fix, an existing zero-argument rule such as IS NULL was
+// classified as an untouched starter and replaced on the next
+// -appendFilterForColumn:value:isNull: call (cell drop / drag/drop), silently
+// dropping the user's NULL filter. After the fix the existing IS NULL must be
+// preserved as one branch of an AND-group when a new rule is appended.
+- (void)testExistingIsNullRuleIsPreservedWhenAppendingNewFilter
+{
+	NSString *columnName = @"deleted_at";
+	id controller = [self ruleFilterControllerForTypeGrouping:@"date" columnName:columnName];
+
+	NSDictionary *isNullLeaf = [self serializedFilterForColumn:columnName operator:@"IS NULL" values:@[]];
+	((void (*)(id, SEL, NSDictionary *))objc_msgSend)(controller, @selector(restoreSerializedFilters:), isNullLeaf);
+
+	NSDictionary *restored = ((NSDictionary *(*)(id, SEL))objc_msgSend)(controller, @selector(serializedFilter));
+	XCTAssertEqualObjects(restored[@"filterComparison"], @"IS NULL", @"IS NULL leaf must restore as itself before any append");
+
+	BOOL appended = ((BOOL (*)(id, SEL, NSString *, NSString *, BOOL))objc_msgSend)(
+		controller, @selector(appendFilterForColumn:value:isNull:), columnName, @"2026-05-23", NO);
+	XCTAssertTrue(appended, @"append must succeed for a real column/value");
+
+	NSDictionary *merged = ((NSDictionary *(*)(id, SEL))objc_msgSend)(controller, @selector(serializedFilter));
+	XCTAssertEqualObjects(merged[@"filterClass"], @"groupNode", @"existing IS NULL + new append must produce an AND group");
+	XCTAssertEqualObjects(merged[@"isConjunction"], @YES);
+
+	NSArray<NSDictionary *> *children = merged[@"children"];
+	XCTAssertEqual([children count], 2u, @"AND group must contain both the IS NULL rule and the new appended rule");
+	XCTAssertEqualObjects(children[0][@"filterComparison"], @"IS NULL", @"original IS NULL must remain as a child, not be replaced");
 }
 
 @end

--- a/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
+++ b/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
@@ -24,6 +24,9 @@
 
 @implementation SACellFilterOperatorRoundTripControllerTests
 
+/**
+ * Verifies every advertised operator round-trips through SPRuleFilterController without changing its serialized leaf.
+ */
 - (void)testAllAdvertisedOperatorsRestoreAndSerializeThroughRuleFilterController
 {
 	NSArray<NSString *> *typeGroupings = @[
@@ -95,14 +98,13 @@
 	return values;
 }
 
-// Regression for the SerIsUntouchedStarterRule zero-value guard.
-// Before the fix, an existing zero-argument rule such as IS NULL was
-// classified as an untouched starter and replaced on the next
-// -appendFilterForColumn:value:isNull: call (cell drop / drag/drop), silently
-// dropping the user's NULL filter. After the fix the existing IS NULL must be
-// preserved as one branch of an AND-group when a new rule is appended.
+/**
+ * Verifies appending a filter preserves an existing IS NULL rule as an AND-group child.
+ */
 - (void)testExistingIsNullRuleIsPreservedWhenAppendingNewFilter
 {
+	// Regression for the SerIsUntouchedStarterRule zero-value guard: before the
+	// fix, this append path replaced the user's existing zero-argument NULL rule.
 	NSString *columnName = @"deleted_at";
 	id controller = [self ruleFilterControllerForTypeGrouping:@"date" columnName:columnName];
 

--- a/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
+++ b/UnitTests/SACellFilterOperatorRoundTripControllerTests.m
@@ -1,0 +1,97 @@
+//
+//  SACellFilterOperatorRoundTripControllerTests.m
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <objc/message.h>
+
+#import "sequel-ace-Swift.h"
+
+@interface NSObject (SACellFilterRuleControllerTesting)
++ (NSDictionary *)makeSerializedFilterForColumn:(NSString *)colName operator:(NSString *)opName values:(NSArray *)values;
+- (void)restoreSerializedFilters:(NSDictionary *)serialized;
+- (NSDictionary *)serializedFilter;
+- (void)setColumns:(NSArray *)dataColumns;
+@end
+
+@interface SACellFilterOperatorRoundTripControllerTests : XCTestCase
+@end
+
+@implementation SACellFilterOperatorRoundTripControllerTests
+
+- (void)testAllAdvertisedOperatorsRestoreAndSerializeThroughRuleFilterController
+{
+	NSArray<NSString *> *typeGroupings = @[
+		@"bit",
+		@"integer",
+		@"float",
+		@"date",
+		@"string",
+		@"binary",
+		@"textdata",
+		@"blobdata",
+		@"enum",
+		@"geometry",
+	];
+
+	for (NSString *typeGrouping in typeGroupings) {
+		NSArray<SACellFilterOperator *> *operators = [SACellFilterOperator operatorsForTypeGrouping:typeGrouping];
+		XCTAssertGreaterThan([operators count], 0, @"%@ should advertise at least one operator", typeGrouping);
+
+		for (SACellFilterOperator *op in operators) {
+			NSString *columnName = [NSString stringWithFormat:@"%@_column", typeGrouping];
+			id controller = [self ruleFilterControllerForTypeGrouping:typeGrouping columnName:columnName];
+			NSArray<NSString *> *values = [self valuesForOperator:op];
+			NSDictionary *leaf = [self serializedFilterForColumn:columnName operator:[op serializedName] values:values];
+
+			((void (*)(id, SEL, NSDictionary *))objc_msgSend)(controller, @selector(restoreSerializedFilters:), leaf);
+			NSDictionary *serialized = ((NSDictionary *(*)(id, SEL))objc_msgSend)(controller, @selector(serializedFilter));
+
+			XCTAssertEqualObjects(serialized[@"filterClass"], @"expressionNode", @"%@/%@ should restore as an expression", typeGrouping, [op serializedName]);
+			XCTAssertEqualObjects(serialized[@"column"], columnName, @"%@/%@ changed column during restore", typeGrouping, [op serializedName]);
+			XCTAssertEqualObjects(serialized[@"filterComparison"], [op serializedName], @"%@/%@ changed comparison during restore", typeGrouping, [op serializedName]);
+			XCTAssertEqualObjects(serialized[@"filterValues"], values, @"%@/%@ changed values during restore", typeGrouping, [op serializedName]);
+		}
+	}
+}
+
+- (id)ruleFilterControllerForTypeGrouping:(NSString *)typeGrouping columnName:(NSString *)columnName
+{
+	Class controllerClass = NSClassFromString(@"SPRuleFilterController");
+	XCTAssertNotNil(controllerClass);
+
+	id controller = [[controllerClass alloc] init];
+	NSRuleEditor *ruleEditor = [[NSRuleEditor alloc] initWithFrame:NSMakeRect(0, 0, 600, 120)];
+	[ruleEditor setDelegate:(id<NSRuleEditorDelegate>)controller];
+	[controller setValue:ruleEditor forKey:@"filterRuleEditor"];
+	NSArray *columns = @[
+		@{
+			@"name": columnName,
+			@"typegrouping": typeGrouping,
+		},
+	];
+	((void (*)(id, SEL, NSArray *))objc_msgSend)(controller, @selector(setColumns:), columns);
+	return controller;
+}
+
+- (NSDictionary *)serializedFilterForColumn:(NSString *)columnName operator:(NSString *)operatorName values:(NSArray<NSString *> *)values
+{
+	Class controllerClass = NSClassFromString(@"SPRuleFilterController");
+	XCTAssertNotNil(controllerClass);
+	return ((NSDictionary *(*)(id, SEL, NSString *, NSString *, NSArray *))objc_msgSend)(controllerClass, @selector(makeSerializedFilterForColumn:operator:values:), columnName, operatorName, values);
+}
+
+- (NSArray<NSString *> *)valuesForOperator:(SACellFilterOperator *)op
+{
+	NSMutableArray<NSString *> *values = [NSMutableArray arrayWithCapacity:(NSUInteger)[op valueCount]];
+	for (NSInteger i = 0; i < [op valueCount]; i++) {
+		[values addObject:[NSString stringWithFormat:@"sample%ld", (long)i]];
+	}
+	return values;
+}
+
+@end

--- a/UnitTests/SACellFilterOperatorRoundTripTests.swift
+++ b/UnitTests/SACellFilterOperatorRoundTripTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 final class SACellFilterOperatorRoundTripTests: XCTestCase {
 
+    /// Verifies every advertised operator has a matching ContentFilters.plist definition.
     func testAllAdvertisedOperatorsExistInContentFiltersPlist() throws {
         let contentFilters = try loadContentFilters()
 

--- a/UnitTests/SACellFilterOperatorRoundTripTests.swift
+++ b/UnitTests/SACellFilterOperatorRoundTripTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class SACellFilterOperatorRoundTripTests: XCTestCase {
 
-    func testAllAdvertisedOperatorsRoundTripAgainstContentFiltersPlist() throws {
+    func testAllAdvertisedOperatorsExistInContentFiltersPlist() throws {
         let contentFilters = try loadContentFilters()
 
         for pair in SACellFilterOperator.allAdvertisedPairs() {
@@ -21,11 +21,6 @@ final class SACellFilterOperatorRoundTripTests: XCTestCase {
             XCTAssertNotNil(definition, "\(pair.op.serializedName) missing from ContentFilters.plist for typegrouping \(pair.typeGrouping)")
             XCTAssertEqual(definition?["MenuLabel"] as? String, pair.op.serializedName)
             XCTAssertEqual(definition?["NumberOfArguments"] as? Int, pair.op.valueCount)
-
-            let leaf = serializedFilter(column: "\(pair.typeGrouping)_column", operatorName: pair.op.serializedName, values: values(for: pair.op))
-            let restored = serializeRestoredFilter(leaf, filterDefinition: definition)
-
-            XCTAssertEqual(restored["filterComparison"] as? String, pair.op.serializedName, "\(pair.op.serializedName) failed to round-trip for typegrouping \(pair.typeGrouping)")
         }
     }
 
@@ -56,23 +51,4 @@ final class SACellFilterOperatorRoundTripTests: XCTestCase {
         }
     }
 
-    private func values(for op: SACellFilterOperator) -> [String] {
-        return Array(repeating: "sample", count: op.valueCount)
-    }
-
-    private func serializedFilter(column: String, operatorName: String, values: [String]) -> [String: Any] {
-        return [
-            "filterClass": "expressionNode",
-            "column": column,
-            "filterComparison": operatorName,
-            "filterValues": values,
-            "enabled": true,
-        ]
-    }
-
-    private func serializeRestoredFilter(_ filter: [String: Any], filterDefinition: [String: Any]?) -> [String: Any] {
-        var restored = filter
-        restored["filterType"] = filterDefinition?["filterType"]
-        return restored
-    }
 }

--- a/UnitTests/SACellFilterOperatorRoundTripTests.swift
+++ b/UnitTests/SACellFilterOperatorRoundTripTests.swift
@@ -1,0 +1,78 @@
+//
+//  SACellFilterOperatorRoundTripTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SACellFilterOperatorRoundTripTests: XCTestCase {
+
+    func testAllAdvertisedOperatorsRoundTripAgainstContentFiltersPlist() throws {
+        let contentFilters = try loadContentFilters()
+
+        for pair in SACellFilterOperator.allAdvertisedPairs() {
+            let filterType = filterType(for: pair.typeGrouping)
+            let definitions = try XCTUnwrap(contentFilters[filterType] as? [[String: Any]], "Missing filter definitions for \(filterType)")
+            let definition = definitions.first { $0["MenuLabel"] as? String == pair.op.serializedName }
+
+            XCTAssertNotNil(definition, "\(pair.op.serializedName) missing from ContentFilters.plist for typegrouping \(pair.typeGrouping)")
+            XCTAssertEqual(definition?["MenuLabel"] as? String, pair.op.serializedName)
+            XCTAssertEqual(definition?["NumberOfArguments"] as? Int, pair.op.valueCount)
+
+            let leaf = serializedFilter(column: "\(pair.typeGrouping)_column", operatorName: pair.op.serializedName, values: values(for: pair.op))
+            let restored = serializeRestoredFilter(leaf, filterDefinition: definition)
+
+            XCTAssertEqual(restored["filterComparison"] as? String, pair.op.serializedName, "\(pair.op.serializedName) failed to round-trip for typegrouping \(pair.typeGrouping)")
+        }
+    }
+
+    private func loadContentFilters() throws -> [String: Any] {
+        let candidateBundles = [Bundle.main, Bundle(for: Self.self)] + Bundle.allBundles + Bundle.allFrameworks
+        for bundle in candidateBundles {
+            guard let path = bundle.path(forResource: "ContentFilters", ofType: "plist"),
+                  let filters = NSDictionary(contentsOfFile: path) as? [String: Any] else {
+                continue
+            }
+            return filters
+        }
+
+        XCTFail("Could not find ContentFilters.plist in any loaded bundle")
+        return [:]
+    }
+
+    private func filterType(for typeGrouping: String) -> String {
+        switch typeGrouping {
+        case "bit", "integer", "float":
+            return "number"
+        case "geometry":
+            return "spatial"
+        case "string", "binary", "textdata", "blobdata", "enum":
+            return "string"
+        default:
+            return typeGrouping
+        }
+    }
+
+    private func values(for op: SACellFilterOperator) -> [String] {
+        return Array(repeating: "sample", count: op.valueCount)
+    }
+
+    private func serializedFilter(column: String, operatorName: String, values: [String]) -> [String: Any] {
+        return [
+            "filterClass": "expressionNode",
+            "column": column,
+            "filterComparison": operatorName,
+            "filterValues": values,
+            "enabled": true,
+        ]
+    }
+
+    private func serializeRestoredFilter(_ filter: [String: Any], filterDefinition: [String: Any]?) -> [String: Any] {
+        var restored = filter
+        restored["filterType"] = filterDefinition?["filterType"]
+        return restored
+    }
+}

--- a/UnitTests/SACellFilterOperatorTests.swift
+++ b/UnitTests/SACellFilterOperatorTests.swift
@@ -60,11 +60,15 @@ final class SACellFilterOperatorTests: XCTestCase {
         XCTAssertEqual(SACellFilterOperator.operators(for: "integer", cellIsNull: true).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
     }
 
-    /// Verifies non-NULL cells hide NULL-only operators while keeping value comparisons.
-    func testNonNullCellHidesNullOnlyOperators() {
-        XCTAssertEqual(SACellFilterOperator.operators(for: "geometry", cellIsNull: false).map(\.serializedName), [])
-        XCTAssertEqual(SACellFilterOperator.operators(for: "binary", cellIsNull: false).map(\.serializedName), [])
-        XCTAssertEqual(SACellFilterOperator.operators(for: "blobdata", cellIsNull: false).map(\.serializedName), [])
+    /// Verifies non-NULL cells expose value comparisons AND keep NULL operators available.
+    func testNonNullCellKeepsNullOperatorsAlongsideValueOperators() {
+        // NULL-only catalogs (geometry / binary / blobdata): non-NULL cells still
+        // expose IS NULL / IS NOT NULL so the Filter submenu remains usable.
+        XCTAssertEqual(SACellFilterOperator.operators(for: "geometry", cellIsNull: false).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "binary", cellIsNull: false).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "blobdata", cellIsNull: false).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
+        // Value-bearing catalogs (date / string / number) get value comparisons
+        // first followed by IS NULL / IS NOT NULL.
         XCTAssertEqual(SACellFilterOperator.operators(for: "date", cellIsNull: false).map(\.serializedName), [
             "=",
             "≠",
@@ -72,6 +76,8 @@ final class SACellFilterOperatorTests: XCTestCase {
             "is before",
             "is after or equal to",
             "is before or equal to",
+            "IS NULL",
+            "IS NOT NULL",
         ])
     }
 

--- a/UnitTests/SACellFilterOperatorTests.swift
+++ b/UnitTests/SACellFilterOperatorTests.swift
@@ -10,12 +10,14 @@ import XCTest
 
 final class SACellFilterOperatorTests: XCTestCase {
 
+    /// Verifies missing, empty, and unknown type groupings return no filter operators.
     func testUnknownAndMissingTypeGroupingReturnNoOperators() {
         XCTAssertTrue(SACellFilterOperator.operators(for: nil).isEmpty)
         XCTAssertTrue(SACellFilterOperator.operators(for: "unknown_type_group").isEmpty)
         XCTAssertTrue(SACellFilterOperator.operators(for: "").isEmpty)
     }
 
+    /// Verifies numeric type groupings expose the exact serialized operator names.
     func testNumberFamilyOperatorsUseExactSerializedNames() {
         let expected = ["=", "≠", ">", "<", "≥", "≤", "IS NULL", "IS NOT NULL"]
 
@@ -24,6 +26,7 @@ final class SACellFilterOperatorTests: XCTestCase {
         XCTAssertEqual(serializedNames(for: "float"), expected)
     }
 
+    /// Verifies date type groupings expose the exact date comparison labels.
     func testDateOperatorsUseExactSerializedNames() {
         XCTAssertEqual(
             serializedNames(for: "date"),
@@ -31,6 +34,7 @@ final class SACellFilterOperatorTests: XCTestCase {
         )
     }
 
+    /// Verifies string-like type groupings expose equality, pattern, contains, and NULL operators.
     func testStringFamilyOperatorsUseExactSerializedNames() {
         let expected = ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain", "IS NULL", "IS NOT NULL"]
 
@@ -39,20 +43,24 @@ final class SACellFilterOperatorTests: XCTestCase {
         XCTAssertEqual(serializedNames(for: "enum"), expected)
     }
 
+    /// Verifies binary and blob columns only advertise NULL-safe operators.
     func testBinaryAndBlobOnlyAdvertiseNullOperators() {
         XCTAssertEqual(serializedNames(for: "binary"), ["IS NULL", "IS NOT NULL"])
         XCTAssertEqual(serializedNames(for: "blobdata"), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies geometry columns only advertise NULL-safe operators.
     func testGeometryOnlyAdvertisesNullOperators() {
         XCTAssertEqual(serializedNames(for: "geometry"), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies NULL cells suppress value-bearing operators for any type grouping.
     func testNullCellOnlyShowsNullOperators() {
         XCTAssertEqual(SACellFilterOperator.operators(for: "string", cellIsNull: true).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
         XCTAssertEqual(SACellFilterOperator.operators(for: "integer", cellIsNull: true).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
     }
 
+    /// Verifies non-NULL cells hide NULL-only operators while keeping value comparisons.
     func testNonNullCellHidesNullOnlyOperators() {
         XCTAssertEqual(SACellFilterOperator.operators(for: "geometry", cellIsNull: false).map(\.serializedName), [])
         XCTAssertEqual(SACellFilterOperator.operators(for: "binary", cellIsNull: false).map(\.serializedName), [])
@@ -67,6 +75,7 @@ final class SACellFilterOperatorTests: XCTestCase {
         ])
     }
 
+    /// Verifies advertised operator pairs cover only concrete catalog entries.
     func testAdvertisedPairsCoverEveryCatalogEntry() {
         let pairs = SACellFilterOperator.allAdvertisedPairs()
         XCTAssertEqual(pairs.count, 62)

--- a/UnitTests/SACellFilterOperatorTests.swift
+++ b/UnitTests/SACellFilterOperatorTests.swift
@@ -35,10 +35,13 @@ final class SACellFilterOperatorTests: XCTestCase {
         let expected = ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain", "IS NULL", "IS NOT NULL"]
 
         XCTAssertEqual(serializedNames(for: "string"), expected)
-        XCTAssertEqual(serializedNames(for: "binary"), expected)
         XCTAssertEqual(serializedNames(for: "textdata"), expected)
-        XCTAssertEqual(serializedNames(for: "blobdata"), expected)
         XCTAssertEqual(serializedNames(for: "enum"), expected)
+    }
+
+    func testBinaryAndBlobOnlyAdvertiseNullOperators() {
+        XCTAssertEqual(serializedNames(for: "binary"), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(serializedNames(for: "blobdata"), ["IS NULL", "IS NOT NULL"])
     }
 
     func testGeometryOnlyAdvertisesNullOperators() {
@@ -52,6 +55,8 @@ final class SACellFilterOperatorTests: XCTestCase {
 
     func testNonNullCellHidesNullOnlyOperators() {
         XCTAssertEqual(SACellFilterOperator.operators(for: "geometry", cellIsNull: false).map(\.serializedName), [])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "binary", cellIsNull: false).map(\.serializedName), [])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "blobdata", cellIsNull: false).map(\.serializedName), [])
         XCTAssertEqual(SACellFilterOperator.operators(for: "date", cellIsNull: false).map(\.serializedName), [
             "=",
             "≠",
@@ -64,7 +69,7 @@ final class SACellFilterOperatorTests: XCTestCase {
 
     func testAdvertisedPairsCoverEveryCatalogEntry() {
         let pairs = SACellFilterOperator.allAdvertisedPairs()
-        XCTAssertEqual(pairs.count, 74)
+        XCTAssertEqual(pairs.count, 62)
         XCTAssertFalse(pairs.contains { $0.typeGrouping.isEmpty })
         XCTAssertFalse(pairs.contains { $0.typeGrouping == "unknown_type_group" })
     }

--- a/UnitTests/SACellFilterOperatorTests.swift
+++ b/UnitTests/SACellFilterOperatorTests.swift
@@ -1,0 +1,75 @@
+//
+//  SACellFilterOperatorTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SACellFilterOperatorTests: XCTestCase {
+
+    func testUnknownAndMissingTypeGroupingReturnNoOperators() {
+        XCTAssertTrue(SACellFilterOperator.operators(for: nil).isEmpty)
+        XCTAssertTrue(SACellFilterOperator.operators(for: "unknown_type_group").isEmpty)
+        XCTAssertTrue(SACellFilterOperator.operators(for: "").isEmpty)
+    }
+
+    func testNumberFamilyOperatorsUseExactSerializedNames() {
+        let expected = ["=", "≠", ">", "<", "≥", "≤", "IS NULL", "IS NOT NULL"]
+
+        XCTAssertEqual(serializedNames(for: "bit"), expected)
+        XCTAssertEqual(serializedNames(for: "integer"), expected)
+        XCTAssertEqual(serializedNames(for: "float"), expected)
+    }
+
+    func testDateOperatorsUseExactSerializedNames() {
+        XCTAssertEqual(
+            serializedNames(for: "date"),
+            ["=", "≠", "is after", "is before", "is after or equal to", "is before or equal to", "IS NULL", "IS NOT NULL"]
+        )
+    }
+
+    func testStringFamilyOperatorsUseExactSerializedNames() {
+        let expected = ["=", "≠", "LIKE", "NOT LIKE", "contains", "does not contain", "IS NULL", "IS NOT NULL"]
+
+        XCTAssertEqual(serializedNames(for: "string"), expected)
+        XCTAssertEqual(serializedNames(for: "binary"), expected)
+        XCTAssertEqual(serializedNames(for: "textdata"), expected)
+        XCTAssertEqual(serializedNames(for: "blobdata"), expected)
+        XCTAssertEqual(serializedNames(for: "enum"), expected)
+    }
+
+    func testGeometryOnlyAdvertisesNullOperators() {
+        XCTAssertEqual(serializedNames(for: "geometry"), ["IS NULL", "IS NOT NULL"])
+    }
+
+    func testNullCellOnlyShowsNullOperators() {
+        XCTAssertEqual(SACellFilterOperator.operators(for: "string", cellIsNull: true).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "integer", cellIsNull: true).map(\.serializedName), ["IS NULL", "IS NOT NULL"])
+    }
+
+    func testNonNullCellHidesNullOnlyOperators() {
+        XCTAssertEqual(SACellFilterOperator.operators(for: "geometry", cellIsNull: false).map(\.serializedName), [])
+        XCTAssertEqual(SACellFilterOperator.operators(for: "date", cellIsNull: false).map(\.serializedName), [
+            "=",
+            "≠",
+            "is after",
+            "is before",
+            "is after or equal to",
+            "is before or equal to",
+        ])
+    }
+
+    func testAdvertisedPairsCoverEveryCatalogEntry() {
+        let pairs = SACellFilterOperator.allAdvertisedPairs()
+        XCTAssertEqual(pairs.count, 74)
+        XCTAssertFalse(pairs.contains { $0.typeGrouping.isEmpty })
+        XCTAssertFalse(pairs.contains { $0.typeGrouping == "unknown_type_group" })
+    }
+
+    private func serializedNames(for typeGrouping: String) -> [String] {
+        return SACellFilterOperator.operators(for: typeGrouping).map(\.serializedName)
+    }
+}

--- a/UnitTests/SACellFilterOperatorTests.swift
+++ b/UnitTests/SACellFilterOperatorTests.swift
@@ -77,7 +77,7 @@ final class SACellFilterOperatorTests: XCTestCase {
             "is after or equal to",
             "is before or equal to",
             "IS NULL",
-            "IS NOT NULL",
+            "IS NOT NULL"
         ])
     }
 

--- a/UnitTests/SACellFilterRuleControllerStubs.m
+++ b/UnitTests/SACellFilterRuleControllerStubs.m
@@ -1,0 +1,50 @@
+//
+//  SACellFilterRuleControllerStubs.m
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.05.23.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+#import "SPQueryController.h"
+#import "SPContentFilterManager.h"
+#import "SPTableContent.h"
+
+@implementation SPQueryController
+
++ (SPQueryController *)sharedQueryController
+{
+	return nil;
+}
+
+- (NSMutableDictionary *)contentFilterForFileURL:(NSURL *)fileURL
+{
+	return nil;
+}
+
+@end
+
+@implementation SPContentFilterManager
+
+- (instancetype)initWithDatabaseDocument:(SPDatabaseDocument *)document forFilterType:(NSString *)compareType
+{
+	return [super init];
+}
+
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
+#pragma clang diagnostic ignored "-Wprotocol"
+
+@implementation SPTableContent
+
+- (void)toggleRuleEditorVisible:(id)sender
+{
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
+		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
+		CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
 		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
 		17E641590EF01EF6001BC333 /* SPTableContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414F0EF01EF6001BC333 /* SPTableContent.m */; };
 		17E6415A0EF01EF6001BC333 /* SPDatabaseDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641510EF01EF6001BC333 /* SPDatabaseDocument.m */; };
@@ -1204,6 +1206,7 @@
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
+		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -2428,6 +2431,7 @@
 				B6E4019A9F1C4A8AA0B3D104 /* SALocalNetworkPermissionCheckerTests.swift */,
 				C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */,
 				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
+				CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
 				F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */,
 				F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */,
@@ -2872,6 +2876,7 @@
 				1AB068AF24A355CC00E2AAC2 /* client-key-bad-start.pem in Resources */,
 				1AB068B024A355CC00E2AAC2 /* client-key-lf.pem in Resources */,
 				1AB068B124A355CC00E2AAC2 /* client-key-crlf.pem in Resources */,
+				CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3127,6 +3132,7 @@
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
+				CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
 		C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */; };
 		C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */; };
+		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
+		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
+		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
 		17E641590EF01EF6001BC333 /* SPTableContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414F0EF01EF6001BC333 /* SPTableContent.m */; };
 		17E6415A0EF01EF6001BC333 /* SPDatabaseDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641510EF01EF6001BC333 /* SPDatabaseDocument.m */; };
@@ -1199,6 +1202,8 @@
 		9BE76F9BF9BDA2921CDD05AF /* SPFilterTableController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFilterTableController.h; sourceTree = "<group>"; };
 		AA000001000000000000001A /* SAAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutView.swift; sourceTree = "<group>"; };
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
+		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
+		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -1496,6 +1501,7 @@
 			children = (
 				17E6414E0EF01EF6001BC333 /* SPTableContent.h */,
 				17E6414F0EF01EF6001BC333 /* SPTableContent.m */,
+				CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */,
 			);
 			name = "Table Content";
 			path = TableContent;
@@ -2421,6 +2427,7 @@
 				C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */,
 				B6E4019A9F1C4A8AA0B3D104 /* SALocalNetworkPermissionCheckerTests.swift */,
 				C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */,
+				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
 				F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */,
 				F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */,
@@ -3118,6 +3125,8 @@
 				5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */,
 				C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */,
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
+				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
+				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
@@ -3164,6 +3173,7 @@
 				17E641560EF01EF6001BC333 /* SPCustomQuery.m in Sources */,
 				C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */,
 				C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */,
+				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				17E641570EF01EF6001BC333 /* SPAppController.m in Sources */,
 				507FF1121BBCC57600104523 /* SPFunctions.m in Sources */,
 				5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
 		CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
+		CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
 		CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
@@ -1209,6 +1210,7 @@
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
 		CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMerge.swift; sourceTree = "<group>"; };
+		CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterAction.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
 		CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMergeTests.swift; sourceTree = "<group>"; };
@@ -1511,6 +1513,7 @@
 				17E6414F0EF01EF6001BC333 /* SPTableContent.m */,
 				CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */,
 				CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */,
+				CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */,
 			);
 			name = "Table Content";
 			path = TableContent;
@@ -3190,6 +3193,7 @@
 				C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */,
 				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
+				CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */,
 				17E641570EF01EF6001BC333 /* SPAppController.m in Sources */,
 				507FF1121BBCC57600104523 /* SPFunctions.m in Sources */,
 				5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		CF0000132F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
+		CF0000152F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */; };
+		CF0000212F8C000600C4C14A /* SACellFilterRuleControllerStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */; };
 		CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
 		CF0000092F8C000600C4C14A /* SACellFilterMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */; };
 		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
@@ -105,6 +107,9 @@
 		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
 		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
 		DD00DD00DD00DD00DD000005 /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
+		CF0000182F8C000600C4C14A /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
+		CF0000192F8C000600C4C14A /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
+		CF0000202F8C000600C4C14A /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
 		1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
 		1A11E50425A327F1001CB721 /* SPPanelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A11E50325A327F1001CB721 /* SPPanelOptions.m */; };
@@ -211,6 +216,7 @@
 		503CDBB21ACDC204004F8A2F /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 503CDBB11ACDC204004F8A2F /* Quartz.framework */; };
 		505F568F1BCEE485007467DD /* SPFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF1111BBCC57600104523 /* SPFunctions.m */; };
 		506CE9311A311C6C0039F736 /* SPRuleFilterController.m in Sources */ = {isa = PBXBuildFile; fileRef = 506CE9301A311C6C0039F736 /* SPRuleFilterController.m */; };
+		CF0000172F8C000600C4C14A /* SPRuleFilterController.m in Sources */ = {isa = PBXBuildFile; fileRef = 506CE9301A311C6C0039F736 /* SPRuleFilterController.m */; };
 		507FF1121BBCC57600104523 /* SPFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF1111BBCC57600104523 /* SPFunctions.m */; };
 		507FF1621BBF0D5000104523 /* SPTableCopyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 112730551180788A000737FD /* SPTableCopyTest.m */; };
 		50805B0D1BF2A068005F7A99 /* SPPopUpButtonCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 50805B0C1BF2A068005F7A99 /* SPPopUpButtonCell.m */; };
@@ -1217,6 +1223,8 @@
 		CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMenuBuilder.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
+		CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SACellFilterOperatorRoundTripControllerTests.m; sourceTree = "<group>"; };
+		CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SACellFilterRuleControllerStubs.m; sourceTree = "<group>"; };
 		CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMergeTests.swift; sourceTree = "<group>"; };
 		CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMenuBuilderTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
@@ -2447,6 +2455,8 @@
 				C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */,
 				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
 				CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */,
+				CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */,
+				CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */,
 				CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */,
 				CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
@@ -3152,8 +3162,14 @@
 				CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
 				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
 				CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */,
+				CF0000152F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m in Sources */,
+				CF0000212F8C000600C4C14A /* SACellFilterRuleControllerStubs.m in Sources */,
 				CF0000092F8C000600C4C14A /* SACellFilterMergeTests.swift in Sources */,
 				CF0000132F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift in Sources */,
+				CF0000182F8C000600C4C14A /* SPFilterRuleTextField.swift in Sources */,
+				CF0000202F8C000600C4C14A /* SPFilterRuleEditor.swift in Sources */,
+				CF0000192F8C000600C4C14A /* SPRuleFilterDropBox.swift in Sources */,
+				CF0000172F8C000600C4C14A /* SPRuleFilterController.m in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
 		CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
 		CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */; };
+		CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */; };
+		CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */; };
+		CF0000132F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
 		CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
@@ -1211,9 +1214,11 @@
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
 		CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMerge.swift; sourceTree = "<group>"; };
 		CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterAction.swift; sourceTree = "<group>"; };
+		CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMenuBuilder.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
 		CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMergeTests.swift; sourceTree = "<group>"; };
+		CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMenuBuilderTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -1514,6 +1519,7 @@
 				CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */,
 				CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */,
 				CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */,
+				CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */,
 			);
 			name = "Table Content";
 			path = TableContent;
@@ -2442,6 +2448,7 @@
 				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
 				CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */,
 				CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */,
+				CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
 				F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */,
 				F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */,
@@ -3142,9 +3149,11 @@
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
+				CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
 				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
 				CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */,
 				CF0000092F8C000600C4C14A /* SACellFilterMergeTests.swift in Sources */,
+				CF0000132F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
@@ -3194,6 +3203,7 @@
 				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */,
+				CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
 				17E641570EF01EF6001BC333 /* SPAppController.m in Sources */,
 				507FF1121BBCC57600104523 /* SPFunctions.m in Sources */,
 				5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */; };
 		CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */; };
 		CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */; };
+		CF0000232F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */; };
+		CF0000252F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */; };
+		CF0000262F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */; };
 		CF0000132F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
@@ -1221,7 +1224,9 @@
 		CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMerge.swift; sourceTree = "<group>"; };
 		CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterAction.swift; sourceTree = "<group>"; };
 		CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMenuBuilder.swift; sourceTree = "<group>"; };
+		CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterColumnIdentifier.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
+		CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterColumnIdentifierTests.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
 		CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SACellFilterOperatorRoundTripControllerTests.m; sourceTree = "<group>"; };
 		CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SACellFilterRuleControllerStubs.m; sourceTree = "<group>"; };
@@ -1528,6 +1533,7 @@
 				CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */,
 				CF00000F2F8C000600C4C14A /* SACellFilterAction.swift */,
 				CF0000112F8C000600C4C14A /* SACellFilterMenuBuilder.swift */,
+				CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */,
 			);
 			name = "Table Content";
 			path = TableContent;
@@ -2454,6 +2460,7 @@
 				B6E4019A9F1C4A8AA0B3D104 /* SALocalNetworkPermissionCheckerTests.swift */,
 				C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */,
 				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
+				CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */,
 				CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */,
 				CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */,
 				CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */,
@@ -3160,7 +3167,9 @@
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
+				CF0000252F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */,
 				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
+				CF0000262F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift in Sources */,
 				CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */,
 				CF0000152F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m in Sources */,
 				CF0000212F8C000600C4C14A /* SACellFilterRuleControllerStubs.m in Sources */,
@@ -3220,6 +3229,7 @@
 				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */,
 				CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
+				CF0000232F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */,
 				17E641570EF01EF6001BC333 /* SPAppController.m in Sources */,
 				507FF1121BBCC57600104523 /* SPFunctions.m in Sources */,
 				5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -70,9 +70,12 @@
 		C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */; };
 		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
+		CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
+		CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */; };
 		CF0000082F8C000600C4C14A /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
+		CF0000092F8C000600C4C14A /* SACellFilterMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */; };
 		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
 		17E641590EF01EF6001BC333 /* SPTableContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414F0EF01EF6001BC333 /* SPTableContent.m */; };
 		17E6415A0EF01EF6001BC333 /* SPDatabaseDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641510EF01EF6001BC333 /* SPDatabaseDocument.m */; };
@@ -1205,8 +1208,10 @@
 		AA000001000000000000001A /* SAAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutView.swift; sourceTree = "<group>"; };
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
+		CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMerge.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };
+		CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterMergeTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -1505,6 +1510,7 @@
 				17E6414E0EF01EF6001BC333 /* SPTableContent.h */,
 				17E6414F0EF01EF6001BC333 /* SPTableContent.m */,
 				CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */,
+				CF00000C2F8C000600C4C14A /* SACellFilterMerge.swift */,
 			);
 			name = "Table Content";
 			path = TableContent;
@@ -2432,6 +2438,7 @@
 				C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */,
 				CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */,
 				CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */,
+				CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
 				F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */,
 				F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */,
@@ -3131,8 +3138,10 @@
 				C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */,
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
+				CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */,
 				CF0000062F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift in Sources */,
+				CF0000092F8C000600C4C14A /* SACellFilterMergeTests.swift in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
@@ -3180,6 +3189,7 @@
 				C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */,
 				C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */,
 				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
+				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				17E641570EF01EF6001BC333 /* SPAppController.m in Sources */,
 				507FF1121BBCC57600104523 /* SPFunctions.m in Sources */,
 				5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */,


### PR DESCRIPTION
## Changes:
- #added "Filter by Selected Value" context menu on Table Content cells (right-click → `Filter…` submenu with type-aware operators)
- #added 6 Swift sources (`SACellFilterOperator`, `SACellFilterMenuBuilder`, `SACellFilterAction`, `SACellFilterMerge`, `SACellFilterColumnIdentifier`, plus descriptor struct) following the existing `SA*` modernization convention
- #added 35 unit tests (operator catalog, menu builder, AND-merge with placeholder strip, column-identifier normalization, real `SPRuleFilterController` round-trip, IS NULL preservation regression)
- #changed `SPCopyTable.menuForEvent:` to insert the `Filter…` submenu (~15 LOC ObjC hook; full feature logic lives in Swift)
- #changed `SPTableContent` adds `applyCellFilterForColumn:operator:values:isNull:` mirroring the existing FK-navigation apply sequence
- #fixed Pre-existing `SerIsUntouchedStarterRule` bug in `SPRuleFilterController.m` — zero-argument operators (`IS NULL` / `IS NOT NULL`) were misclassified as untouched starter and could be replaced on subsequent drag-drop append; now requires `[values count] > 0` before classifying as starter
- #added English localization key for the submenu title
- #added Docstrings on the new Swift sources to follow project conventions

## Closes following issues:
- No matching open feature request was found. This is a SQLyog-inspired feature addition.

## Tested:
- Processors:
  - [x] Apple Silicon
  - [ ] Intel
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other
- Xcode Version: 16.4 (CI uses Xcode 16.2)

## Screenshots:

(To be added — right-click a Table Content cell to see the `Filter…` submenu with operators tailored to the column type.)

## Additional notes:

### User-facing behavior

Right-click any cell in the Table Content view → `Filter…` submenu opens with operators tailored to the column type:

| Type group | Operators offered |
|------------|-------------------|
| string / textdata / enum | `=`, `≠`, `LIKE`, `NOT LIKE`, `contains`, `does not contain`, `IS NULL`, `IS NOT NULL` |
| integer / float / bit | `=`, `≠`, `>`, `<`, `≥`, `≤`, `IS NULL`, `IS NOT NULL` |
| date | `=`, `≠`, `is after`, `is before`, `is after or equal to`, `is before or equal to`, `IS NULL`, `IS NOT NULL` |
| binary / blobdata / geometry / NULL cell / empty cell | `IS NULL`, `IS NOT NULL` only |

The chosen operator is AND-merged into the existing rule editor filter and the table re-queries immediately. Untouched starter rows in the rule editor (column-only / value-only-empty rows) are stripped during merge so the result is a clean filter, not an impossible WHERE clause.

### Architecture highlights

- **Convergence-point protection**: 30+ `queryString:` direct callers throughout the table-content code path are NOT touched. Safety is enforced where they converge.
- **Operator catalog with `MenuLabel`-accurate serialized names** (`SACellFilterOperator`): each operator carries both a user-facing `menuTitle` and the exact `serializedName` the controller's `_operatorNamed:forColumn:` lookup expects. Round-trip-verified against `ContentFilters.plist`.
- **3-state filter merge** (`SACellFilterMerge`): empty / untouched starter / real — each handled distinctly. Half-touched placeholder rows are stripped during merge.
- **Empty / nil cell defensive routing**: cells whose display string is empty or nil route to NULL-operators-only, mirroring the controller's own starter semantics so cell-filter never produces non-persistable rules.
- **Framework consistency fix**: pre-existing IS NULL drag/drop bug in `SerIsUntouchedStarterRule` surfaced and fixed during audit.

### Audit history

This branch went through 3 rounds of plan review with an independent adversary peer + 2 rounds of code-level adversary audit. All P0-P3 findings (5 P1 + 2 P2 + 1 P3 + 2 follow-ups) are resolved. Final adversary verdict: `P0=0 P1=0 P2=0 P3=0`.

### Known limitation (deferred to follow-up)

Drag-and-drop from a cell directly onto the rule editor's drop box bypasses the cell-filter menu layer entirely (this is a pre-existing code path, not introduced by this PR). When the dragged cell value is the empty string, the drag/drop path will still create a `filterValues:[""]` rule. The new `SerIsUntouchedStarterRule` zero-value guard limits the blast radius (existing `IS NULL` rules are no longer replaced via drag/drop). Empty-string equality remains available through the rule editor directly.

### Tests

Run:
```
xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" \
  -only-testing:'Unit Tests/SACellFilterMenuBuilderTests' \
  -only-testing:'Unit Tests/SACellFilterMergeTests' \
  -only-testing:'Unit Tests/SACellFilterOperatorTests' \
  -only-testing:'Unit Tests/SACellFilterOperatorRoundTripTests' \
  -only-testing:'Unit Tests/SACellFilterOperatorRoundTripControllerTests' \
  -only-testing:'Unit Tests/SACellFilterColumnIdentifierTests' \
  CODE_SIGNING_ALLOWED=NO
```
→ 35 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Filter by Selected Value" context-menu submenu for table cells, offering appropriate comparison operators (equality, pattern, containment, NULL checks) per column type.
  * Menu builders now tailor operator lists based on column type and selected-cell NULL/empty state.

* **Bug Fixes**
  * Preserves existing IS NULL rules when appending new filters and correctly treats empty-string/placeholder rows to avoid accidental replacement.

* **Localization**
  * Added localization entry for the new submenu title.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->