### PR TITLE
#added UUID_v4() in the content view

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -2713,8 +2713,8 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 					fieldValue = [NSString stringWithFormat:@"b'%@'", ((![desc length] || [desc isEqualToString:@"0"]) ? @"0" : desc)];
 				} else if ([fieldTypeGroup isEqualToString:@"date"] && [desc isEqualToString:@"NOW()"]) {
 					fieldValue = @"NOW()";
-				} else if ([fieldTypeGroup isEqualToString:@"string"] && [[rowObject description] isEqualToString:@"UUID()"]) {
-					fieldValue = @"UUID()";
+				} else if ([fieldTypeGroup isEqualToString:@"string"] && ([desc isEqualToString:@"UUID()"] || [desc isEqualToString:@"UUID_v4()"])) {
+					fieldValue = desc;
 				} else {
 					fieldValue = [mySQLConnection escapeAndQuoteString:desc];
 				}


### PR DESCRIPTION
## Changes:
- The content-view save path already sends `UUID()` to the server unquoted for string columns. The same branch in `-deriveQueryString` now also recognizes `UUID_v4()`, so setting a `CHAR`/`VARCHAR` cell to `UUID_v4()` runs the MariaDB function instead of storing the literal text `'UUID_v4()'`.

## Closes following issues:
- Closes: #2373

## Tested:
- Processors:
  - [x] Apple Silicon (M1 Pro)
  - [ ] Intel
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe, Darwin 25.5.0)
- Localizations:
  - [x] English (no new strings)
- Xcode Version: 26.5 (17F42)

## Screenshots:
N/A, no UI change.

## Additional notes:
- The value is matched as an exact string, the same way `UUID()` and `NOW()` already are. Anything else still goes through normal quoting. Native UUID-type and binary columns are not covered, which matches `UUID()` today. Happy to widen that in a follow-up.
- I checked it against MariaDB. A string cell set to `UUID_v4()` now inserts a generated UUID rather than the literal string, on both the insert and update paths. No unit test here: `-deriveQueryString` runs off live table and connection state, and the existing passthroughs shipped without one too (#2051, #2069).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of UUID() and UUID_v4() expressions in table content operations to correctly preserve expression text when saving data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sequel-Ace/Sequel-Ace/pull/2425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->