### PR TITLE
Modernization Phase D2: Extract favorites-action pure cores

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -324,9 +324,45 @@ C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select
 - Files: `Source/Model/SAConnectionInfo+Favorite.swift`,
   `UnitTests/SAConnectionInfoFavoriteTests.swift`, `SPConnectionController.m`
 
-**D2. Extract favorites management actions**
-- `addFavorite:`, `removeFavorite:`, `duplicateFavorite:`, `addGroup:`, `sortFavorites:`, `importFavorites:`, `exportFavorites:`
-- Move to `SAFavoritesManager` that wraps `SAFavoritesProviding`
+**D2. Extract favorites management actions** — ✅ Done (scoped to the pure cores)
+- The full "SAFavoritesManager wrapping SAFavoritesProviding" vision was
+  too big for one behaviour-preserving PR — the actions are sheet/panel/
+  outline-view orchestration. Extracted the pure cores instead:
+- `SAConnectionInfo+Favorite.swift` gains the encode-side counterparts of
+  the D1 decoder (same private `FavoriteKey` literals):
+  - `defaultNewFavoriteDictionary(withID:)` — the 30-key new-favorite
+    template previously built inline as parallel objects/keys arrays in
+    `-addFavorite:`. Historical wire-format quirks preserved and pinned:
+    no `useCompression` key, no SSL *path* keys (only enabled flags),
+    vaultPort/vaultOIDCMount stored as `""` (not absent).
+  - `duplicatedFavoriteDictionary(fromFavorite:withID:)` — fresh ID +
+    localized "<name> Copy", source dict untouched; nil-tolerant (a group
+    selection makes `-selectedFavorite` return nil).
+- New `SAFavoriteDeletionPrompt` (Swift, pure Foundation, ConnectionView)
+  owns the three-way delete-confirmation rule from `-removeNode:`:
+  favorite → confirm w/ favorite wording, group w/ children → confirm w/
+  group wording, empty group → delete with no alert.
+- The three controller actions are now thin: `-addFavorite:` lost its ~70
+  template lines, `-duplicateFavorite:` its ID/name mutation,
+  `-removeNode:` its message composition.
+- 11 new unit tests: 6 in `SAConnectionInfoFavoriteTests` (template key
+  set + values + decoder round-trip ≈ blank-form equivalence; duplicate
+  ID/suffix/no-mutation + nil source) and 5 in
+  `SAFavoriteDeletionPromptTests` (three-way rule, childCount ignored for
+  favorites, nil name).
+- Import/export (`importFavorites:`/`exportFavorites:`) and `sortFavorites:`
+  stay — heavy UI flows, and the import path was just rewritten by the
+  connection-string PR (#2398). Revisit once that settles.
+- ⚠️ Tooling note: hand-editing project.pbxproj while Xcode has the project
+  open is an edit war — Xcode clobbers on-disk changes with its in-memory
+  model when it saves (lost several Unit-Tests build entries twice). New
+  files should be added via the Xcode MCP `XcodeWrite` (registers them in
+  Xcode's live model with real IDs); extra target memberships can be
+  added on disk immediately after an Xcode save, then committed promptly.
+- Files: `Source/Model/SAConnectionInfo+Favorite.swift`,
+  `Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteDeletionPrompt.swift`,
+  `UnitTests/SAConnectionInfoFavoriteTests.swift`,
+  `UnitTests/SAFavoriteDeletionPromptTests.swift`, `SPConnectionController.m`
 
 **D3. Extract form validation** — ✅ Done
 - New `SAConnectionDetailsValidator` (Swift, no AppKit) owns the
@@ -384,6 +420,6 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 5. **Phase B2** (favorites data source tests) — 🟡 B2a done (search matcher), B2b pending (needs test-target ObjC plumbing)
 6. **Phase C1** (SwiftUI favorites list) — first visible SwiftUI — 🟡 C1a + C1b done (wrap + pure SwiftUI list); reorder/rename/persistence + hosting (C3) still pending before it replaces the AppKit list
 7. ~~**Phase A2** (task controller) — large but impactful~~ ✅ Done (progress UI extracted; working-level counter stays on the document)
-8. **Phase D1-D3** (SPConnectionController cleanup) — 🟡 D1 + D3 done; D2 (favorites actions → SAFavoritesManager) pending — note the file grew to ~5,250 lines after the connection-string import PR (#2398), so D2 should wait for that area to settle / be rebased onto it deliberately
+8. ~~**Phase D1-D3** (SPConnectionController cleanup)~~ ✅ Done (D1 + D2 scoped-down + D3; import/export extraction deferred until the #2398 import area settles)
 9. **Phase C2-C3** (SwiftUI connection form) — bigger effort
 10. **Phase E** (table content/custom query) — long-term

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteDeletionPrompt.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteDeletionPrompt.swift
@@ -1,0 +1,61 @@
+//
+//  SAFavoriteDeletionPrompt.swift
+//  Sequel Ace
+//
+//  Created as part of the modernization effort (Phase D2).
+//
+//  Composes the confirmation alert shown before deleting a favorites-tree
+//  node, lifted out of -[SPConnectionController removeNode:]. Pure
+//  Foundation (no AppKit), so it compiles into the Unit Tests target and
+//  the three-way rule is pinned by tests:
+//  - favorite          → confirm with the favorite wording
+//  - group with items  → confirm with the group wording
+//  - empty group       → no confirmation, delete immediately
+//
+
+import Foundation
+
+@objc final class SAFavoriteDeletionPrompt: NSObject {
+
+    /// False for an empty group — deleting it loses nothing, so the
+    /// controller skips the alert and removes the node directly.
+    @objc let needsConfirmation: Bool
+
+    /// Alert message title, e.g. "Delete favorite 'Prod'?". Empty when no
+    /// confirmation is needed.
+    @objc let title: String
+
+    /// Alert informative text. Empty when no confirmation is needed.
+    @objc let informativeText: String
+
+    private init(needsConfirmation: Bool, title: String, informativeText: String) {
+        self.needsConfirmation = needsConfirmation
+        self.title = title
+        self.informativeText = informativeText
+    }
+
+    /// Builds the prompt for the selected node. `name` is the favorite's
+    /// name or the group's node name; `childCount` only matters for groups.
+    @objc(promptForGroup:name:childCount:)
+    static func prompt(forGroup isGroup: Bool, name: String?, childCount: Int) -> SAFavoriteDeletionPrompt {
+        let displayName = name ?? ""
+
+        if !isGroup {
+            return SAFavoriteDeletionPrompt(
+                needsConfirmation: true,
+                title: String(format: NSLocalizedString("Delete favorite '%@'?", comment: "delete database message"), displayName),
+                informativeText: String(format: NSLocalizedString("Are you sure you want to delete the favorite '%@'? This operation cannot be undone.", comment: "delete database informative message"), displayName)
+            )
+        }
+
+        if childCount > 0 {
+            return SAFavoriteDeletionPrompt(
+                needsConfirmation: true,
+                title: String(format: NSLocalizedString("Delete group '%@'?", comment: "delete database message"), displayName),
+                informativeText: String(format: NSLocalizedString("Are you sure you want to delete the group '%@'? All groups and favorites within this group will also be deleted. This operation cannot be undone.", comment: "delete database informative message"), displayName)
+            )
+        }
+
+        return SAFavoriteDeletionPrompt(needsConfirmation: false, title: "", informativeText: "")
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1702,74 +1702,9 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 {
     NSNumber *favoriteID = [self _createNewFavoriteID];
 
-    NSArray *objects = @[
-        NSLocalizedString(@"New Favorite", @"new favorite name"),
-        @0,
-        @"",
-        @"",
-        @"",
-        @(-1),
-        @"",
-        @0,
-        @"",
-        @(NSControlStateValueOff),
-        @(NSControlStateValueOff),
-        @(NSControlStateValueOff),
-        @"",
-        @"default",
-        @(NSControlStateValueOff),
-        @(NSControlStateValueOff),
-        @(NSControlStateValueOff),
-        @(NSControlStateValueOff),
-        @"",
-        @"",
-        @"",
-        @(NSControlStateValueOff),
-        @"",
-        @"",
-        @"",
-        @"",
-        @"",
-        @"",
-        @"",
-        favoriteID
-    ];
-
-    NSArray *keys = @[
-        SPFavoriteNameKey,
-        SPFavoriteTypeKey,
-        SPFavoriteHostKey,
-        SPFavoriteSocketKey,
-        SPFavoriteUserKey,
-        SPFavoriteColorIndexKey,
-        SPFavoritePortKey,
-        SPFavoriteTimeZoneModeKey,
-        SPFavoriteTimeZoneIdentifierKey,
-        SPFavoriteAllowDataLocalInfileKey,
-        SPFavoriteEnableClearTextPluginKey,
-        SPFavoriteUseAWSIAMAuthKey,
-        SPFavoriteAWSRegionKey,
-        SPFavoriteAWSProfileKey,
-        SPFavoriteUseSSLKey,
-        SPFavoriteSSLKeyFileLocationEnabledKey,
-        SPFavoriteSSLCertificateFileLocationEnabledKey,
-        SPFavoriteSSLCACertFileLocationEnabledKey,
-        SPFavoriteDatabaseKey,
-        SPFavoriteSSHHostKey,
-        SPFavoriteSSHUserKey,
-        SPFavoriteSSHKeyLocationEnabledKey,
-        SPFavoriteSSHKeyLocationKey,
-        SPFavoriteSSHPortKey,
-        SPFavoriteSSHRemoteSocketPathKey,
-        SPFavoriteVaultHostKey,
-        SPFavoriteVaultPortKey,
-        SPFavoriteVaultOIDCMountKey,
-        SPFavoriteVaultCredentialsPathKey,
-        SPFavoriteIDKey
-    ];
-
-    // Create default favorite
-    NSMutableDictionary *favorite = [NSMutableDictionary dictionaryWithObjects:objects forKeys:keys];
+    // Create default favorite (template + wire-format quirks live in
+    // SAConnectionInfo+Favorite.swift, pinned by SAConnectionInfoFavoriteTests)
+    NSMutableDictionary *favorite = [SAConnectionInfoObjC defaultNewFavoriteDictionaryWithID:favoriteID];
 
     SPTreeNode *selectedNode = [self selectedFavoriteNode];
 
@@ -1826,24 +1761,19 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 {
     if ([favoritesOutlineView numberOfSelectedRows] == 1) {
 
-        BOOL suppressWarning = NO;
         SPTreeNode *node = [self selectedFavoriteNode];
 
-        NSString *message = @"";
-        NSString *informativeMessage = @"";
+        // The favorite/group/empty-group wording (and whether to ask at all)
+        // lives in SAFavoriteDeletionPrompt, pinned by unit tests.
+        NSString *nodeDisplayName = [node isGroup]
+            ? [[node representedObject] nodeName]
+            : [[[node representedObject] nodeFavorite] objectForKey:SPFavoriteNameKey];
+        SAFavoriteDeletionPrompt *prompt = [SAFavoriteDeletionPrompt promptForGroup:[node isGroup]
+                                                                               name:nodeDisplayName
+                                                                         childCount:[[node childNodes] count]];
 
-        if (![node isGroup]) {
-            message = [NSString stringWithFormat:NSLocalizedString(@"Delete favorite '%@'?", @"delete database message"), [[[node representedObject] nodeFavorite] objectForKey:SPFavoriteNameKey]];
-            informativeMessage = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to delete the favorite '%@'? This operation cannot be undone.", @"delete database informative message"), [[[node representedObject] nodeFavorite] objectForKey:SPFavoriteNameKey]];
-        } else if ([[node childNodes] count] > 0) {
-            message = [NSString stringWithFormat:NSLocalizedString(@"Delete group '%@'?", @"delete database message"), [[node representedObject] nodeName]];
-            informativeMessage = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to delete the group '%@'? All groups and favorites within this group will also be deleted. This operation cannot be undone.", @"delete database informative message"), [[node representedObject] nodeName]];
-        } else {
-            suppressWarning = YES;
-        }
-
-        if (!suppressWarning) {
-            [NSAlert createDefaultAlertWithTitle:message message:informativeMessage primaryButtonTitle:NSLocalizedString(@"Delete", @"delete button") primaryButtonHandler:^{
+        if (prompt.needsConfirmation) {
+            [NSAlert createDefaultAlertWithTitle:prompt.title message:prompt.informativeText primaryButtonTitle:NSLocalizedString(@"Delete", @"delete button") primaryButtonHandler:^{
                 [self _removeNode:[self selectedFavoriteNode]];
             } cancelButtonHandler:nil];
         } else {
@@ -1859,15 +1789,9 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 {
     if ([favoritesOutlineView numberOfSelectedRows] == 1) {
 
-        NSMutableDictionary *favorite = [NSMutableDictionary dictionaryWithDictionary:[self selectedFavorite]];
-
+        // Fresh unique ID + "<name> Copy" (rules in SAConnectionInfo+Favorite.swift)
         NSNumber *favoriteID = [self _createNewFavoriteID];
-
-        // Update the unique ID
-        [favorite setObject:favoriteID forKey:SPFavoriteIDKey];
-
-        // Alter the name for clarity
-        [favorite setObject:[NSString stringWithFormat:NSLocalizedString(@"%@ Copy", @"Initial favourite name after duplicating a previous favourite"), [favorite objectForKey:SPFavoriteNameKey]] forKey:SPFavoriteNameKey];
+        NSMutableDictionary *favorite = [SAConnectionInfoObjC duplicatedFavoriteDictionaryFromFavorite:[self selectedFavorite] withID:favoriteID];
 
         SPTreeNode *selectedNode = [self selectedFavoriteNode];
 

--- a/Source/Model/SAConnectionInfo+Favorite.swift
+++ b/Source/Model/SAConnectionInfo+Favorite.swift
@@ -33,8 +33,10 @@ import Foundation
 // MARK: - Favorite dictionary keys (inlined; keep in sync with SPConstants.m)
 
 private enum FavoriteKey {
+    static let id = "id"
     static let type = "type"
     static let name = "name"
+    static let useAWSIAMAuth = "useAWSIAMAuth"
     static let host = "host"
     static let socket = "socket"
     static let user = "user"
@@ -49,6 +51,9 @@ private enum FavoriteKey {
     static let awsRegion = "awsRegion"
     static let awsProfile = "awsProfile"
     static let vaultHost = "vaultHost"
+    // Not decoded (see header) but written by the new-favorite template.
+    static let vaultPort = "vaultPort"
+    static let vaultOIDCMount = "vaultOIDCMount"
     static let vaultCredentialsPath = "vaultCredentialsPath"
     static let useSSL = "useSSL"
     static let sslKeyFileLocationEnabled = "sslKeyFileLocationEnabled"
@@ -170,5 +175,73 @@ extension SAConnectionInfoObjC {
     @objc(infoFromFavoriteDictionary:)
     class func info(fromFavoriteDictionary favorite: NSDictionary?) -> SAConnectionInfoObjC {
         SAConnectionInfoObjC(info: .fromFavoriteDictionary(favorite as? [AnyHashable: Any]))
+    }
+}
+
+// MARK: - Favorite dictionary templates (Phase D2)
+
+extension SAConnectionInfoObjC {
+
+    /// The plist dictionary for a brand-new favorite, as previously built
+    /// inline in -[SPConnectionController addFavorite:]. The key set and
+    /// values are part of the favorites wire format — note the historical
+    /// quirks preserved deliberately:
+    /// - no `useCompression` key (the decoder defaults it to true),
+    /// - no SSL key/cert/CA *path* keys (only the enabled flags),
+    /// - vaultPort / vaultOIDCMount stored as "" (not absent).
+    @objc(defaultNewFavoriteDictionaryWithID:)
+    class func defaultNewFavoriteDictionary(withID favoriteID: NSNumber) -> NSMutableDictionary {
+        let off = NSNumber(value: 0)
+        let favorite: [String: Any] = [
+            FavoriteKey.name: NSLocalizedString("New Favorite", comment: "new favorite name"),
+            FavoriteKey.type: NSNumber(value: 0),
+            FavoriteKey.host: "",
+            FavoriteKey.socket: "",
+            FavoriteKey.user: "",
+            FavoriteKey.colorIndex: NSNumber(value: -1),
+            FavoriteKey.port: "",
+            FavoriteKey.timeZoneMode: NSNumber(value: 0),
+            FavoriteKey.timeZoneIdentifier: "",
+            FavoriteKey.allowDataLocalInfile: off,
+            FavoriteKey.enableClearTextPlugin: off,
+            FavoriteKey.useAWSIAMAuth: off,
+            FavoriteKey.awsRegion: "",
+            FavoriteKey.awsProfile: "default",
+            FavoriteKey.useSSL: off,
+            FavoriteKey.sslKeyFileLocationEnabled: off,
+            FavoriteKey.sslCertificateFileLocationEnabled: off,
+            FavoriteKey.sslCACertFileLocationEnabled: off,
+            FavoriteKey.database: "",
+            FavoriteKey.sshHost: "",
+            FavoriteKey.sshUser: "",
+            FavoriteKey.sshKeyLocationEnabled: off,
+            FavoriteKey.sshKeyLocation: "",
+            FavoriteKey.sshPort: "",
+            FavoriteKey.sshRemoteSocketPath: "",
+            FavoriteKey.vaultHost: "",
+            FavoriteKey.vaultPort: "",
+            FavoriteKey.vaultOIDCMount: "",
+            FavoriteKey.vaultCredentialsPath: "",
+            FavoriteKey.id: favoriteID,
+        ]
+        return NSMutableDictionary(dictionary: favorite)
+    }
+
+    /// A duplicate of an existing favorite dictionary: same values, a fresh
+    /// unique ID, and the name suffixed for clarity ("<name> Copy", as
+    /// previously built inline in -[SPConnectionController duplicateFavorite:]).
+    /// The source dictionary is not modified.
+    @objc(duplicatedFavoriteDictionaryFromFavorite:withID:)
+    class func duplicatedFavoriteDictionary(fromFavorite favorite: NSDictionary?, withID favoriteID: NSNumber) -> NSMutableDictionary {
+        let duplicate = favorite.map(NSMutableDictionary.init(dictionary:)) ?? NSMutableDictionary()
+        duplicate[FavoriteKey.id] = favoriteID
+
+        let name = stringValue(favorite?[FavoriteKey.name], default: "")
+        duplicate[FavoriteKey.name] = String(
+            format: NSLocalizedString("%@ Copy", comment: "Initial favourite name after duplicating a previous favourite"),
+            name
+        )
+
+        return duplicate
     }
 }

--- a/UnitTests/SAConnectionInfoFavoriteTests.swift
+++ b/UnitTests/SAConnectionInfoFavoriteTests.swift
@@ -287,4 +287,94 @@ final class SAConnectionInfoFavoriteTests: XCTestCase {
         XCTAssertTrue(bridged.useCompression)
         XCTAssertEqual(bridged.awsProfile, "default")
     }
+
+    // MARK: - New-favorite template (Phase D2)
+
+    func testDefaultNewFavoriteTemplateMatchesHistoricalKeySet() {
+        let template = SAConnectionInfoObjC.defaultNewFavoriteDictionary(withID: NSNumber(value: 12345))
+
+        // Exactly the 30 keys -[SPConnectionController addFavorite:] used to write.
+        let expectedKeys: Set<String> = [
+            "name", "type", "host", "socket", "user", "colorIndex", "port",
+            "timeZoneMode", "timeZone", "allowDataLocalInfile",
+            "enableClearTextPlugin", "useAWSIAMAuth", "awsRegion", "awsProfile",
+            "useSSL", "sslKeyFileLocationEnabled",
+            "sslCertificateFileLocationEnabled", "sslCACertFileLocationEnabled",
+            "database", "sshHost", "sshUser", "sshKeyLocationEnabled",
+            "sshKeyLocation", "sshPort", "sshRemoteSocketPath",
+            "vaultHost", "vaultPort", "vaultOIDCMount", "vaultCredentialsPath",
+            "id",
+        ]
+        XCTAssertEqual(Set(template.allKeys.compactMap { $0 as? String }), expectedKeys)
+
+        // Historical quirks stay: no useCompression key, no SSL path keys.
+        XCTAssertNil(template["useCompression"])
+        XCTAssertNil(template["sslKeyFileLocation"])
+        XCTAssertNil(template["sslCertificateFileLocation"])
+        XCTAssertNil(template["sslCACertFileLocation"])
+    }
+
+    func testDefaultNewFavoriteTemplateValues() {
+        let template = SAConnectionInfoObjC.defaultNewFavoriteDictionary(withID: NSNumber(value: 777))
+
+        XCTAssertEqual(template["name"] as? String, "New Favorite")
+        XCTAssertEqual((template["type"] as? NSNumber)?.intValue, 0)
+        XCTAssertEqual((template["colorIndex"] as? NSNumber)?.intValue, -1)
+        XCTAssertEqual((template["timeZoneMode"] as? NSNumber)?.intValue, 0)
+        XCTAssertEqual((template["useSSL"] as? NSNumber)?.intValue, 0)
+        XCTAssertEqual(template["awsProfile"] as? String, "default")
+        XCTAssertEqual(template["host"] as? String, "")
+        XCTAssertEqual(template["vaultPort"] as? String, "")
+        XCTAssertEqual(template["vaultOIDCMount"] as? String, "")
+        XCTAssertEqual((template["id"] as? NSNumber)?.intValue, 777)
+    }
+
+    func testDefaultNewFavoriteTemplateRoundTripsThroughDecoder() {
+        // Decoding the template must equal decoding "no favorite" except for
+        // the name — the template is the encode-side twin of the decoder.
+        let template = SAConnectionInfoObjC.defaultNewFavoriteDictionary(withID: NSNumber(value: 1))
+        let decoded = SAConnectionInfo.fromFavoriteDictionary(template as? [AnyHashable: Any])
+        let blank = SAConnectionInfo.fromFavoriteDictionary(nil)
+
+        XCTAssertEqual(decoded.name, "New Favorite")
+        XCTAssertEqual(decoded.type, blank.type)
+        XCTAssertEqual(decoded.colorIndex, blank.colorIndex)
+        XCTAssertEqual(decoded.useCompression, blank.useCompression)
+        XCTAssertEqual(decoded.timeZoneMode, blank.timeZoneMode)
+        XCTAssertEqual(decoded.timeZoneIdentifier, blank.timeZoneIdentifier)
+        XCTAssertEqual(decoded.awsProfile, blank.awsProfile)
+        XCTAssertEqual(decoded.useSSL, blank.useSSL)
+        XCTAssertEqual(decoded.useAWSIAMAuth, blank.useAWSIAMAuth)
+    }
+
+    // MARK: - Favorite duplication (Phase D2)
+
+    func testDuplicatedFavoriteGetsNewIDAndCopySuffix() {
+        let original: NSDictionary = [
+            "id": NSNumber(value: 100),
+            "name": "Prod",
+            "host": "db.example.com",
+            "type": NSNumber(value: 2),
+        ]
+
+        let duplicate = SAConnectionInfoObjC.duplicatedFavoriteDictionary(fromFavorite: original, withID: NSNumber(value: 200))
+
+        XCTAssertEqual((duplicate["id"] as? NSNumber)?.intValue, 200)
+        XCTAssertEqual(duplicate["name"] as? String, "Prod Copy")
+        // Everything else carries over untouched.
+        XCTAssertEqual(duplicate["host"] as? String, "db.example.com")
+        XCTAssertEqual((duplicate["type"] as? NSNumber)?.intValue, 2)
+        // And the source is not mutated.
+        XCTAssertEqual((original["id"] as? NSNumber)?.intValue, 100)
+        XCTAssertEqual(original["name"] as? String, "Prod")
+    }
+
+    func testDuplicatedFavoriteFromNilYieldsMinimalDictionary() {
+        // Defensive path: -selectedFavorite returns nil for group selections.
+        let duplicate = SAConnectionInfoObjC.duplicatedFavoriteDictionary(fromFavorite: nil, withID: NSNumber(value: 5))
+
+        XCTAssertEqual((duplicate["id"] as? NSNumber)?.intValue, 5)
+        XCTAssertEqual(duplicate["name"] as? String, " Copy")
+        XCTAssertEqual(duplicate.count, 2)
+    }
 }

--- a/UnitTests/SAFavoriteDeletionPromptTests.swift
+++ b/UnitTests/SAFavoriteDeletionPromptTests.swift
@@ -1,0 +1,53 @@
+//
+//  SAFavoriteDeletionPromptTests.swift
+//  Unit Tests
+//
+//  Pins the delete-confirmation rules lifted out of
+//  -[SPConnectionController removeNode:] (Phase D2).
+//
+
+import XCTest
+
+final class SAFavoriteDeletionPromptTests: XCTestCase {
+
+    func testFavoriteAlwaysNeedsConfirmationWithFavoriteWording() {
+        let prompt = SAFavoriteDeletionPrompt.prompt(forGroup: false, name: "Prod", childCount: 0)
+
+        XCTAssertTrue(prompt.needsConfirmation)
+        XCTAssertEqual(prompt.title, "Delete favorite 'Prod'?")
+        XCTAssertEqual(prompt.informativeText,
+                       "Are you sure you want to delete the favorite 'Prod'? This operation cannot be undone.")
+    }
+
+    func testGroupWithChildrenNeedsConfirmationWithGroupWording() {
+        let prompt = SAFavoriteDeletionPrompt.prompt(forGroup: true, name: "Work", childCount: 3)
+
+        XCTAssertTrue(prompt.needsConfirmation)
+        XCTAssertEqual(prompt.title, "Delete group 'Work'?")
+        XCTAssertEqual(prompt.informativeText,
+                       "Are you sure you want to delete the group 'Work'? All groups and favorites within this group will also be deleted. This operation cannot be undone.")
+    }
+
+    func testEmptyGroupSkipsConfirmation() {
+        let prompt = SAFavoriteDeletionPrompt.prompt(forGroup: true, name: "Empty", childCount: 0)
+
+        XCTAssertFalse(prompt.needsConfirmation)
+        XCTAssertEqual(prompt.title, "")
+        XCTAssertEqual(prompt.informativeText, "")
+    }
+
+    func testFavoriteWithChildCountStillUsesFavoriteWording() {
+        // childCount is only meaningful for groups; favorites ignore it.
+        let prompt = SAFavoriteDeletionPrompt.prompt(forGroup: false, name: "Solo", childCount: 9)
+
+        XCTAssertTrue(prompt.needsConfirmation)
+        XCTAssertEqual(prompt.title, "Delete favorite 'Solo'?")
+    }
+
+    func testNilNameFormatsAsEmptyString() {
+        let prompt = SAFavoriteDeletionPrompt.prompt(forGroup: false, name: nil, childCount: 0)
+
+        XCTAssertTrue(prompt.needsConfirmation)
+        XCTAssertEqual(prompt.title, "Delete favorite ''?")
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -212,6 +212,9 @@
 		50EA92681AB23EFC008D3C4F /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
 		50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */; };
 		50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 50F530511ABCF66B002F2C1A /* resetTemplate.pdf */; };
+		510247F62FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */; };
+		510247F92FD9F2DD00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */; };
+		510247F82FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F72FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift */; };
 		5132930C25F586A900D803AD /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5132930925F586A900D803AD /* NotificationToken.swift */; };
 		5132930D25F586A900D803AD /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5132930A25F586A900D803AD /* TabManager.swift */; };
 		513515D2259354BB001E4533 /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513515D1259354BB001E4533 /* NSImageExtensions.swift */; };
@@ -258,9 +261,6 @@
 		51B09FD32F7677EB003BAFFF /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD22F7677EB003BAFFF /* FirebaseCrashlytics */; };
 		51B09FD72F767A3E003BAFFF /* SAConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */; };
 		51B09FD82F767A3F003BAFFF /* SAConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */; };
-		5AF0C4000000000000000002 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
-		5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
-		5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */; };
 		51B09FDD2F767A4C003BAFFF /* SAConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */; };
 		51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FDE2F767A53003BAFFF /* SADatabaseDocumentProviding.swift */; };
 		51B09FE12F767A5E003BAFFF /* SAFavoritesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B09FE02F767A5E003BAFFF /* SAFavoritesProviding.swift */; };
@@ -377,12 +377,15 @@
 		58FEF16D0F23D66600518E8E /* SPSQLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 58FEF16C0F23D66600518E8E /* SPSQLParser.m */; };
 		58FEF57E0F3B4E9700518E8E /* SPTableData.m in Sources */ = {isa = PBXBuildFile; fileRef = 58FEF57D0F3B4E9700518E8E /* SPTableData.m */; };
 		5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C1000000000000000001 /* SAFavoritesListView.swift */; };
-		5AF0C3000000000000000002 /* SATaskController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C3000000000000000001 /* SATaskController.swift */; };
 		5AF0C2000000000000000002 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
 		5AF0C2000000000000000003 /* SAFavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000001 /* SAFavoriteItem.swift */; };
 		5AF0C2000000000000000012 /* SAFavoriteItem+Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */; };
 		5AF0C2000000000000000022 /* SAFavoritesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000021 /* SAFavoritesList.swift */; };
 		5AF0C2000000000000000032 /* SAFavoriteItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */; };
+		5AF0C3000000000000000002 /* SATaskController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C3000000000000000001 /* SATaskController.swift */; };
+		5AF0C4000000000000000002 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
+		5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
+		5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */; };
 		65F52CC824AE21D600FED3CB /* SPFilePreferencePane.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */; };
 		6CB1977AAE8D7D64B7593E66 /* SPBundleManagerAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */; };
 		6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */; };
@@ -981,6 +984,8 @@
 		50E217B518174280009D3580 /* SPFavoriteColorSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFavoriteColorSupport.m; sourceTree = "<group>"; };
 		50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseActionTest.m; sourceTree = "<group>"; };
 		50F530511ABCF66B002F2C1A /* resetTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = resetTemplate.pdf; sourceTree = "<group>"; };
+		510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteDeletionPrompt.swift; sourceTree = "<group>"; };
+		510247F72FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteDeletionPromptTests.swift; sourceTree = "<group>"; };
 		510EE15C27B6C35F008544E7 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		511B309F25ABBC6500D010E3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		511E8F6926EF72FD001FC731 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1028,8 +1033,6 @@
 		51A709382565B99F001F1D2F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfo.swift; sourceTree = "<group>"; };
-		5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+Favorite.swift"; sourceTree = "<group>"; };
-		5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoFavoriteTests.swift; sourceTree = "<group>"; };
 		51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDelegate.swift; sourceTree = "<group>"; };
 		51B09FDE2F767A53003BAFFF /* SADatabaseDocumentProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseDocumentProviding.swift; sourceTree = "<group>"; };
 		51B09FE02F767A5E003BAFFF /* SAFavoritesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesProviding.swift; sourceTree = "<group>"; };
@@ -1178,11 +1181,13 @@
 		58FEF57C0F3B4E9700518E8E /* SPTableData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTableData.h; sourceTree = "<group>"; };
 		58FEF57D0F3B4E9700518E8E /* SPTableData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableData.m; sourceTree = "<group>"; };
 		5AF0C1000000000000000001 /* SAFavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesListView.swift; sourceTree = "<group>"; };
-		5AF0C3000000000000000001 /* SATaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskController.swift; sourceTree = "<group>"; };
 		5AF0C2000000000000000001 /* SAFavoriteItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteItem.swift; sourceTree = "<group>"; };
 		5AF0C2000000000000000011 /* SAFavoriteItem+Tree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAFavoriteItem+Tree.swift"; sourceTree = "<group>"; };
 		5AF0C2000000000000000021 /* SAFavoritesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoritesList.swift; sourceTree = "<group>"; };
 		5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteItemTests.swift; sourceTree = "<group>"; };
+		5AF0C3000000000000000001 /* SATaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATaskController.swift; sourceTree = "<group>"; };
+		5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+Favorite.swift"; sourceTree = "<group>"; };
+		5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoFavoriteTests.swift; sourceTree = "<group>"; };
 		65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFilePreferencePane.m; sourceTree = "<group>"; };
 		65F52CCC24AE21F200FED3CB /* SPFilePreferencePane.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPFilePreferencePane.h; sourceTree = "<group>"; };
 		6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBundleManagerAdditions.swift; sourceTree = "<group>"; };
@@ -1855,6 +1860,7 @@
 				5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */,
 				5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */,
 				AAA7A8F76494CE39908140FA /* SPDuplicateImportViewController.swift */,
+				510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */,
 			);
 			name = "Connection View";
 			path = ConnectionView;
@@ -2413,7 +2419,7 @@
 			path = MGTemplateEngine;
 			sourceTree = "<group>";
 		};
-		2A37F4AAFDCFA73011CA2CEA = {
+		2A37F4AAFDCFA73011CA2CEA /* sequel-pro */ = {
 			isa = PBXGroup;
 			children = (
 				518E02F227B91FBC007973E3 /* Entitlements */,
@@ -2517,6 +2523,7 @@
 				5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */,
 				5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */,
 				5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */,
+				510247F72FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -2868,7 +2875,7 @@
 				cs,
 				eo,
 			);
-			mainGroup = 2A37F4AAFDCFA73011CA2CEA;
+			mainGroup = 2A37F4AAFDCFA73011CA2CEA /* sequel-pro */;
 			packageReferences = (
 				51D9527425AE2B5300574BEB /* XCRemoteSwiftPackageReference "fmdb" */,
 				51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */,
@@ -3220,6 +3227,8 @@
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */,
+				510247F92FD9F2DD00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */,
+				510247F82FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift in Sources */,
 				5AF0C2000000000000000003 /* SAFavoriteItem.swift in Sources */,
 				5AF0C2000000000000000032 /* SAFavoriteItemTests.swift in Sources */,
 				5147B00D2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
@@ -3479,6 +3488,7 @@
 				584D88A91515034200F24774 /* NSNotificationCenterThreadingAdditions.m in Sources */,
 				584D899D15162CBE00F24774 /* SPDataBase64EncodingAdditions.m in Sources */,
 				1798F1871550175B004B0AB8 /* SPFavoritesExporter.m in Sources */,
+				510247F62FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */,
 				1798F1881550175B004B0AB8 /* SPFavoritesImporter.m in Sources */,
 				51B09FE72F768E39003BAFFF /* SAConnectionViewCoordinator.swift in Sources */,
 				1A89556625D6BEED0060CE72 /* GitHubReleaseManager.swift in Sources */,


### PR DESCRIPTION
<!-- #changed -->

> **Stacked PR:** based on #2436 (Phase D1) — only the last commit is new here. Will retarget to `main` automatically when #2436 merges.

## Changes:
- `SAConnectionInfo+Favorite.swift` gains the **encode-side counterparts of the D1 decoder**, sharing the same private `FavoriteKey` literals (no second copy of the inlined key strings):
  - `defaultNewFavoriteDictionary(withID:)` replaces the 30-entry parallel objects/keys arrays previously built inline in `-[SPConnectionController addFavorite:]`. Historical wire-format quirks are preserved deliberately and pinned by tests: no `useCompression` key (the decoder defaults it to YES), no SSL key/cert/CA *path* keys (only the enabled flags), and `vaultPort`/`vaultOIDCMount` stored as `""` rather than absent.
  - `duplicatedFavoriteDictionary(fromFavorite:withID:)` replaces the inline ID + localized "<name> Copy" mutation in `-duplicateFavorite:`. The parameter is nullable because `-selectedFavorite` returns nil for group selections; the source dictionary is never mutated.
- New `SAFavoriteDeletionPrompt` (pure Foundation, no AppKit) owns the three-way delete-confirmation rule from `-removeNode:`: favorite → confirm with favorite wording; group with children → confirm with group wording; empty group → delete immediately, no alert.
- The three controller actions become thin orchestration: `-addFavorite:` loses ~70 template lines, `-duplicateFavorite:` its dict mutation, `-removeNode:` its message composition.
- **Scope note:** the plan's full "move all favorites actions to an `SAFavoritesManager`" is deliberately deferred — `importFavorites:`/`exportFavorites:`/`sortFavorites:` are sheet/panel-driven UI flows, and the import path was just rewritten by #2398. This PR extracts only the pure, testable cores.
- 11 new unit tests: 6 added to `SAConnectionInfoFavoriteTests` (template key set, values, and a round-trip invariant — decoding the template equals decoding "no favorite" except the name; duplication ID/suffix/source-not-mutated/nil-source) and 5 in the new `SAFavoriteDeletionPromptTests` (the three-way rule, childCount ignored for favorites, nil name).

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon (build target arm64)
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [x] English (no localization changes — all strings keep their existing NSLocalizedString keys/comments)
- Xcode Version: 26.5 (17F42)

## Screenshots:
N/A — no visual change intended (alert wording is byte-identical, pinned by tests).

## Additional notes:
- Verified with the full unit-test suite via `xcodebuild` — **556 pass**; the single failure (`SPTableContentColumnFilterTests` — "Could not find PreferenceDefaults.plist") is pre-existing on main and unrelated. Verification ran with `CODE_SIGNING_ALLOWED=NO` because the local keychain is missing the Apple WWDR G3 intermediate (environment issue, not related to this change).
- The new project-file entries were added through Xcode itself (real Xcode-assigned IDs) after discovering that hand-editing `project.pbxproj` while Xcode has the project open gets silently clobbered by Xcode's in-memory model on save — this sharp edge is now documented in the modernization plan doc.
- One micro-behaviour note: duplicating with no favorite dictionary (only reachable if the action ever fires on a group selection) now yields a `" Copy"` name instead of ObjC's `"(null) Copy"`; the action is gated to single favorite selections, so this path is defensive only.
- Built on macOS 26.5 (Tahoe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal organization of favorites management code to reduce complexity.

* **Tests**
  * Added comprehensive unit tests for favorite operations including creation, duplication, and deletion.

* **Chores**
  * Updated project configuration for build optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->