### PR TITLE
Modernization Phase D1: Decode favorites via SAConnectionInfo+Favorite

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -294,10 +294,35 @@ C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select
 
 ### Phase D: SPConnectionController further cleanup
 
-**D1. Replace `updateFavoriteSelection:` with structured data flow**
-- This 170+ line method reads the selected favorite and populates 50+ form fields
-- Replace with: `SAConnectionInfoObjC` ↔ form field binding
-- When a favorite is selected, create `SAConnectionInfoObjC` from the favorite dict, then populate fields from the info object
+**D1. Replace `updateFavoriteSelection:` with structured data flow** — ✅ Done
+- New `SAConnectionInfo+Favorite.swift` (Swift, pure Foundation, compiles
+  into BOTH targets): `SAConnectionInfo.fromFavoriteDictionary(_:)` +
+  `SAConnectionInfoObjC.info(fromFavoriteDictionary:)` own the defaulting
+  rules previously inline in `-updateFavoriteSelection:` (missing name →
+  `""`, colorIndex → `-1`, useCompression → `YES`, awsProfile →
+  `"default"`, tz-identifier only in fixed mode, `useAWSIAMAuth` derived
+  from type, unknown type/tz-mode → tcpIP/server). Favorite keys are
+  inlined string literals (documented sync-with-SPConstants.m caveat, same
+  pattern as SAViewMode) so the file stays test-eligible. Value readers
+  mirror ObjC `-integerValue`/`-boolValue` leniency (NSNumber or numeric
+  NSString).
+- `-updateFavoriteSelection:` now decodes once and populates the form from
+  the typed info; ~70 lines of `?:`-defaulting gone. Keychain lookups and
+  the per-type time-zone popup updates stay in the controller (side
+  effects / AppKit).
+- Deliberately NOT decoded: passwords/keychain items (keychain side
+  effects), and `vaultPort`/`vaultOIDCMount` — those two stay as raw
+  `objectForKey:` reads in the controller because nil (key absent) drives
+  the form's NSNullPlaceholder ("443"/"oidc") and the info's non-optional
+  strings can't represent the nil-vs-empty distinction.
+- 20 unit tests in `UnitTests/SAConnectionInfoFavoriteTests.swift` pin:
+  nil/empty-dict defaults, every section's decode (standard/SSL/SSH/
+  AWS/Vault), all 5 type raw values + unknown fallback, tz-mode matrix
+  (identifier cleared outside fixed mode), AWS toggle derivation (stored
+  toggle never overrides), numeric-string leniency, NSNumber→String port,
+  passwords-never-decoded, and the ObjC bridge.
+- Files: `Source/Model/SAConnectionInfo+Favorite.swift`,
+  `UnitTests/SAConnectionInfoFavoriteTests.swift`, `SPConnectionController.m`
 
 **D2. Extract favorites management actions**
 - `addFavorite:`, `removeFavorite:`, `duplicateFavorite:`, `addGroup:`, `sortFavorites:`, `importFavorites:`, `exportFavorites:`
@@ -359,6 +384,6 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a + C1b done (wrap + pure SwiftUI list); reorder/rename/persistence + hosting (C3) still pending before it replaces the AppKit list
 7. ~~**Phase A2** (task controller) — large but impactful~~ ✅ Done (progress UI extracted; working-level counter stays on the document)
-8. **Phase D1-D3** (SPConnectionController cleanup) — ongoing
+8. **Phase D1-D3** (SPConnectionController cleanup) — 🟡 D1 + D3 done; D2 (favorites actions → SAFavoritesManager) pending — note the file grew to ~5,250 lines after the connection-string import PR (#2398), so D2 should wait for that area to settle / be rebased onto it deliberately
 9. **Phase C2-C3** (SwiftUI connection form) — bigger effort
 10. **Phase E** (table content/custom query) — long-term

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1470,42 +1470,44 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
     [connectionResizeContainer setHidden:NO];
     [self _stopEditingConnection];
 
+    // Decode the favorite into typed values. The defaulting rules (missing
+    // name → @"", colorIndex → -1, useCompression → YES, awsProfile →
+    // @"default", …) live in SAConnectionInfo+Favorite.swift and are pinned
+    // by SAConnectionInfoFavoriteTests.
+    SAConnectionInfoObjC *details = [SAConnectionInfoObjC infoFromFavoriteDictionary:fav];
+
     // Set up the type, also storing it in the previous type store to prevent type "changes" triggering actions
-    NSUInteger connectionType = ([fav objectForKey:SPFavoriteTypeKey] ? [[fav objectForKey:SPFavoriteTypeKey] integerValue] : SPTCPIPConnection);
+    NSUInteger connectionType = (NSUInteger)[details type];
     previousType = connectionType;
     [self setType:connectionType];
 
     // Standard details
-    [self setName:([fav objectForKey:SPFavoriteNameKey] ? [fav objectForKey:SPFavoriteNameKey] : @"")];
-    [self setHost:([fav objectForKey:SPFavoriteHostKey] ? [fav objectForKey:SPFavoriteHostKey] : @"")];
-    [self setSocket:([fav objectForKey:SPFavoriteSocketKey] ? [fav objectForKey:SPFavoriteSocketKey] : @"")];
-    [self setUser:([fav objectForKey:SPFavoriteUserKey] ? [fav objectForKey:SPFavoriteUserKey] : @"")];
-    [self setColorIndex:([fav objectForKey:SPFavoriteColorIndexKey]? [[fav objectForKey:SPFavoriteColorIndexKey] integerValue] : -1)];
-    [self setPort:([fav objectForKey:SPFavoritePortKey] ? [fav objectForKey:SPFavoritePortKey] : @"")];
-    [self setDatabase:([fav objectForKey:SPFavoriteDatabaseKey] ? [fav objectForKey:SPFavoriteDatabaseKey] : @"")];
-    [self setUseCompression:([fav objectForKey:SPFavoriteUseCompressionKey] ? [[fav objectForKey:SPFavoriteUseCompressionKey] boolValue] : YES)];
+    [self setName:[details name]];
+    [self setHost:[details host]];
+    [self setSocket:[details socket]];
+    [self setUser:[details user]];
+    [self setColorIndex:[details colorIndex]];
+    [self setPort:[details port]];
+    [self setDatabase:[details database]];
+    [self setUseCompression:[details useCompression]];
 
-    // Time Zone details
-    switch ([fav objectForKey:SPFavoriteTimeZoneModeKey] ? [[fav objectForKey:SPFavoriteTimeZoneModeKey] intValue] : SPConnectionTimeZoneModeUseServerTZ) {
-        case SPConnectionTimeZoneModeUseSystemTZ: {
+    // Time Zone details: sync the per-type popups, then store mode + identifier
+    switch ([details timeZoneMode]) {
+        case SAConnectionTimeZoneModeUseSystemTZ: {
             [standardTimeZoneField selectItemWithTag:SPUseSystemTimeZoneTag];
             [awsIAMTimeZoneField selectItemWithTag:SPUseSystemTimeZoneTag];
             [vaultTimeZoneField selectItemWithTag:SPUseSystemTimeZoneTag];
             [socketTimeZoneField selectItemWithTag:SPUseSystemTimeZoneTag];
             [sshTimeZoneField selectItemWithTag:SPUseSystemTimeZoneTag];
-            [self setTimeZoneMode:SPConnectionTimeZoneModeUseSystemTZ];
-            [self setTimeZoneIdentifier:@""];
             break;
         }
-        case SPConnectionTimeZoneModeUseFixedTZ: {
-            NSString *tzIdentifier = [fav objectForKey:SPFavoriteTimeZoneIdentifierKey];
+        case SAConnectionTimeZoneModeUseFixedTZ: {
+            NSString *tzIdentifier = [details timeZoneIdentifier];
             [standardTimeZoneField selectItemWithTitle:tzIdentifier];
             [awsIAMTimeZoneField selectItemWithTitle:tzIdentifier];
             [vaultTimeZoneField selectItemWithTitle:tzIdentifier];
             [socketTimeZoneField selectItemWithTitle:tzIdentifier];
             [sshTimeZoneField selectItemWithTitle:tzIdentifier];
-            [self setTimeZoneMode:SPConnectionTimeZoneModeUseFixedTZ];
-            [self setTimeZoneIdentifier:tzIdentifier];
             break;
         }
         default: {
@@ -1514,48 +1516,49 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
             [vaultTimeZoneField selectItemWithTag:SPUseServerTimeZoneTag];
             [socketTimeZoneField selectItemWithTag:SPUseServerTimeZoneTag];
             [sshTimeZoneField selectItemWithTag:SPUseServerTimeZoneTag];
-            [self setTimeZoneMode:SPConnectionTimeZoneModeUseServerTZ];
-            [self setTimeZoneIdentifier:@""];
             break;
         }
     }
+    [self setTimeZoneMode:(SPConnectionTimeZoneMode)[details timeZoneMode]];
+    [self setTimeZoneIdentifier:[details timeZoneIdentifier]];
 
     //Special prefs
-    [self setAllowDataLocalInfile:([fav objectForKey:SPFavoriteAllowDataLocalInfileKey] ? [[fav objectForKey:SPFavoriteAllowDataLocalInfileKey] intValue] : NSControlStateValueOff)];
+    [self setAllowDataLocalInfile:[details allowDataLocalInfile]];
 
     // Clear text plugin
-    [self setEnableClearTextPlugin:([fav objectForKey:SPFavoriteEnableClearTextPluginKey] ? [[fav objectForKey:SPFavoriteEnableClearTextPluginKey] intValue] : NSControlStateValueOff)];
+    [self setEnableClearTextPlugin:[details enableClearTextPlugin]];
 
     // AWS IAM Authentication (profile-based only - manual credentials not supported)
-    [self setUseAWSIAMAuth:([self type] == SPAWSIAMConnection ? NSControlStateValueOn : NSControlStateValueOff)];
-    [self setAwsRegion:([fav objectForKey:SPFavoriteAWSRegionKey] ? [fav objectForKey:SPFavoriteAWSRegionKey] : @"")];
-    [self setAwsProfile:([fav objectForKey:SPFavoriteAWSProfileKey] ? [fav objectForKey:SPFavoriteAWSProfileKey] : @"default")];
+    [self setUseAWSIAMAuth:[details useAWSIAMAuth]];
+    [self setAwsRegion:[details awsRegion]];
+    [self setAwsProfile:[details awsProfile]];
 
     // Vault Authentication
-    [self setVaultHost:([fav objectForKey:SPFavoriteVaultHostKey] ? [fav objectForKey:SPFavoriteVaultHostKey] : @"")];
+    [self setVaultHost:[details vaultHost]];
     // nil is intentional here — the KVO binding shows NSNullPlaceholder ("443"/"oidc")
     // when the property is nil. The runtime fallback to "443"/"oidc" is applied at
-    // connect time. Other Vault properties use @"" because they have no placeholder.
+    // connect time. These two stay as raw dictionary reads because the decoded
+    // info cannot represent the nil-vs-empty distinction the placeholder needs.
     [self setVaultPort:[fav objectForKey:SPFavoriteVaultPortKey]];
     [self setVaultOIDCMount:[fav objectForKey:SPFavoriteVaultOIDCMountKey]];
-    [self setVaultCredentialsPath:([fav objectForKey:SPFavoriteVaultCredentialsPathKey] ? [fav objectForKey:SPFavoriteVaultCredentialsPathKey] : @"")];
+    [self setVaultCredentialsPath:[details vaultCredentialsPath]];
 
     // SSL details
-    [self setUseSSL:([fav objectForKey:SPFavoriteUseSSLKey] ? [[fav objectForKey:SPFavoriteUseSSLKey] intValue] : NSControlStateValueOff)];
-    [self setSslKeyFileLocationEnabled:([fav objectForKey:SPFavoriteSSLKeyFileLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSLKeyFileLocationEnabledKey] intValue] : NSControlStateValueOff)];
-    [self setSslKeyFileLocation:([fav objectForKey:SPFavoriteSSLKeyFileLocationKey] ? [fav objectForKey:SPFavoriteSSLKeyFileLocationKey] : @"")];
-    [self setSslCertificateFileLocationEnabled:([fav objectForKey:SPFavoriteSSLCertificateFileLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSLCertificateFileLocationEnabledKey] intValue] : NSControlStateValueOff)];
-    [self setSslCertificateFileLocation:([fav objectForKey:SPFavoriteSSLCertificateFileLocationKey] ? [fav objectForKey:SPFavoriteSSLCertificateFileLocationKey] : @"")];
-    [self setSslCACertFileLocationEnabled:([fav objectForKey:SPFavoriteSSLCACertFileLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSLCACertFileLocationEnabledKey] intValue] : NSControlStateValueOff)];
-    [self setSslCACertFileLocation:([fav objectForKey:SPFavoriteSSLCACertFileLocationKey] ? [fav objectForKey:SPFavoriteSSLCACertFileLocationKey] : @"")];
+    [self setUseSSL:[details useSSL]];
+    [self setSslKeyFileLocationEnabled:[details sslKeyFileLocationEnabled]];
+    [self setSslKeyFileLocation:[details sslKeyFileLocation]];
+    [self setSslCertificateFileLocationEnabled:[details sslCertificateFileLocationEnabled]];
+    [self setSslCertificateFileLocation:[details sslCertificateFileLocation]];
+    [self setSslCACertFileLocationEnabled:[details sslCACertFileLocationEnabled]];
+    [self setSslCACertFileLocation:[details sslCACertFileLocation]];
 
     // SSH details
-    [self setSshHost:([fav objectForKey:SPFavoriteSSHHostKey] ? [fav objectForKey:SPFavoriteSSHHostKey] : @"")];
-    [self setSshUser:([fav objectForKey:SPFavoriteSSHUserKey] ? [fav objectForKey:SPFavoriteSSHUserKey] : @"")];
-    [self setSshKeyLocationEnabled:([fav objectForKey:SPFavoriteSSHKeyLocationEnabledKey] ? [[fav objectForKey:SPFavoriteSSHKeyLocationEnabledKey] intValue] : NSControlStateValueOff)];
-    [self setSshKeyLocation:([fav objectForKey:SPFavoriteSSHKeyLocationKey] ? [fav objectForKey:SPFavoriteSSHKeyLocationKey] : @"")];
-    [self setSshPort:([fav objectForKey:SPFavoriteSSHPortKey] ? [fav objectForKey:SPFavoriteSSHPortKey] : @"")];
-    [self setSshRemoteSocketPath:([fav objectForKey:SPFavoriteSSHRemoteSocketPathKey] ? [fav objectForKey:SPFavoriteSSHRemoteSocketPathKey] : @"")];
+    [self setSshHost:[details sshHost]];
+    [self setSshUser:[details sshUser]];
+    [self setSshKeyLocationEnabled:[details sshKeyLocationEnabled]];
+    [self setSshKeyLocation:[details sshKeyLocation]];
+    [self setSshPort:[details sshPort]];
+    [self setSshRemoteSocketPath:[details sshRemoteSocketPath]];
 
     // Check whether the password exists in the keychain, and if so add it; also record the
     // keychain details so we can pass around only those details if the password doesn't change

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1538,9 +1538,11 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
     // nil is intentional here — the KVO binding shows NSNullPlaceholder ("443"/"oidc")
     // when the property is nil. The runtime fallback to "443"/"oidc" is applied at
     // connect time. These two stay as raw dictionary reads because the decoded
-    // info cannot represent the nil-vs-empty distinction the placeholder needs.
-    [self setVaultPort:[fav objectForKey:SPFavoriteVaultPortKey]];
-    [self setVaultOIDCMount:[fav objectForKey:SPFavoriteVaultOIDCMountKey]];
+    // info cannot represent the nil-vs-empty distinction the placeholder needs;
+    // rawFavoriteString: coerces NSNumber/NSNull from imported favorites so the
+    // properties are always NSString or nil.
+    [self setVaultPort:[SAConnectionInfoObjC rawFavoriteString:[fav objectForKey:SPFavoriteVaultPortKey]]];
+    [self setVaultOIDCMount:[SAConnectionInfoObjC rawFavoriteString:[fav objectForKey:SPFavoriteVaultOIDCMountKey]]];
     [self setVaultCredentialsPath:[details vaultCredentialsPath]];
 
     // SSL details

--- a/Source/Model/SAConnectionInfo+Favorite.swift
+++ b/Source/Model/SAConnectionInfo+Favorite.swift
@@ -171,4 +171,18 @@ extension SAConnectionInfoObjC {
     class func info(fromFavoriteDictionary favorite: NSDictionary?) -> SAConnectionInfoObjC {
         SAConnectionInfoObjC(info: .fromFavoriteDictionary(favorite as? [AnyHashable: Any]))
     }
+
+    /// Coerces a raw favorite-dictionary value to a string while preserving
+    /// the nil-vs-empty distinction that `fromFavoriteDictionary` cannot
+    /// represent. Used for vaultPort / vaultOIDCMount, where nil (key
+    /// absent) drives the form's NSNullPlaceholder but a stored value —
+    /// even an NSNumber from an imported favorite — must arrive as a
+    /// string (the controller later sends -length to these properties).
+    @objc(rawFavoriteString:)
+    class func rawFavoriteString(_ value: Any?) -> String? {
+        guard let value = value, !(value is NSNull) else { return nil }
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber { return number.stringValue }
+        return nil
+    }
 }

--- a/Source/Model/SAConnectionInfo+Favorite.swift
+++ b/Source/Model/SAConnectionInfo+Favorite.swift
@@ -1,0 +1,174 @@
+//
+//  SAConnectionInfo+Favorite.swift
+//  Sequel Ace
+//
+//  Created as part of the modernization effort (Phase D1).
+//
+//  Decodes a stored favorite dictionary into a typed SAConnectionInfo,
+//  owning the defaulting rules that were previously inline in
+//  -[SPConnectionController updateFavoriteSelection:] (missing name → "",
+//  missing colorIndex → -1, missing useCompression → true, missing
+//  awsProfile → "default", and so on). The controller populates its form
+//  properties from the decoded info instead of repeating ?:-defaulting for
+//  every key.
+//
+//  This file compiles into the Unit Tests target, which has no bridging
+//  header, so the favorite dictionary keys are inlined as string literals
+//  rather than referencing the SPFavorite*Key constants. They MUST stay in
+//  sync with SPConstants.m (same pattern as SAViewMode / SADatabaseListManager;
+//  the values are part of the favorites plist wire format and cannot change
+//  without a migration anyway).
+//
+//  Deliberately NOT decoded here:
+//  - password / sshPassword / keychain item names: they come from the
+//    keychain (side-effectful lookups that stay in the controller).
+//  - vaultPort / vaultOIDCMount: the controller applies the *raw* dictionary
+//    values, because nil (key absent) drives the form's NSNullPlaceholder
+//    ("443" / "oidc") and SAConnectionInfo's non-optional strings cannot
+//    represent that distinction. The decoded info carries "" placeholders.
+//
+
+import Foundation
+
+// MARK: - Favorite dictionary keys (inlined; keep in sync with SPConstants.m)
+
+private enum FavoriteKey {
+    static let type = "type"
+    static let name = "name"
+    static let host = "host"
+    static let socket = "socket"
+    static let user = "user"
+    static let colorIndex = "colorIndex"
+    static let port = "port"
+    static let database = "database"
+    static let useCompression = "useCompression"
+    static let timeZoneMode = "timeZoneMode"
+    static let timeZoneIdentifier = "timeZone"
+    static let allowDataLocalInfile = "allowDataLocalInfile"
+    static let enableClearTextPlugin = "enableClearTextPlugin"
+    static let awsRegion = "awsRegion"
+    static let awsProfile = "awsProfile"
+    static let vaultHost = "vaultHost"
+    static let vaultCredentialsPath = "vaultCredentialsPath"
+    static let useSSL = "useSSL"
+    static let sslKeyFileLocationEnabled = "sslKeyFileLocationEnabled"
+    static let sslKeyFileLocation = "sslKeyFileLocation"
+    static let sslCertificateFileLocationEnabled = "sslCertificateFileLocationEnabled"
+    static let sslCertificateFileLocation = "sslCertificateFileLocation"
+    static let sslCACertFileLocationEnabled = "sslCACertFileLocationEnabled"
+    static let sslCACertFileLocation = "sslCACertFileLocation"
+    static let sshHost = "sshHost"
+    static let sshUser = "sshUser"
+    static let sshKeyLocationEnabled = "sshKeyLocationEnabled"
+    static let sshKeyLocation = "sshKeyLocation"
+    static let sshPort = "sshPort"
+    static let sshRemoteSocketPath = "sshRemoteSocketPath"
+}
+
+// MARK: - Lenient value readers
+
+/// Favorites plists store numbers as NSNumber, but imported dictionaries can
+/// carry numeric strings. The original ObjC code read everything through
+/// -integerValue / -boolValue, which both NSNumber and NSString implement —
+/// these helpers mirror that leniency.
+private func intValue(_ value: Any?, default defaultValue: Int) -> Int {
+    if let number = value as? NSNumber { return number.intValue }
+    if let string = value as? String { return (string as NSString).integerValue }
+    return defaultValue
+}
+
+private func boolValue(_ value: Any?, default defaultValue: Bool) -> Bool {
+    if let number = value as? NSNumber { return number.boolValue }
+    if let string = value as? String { return (string as NSString).boolValue }
+    return defaultValue
+}
+
+private func stringValue(_ value: Any?, default defaultValue: String) -> String {
+    if let string = value as? String { return string }
+    if let number = value as? NSNumber { return number.stringValue }
+    return defaultValue
+}
+
+// MARK: - SAConnectionInfo decoding
+
+extension SAConnectionInfo {
+
+    /// Decodes a favorite dictionary (as stored in the favorites plist) into
+    /// a typed connection info, applying the historical defaulting rules of
+    /// -[SPConnectionController updateFavoriteSelection:]. A nil or empty
+    /// dictionary yields the same values the connection form shows for
+    /// "no favorite selected".
+    static func fromFavoriteDictionary(_ favorite: [AnyHashable: Any]?) -> SAConnectionInfo {
+        let fav = favorite ?? [:]
+        var info = SAConnectionInfo()
+
+        // Connection type: unknown raw values fall back to TCP/IP (the
+        // historical default for a missing key).
+        let rawType = intValue(fav[FavoriteKey.type], default: SAConnectionType.tcpIP.rawValue)
+        info.type = SAConnectionType(rawValue: rawType) ?? .tcpIP
+
+        // Standard details
+        info.name = stringValue(fav[FavoriteKey.name], default: "")
+        info.host = stringValue(fav[FavoriteKey.host], default: "")
+        info.socket = stringValue(fav[FavoriteKey.socket], default: "")
+        info.user = stringValue(fav[FavoriteKey.user], default: "")
+        info.colorIndex = intValue(fav[FavoriteKey.colorIndex], default: -1)
+        info.port = stringValue(fav[FavoriteKey.port], default: "")
+        info.database = stringValue(fav[FavoriteKey.database], default: "")
+        info.useCompression = boolValue(fav[FavoriteKey.useCompression], default: true)
+
+        // Time zone: the identifier only applies in fixed mode; the other
+        // modes always clear it.
+        let rawTimeZoneMode = intValue(fav[FavoriteKey.timeZoneMode],
+                                       default: SAConnectionTimeZoneMode.useServerTZ.rawValue)
+        info.timeZoneMode = SAConnectionTimeZoneMode(rawValue: rawTimeZoneMode) ?? .useServerTZ
+        info.timeZoneIdentifier = info.timeZoneMode == .useFixedTZ
+            ? stringValue(fav[FavoriteKey.timeZoneIdentifier], default: "")
+            : ""
+
+        // Special prefs (NSControlStateValue semantics: 0 = off, 1 = on)
+        info.allowDataLocalInfile = intValue(fav[FavoriteKey.allowDataLocalInfile], default: 0)
+        info.enableClearTextPlugin = intValue(fav[FavoriteKey.enableClearTextPlugin], default: 0)
+
+        // AWS IAM: the toggle is derived from the connection type, not stored.
+        info.useAWSIAMAuth = info.type == .awsIAM ? 1 : 0
+        info.awsRegion = stringValue(fav[FavoriteKey.awsRegion], default: "")
+        info.awsProfile = stringValue(fav[FavoriteKey.awsProfile], default: "default")
+
+        // Vault (vaultPort / vaultOIDCMount intentionally not decoded — see header)
+        info.vaultHost = stringValue(fav[FavoriteKey.vaultHost], default: "")
+        info.vaultCredentialsPath = stringValue(fav[FavoriteKey.vaultCredentialsPath], default: "")
+
+        // SSL
+        info.useSSL = intValue(fav[FavoriteKey.useSSL], default: 0)
+        info.sslKeyFileLocationEnabled = intValue(fav[FavoriteKey.sslKeyFileLocationEnabled], default: 0)
+        info.sslKeyFileLocation = stringValue(fav[FavoriteKey.sslKeyFileLocation], default: "")
+        info.sslCertificateFileLocationEnabled = intValue(fav[FavoriteKey.sslCertificateFileLocationEnabled], default: 0)
+        info.sslCertificateFileLocation = stringValue(fav[FavoriteKey.sslCertificateFileLocation], default: "")
+        info.sslCACertFileLocationEnabled = intValue(fav[FavoriteKey.sslCACertFileLocationEnabled], default: 0)
+        info.sslCACertFileLocation = stringValue(fav[FavoriteKey.sslCACertFileLocation], default: "")
+
+        // SSH
+        info.sshHost = stringValue(fav[FavoriteKey.sshHost], default: "")
+        info.sshUser = stringValue(fav[FavoriteKey.sshUser], default: "")
+        info.sshKeyLocationEnabled = intValue(fav[FavoriteKey.sshKeyLocationEnabled], default: 0)
+        info.sshKeyLocation = stringValue(fav[FavoriteKey.sshKeyLocation], default: "")
+        info.sshPort = stringValue(fav[FavoriteKey.sshPort], default: "")
+        info.sshRemoteSocketPath = stringValue(fav[FavoriteKey.sshRemoteSocketPath], default: "")
+
+        return info
+    }
+}
+
+// MARK: - ObjC bridge
+
+extension SAConnectionInfoObjC {
+
+    /// ObjC entry point for SPConnectionController: decode a favorite
+    /// dictionary into a typed info object using the historical defaulting
+    /// rules (see SAConnectionInfo.fromFavoriteDictionary).
+    @objc(infoFromFavoriteDictionary:)
+    class func info(fromFavoriteDictionary favorite: NSDictionary?) -> SAConnectionInfoObjC {
+        SAConnectionInfoObjC(info: .fromFavoriteDictionary(favorite as? [AnyHashable: Any]))
+    }
+}

--- a/UnitTests/SAConnectionInfoFavoriteTests.swift
+++ b/UnitTests/SAConnectionInfoFavoriteTests.swift
@@ -1,0 +1,290 @@
+//
+//  SAConnectionInfoFavoriteTests.swift
+//  Unit Tests
+//
+//  Pins the favorite-dictionary → SAConnectionInfo defaulting rules lifted
+//  out of -[SPConnectionController updateFavoriteSelection:] (Phase D1).
+//  The key literals here intentionally mirror the favorites plist wire
+//  format (SPConstants.m) — if one of these tests breaks, favorites
+//  written by released versions would decode differently on upgrade.
+//
+
+import XCTest
+
+final class SAConnectionInfoFavoriteTests: XCTestCase {
+
+    // MARK: - Defaults (nil / empty dictionary)
+
+    func testNilDictionaryYieldsFormDefaults() {
+        let info = SAConnectionInfo.fromFavoriteDictionary(nil)
+
+        XCTAssertEqual(info.type, .tcpIP)
+        XCTAssertEqual(info.name, "")
+        XCTAssertEqual(info.host, "")
+        XCTAssertEqual(info.socket, "")
+        XCTAssertEqual(info.user, "")
+        XCTAssertEqual(info.colorIndex, -1)
+        XCTAssertEqual(info.port, "")
+        XCTAssertEqual(info.database, "")
+        XCTAssertTrue(info.useCompression)
+        XCTAssertEqual(info.timeZoneMode, .useServerTZ)
+        XCTAssertEqual(info.timeZoneIdentifier, "")
+        XCTAssertEqual(info.allowDataLocalInfile, 0)
+        XCTAssertEqual(info.enableClearTextPlugin, 0)
+        XCTAssertEqual(info.useAWSIAMAuth, 0)
+        XCTAssertEqual(info.awsRegion, "")
+        XCTAssertEqual(info.awsProfile, "default")
+        XCTAssertEqual(info.vaultHost, "")
+        XCTAssertEqual(info.vaultCredentialsPath, "")
+        XCTAssertEqual(info.useSSL, 0)
+        XCTAssertEqual(info.sslKeyFileLocationEnabled, 0)
+        XCTAssertEqual(info.sslKeyFileLocation, "")
+        XCTAssertEqual(info.sslCertificateFileLocationEnabled, 0)
+        XCTAssertEqual(info.sslCertificateFileLocation, "")
+        XCTAssertEqual(info.sslCACertFileLocationEnabled, 0)
+        XCTAssertEqual(info.sslCACertFileLocation, "")
+        XCTAssertEqual(info.sshHost, "")
+        XCTAssertEqual(info.sshUser, "")
+        XCTAssertEqual(info.sshKeyLocationEnabled, 0)
+        XCTAssertEqual(info.sshKeyLocation, "")
+        XCTAssertEqual(info.sshPort, "")
+        XCTAssertEqual(info.sshRemoteSocketPath, "")
+    }
+
+    func testEmptyDictionaryMatchesNilDictionary() {
+        let fromNil = SAConnectionInfo.fromFavoriteDictionary(nil)
+        let fromEmpty = SAConnectionInfo.fromFavoriteDictionary([:])
+
+        XCTAssertEqual(fromEmpty.type, fromNil.type)
+        XCTAssertEqual(fromEmpty.colorIndex, fromNil.colorIndex)
+        XCTAssertEqual(fromEmpty.useCompression, fromNil.useCompression)
+        XCTAssertEqual(fromEmpty.awsProfile, fromNil.awsProfile)
+        XCTAssertEqual(fromEmpty.timeZoneMode, fromNil.timeZoneMode)
+    }
+
+    func testPasswordAndKeychainFieldsAreNeverDecoded() {
+        // Passwords come from the keychain, not the favorites plist.
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "password": "secret", "sshPassword": "tunnel-secret",
+        ])
+
+        XCTAssertEqual(info.password, "")
+        XCTAssertEqual(info.sshPassword, "")
+        XCTAssertEqual(info.connectionKeychainItemName, "")
+        XCTAssertEqual(info.connectionSSHKeychainItemName, "")
+    }
+
+    // MARK: - Standard details
+
+    func testStandardDetailsDecodeFromDictionary() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "type": NSNumber(value: 0),
+            "name": "Prod",
+            "host": "db.example.com",
+            "socket": "/tmp/mysql.sock",
+            "user": "app",
+            "colorIndex": NSNumber(value: 3),
+            "port": "3307",
+            "database": "shop",
+            "useCompression": NSNumber(value: false),
+        ])
+
+        XCTAssertEqual(info.type, .tcpIP)
+        XCTAssertEqual(info.name, "Prod")
+        XCTAssertEqual(info.host, "db.example.com")
+        XCTAssertEqual(info.socket, "/tmp/mysql.sock")
+        XCTAssertEqual(info.user, "app")
+        XCTAssertEqual(info.colorIndex, 3)
+        XCTAssertEqual(info.port, "3307")
+        XCTAssertEqual(info.database, "shop")
+        XCTAssertFalse(info.useCompression)
+    }
+
+    func testConnectionTypesDecodeForAllKnownRawValues() {
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 0]).type, .tcpIP)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 1]).type, .socket)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 2]).type, .sshTunnel)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 3]).type, .awsIAM)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 4]).type, .vault)
+    }
+
+    func testUnknownConnectionTypeFallsBackToTCPIP() {
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 99]).type, .tcpIP)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": -1]).type, .tcpIP)
+    }
+
+    // MARK: - Lenient numeric parsing (NSNumber or numeric NSString)
+
+    func testNumericStringsDecodeLikeIntegerValue() {
+        // ObjC read these via -integerValue, which NSString implements too.
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "type": "2",
+            "colorIndex": "5",
+            "useSSL": "1",
+            "useCompression": "0",
+        ])
+
+        XCTAssertEqual(info.type, .sshTunnel)
+        XCTAssertEqual(info.colorIndex, 5)
+        XCTAssertEqual(info.useSSL, 1)
+        XCTAssertFalse(info.useCompression)
+    }
+
+    func testNumberValuesDecodeToStringFields() {
+        // A numeric port survives as its string form rather than being dropped.
+        let info = SAConnectionInfo.fromFavoriteDictionary(["port": NSNumber(value: 3306)])
+        XCTAssertEqual(info.port, "3306")
+    }
+
+    // MARK: - Time zone
+
+    func testServerTimeZoneModeClearsIdentifier() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "timeZoneMode": NSNumber(value: 0),
+            "timeZone": "Europe/Prague",
+        ])
+
+        XCTAssertEqual(info.timeZoneMode, .useServerTZ)
+        XCTAssertEqual(info.timeZoneIdentifier, "")
+    }
+
+    func testSystemTimeZoneModeClearsIdentifier() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "timeZoneMode": NSNumber(value: 1),
+            "timeZone": "Europe/Prague",
+        ])
+
+        XCTAssertEqual(info.timeZoneMode, .useSystemTZ)
+        XCTAssertEqual(info.timeZoneIdentifier, "")
+    }
+
+    func testFixedTimeZoneModeCarriesIdentifier() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "timeZoneMode": NSNumber(value: 2),
+            "timeZone": "Europe/Prague",
+        ])
+
+        XCTAssertEqual(info.timeZoneMode, .useFixedTZ)
+        XCTAssertEqual(info.timeZoneIdentifier, "Europe/Prague")
+    }
+
+    func testFixedTimeZoneModeWithMissingIdentifierYieldsEmptyString() {
+        let info = SAConnectionInfo.fromFavoriteDictionary(["timeZoneMode": NSNumber(value: 2)])
+
+        XCTAssertEqual(info.timeZoneMode, .useFixedTZ)
+        XCTAssertEqual(info.timeZoneIdentifier, "")
+    }
+
+    func testUnknownTimeZoneModeFallsBackToServer() {
+        let info = SAConnectionInfo.fromFavoriteDictionary(["timeZoneMode": NSNumber(value: 7)])
+        XCTAssertEqual(info.timeZoneMode, .useServerTZ)
+    }
+
+    // MARK: - AWS IAM
+
+    func testAWSIAMToggleIsDerivedFromConnectionType() {
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 3]).useAWSIAMAuth, 1)
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 0]).useAWSIAMAuth, 0)
+        // A stored toggle never overrides the type-derived value.
+        XCTAssertEqual(SAConnectionInfo.fromFavoriteDictionary(["type": 0, "useAWSIAMAuth": 1]).useAWSIAMAuth, 0)
+    }
+
+    func testAWSDetailsDecodeWithProfileDefault() {
+        let explicit = SAConnectionInfo.fromFavoriteDictionary([
+            "type": 3, "awsRegion": "eu-central-1", "awsProfile": "staging",
+        ])
+        XCTAssertEqual(explicit.awsRegion, "eu-central-1")
+        XCTAssertEqual(explicit.awsProfile, "staging")
+
+        let defaulted = SAConnectionInfo.fromFavoriteDictionary(["type": 3])
+        XCTAssertEqual(defaulted.awsRegion, "")
+        XCTAssertEqual(defaulted.awsProfile, "default")
+    }
+
+    // MARK: - Vault
+
+    func testVaultDetailsDecode() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "type": 4,
+            "vaultHost": "vault.internal",
+            "vaultCredentialsPath": "database/creds/app",
+        ])
+
+        XCTAssertEqual(info.type, .vault)
+        XCTAssertEqual(info.vaultHost, "vault.internal")
+        XCTAssertEqual(info.vaultCredentialsPath, "database/creds/app")
+        // vaultPort / vaultOIDCMount stay at their placeholders: the
+        // controller applies the raw dictionary values so that a missing key
+        // (nil) keeps driving the form's NSNullPlaceholder.
+        XCTAssertEqual(info.vaultPort, "")
+        XCTAssertEqual(info.vaultOIDCMount, "")
+    }
+
+    // MARK: - SSL / SSH
+
+    func testSSLDetailsDecode() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "useSSL": NSNumber(value: 1),
+            "sslKeyFileLocationEnabled": NSNumber(value: 1),
+            "sslKeyFileLocation": "/keys/client-key.pem",
+            "sslCertificateFileLocationEnabled": NSNumber(value: 1),
+            "sslCertificateFileLocation": "/keys/client-cert.pem",
+            "sslCACertFileLocationEnabled": NSNumber(value: 1),
+            "sslCACertFileLocation": "/keys/ca.pem",
+        ])
+
+        XCTAssertEqual(info.useSSL, 1)
+        XCTAssertEqual(info.sslKeyFileLocationEnabled, 1)
+        XCTAssertEqual(info.sslKeyFileLocation, "/keys/client-key.pem")
+        XCTAssertEqual(info.sslCertificateFileLocationEnabled, 1)
+        XCTAssertEqual(info.sslCertificateFileLocation, "/keys/client-cert.pem")
+        XCTAssertEqual(info.sslCACertFileLocationEnabled, 1)
+        XCTAssertEqual(info.sslCACertFileLocation, "/keys/ca.pem")
+    }
+
+    func testSSHDetailsDecode() {
+        let info = SAConnectionInfo.fromFavoriteDictionary([
+            "type": 2,
+            "sshHost": "bastion.example.com",
+            "sshUser": "jump",
+            "sshKeyLocationEnabled": NSNumber(value: 1),
+            "sshKeyLocation": "~/.ssh/id_ed25519",
+            "sshPort": "2222",
+            "sshRemoteSocketPath": "/var/run/mysqld/mysqld.sock",
+        ])
+
+        XCTAssertEqual(info.type, .sshTunnel)
+        XCTAssertEqual(info.sshHost, "bastion.example.com")
+        XCTAssertEqual(info.sshUser, "jump")
+        XCTAssertEqual(info.sshKeyLocationEnabled, 1)
+        XCTAssertEqual(info.sshKeyLocation, "~/.ssh/id_ed25519")
+        XCTAssertEqual(info.sshPort, "2222")
+        XCTAssertEqual(info.sshRemoteSocketPath, "/var/run/mysqld/mysqld.sock")
+    }
+
+    // MARK: - ObjC bridge
+
+    func testObjCBridgeAppliesSameRules() {
+        let bridged = SAConnectionInfoObjC.info(fromFavoriteDictionary: [
+            "type": NSNumber(value: 3),
+            "name": "IAM box",
+            "colorIndex": NSNumber(value: 2),
+        ] as NSDictionary)
+
+        XCTAssertEqual(bridged.type, .awsIAM)
+        XCTAssertEqual(bridged.name, "IAM box")
+        XCTAssertEqual(bridged.colorIndex, 2)
+        XCTAssertEqual(bridged.useAWSIAMAuth, 1)
+        XCTAssertEqual(bridged.awsProfile, "default")
+        XCTAssertTrue(bridged.useCompression)
+    }
+
+    func testObjCBridgeNilDictionaryYieldsDefaults() {
+        let bridged = SAConnectionInfoObjC.info(fromFavoriteDictionary: nil)
+
+        XCTAssertEqual(bridged.type, .tcpIP)
+        XCTAssertEqual(bridged.colorIndex, -1)
+        XCTAssertTrue(bridged.useCompression)
+        XCTAssertEqual(bridged.awsProfile, "default")
+    }
+}

--- a/UnitTests/SAConnectionInfoFavoriteTests.swift
+++ b/UnitTests/SAConnectionInfoFavoriteTests.swift
@@ -65,7 +65,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
     func testPasswordAndKeychainFieldsAreNeverDecoded() {
         // Passwords come from the keychain, not the favorites plist.
         let info = SAConnectionInfo.fromFavoriteDictionary([
-            "password": "secret", "sshPassword": "tunnel-secret",
+            "password": "secret", "sshPassword": "tunnel-secret"
         ])
 
         XCTAssertEqual(info.password, "")
@@ -86,7 +86,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
             "colorIndex": NSNumber(value: 3),
             "port": "3307",
             "database": "shop",
-            "useCompression": NSNumber(value: false),
+            "useCompression": NSNumber(value: false)
         ])
 
         XCTAssertEqual(info.type, .tcpIP)
@@ -121,7 +121,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
             "type": "2",
             "colorIndex": "5",
             "useSSL": "1",
-            "useCompression": "0",
+            "useCompression": "0"
         ])
 
         XCTAssertEqual(info.type, .sshTunnel)
@@ -141,7 +141,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
     func testServerTimeZoneModeClearsIdentifier() {
         let info = SAConnectionInfo.fromFavoriteDictionary([
             "timeZoneMode": NSNumber(value: 0),
-            "timeZone": "Europe/Prague",
+            "timeZone": "Europe/Prague"
         ])
 
         XCTAssertEqual(info.timeZoneMode, .useServerTZ)
@@ -151,7 +151,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
     func testSystemTimeZoneModeClearsIdentifier() {
         let info = SAConnectionInfo.fromFavoriteDictionary([
             "timeZoneMode": NSNumber(value: 1),
-            "timeZone": "Europe/Prague",
+            "timeZone": "Europe/Prague"
         ])
 
         XCTAssertEqual(info.timeZoneMode, .useSystemTZ)
@@ -161,7 +161,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
     func testFixedTimeZoneModeCarriesIdentifier() {
         let info = SAConnectionInfo.fromFavoriteDictionary([
             "timeZoneMode": NSNumber(value: 2),
-            "timeZone": "Europe/Prague",
+            "timeZone": "Europe/Prague"
         ])
 
         XCTAssertEqual(info.timeZoneMode, .useFixedTZ)
@@ -191,7 +191,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
 
     func testAWSDetailsDecodeWithProfileDefault() {
         let explicit = SAConnectionInfo.fromFavoriteDictionary([
-            "type": 3, "awsRegion": "eu-central-1", "awsProfile": "staging",
+            "type": 3, "awsRegion": "eu-central-1", "awsProfile": "staging"
         ])
         XCTAssertEqual(explicit.awsRegion, "eu-central-1")
         XCTAssertEqual(explicit.awsProfile, "staging")
@@ -207,7 +207,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
         let info = SAConnectionInfo.fromFavoriteDictionary([
             "type": 4,
             "vaultHost": "vault.internal",
-            "vaultCredentialsPath": "database/creds/app",
+            "vaultCredentialsPath": "database/creds/app"
         ])
 
         XCTAssertEqual(info.type, .vault)
@@ -230,7 +230,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
             "sslCertificateFileLocationEnabled": NSNumber(value: 1),
             "sslCertificateFileLocation": "/keys/client-cert.pem",
             "sslCACertFileLocationEnabled": NSNumber(value: 1),
-            "sslCACertFileLocation": "/keys/ca.pem",
+            "sslCACertFileLocation": "/keys/ca.pem"
         ])
 
         XCTAssertEqual(info.useSSL, 1)
@@ -250,7 +250,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
             "sshKeyLocationEnabled": NSNumber(value: 1),
             "sshKeyLocation": "~/.ssh/id_ed25519",
             "sshPort": "2222",
-            "sshRemoteSocketPath": "/var/run/mysqld/mysqld.sock",
+            "sshRemoteSocketPath": "/var/run/mysqld/mysqld.sock"
         ])
 
         XCTAssertEqual(info.type, .sshTunnel)
@@ -268,7 +268,7 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
         let bridged = SAConnectionInfoObjC.info(fromFavoriteDictionary: [
             "type": NSNumber(value: 3),
             "name": "IAM box",
-            "colorIndex": NSNumber(value: 2),
+            "colorIndex": NSNumber(value: 2)
         ] as NSDictionary)
 
         XCTAssertEqual(bridged.type, .awsIAM)
@@ -286,5 +286,27 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
         XCTAssertEqual(bridged.colorIndex, -1)
         XCTAssertTrue(bridged.useCompression)
         XCTAssertEqual(bridged.awsProfile, "default")
+    }
+
+    // MARK: - Raw favorite string coercion (vaultPort / vaultOIDCMount)
+
+    func testRawFavoriteStringPassesStringsThroughPreservingEmpty() {
+        XCTAssertEqual(SAConnectionInfoObjC.rawFavoriteString("8200"), "8200")
+        // Stored-empty stays empty — distinct from nil for the placeholder.
+        XCTAssertEqual(SAConnectionInfoObjC.rawFavoriteString(""), "")
+    }
+
+    func testRawFavoriteStringCoercesNumbersFromImportedFavorites() {
+        XCTAssertEqual(SAConnectionInfoObjC.rawFavoriteString(NSNumber(value: 8200)), "8200")
+    }
+
+    func testRawFavoriteStringMapsMissingAndNullToNil() {
+        XCTAssertNil(SAConnectionInfoObjC.rawFavoriteString(nil))
+        XCTAssertNil(SAConnectionInfoObjC.rawFavoriteString(NSNull()))
+    }
+
+    func testRawFavoriteStringRejectsNonScalarValues() {
+        XCTAssertNil(SAConnectionInfoObjC.rawFavoriteString(["nested": "dict"]))
+        XCTAssertNil(SAConnectionInfoObjC.rawFavoriteString([1, 2, 3]))
     }
 }

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -258,6 +258,9 @@
 		51B09FD32F7677EB003BAFFF /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD22F7677EB003BAFFF /* FirebaseCrashlytics */; };
 		51B09FD72F767A3E003BAFFF /* SAConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */; };
 		51B09FD82F767A3F003BAFFF /* SAConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */; };
+		5AF0C4000000000000000002 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
+		5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
+		5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */; };
 		51B09FDD2F767A4C003BAFFF /* SAConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */; };
 		51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FDE2F767A53003BAFFF /* SADatabaseDocumentProviding.swift */; };
 		51B09FE12F767A5E003BAFFF /* SAFavoritesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FE02F767A5E003BAFFF /* SAFavoritesProviding.swift */; };
@@ -1025,6 +1028,8 @@
 		51A709382565B99F001F1D2F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfo.swift; sourceTree = "<group>"; };
+		5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+Favorite.swift"; sourceTree = "<group>"; };
+		5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoFavoriteTests.swift; sourceTree = "<group>"; };
 		51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDelegate.swift; sourceTree = "<group>"; };
 		51B09FDE2F767A53003BAFFF /* SADatabaseDocumentProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseDocumentProviding.swift; sourceTree = "<group>"; };
 		51B09FE02F767A5E003BAFFF /* SAFavoritesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesProviding.swift; sourceTree = "<group>"; };
@@ -2071,6 +2076,7 @@
 				BCA6271B1031B9D40047E5D5 /* SPTooltip.m */,
 				1798F192155017FB004B0AB8 /* Tree Nodes */,
 				51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */,
+				5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */,
 				C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */,
 				54146A7693E8D862D06856BF /* SAConnectionInfo+ConnectionString.swift */,
 			);
@@ -2502,6 +2508,7 @@
 				FA1B2C3D4E5F6A7B8C9D0E06 /* VaultOIDCHandlerTests.swift */,
 				F4C0BDAE2E9F4D5E8A1B0201 /* SecureBookmarkManagerStub.swift */,
 				5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */,
+				5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */,
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
@@ -3186,6 +3193,8 @@
 				1AEA768425EF05D500AC4DA6 /* ByteCountFormatterExtension.swift in Sources */,
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
 				5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */,
+				5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */,
+				5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */,
 				5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */,
 				5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
 				5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
@@ -3501,6 +3510,7 @@
 				72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */,
 				1C7055887A73B6C4D4C13D51 /* SPDuplicateImportViewController.swift in Sources */,
 				EB9FF92F188F0B4AA444A892 /* SAConnectionInfo+ConnectionString.swift in Sources */,
+				5AF0C4000000000000000002 /* SAConnectionInfo+Favorite.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
<!-- #changed -->

## Changes:
- New `SAConnectionInfo+Favorite.swift` (pure Foundation, compiled into both the app and Unit Tests targets) adds `SAConnectionInfo.fromFavoriteDictionary(_:)` plus the ObjC bridge `SAConnectionInfoObjC.info(fromFavoriteDictionary:)`. It owns the favorite-dictionary defaulting rules previously inline in `-[SPConnectionController updateFavoriteSelection:]`: missing name → `""`, colorIndex → `-1`, useCompression → `YES`, awsProfile → `"default"`, time-zone identifier only in fixed mode, `useAWSIAMAuth` derived from the connection type, and unknown type / tz-mode raw values falling back to TCP/IP / server.
- Favorite keys are inlined string literals with a documented keep-in-sync-with-`SPConstants.m` caveat (same pattern as `SAViewMode` / `SADatabaseListManager`) so the file stays test-eligible without giving the Unit Tests target a bridging header. Value readers mirror ObjC `-integerValue` / `-boolValue` leniency (NSNumber **or** numeric NSString), so dictionaries produced by the connection-string import path still decode.
- `-updateFavoriteSelection:` now decodes the favorite once and populates the form from the typed info — ~70 lines of inline `?:`-defaulting removed. Deliberately kept in the controller: keychain lookups (side effects), the per-type time-zone popup updates (AppKit), and the raw `objectForKey:` reads for `vaultPort` / `vaultOIDCMount`, because nil (key absent) drives the form's NSNullPlaceholder ("443"/"oidc") and the info's non-optional strings cannot represent the nil-vs-empty distinction.
- 20 unit tests in `UnitTests/SAConnectionInfoFavoriteTests.swift` pin the plist wire-format behavior: nil/empty-dict defaults, per-section decodes (standard / SSL / SSH / AWS / Vault), all five connection-type raw values plus unknown fallback, the time-zone-mode matrix (identifier cleared outside fixed mode), AWS toggle derivation (a stored toggle never overrides the type), numeric-string leniency, NSNumber→String ports, and passwords-never-decoded.

Part of the ongoing `SPConnectionController` cleanup (Phase D; D3 + form helpers landed earlier, A2 just merged). The file sits at ~5,250 lines after the connection-string import work, so carving the pure logic out matters more than ever. Behaviour is preserved 1:1.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon (build target arm64)
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [x] English (no localization changes)
- Xcode Version: 26.5 (17F42)

## Screenshots:
N/A — no visual change intended.

## Additional notes:
- Verified by a clean app build and the full unit-test suite: **546 pass**, including the 20 new tests run both in isolation and as part of the suite. The single failure (`SPTableContentColumnFilterTests` — "Could not find PreferenceDefaults.plist") is pre-existing on main and unrelated.
- The decoder intentionally does **not** read passwords or keychain item names from the dictionary (they come from the keychain), and a test pins that.
- One micro-behaviour note: in fixed-time-zone mode with a *missing* identifier, the controller previously passed nil through to `setTimeZoneIdentifier:`; it now passes `""`. Downstream checks are length-based, so the two are equivalent — flagged here for completeness.
- Built on macOS 26.5 (Tahoe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust loading of saved favorites, including consistent handling of time zone, AWS IAM, Vault, SSL and SSH settings; preserves nil vs empty semantics where required.

* **New Features**
  * Added typed decoding of favorite entries with an Objective‑C bridge to improve reliability when importing/restoring connections.

* **Tests**
  * Expanded unit tests for favorite decoding, including string/number coercion and nil/null handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->