### PR TITLE
Modernization Phase A2: Extract task progress UI into SATaskController

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -77,11 +77,46 @@ A1c — `-_selectDatabaseAndItem:` (background-thread selection flow) + callback
   `SADatabaseListManagerTests` (21 tests) still pass.
 - Files: `Source/Controllers/MainViewControllers/SPDatabaseDocument.m`, `SADatabaseListManager.swift`
 
-**A2. Extract task/progress management (~257 lines)**
-- `startTaskWithDescription:`, `endTask`, `setTaskPercentage:`, `enableTaskCancellation:`, progress window fade, cancel button
-- Already has `SATaskManaging` protocol — create `SATaskController` that implements it
-- Move the progress window, indicators, and timer management out of the document
-- Files: `SPDatabaseDocument.m`, new `SATaskController.swift`
+**A2. Extract task/progress management (~257 lines)** — ✅ Done (scoped to the progress UI)
+- New `SATaskController` (Swift, app-target only) owns the task *progress
+  UI*: the borderless progress window (created + configured in its init
+  from `ProgressIndicatorLayer.xib`, now File's-Owner = `SATaskController`),
+  the `YRKSpinningProgressIndicator`, the description / query-duration
+  labels, the cancel button, and the fade-in / query-execution-time
+  timers. It also owns the determinate/indeterminate display state, the
+  percentage-throttling, and the cancellation callback state.
+- `SATaskControllerDelegate` (Swift `@objc protocol`, defined alongside the
+  controller) exposes the two hooks the controller can't own:
+  `taskParentWindow()` (parent window to centre over / parent the panel to)
+  and `taskControllerDidRequestCancellation()` (kills the running query via
+  the database-structure connection where available). Both implemented in
+  `SPDatabaseDocument.m`; conformance declared in `SPDatabaseDocument.swift`.
+  The delegate requirements are *methods* (not a property) so the existing
+  ObjC method `-taskParentWindow` satisfies the @objc protocol — a `{ get }`
+  property requirement would import the ObjC getter as a method and fail to
+  conform.
+- The document keeps the working-level counter (`_isWorkingLevel`) and the
+  document-wide orchestration around it (`SPDocumentTaskStart/EndNotification`,
+  toolbar `validateVisibleItems`, `databaseListIsSelectable`,
+  `chooseDatabaseButton` enablement). `_isWorkingLevel` gates behaviour in
+  ~8 unrelated document methods, so it stays on the document; only the
+  progress *UI* moved. `SPDatabaseDocument`'s `SATaskManaging` methods are
+  now thin trampolines: they manage that document-wide state and forward
+  the presentation to `taskController` (`beginTaskIsFirstLevel:`,
+  `endTaskDisplay`, `setTaskPercentage:`, `enableTaskCancellation…`, etc.).
+  `cancelTask:` / `centerTaskWindow` / `fadeInTaskProgressWindow:` /
+  `showQueryExecutionTime` moved entirely to the controller; the document's
+  12 task ivars + 5 task IBOutlets are gone.
+- No unit tests: the controller is AppKit/nib/timer plumbing that needs a
+  live `NSWindow` + nib load + `YRKSpinningProgressIndicator` to exercise;
+  the only branchy logic (percentage throttling) is trivial. Same rationale
+  as A1c. Verified by a clean app build + the existing suite (522 pass; the
+  one pre-existing `PreferenceDefaults.plist` bundle failure is unrelated).
+- Files: `Source/Controllers/MainViewControllers/SATaskController.swift`,
+  `SPDatabaseDocument.{h,m,swift}`, `Source/Protocols` (none — delegate
+  lives with the controller), `Source/Sequel-Ace-Bridging-Header.h`
+  (imports `YRKSpinningProgressIndicator.h` for Swift), and
+  `Source/Interfaces/ProgressIndicatorLayer.xib` (File's Owner class).
 
 **A3. Extract view state switching to use SAViewMode (~188 lines)** — ✅ Done
 - `viewStructure`, `viewContent`, `viewQuery`, `viewStatus`, `viewRelations`, `viewTriggers`
@@ -323,7 +358,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 4. ~~**Phase A4** (window title) — quick, easy~~ ✅ Done
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a + C1b done (wrap + pure SwiftUI list); reorder/rename/persistence + hosting (C3) still pending before it replaces the AppKit list
-7. **Phase A2** (task controller) — large but impactful
+7. ~~**Phase A2** (task controller) — large but impactful~~ ✅ Done (progress UI extracted; working-level counter stays on the document)
 8. **Phase D1-D3** (SPConnectionController cleanup) — ongoing
 9. **Phase C2-C3** (SwiftUI connection form) — bigger effort
 10. **Phase E** (table content/custom query) — long-term

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -52,7 +52,23 @@ import AppKit
 
     // MARK: - Progress UI state
 
-    private var taskProgressWindow: NSWindow!
+    /// The borderless child window that hosts the progress layer. Created
+    /// lazily (on first use, after the nib has loaded its outlets) so the
+    /// property is a plain non-optional rather than an implicitly unwrapped one.
+    private lazy var taskProgressWindow: NSWindow = {
+        let window = NSWindow(contentRect: taskProgressLayer.bounds,
+                              styleMask: .borderless,
+                              backing: .buffered,
+                              defer: false)
+        window.isReleasedWhenClosed = false
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.alphaValue = 0.0
+        // Retains the layer (and its subviews / outlets) for the controller's lifetime.
+        window.contentView = taskProgressLayer
+        return window
+    }()
+
     private var taskDisplayIsIndeterminate = true
     private var taskProgressValue: CGFloat = 0
     private var taskDisplayLastValue: CGFloat = 0
@@ -74,27 +90,22 @@ import AppKit
         super.init()
 
         var topLevelObjects: NSArray?
-        Bundle.main.loadNibNamed("ProgressIndicatorLayer", owner: self, topLevelObjects: &topLevelObjects)
+        guard Bundle.main.loadNibNamed("ProgressIndicatorLayer", owner: self, topLevelObjects: &topLevelObjects),
+              taskProgressLayer != nil,
+              taskProgressIndicator != nil else {
+            // The nib ships in the app bundle; a failure here means a broken
+            // build, so fail loudly rather than limping on with nil outlets.
+            fatalError("SATaskController: failed to load ProgressIndicatorLayer.xib or connect its outlets")
+        }
 
-        // Set up the progress indicator child window and layer - change indicator color and size
+        // Set up the progress indicator - change indicator color and shadow.
+        // (The child window itself is created lazily; see `taskProgressWindow`.)
         taskProgressIndicator.setForeColor(.white)
         let progressIndicatorShadow = NSShadow()
         progressIndicatorShadow.shadowOffset = NSSize(width: 1.0, height: -1.0)
         progressIndicatorShadow.shadowBlurRadius = 1.0
         progressIndicatorShadow.shadowColor = NSColor(calibratedWhite: 0.0, alpha: 0.75)
         taskProgressIndicator.shadow = progressIndicatorShadow
-
-        let window = NSWindow(contentRect: taskProgressLayer.bounds,
-                              styleMask: .borderless,
-                              backing: .buffered,
-                              defer: false)
-        window.isReleasedWhenClosed = false
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.alphaValue = 0.0
-        // Retains the layer (and its subviews / outlets) for the controller's lifetime.
-        window.contentView = taskProgressLayer
-        taskProgressWindow = window
     }
 
     // MARK: - Task lifecycle (driven by SPDatabaseDocument)
@@ -186,12 +197,13 @@ import AppKit
         taskProgressValue = taskPercentage
         if taskProgressValue >= taskDisplayLastValue + taskProgressValueDisplayInterval
             || taskProgressValue <= taskDisplayLastValue - taskProgressValueDisplayInterval {
+            let value = Double(taskProgressValue)
             if Thread.isMainThread {
-                taskProgressIndicator.setDoubleValue(Double(taskProgressValue))
+                taskProgressIndicator.setDoubleValue(value)
             } else {
-                taskProgressIndicator.performSelector(onMainThread: #selector(YRKSpinningProgressIndicator.setNumberValue(_:)),
-                                                      with: NSNumber(value: Double(taskProgressValue)),
-                                                      waitUntilDone: false)
+                DispatchQueue.main.async { [weak self] in
+                    self?.taskProgressIndicator.setDoubleValue(value)
+                }
             }
             taskDisplayLastValue = taskProgressValue
         }
@@ -213,7 +225,13 @@ import AppKit
 
     @objc private func makeProgressIndeterminate() {
         if taskDisplayIsIndeterminate { return }
-        NSObject.cancelPreviousPerformRequests(withTarget: taskProgressIndicator as Any)
+        // Cancel any delayed switch scheduled by setTaskProgressToIndeterminate(afterDelay:).
+        // (The original ObjC cancelled against the indicator, but the delayed
+        // perform is scheduled on self — so it never actually cancelled. Target
+        // self + the matching selector so the pending call is really dropped.)
+        NSObject.cancelPreviousPerformRequests(withTarget: self,
+                                               selector: #selector(makeProgressIndeterminate),
+                                               object: nil)
         taskDisplayIsIndeterminate = true
         taskProgressIndicator.setIndeterminate(true)
         taskProgressIndicator.startAnimation(self)
@@ -235,6 +253,11 @@ import AppKit
     /// Allow a task to be cancelled, enabling the button with a supplied title
     /// and optionally supplying a callback object and function.
     /// The caller (document) guarantees a task is active before calling.
+    ///
+    /// - Important: `callbackFunction` must be a selector that takes no
+    ///   arguments and returns void (e.g. `@objc func myCallback()`). It is
+    ///   invoked via `perform(_:)` from `cancelTask(_:)`; a selector with
+    ///   parameters or a return value is undefined behaviour.
     @objc(enableTaskCancellationWithTitle:callbackObject:callbackFunction:)
     func enableTaskCancellation(withTitle buttonTitle: String, callbackObject: NSObject?, callbackFunction: Selector?) {
         if let callbackObject = callbackObject, let callbackFunction = callbackFunction {
@@ -269,8 +292,12 @@ import AppKit
         // connection where available, for speed - no connection overhead).
         delegate?.taskControllerDidRequestCancellation()
 
+        // The callback selector is documented (on enableTaskCancellation) to be
+        // a no-argument, void-returning method; guard against a non-responding
+        // object rather than crashing.
         if let callbackObject = taskCancellationCallbackObject,
-           let callbackSelector = taskCancellationCallbackSelector {
+           let callbackSelector = taskCancellationCallbackSelector,
+           callbackObject.responds(to: callbackSelector) {
             callbackObject.perform(callbackSelector)
         }
     }

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -1,0 +1,360 @@
+//
+//  SATaskController.swift
+//  Sequel Ace
+//
+//  Created as part of the modernization effort (Phase A2).
+//
+//  Owns the document-wide task *progress UI*: the borderless progress
+//  window, the spinning/determinate indicator, the description and
+//  query-duration labels, the cancel button, and the fade-in / query-time
+//  timers. Lifted out of SPDatabaseDocument, which previously carried all
+//  of this inline alongside its working-level bookkeeping.
+//
+//  The document keeps the working-level counter (`_isWorkingLevel`) and the
+//  surrounding orchestration (task start/end notifications, toolbar
+//  validation, database-list selectability) because those gate behaviour
+//  across the whole document, not just the progress UI. SPDatabaseDocument's
+//  SATaskManaging methods are thin trampolines that drive this controller
+//  for the UI while still managing that document-wide state themselves.
+//
+//  The view tree is loaded from ProgressIndicatorLayer.xib with this
+//  controller as File's Owner; the five outlets below mirror the
+//  connections that used to point at SPDatabaseDocument.
+//
+
+import AppKit
+
+/// Hooks the task controller needs back from its host document — things it
+/// cannot own because they belong to the document's wider lifecycle.
+@objc protocol SATaskControllerDelegate: AnyObject {
+
+    /// The window the progress panel should be centred over / parented to.
+    func taskParentWindow() -> NSWindow?
+
+    /// Invoked when the user clicks the cancel button. The document cancels
+    /// the running query (directly, or via the database-structure connection
+    /// for speed). The per-task cancellation callback is invoked separately
+    /// by the controller after this returns.
+    func taskControllerDidRequestCancellation()
+}
+
+@objc final class SATaskController: NSObject {
+
+    @objc weak var delegate: SATaskControllerDelegate?
+
+    // MARK: - Outlets (ProgressIndicatorLayer.xib, File's Owner = self)
+
+    @IBOutlet private var taskProgressLayer: NSBox!
+    @IBOutlet private var taskProgressIndicator: YRKSpinningProgressIndicator!
+    @IBOutlet private var taskDescriptionText: NSTextField!
+    @IBOutlet private var taskDurationTime: NSTextField!
+    @IBOutlet private var taskCancelButton: NSButton!
+
+    // MARK: - Progress UI state
+
+    private var taskProgressWindow: NSWindow!
+    private var taskDisplayIsIndeterminate = true
+    private var taskProgressValue: CGFloat = 0
+    private var taskDisplayLastValue: CGFloat = 0
+    private var taskProgressValueDisplayInterval: CGFloat = 1
+    private var taskDrawTimer: Timer?
+    private var queryExecutionTimer: Timer?
+    private var taskFadeInStartDate: Date?
+    private var queryStartDate: Date?
+
+    // MARK: - Cancellation state
+
+    private var taskCanBeCancelled = false
+    private var taskCancellationCallbackObject: NSObject?
+    private var taskCancellationCallbackSelector: Selector?
+
+    // MARK: - Setup
+
+    @objc override init() {
+        super.init()
+
+        var topLevelObjects: NSArray?
+        Bundle.main.loadNibNamed("ProgressIndicatorLayer", owner: self, topLevelObjects: &topLevelObjects)
+
+        // Set up the progress indicator child window and layer - change indicator color and size
+        taskProgressIndicator.setForeColor(.white)
+        let progressIndicatorShadow = NSShadow()
+        progressIndicatorShadow.shadowOffset = NSSize(width: 1.0, height: -1.0)
+        progressIndicatorShadow.shadowBlurRadius = 1.0
+        progressIndicatorShadow.shadowColor = NSColor(calibratedWhite: 0.0, alpha: 0.75)
+        taskProgressIndicator.shadow = progressIndicatorShadow
+
+        let window = NSWindow(contentRect: taskProgressLayer.bounds,
+                              styleMask: .borderless,
+                              backing: .buffered,
+                              defer: false)
+        window.isReleasedWhenClosed = false
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.alphaValue = 0.0
+        // Retains the layer (and its subviews / outlets) for the controller's lifetime.
+        window.contentView = taskProgressLayer
+        taskProgressWindow = window
+    }
+
+    // MARK: - Task lifecycle (driven by SPDatabaseDocument)
+
+    /// Prepare the progress UI for a newly started task. `isFirstLevel` is
+    /// true when the working level just moved from 0 to 1.
+    @objc(beginTaskIsFirstLevel:)
+    func beginTask(isFirstLevel: Bool) {
+
+        // Reset the progress indicator if necessary
+        if isFirstLevel || !taskDisplayIsIndeterminate {
+            taskDisplayIsIndeterminate = true
+            taskProgressIndicator.setIndeterminate(true)
+            taskProgressIndicator.startAnimation(self)
+            taskDisplayLastValue = 0
+        }
+
+        // If the working level just moved to start a task, set up the interface
+        if isFirstLevel {
+            taskCancelButton.isHidden = true
+
+            // Schedule appearance of the task window in the near future, using a frame timer.
+            taskFadeInStartDate = Date()
+            queryStartDate = Date()
+            taskDrawTimer = Timer.scheduledTimer(timeInterval: 1.0 / 30.0,
+                                                 target: self,
+                                                 selector: #selector(fadeInTaskProgressWindow(_:)),
+                                                 userInfo: nil,
+                                                 repeats: true)
+            queryExecutionTimer = Timer.scheduledTimer(timeInterval: 1.0,
+                                                       target: self,
+                                                       selector: #selector(showQueryExecutionTime),
+                                                       userInfo: nil,
+                                                       repeats: true)
+        }
+    }
+
+    /// Tear down the progress UI once all tasks have ended (working level
+    /// back at 0).
+    @objc func endTaskDisplay() {
+
+        // Cancel the draw timer if it exists
+        taskDrawTimer?.invalidate()
+
+        if let queryExecutionTimer = queryExecutionTimer {
+            queryStartDate = Date()
+            showQueryExecutionTime()
+            queryExecutionTimer.invalidate()
+        }
+
+        // Hide the task interface and reset to indeterminate
+        if taskDisplayIsIndeterminate {
+            taskProgressIndicator.stopAnimation(self)
+        }
+        taskProgressWindow.alphaValue = 0.0
+        taskProgressWindow.orderOut(self)
+        taskDisplayIsIndeterminate = true
+        taskProgressIndicator.setIndeterminate(true)
+    }
+
+    // MARK: - Description & progress
+
+    /// Updates the task description shown to the user.
+    @objc(setTaskDescription:)
+    func setTaskDescription(_ description: String) {
+        taskDescriptionText.attributedStringValue = attributedString(description)
+    }
+
+    /// Sets the task percentage progress - the first call to this automatically
+    /// switches the progress display to determinate.
+    /// Can be called from background threads - forwards to main thread as appropriate.
+    @objc(setTaskPercentage:)
+    func setTaskPercentage(_ taskPercentage: CGFloat) {
+
+        // If the task display is currently indeterminate, set it to determinate on the main thread.
+        if taskDisplayIsIndeterminate {
+            if !Thread.isMainThread {
+                DispatchQueue.main.async { self.setTaskPercentage(taskPercentage) }
+                return
+            }
+
+            taskDisplayIsIndeterminate = false
+            taskProgressIndicator.stopAnimation(self)
+            taskProgressIndicator.setDoubleValue(0.5)
+        }
+
+        // Check the supplied progress. Compare it to the display interval - how often
+        // the interface is updated - and update the interface if the value has changed enough.
+        taskProgressValue = taskPercentage
+        if taskProgressValue >= taskDisplayLastValue + taskProgressValueDisplayInterval
+            || taskProgressValue <= taskDisplayLastValue - taskProgressValueDisplayInterval {
+            if Thread.isMainThread {
+                taskProgressIndicator.setDoubleValue(Double(taskProgressValue))
+            } else {
+                taskProgressIndicator.performSelector(onMainThread: #selector(YRKSpinningProgressIndicator.setNumberValue(_:)),
+                                                      with: NSNumber(value: Double(taskProgressValue)),
+                                                      waitUntilDone: false)
+            }
+            taskDisplayLastValue = taskProgressValue
+        }
+    }
+
+    /// Sets the task progress indicator back to indeterminate (also performed
+    /// automatically whenever a new task is started).
+    /// This can optionally be called with afterDelay set, in which case the
+    /// indeterminate switch will be made after a short pause to minimise
+    /// flicker for short actions. Should be called on the main thread.
+    @objc(setTaskProgressToIndeterminateAfterDelay:)
+    func setTaskProgressToIndeterminate(afterDelay: Bool) {
+        if afterDelay {
+            perform(#selector(makeProgressIndeterminate), with: nil, afterDelay: 0.5)
+            return
+        }
+        makeProgressIndeterminate()
+    }
+
+    @objc private func makeProgressIndeterminate() {
+        if taskDisplayIsIndeterminate { return }
+        NSObject.cancelPreviousPerformRequests(withTarget: taskProgressIndicator as Any)
+        taskDisplayIsIndeterminate = true
+        taskProgressIndicator.setIndeterminate(true)
+        taskProgressIndicator.startAnimation(self)
+        taskDisplayLastValue = 0
+    }
+
+    /// Support pausing and restarting the task progress indicator.
+    /// Only works while the indicator is in indeterminate mode.
+    @objc(setTaskIndicatorShouldAnimate:)
+    func setTaskIndicatorShouldAnimate(_ shouldAnimate: Bool) {
+        let selector = shouldAnimate
+            ? #selector(YRKSpinningProgressIndicator.startAnimation(_:))
+            : #selector(YRKSpinningProgressIndicator.stopAnimation(_:))
+        taskProgressIndicator.performSelector(onMainThread: selector, with: self, waitUntilDone: false)
+    }
+
+    // MARK: - Cancellation
+
+    /// Allow a task to be cancelled, enabling the button with a supplied title
+    /// and optionally supplying a callback object and function.
+    /// The caller (document) guarantees a task is active before calling.
+    @objc(enableTaskCancellationWithTitle:callbackObject:callbackFunction:)
+    func enableTaskCancellation(withTitle buttonTitle: String, callbackObject: NSObject?, callbackFunction: Selector?) {
+        if let callbackObject = callbackObject, let callbackFunction = callbackFunction {
+            taskCancellationCallbackObject = callbackObject
+            taskCancellationCallbackSelector = callbackFunction
+        }
+        taskCanBeCancelled = true
+
+        let colorTitle = NSAttributedString(string: buttonTitle,
+                                            attributes: [.foregroundColor: NSColor.white])
+        taskCancelButton.attributedTitle = colorTitle
+        taskCancelButton.isEnabled = true
+        taskCancelButton.isHidden = false
+    }
+
+    /// Disable task cancellation. Called automatically at the end of a task.
+    /// The caller (document) guarantees a task is active before calling.
+    @objc func disableTaskCancellation() {
+        taskCanBeCancelled = false
+        taskCancellationCallbackObject = nil
+        taskCancellationCallbackSelector = nil
+        taskCancelButton.isHidden = true
+    }
+
+    /// Action sent by the cancel button when it's active.
+    @IBAction private func cancelTask(_ sender: Any?) {
+        if !taskCanBeCancelled { return }
+
+        taskCancelButton.isEnabled = false
+
+        // The document cancels the running query (using the database-structure
+        // connection where available, for speed - no connection overhead).
+        delegate?.taskControllerDidRequestCancellation()
+
+        if let callbackObject = taskCancellationCallbackObject,
+           let callbackSelector = taskCancellationCallbackSelector {
+            callbackObject.perform(callbackSelector)
+        }
+    }
+
+    // MARK: - Query-execution timer
+
+    /// Reset the query-execution timer's start date (e.g. after a
+    /// connection-lost dialog is dismissed).
+    @objc func resetQueryTimer() {
+        queryStartDate = Date()
+    }
+
+    /// Show query execution time on the progress window.
+    @objc func showQueryExecutionTime() {
+        guard let queryStartDate = queryStartDate else { return }
+        let timeSinceQueryStarted = Date().timeIntervalSince(queryStartDate)
+        let queryRunningTime = DateComponentsFormatter.hourMinSecFormatter.string(from: timeSinceQueryStarted) ?? ""
+        taskDurationTime.attributedStringValue = attributedString(queryRunningTime)
+    }
+
+    // MARK: - Window placement & teardown
+
+    /// Reposition the task window within the parent window.
+    @objc func centerInParentWindow() {
+        guard let mainWindow = delegate?.taskParentWindow() else { return }
+        let mainWindowRect = mainWindow.frame
+        let taskWindowRect = taskProgressWindow.frame
+
+        var newBottomLeftPoint = NSPoint.zero
+        newBottomLeftPoint.x = (mainWindowRect.origin.x + mainWindowRect.size.width / 2 - taskWindowRect.size.width / 2).rounded()
+        newBottomLeftPoint.y = (mainWindowRect.origin.y + mainWindowRect.size.height / 2 - taskWindowRect.size.height / 2).rounded()
+
+        taskProgressWindow.setFrameOrigin(newBottomLeftPoint)
+    }
+
+    /// Tear down the progress window and timers on document close.
+    @objc func shutDown() {
+        taskProgressWindow.close()
+        taskDrawTimer?.invalidate()
+        queryExecutionTimer?.invalidate()
+    }
+
+    /// Show the task progress window, after a small delay to minimise flicker.
+    @objc private func fadeInTaskProgressWindow(_ theTimer: Timer) {
+        guard let taskFadeInStartDate = taskFadeInStartDate else { return }
+        let timeSinceFadeInStart = Date().timeIntervalSince(taskFadeInStartDate)
+
+        // Keep the window hidden for the first ~0.5 secs
+        if timeSinceFadeInStart < 0.5 { return }
+
+        if taskProgressWindow.parent == nil {
+            delegate?.taskParentWindow()?.addChildWindow(taskProgressWindow, ordered: .above)
+        }
+
+        var alphaValue = taskProgressWindow.alphaValue
+
+        // If the task progress window is still hidden, center it before revealing it
+        if alphaValue == 0 { centerInParentWindow() }
+
+        // Fade in the task window over 0.6 seconds
+        alphaValue = CGFloat((timeSinceFadeInStart - 0.5) / 0.6)
+        if alphaValue > 1.0 { alphaValue = 1.0 }
+        taskProgressWindow.alphaValue = alphaValue
+
+        // If the window has been fully faded in, clean up the timer.
+        if alphaValue == 1.0 {
+            taskDrawTimer?.invalidate()
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Builds the bold, shadowed attributed string used for both the task
+    /// description and the query-duration labels.
+    private func attributedString(_ string: String) -> NSAttributedString {
+        let textShadow = NSShadow()
+        textShadow.shadowColor = NSColor(calibratedWhite: 0.0, alpha: 0.75)
+        textShadow.shadowOffset = NSSize(width: 1.0, height: -1.0)
+        textShadow.shadowBlurRadius = 3.0
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.boldSystemFont(ofSize: 13.0),
+            .shadow: textShadow
+        ]
+        return NSAttributedString(string: string, attributes: attributes)
+    }
+}

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -52,6 +52,7 @@
 @class SPTableRelations;
 @class SPHelpViewerClient;
 @class SPDataImport;
+@class SATaskController;
 
 #import "SPDatabaseContentViewDelegate.h"
 #import "SPConnectionControllerDelegateProtocol.h"
@@ -106,11 +107,6 @@
 	SPCharsetCollationHelper *alterDatabaseCharsetHelper;
 
 	@public IBOutlet NSProgressIndicator* queryProgressBar;
-	IBOutlet NSBox *taskProgressLayer;
-	IBOutlet id taskProgressIndicator;
-	IBOutlet id taskDescriptionText;
-	IBOutlet id taskDurationTime;
-	IBOutlet NSButton *taskCancelButton;
 	
 	IBOutlet id databaseNameField;
 	IBOutlet id databaseEncodingButton;
@@ -188,18 +184,7 @@
 
 	BOOL _workingTimeout;
 
-	NSWindow *taskProgressWindow;
-	BOOL taskDisplayIsIndeterminate;
-	CGFloat taskProgressValue;
-	CGFloat taskDisplayLastValue;
-	CGFloat taskProgressValueDisplayInterval;
-	NSTimer *taskDrawTimer;
-	NSTimer *queryExecutionTimer;
-	NSDate *taskFadeInStartDate;
-	NSDate *queryStartDate;
-	BOOL taskCanBeCancelled;
-	id taskCancellationCallbackObject;
-	SEL taskCancellationCallbackSelector;
+	SATaskController *taskController;
 
 	NSToolbarItem *chooseDatabaseToolbarItem;
 	
@@ -289,18 +274,19 @@
 
 // Task progress and notification methods
 - (void)startTaskWithDescription:(nonnull NSString *)description;
-- (void)fadeInTaskProgressWindow:(nonnull NSTimer *)theTimer;
 - (void)setTaskDescription:(nonnull NSString *)description;
 - (void)setTaskPercentage:(CGFloat)taskPercentage;
 - (void)setTaskProgressToIndeterminateAfterDelay:(BOOL)afterDelay NS_SWIFT_NAME(setTaskProgressToIndeterminate(afterDelay:));
 - (void)endTask;
 - (void)enableTaskCancellationWithTitle:(nonnull NSString *)buttonTitle callbackObject:(nullable NSObject *)callbackObject callbackFunction:(nullable SEL)callbackFunction NS_SWIFT_NAME(enableTaskCancellation(withTitle:callbackObject:callbackFunction:));
 - (void)disableTaskCancellation;
-- (IBAction)cancelTask:(id)sender;
 - (BOOL)isWorking;
 - (void)setDatabaseListIsSelectable:(BOOL)isSelectable;
-- (void)centerTaskWindow;
 - (void)setTaskIndicatorShouldAnimate:(BOOL)shouldAnimate;
+
+// SATaskControllerDelegate (Phase A2 — task progress UI lives in SATaskController)
+- (nullable NSWindow *)taskParentWindow;
+- (void)taskControllerDidRequestCancellation;
 
 // Encoding methods
 - (void)setConnectionEncoding:(NSString *)mysqlEncoding reloadingViews:(BOOL)reloadViews;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -223,16 +223,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         spfDocData = [[NSMutableDictionary alloc] init];
         runningActivitiesArray = [[NSMutableArray alloc] init];
 
-        taskProgressWindow = nil;
-        taskDisplayIsIndeterminate = YES;
-        taskDisplayLastValue = 0;
-        taskProgressValue = 0;
-        taskProgressValueDisplayInterval = 1;
-        taskDrawTimer = nil;
-        taskFadeInStartDate = nil;
-        taskCanBeCancelled = NO;
-        taskCancellationCallbackObject = nil;
-        taskCancellationCallbackSelector = NULL;
+        // The task progress UI (window, indicators, timers, cancel button)
+        // lives in SATaskController; we keep the working-level counter and
+        // the surrounding orchestration (notifications, toolbar validation,
+        // database-list selectability) here on the document.
+        taskController = [[SATaskController alloc] init];
+        taskController.delegate = self;
+
         alterDatabaseCharsetHelper = nil; //init in awakeFromNib
         addDatabaseCharsetHelper = nil;
 
@@ -314,23 +311,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     NSNib *nibLoader = [[NSNib alloc] initWithNibNamed:@"ConnectionErrorDialog" bundle:[NSBundle mainBundle]];
     [nibLoader instantiateWithOwner:self topLevelObjects:&connectionDialogTopLevelObjects];
 
-    NSArray *progressIndicatorLayerTopLevelObjects = nil;
-    nibLoader = [[NSNib alloc] initWithNibNamed:@"ProgressIndicatorLayer" bundle:[NSBundle mainBundle]];
-    [nibLoader instantiateWithOwner:self topLevelObjects:&progressIndicatorLayerTopLevelObjects];
-
-    // Set up the progress indicator child window and layer - change indicator color and size
-    [taskProgressIndicator setForeColor:[NSColor whiteColor]];
-    NSShadow *progressIndicatorShadow = [[NSShadow alloc] init];
-    [progressIndicatorShadow setShadowOffset:NSMakeSize(1.0f, -1.0f)];
-    [progressIndicatorShadow setShadowBlurRadius:1.0f];
-    [progressIndicatorShadow setShadowColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.75f]];
-    [taskProgressIndicator setShadow:progressIndicatorShadow];
-    taskProgressWindow = [[NSWindow alloc] initWithContentRect:[taskProgressLayer bounds] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
-    [taskProgressWindow setReleasedWhenClosed:NO];
-    [taskProgressWindow setOpaque:NO];
-    [taskProgressWindow setBackgroundColor:[NSColor clearColor]];
-    [taskProgressWindow setAlphaValue:0.0f];
-    [taskProgressWindow setContentView:taskProgressLayer];
+    // The task progress window, indicator and layer are loaded and configured
+    // by SATaskController (created in -initWithWindowController:).
 
     alterDatabaseCharsetHelper = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseAlterEncodingButton CollationButton:databaseAlterCollationButton];
     addDatabaseCharsetHelper   = [[SPCharsetCollationHelper alloc] initWithCharsetButton:databaseEncodingButton CollationButton:databaseCollationButton];
@@ -340,7 +322,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [self.parentWindowControllerWindow setRepresentedURL:(spfFileURL && [spfFileURL isFileURL] ? spfFileURL : nil)];
 
     // Add the progress window to this window
-    [self centerTaskWindow];
+    [taskController centerInParentWindow];
 
     // If not connected, update the favorite selection
     if (!_isConnected) {
@@ -1108,6 +1090,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 #pragma mark -
 #pragma mark Task progress and notification methods
 
+// The task *progress UI* (the borderless window, indicator, description /
+// duration labels, cancel button and the fade-in / query-time timers) lives
+// in SATaskController. The methods below keep the document-wide working-level
+// bookkeeping (`_isWorkingLevel`, task start/end notifications, toolbar
+// validation, database-list selectability) and drive the controller for the
+// presentation.
+
 /**
  * Start a document-wide task, providing a short task description for
  * display to the user.  This sets the document into working mode,
@@ -1127,101 +1116,28 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Set the task text. If a nil string was supplied, a generic query notification is occurring -
     // if a task is not already active, use default text.
     if (!description) {
-        if (!_isWorkingLevel) [self setTaskDescription:NSLocalizedString(@"Working...", @"Generic working description")];
+        if (!_isWorkingLevel) [taskController setTaskDescription:NSLocalizedString(@"Working...", @"Generic working description")];
 
         // Otherwise display the supplied string
     } else {
-        [self setTaskDescription:description];
+        [taskController setTaskDescription:description];
     }
 
     // Increment the task level
     _isWorkingLevel++;
 
-    // Reset the progress indicator if necessary
-    if (_isWorkingLevel == 1 || !taskDisplayIsIndeterminate) {
-        taskDisplayIsIndeterminate = YES;
-        [taskProgressIndicator setIndeterminate:YES];
-        [taskProgressIndicator startAnimation:self];
-        taskDisplayLastValue = 0;
-    }
+    BOOL isFirstLevel = (_isWorkingLevel == 1);
+
+    // Reset the progress indicator (and, on the first level, prepare the
+    // cancel button + schedule the appearance/query-time timers).
+    [taskController beginTaskIsFirstLevel:isFirstLevel];
 
     // If the working level just moved to start a task, set up the interface
-    if (_isWorkingLevel == 1) {
-        [taskCancelButton setHidden:YES];
-
+    if (isFirstLevel) {
         // Set flags and prevent further UI interaction in this window
         databaseListIsSelectable = NO;
         [[NSNotificationCenter defaultCenter] postNotificationName:SPDocumentTaskStartNotification object:self];
         [self.mainToolbar validateVisibleItems];
-
-        SPLog(@"Schedule appearance of the task window in the near future, using a frame timer");
-
-        // Schedule appearance of the task window in the near future, using a frame timer.
-        taskFadeInStartDate = [[NSDate alloc] init];
-        queryStartDate = [[NSDate alloc] init];
-        taskDrawTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 / 30.0 target:self selector:@selector(fadeInTaskProgressWindow:) userInfo:nil repeats:YES];
-        queryExecutionTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(showQueryExecutionTime) userInfo:nil repeats:YES];
-
-    }
-}
-
-/**
- * Show query execution time on progress window.
- */
--(void)showQueryExecutionTime{
-
-    double timeSinceQueryStarted = [[NSDate date] timeIntervalSinceDate:queryStartDate];
-
-    NSString *queryRunningTime = [NSDateComponentsFormatter.hourMinSecFormatter stringFromTimeInterval:timeSinceQueryStarted];
-
-    SPLog(@"showQueryExecutionTime: %@", queryRunningTime);
-
-    NSShadow *textShadow = [[NSShadow alloc] init];
-    [textShadow setShadowColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.75f]];
-    [textShadow setShadowOffset:NSMakeSize(1.0f, -1.0f)];
-    [textShadow setShadowBlurRadius:3.0f];
-
-    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                       [NSFont boldSystemFontOfSize:13.0f], NSFontAttributeName,
-                                       textShadow, NSShadowAttributeName,
-                                       nil];
-    NSAttributedString *queryRunningTimeString = [[NSAttributedString alloc] initWithString:queryRunningTime attributes:attributes];
-
-    [taskDurationTime setAttributedStringValue:queryRunningTimeString];
-
-}
-
-/**
- * Show the task progress window, after a small delay to minimise flicker.
- */
-- (void) fadeInTaskProgressWindow:(NSTimer *)theTimer
-{
-    SPLog(@"fadeInTaskProgressWindow");
-
-    double timeSinceFadeInStart = [[NSDate date] timeIntervalSinceDate:taskFadeInStartDate];
-
-    // Keep the window hidden for the first ~0.5 secs
-    if (timeSinceFadeInStart < 0.5) return;
-
-    if ([taskProgressWindow parentWindow] == nil) {
-        [self.parentWindowControllerWindow addChildWindow:taskProgressWindow ordered:NSWindowAbove];
-    }
-
-    CGFloat alphaValue = [taskProgressWindow alphaValue];
-
-    // If the task progress window is still hidden, center it before revealing it
-    if (alphaValue == 0) [self centerTaskWindow];
-
-    SPLog(@"Fade in the task window over 0.6 seconds");
-
-    // Fade in the task window over 0.6 seconds
-    alphaValue = (float)(timeSinceFadeInStart - 0.5) / 0.6f;
-    if (alphaValue > 1.0f) alphaValue = 1.0f;
-    [taskProgressWindow setAlphaValue:alphaValue];
-
-    // If the window has been fully faded in, clean up the timer.
-    if (alphaValue == 1.0) {
-        [taskDrawTimer invalidate];
     }
 }
 
@@ -1230,18 +1146,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void) setTaskDescription:(NSString *)description
 {
-    NSShadow *textShadow = [[NSShadow alloc] init];
-    [textShadow setShadowColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.75f]];
-    [textShadow setShadowOffset:NSMakeSize(1.0f, -1.0f)];
-    [textShadow setShadowBlurRadius:3.0f];
-
-    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                       [NSFont boldSystemFontOfSize:13.0f], NSFontAttributeName,
-                                       textShadow, NSShadowAttributeName,
-                                       nil];
-    NSAttributedString *string = [[NSAttributedString alloc] initWithString:description attributes:attributes];
-
-    [taskDescriptionText setAttributedStringValue:string];
+    [taskController setTaskDescription:(description ?: @"")];
 }
 
 /**
@@ -1251,31 +1156,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void) setTaskPercentage:(CGFloat)taskPercentage
 {
-
-    SPLog(@"setTaskPercentage = %f", taskPercentage);
-
-    // If the task display is currently indeterminate, set it to determinate on the main thread.
-    if (taskDisplayIsIndeterminate) {
-        if (![NSThread isMainThread]) return [[self onMainThread] setTaskPercentage:taskPercentage];
-
-        taskDisplayIsIndeterminate = NO;
-        [taskProgressIndicator stopAnimation:self];
-        [taskProgressIndicator setDoubleValue:0.5];
-    }
-
-    // Check the supplied progress.  Compare it to the display interval - how often
-    // the interface is updated - and update the interface if the value has changed enough.
-    taskProgressValue = taskPercentage;
-    if (taskProgressValue >= taskDisplayLastValue + taskProgressValueDisplayInterval
-        || taskProgressValue <= taskDisplayLastValue - taskProgressValueDisplayInterval)
-    {
-        if ([NSThread isMainThread]) {
-            [taskProgressIndicator setDoubleValue:taskProgressValue];
-        } else {
-            [taskProgressIndicator performSelectorOnMainThread:@selector(setNumberValue:) withObject:[NSNumber numberWithDouble:taskProgressValue] waitUntilDone:NO];
-        }
-        taskDisplayLastValue = taskProgressValue;
-    }
+    [taskController setTaskPercentage:taskPercentage];
 }
 
 /**
@@ -1287,19 +1168,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  */
 - (void) setTaskProgressToIndeterminateAfterDelay:(BOOL)afterDelay
 {
-    SPLog(@"setTaskProgressToIndeterminateAfterDelay");
-
-    if (afterDelay) {
-        [self performSelector:@selector(setTaskProgressToIndeterminateAfterDelay:) withObject:nil afterDelay:0.5];
-        return;
-    }
-
-    if (taskDisplayIsIndeterminate) return;
-    [NSObject cancelPreviousPerformRequestsWithTarget:taskProgressIndicator];
-    taskDisplayIsIndeterminate = YES;
-    [taskProgressIndicator setIndeterminate:YES];
-    [taskProgressIndicator startAnimation:self];
-    taskDisplayLastValue = 0;
+    [taskController setTaskProgressToIndeterminateAfterDelay:afterDelay];
 }
 
 /**
@@ -1312,13 +1181,9 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // Ensure a call on the main thread
     if (![NSThread isMainThread]) return [[self onMainThread] endTask];
 
-    SPLog(@"_isWorkingLevel = %li", (long)_isWorkingLevel);
-
     // Decrement the working level
     _isWorkingLevel--;
     assert(_isWorkingLevel >= 0);
-
-    SPLog(@"_isWorkingLevel = %li", (long)_isWorkingLevel);
 
     // Ensure cancellation interface is reset
     [self disableTaskCancellation];
@@ -1328,29 +1193,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
         SPLog(@"!_isWorkingLevel, all tasks have ended");
 
-        // Cancel the draw timer if it exists
-        if (taskDrawTimer) {
-            SPLog(@"Cancel the draw timer if it exists");
-            [taskDrawTimer invalidate];
-        }
-
-        if (queryExecutionTimer) {
-            queryStartDate = [[NSDate alloc] init];
-            SPLog(@"self showQueryExecutionTime");
-            [self showQueryExecutionTime];
-            SPLog(@"queryExecutionTimer invalidate");
-            [queryExecutionTimer invalidate];
-        }
-
-        // Hide the task interface and reset to indeterminate
-        if (taskDisplayIsIndeterminate){
-            SPLog(@"taskDisplayIsIndeterminate,stopAnimation ");
-            [taskProgressIndicator stopAnimation:self];
-        }
-        [taskProgressWindow setAlphaValue:0.0f];
-        [taskProgressWindow orderOut:self];
-        taskDisplayIsIndeterminate = YES;
-        [taskProgressIndicator setIndeterminate:YES];
+        // Hide the task interface, stop the timers and reset to indeterminate
+        [taskController endTaskDisplay];
 
         // Re-enable window interface
         databaseListIsSelectable = YES;
@@ -1372,19 +1216,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // If no task is active, return
     if (!_isWorkingLevel) return;
 
-    if (callbackObject && callbackFunction) {
-        taskCancellationCallbackObject = callbackObject;
-        taskCancellationCallbackSelector = callbackFunction;
-    }
-    taskCanBeCancelled = YES;
-
-    NSMutableAttributedString *colorTitle = [[NSMutableAttributedString alloc]
-                                             initWithString:buttonTitle
-                                             attributes:@{NSForegroundColorAttributeName: [NSColor whiteColor]}
-                                             ];
-    [taskCancelButton setAttributedTitle:colorTitle];
-    [taskCancelButton setEnabled:YES];
-    [taskCancelButton setHidden:NO];
+    [taskController enableTaskCancellationWithTitle:buttonTitle callbackObject:callbackObject callbackFunction:callbackFunction];
 }
 
 /**
@@ -1398,32 +1230,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     // If no task is active, return
     if (!_isWorkingLevel) return;
 
-    taskCanBeCancelled = NO;
-    taskCancellationCallbackObject = nil;
-    taskCancellationCallbackSelector = NULL;
-    [taskCancelButton setHidden:YES];
-}
-
-/**
- * Action sent by the cancel button when it's active.
- */
-- (IBAction)cancelTask:(id)sender {
-    if (!taskCanBeCancelled) return;
-
-    [taskCancelButton setEnabled:NO];
-
-    // See whether there is an active database structure task and whether it can be used
-    // to cancel the query, for speed (no connection overhead!)
-    if (databaseStructureRetrieval && [databaseStructureRetrieval connection]) {
-        [mySQLConnection setLastQueryWasCancelled:YES];
-        [[databaseStructureRetrieval connection] killQueryOnThreadID:[mySQLConnection mysqlConnectionThreadId]];
-    } else {
-        [mySQLConnection cancelCurrentQuery];
-    }
-
-    if (taskCancellationCallbackObject && taskCancellationCallbackSelector) {
-        [taskCancellationCallbackObject performSelector:taskCancellationCallbackSelector];
-    }
+    [taskController disableTaskCancellation];
 }
 
 /**
@@ -1444,30 +1251,30 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 }
 
 /**
- * Reposition the task window within the main window.
- */
-- (void)centerTaskWindow
-{
-    NSPoint newBottomLeftPoint;
-    NSRect mainWindowRect = [[self.parentWindowController window] frame];
-    NSRect taskWindowRect = [taskProgressWindow frame];
-
-    newBottomLeftPoint.x = roundf(mainWindowRect.origin.x + mainWindowRect.size.width/2 - taskWindowRect.size.width/2);
-    newBottomLeftPoint.y = roundf(mainWindowRect.origin.y + mainWindowRect.size.height/2 - taskWindowRect.size.height/2);
-
-    [taskProgressWindow setFrameOrigin:newBottomLeftPoint];
-}
-
-/**
  * Support pausing and restarting the task progress indicator.
  * Only works while the indicator is in indeterminate mode.
  */
 - (void)setTaskIndicatorShouldAnimate:(BOOL)shouldAnimate
 {
-    if (shouldAnimate) {
-        [[taskProgressIndicator onMainThread] startAnimation:self];
+    [taskController setTaskIndicatorShouldAnimate:shouldAnimate];
+}
+
+#pragma mark - SATaskControllerDelegate
+
+- (NSWindow *)taskParentWindow
+{
+    return self.parentWindowControllerWindow;
+}
+
+- (void)taskControllerDidRequestCancellation
+{
+    // See whether there is an active database structure task and whether it can be used
+    // to cancel the query, for speed (no connection overhead!)
+    if (databaseStructureRetrieval && [databaseStructureRetrieval connection]) {
+        [mySQLConnection setLastQueryWasCancelled:YES];
+        [[databaseStructureRetrieval connection] killQueryOnThreadID:[mySQLConnection mysqlConnectionThreadId]];
     } else {
-        [[taskProgressIndicator onMainThread] stopAnimation:self];
+        [mySQLConnection cancelCurrentQuery];
     }
 }
 
@@ -6095,7 +5902,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [NSApp endSheet:connectionErrorDialog];
         [connectionErrorDialog orderOut:nil];
 
-        queryStartDate = [[NSDate alloc] init];
+        [taskController resetQueryTimer];
 
         // If 'disconnect' was selected, trigger a window close.
         if (connectionErrorCode == SPMySQLConnectionLostDisconnect) {
@@ -6519,20 +6326,14 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [[NSNotificationCenter defaultCenter] removeObserver:self];
             [NSObject cancelPreviousPerformRequestsWithTarget:self];
 
-            [taskProgressWindow close];
+            // Close the task progress window and invalidate its timers.
+            [taskController shutDown];
 
             if (processListController) [processListController close];
 
             // #2924: The connection controller doesn't retain its delegate (us), but it may outlive us (e.g. when running a bg thread)
             [connectionController setDelegate:nil];
             [printWebView setFrameLoadDelegate:nil];
-
-            if (taskDrawTimer) {
-                [taskDrawTimer invalidate];
-            }
-            if (queryExecutionTimer) {
-                [queryExecutionTimer invalidate];
-            }
         }
     }
 }

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
@@ -41,6 +41,14 @@ extension SPDatabaseDocument: SADatabaseDocumentProviding {}
 // dispatches straight back into the stub until the stack overflows.
 extension SPDatabaseDocument: SATaskManaging {}
 
+// MARK: - SATaskControllerDelegate
+
+// SPDatabaseDocument hosts the SATaskController extracted in Phase A2.
+// `taskParentWindow` and `taskControllerDidRequestCancellation` are
+// implemented in SPDatabaseDocument.m (they reach into the live MySQL
+// connection and the parent window controller).
+extension SPDatabaseDocument: SATaskControllerDelegate {}
+
 // MARK: - Save Accessory
 
 extension SPDatabaseDocument {

--- a/Source/Interfaces/ProgressIndicatorLayer.xib
+++ b/Source/Interfaces/ProgressIndicatorLayer.xib
@@ -6,7 +6,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="SPDatabaseDocument">
+        <customObject id="-2" userLabel="File's Owner" customClass="SATaskController">
             <connections>
                 <outlet property="taskCancelButton" destination="45" id="VCO-R0-XTG"/>
                 <outlet property="taskDescriptionText" destination="15" id="33"/>

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -33,6 +33,7 @@
 #import "SPSQLParser.h"
 #import "SPStringAdditions.h"
 #import "SPDatabaseDocument.h"
+#import "YRKSpinningProgressIndicator.h"
 #import "SPTableContent.h"
 #import "SPProcessListController.h"
 #import "SPBundleManager.h"

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		5146ADF02F79B16900C4C14A /* SAFavoritesListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */; };
 		5146ADF52F79B1A200C4C14A /* SAFavoritesListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */; };
 		5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C1000000000000000001 /* SAFavoritesListView.swift */; };
+		5AF0C3000000000000000002 /* SATaskController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C3000000000000000001 /* SATaskController.swift */; };
 		5AF0C2000000000000000002 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
 		5AF0C2000000000000000003 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
 		5AF0C2000000000000000012 /* SAFavoriteItem+Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */; };
@@ -992,6 +993,7 @@
 		5146ADEF2F79B16900C4C14A /* SAFavoritesListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDelegate.swift; sourceTree = "<group>"; };
 		5146ADF42F79B1A200C4C14A /* SAFavoritesListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListDataSource.swift; sourceTree = "<group>"; };
 		5AF0C1000000000000000001 /* SAFavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListView.swift; sourceTree = "<group>"; };
+		5AF0C3000000000000000001 /* SATaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskController.swift; sourceTree = "<group>"; };
 		5AF0C2000000000000000001 /* SAFavoriteItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteItem.swift; sourceTree = "<group>"; };
 		5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAFavoriteItem+Tree.swift"; sourceTree = "<group>"; };
 		5AF0C2000000000000000021 /* SAFavoritesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesList.swift; sourceTree = "<group>"; };
@@ -1621,6 +1623,7 @@
 				17005CB016D6CEA400AF81F4 /* Table Triggers */,
 				5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */,
 				5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */,
+				5AF0C3000000000000000001 /* SATaskController.swift */,
 			);
 			name = "Main View Controllers";
 			path = MainViewControllers;
@@ -3384,6 +3387,7 @@
 				5146ADFC2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
 				5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
 				5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
+				5AF0C3000000000000000002 /* SATaskController.swift in Sources */,
 				BC2777A011514B940034DF6A /* SPNavigatorController.m in Sources */,
 				589582151154F8F400EDCC28 /* SPMainThreadTrampoline.m in Sources */,
 				51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */,


### PR DESCRIPTION
<!-- #changed -->

## Changes:
- New app-target `SATaskController` (Swift) owns the document-wide task **progress UI** previously inline in `SPDatabaseDocument`: the borderless progress window (built + configured in its `init` from `ProgressIndicatorLayer.xib`, whose File's Owner is now `SATaskController`), the `YRKSpinningProgressIndicator`, the description / query-duration labels, the cancel button, and the fade-in / query-execution-time timers. It also owns the determinate display state, the percentage throttling, and the cancellation callback state.
- New `SATaskControllerDelegate` exposes the two hooks the controller can't own: `taskParentWindow()` (window to centre over / parent the panel to) and `taskControllerDidRequestCancellation()` (kills the running query, preferring the database-structure connection). Both implemented in `SPDatabaseDocument.m`; conformance declared in `SPDatabaseDocument.swift`. The requirements are methods rather than a `{ get }` property so the existing ObjC `-taskParentWindow` getter satisfies the `@objc` protocol.
- `SPDatabaseDocument` keeps the working-level counter (`_isWorkingLevel`) and its surrounding orchestration (`SPDocumentTaskStart/EndNotification`, toolbar `validateVisibleItems`, `databaseListIsSelectable`, `chooseDatabaseButton` enablement) — `_isWorkingLevel` gates behaviour across ~8 unrelated methods, so only the *UI* moved. Its `SATaskManaging` methods are now thin trampolines that drive the controller for presentation.
- The document sheds 12 task ivars and 5 task IBOutlets; `cancelTask:`, `centerTaskWindow`, `fadeInTaskProgressWindow:` and `showQueryExecutionTime` move entirely to the controller.
- `ProgressIndicatorLayer.xib` File's Owner re-pointed to `SATaskController` (its only connections were the 5 task outlets + the `cancelTask:` action). `YRKSpinningProgressIndicator.h` added to the bridging header so Swift can reference the indicator type.

Part of the ongoing decomposition of the 6.5k-line `SPDatabaseDocument` god object (follow-up to Phases A1/A3/A4). Behaviour is preserved 1:1 — these are widely-called methods (~84 external call sites) and the public `SATaskManaging` surface is unchanged.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon (build target arm64)
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [x] English (no localization changes)
- Xcode Version: 26.5 (17F42)

## Screenshots:
N/A — no visual change intended.

## Additional notes:
- Verified by a **clean app build** (no errors/warnings on changed files) and the **existing unit-test suite (522 pass)**. The single failure (`SPTableContentColumnFilterTests` — "Could not find PreferenceDefaults.plist") is pre-existing and unrelated (no preferences/bundle resources touched).
- **No new unit tests:** `SATaskController` is AppKit/nib/timer plumbing that needs a live `NSWindow` + nib load + indicator to exercise; the only branchy logic (percentage throttling) is trivial. Same rationale as Phase A1c.
- **Reviewer note / not verified at runtime:** re-pointing the XIB File's Owner to `SATaskController` relies on the standard by-name nib wiring (all 5 KVC-compliant outlets + the `cancelTask:` action exist on the controller). A quick manual smoke test — run a query, watch the progress panel fade in and the cancel button work — would fully confirm the wiring, which couldn't be done without launching the app.
- Built on macOS 26.5 (Tahoe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Task progress UI moved into a dedicated controller: document-wide progress now appears in a centered, fade-in window with improved indeterminate/determinate indicator behavior, throttled progress updates, reliable start/stop animation, cancel button handling, a visible query execution timer, and task lifecycle orchestration delegated away from the document.

* **Documentation**
  * Updated modernization follow-up plan to mark Phase A2 completed and added an expanded section describing the task controller extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->