### PR TITLE
#fixed Save As now remembers each tab's file for Cmd-S

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2598,6 +2598,10 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             if (error != nil) {
                 NSAlert *errorAlert = [NSAlert alertWithError:error];
                 [errorAlert runModal];
+            } else {
+                // Remember this tab's file so Cmd-S writes back here
+                [self setSqlFileURL:[NSURL fileURLWithPath:fileName]];
+                [self setSqlFileEncoding:[[encodingPopUp selectedItem] tag]];
             }
             [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:fileName]];
 


### PR DESCRIPTION
## Changes:
- Each query tab is its own `SPDatabaseDocument` with a per-tab `sqlFileURL`, and Cmd-S writes back to that URL when it is set. The Save As handler in `saveConnectionPanelDidEnd:` wrote the file but stored only the global `lastSqlFileName` pref, leaving the tab's `sqlFileURL` nil. So after saving in two tabs, Cmd-S in the first tab fell back to the panel seeded with the other tab's last path and wrote to the wrong file (#2306).
- On a successful Save As I set the tab's `sqlFileURL` and `sqlFileEncoding`, the same way opening a `.sql` file already does. Each tab's Cmd-S then writes back to its own file.

## Closes following issues:
- Closes: #2306

## Tested:
- Processors:
  - [x] Apple Silicon (M1 Pro)
  - [ ] Intel
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe, Darwin 25.6.0)
- Localizations:
  - [x] English (no new strings)
- Xcode Version: 26.5

## Screenshots:
N/A, no UI change.

## Additional notes:
- No unit test here: the change is in an `NSSavePanel` completion handler that reads nib-wired outlets, and the open-file path that sets the same two properties shipped without one too. I built and ran the `Unit Tests` scheme; it passes apart from one pre-existing failure unrelated to this change (`SPTableContentColumnFilterTests`, which also fails on `main`).
- Manual check: Save As in two tabs to different files, then Cmd-S in the first tab writes back to its own file, not the other tab's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * SQL file saving now properly preserves file location and encoding information in the editor upon successful save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->