### PR TITLE
Modernization Phase C2a: SwiftUI connection form for TCP/IP  #infra

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -279,11 +279,40 @@ C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select
 - Files: new `SAFavoriteItem.swift`, `SAFavoriteItem+Tree.swift`,
   `SAFavoritesList.swift`, `UnitTests/SAFavoriteItemTests.swift`
 
-**C2. SwiftUI ConnectionFormView**
-- The 55 IBOutlets in ConnectionView.xib are the target
-- Start with a SwiftUI form for TCP/IP connection type only
-- Bind to SAConnectionInfoObjC
-- Files: new `SAConnectionFormView.swift`
+**C2. SwiftUI ConnectionFormView** — 🟡 TCP/IP form + model done; other types + SSL + hosting pending
+- The 55 IBOutlets in ConnectionView.xib are the eventual target.
+
+C2a — TCP/IP form + observable model — ✅ Done
+- New `SAConnectionFormModel` (Swift, ObservableObject, pure
+  Foundation+Combine, BOTH targets) wraps the value-type
+  `SAConnectionInfo` so SwiftUI binds straight into it
+  (`$model.info.host`). It funnels the earlier extractions:
+  `validate()` → `SAConnectionDetailsValidator` (D3), `effectiveName` →
+  `SAConnectionFormHelpers.generateName` (user name wins, whitespace
+  ignored), `canAttemptConnection` gate (socket always, others need a
+  non-blank host), and ObjC bridging via `init(objc:)` / `apply(to:)`
+  (value-copy semantics — edits don't leak back until applied).
+- New `SAConnectionFormView` (SwiftUI, app-target only) renders the
+  XIB's TCP/IP tab fields (Name w/ auto-generated-name placeholder,
+  Host, Username, Password as SecureField, Database, Port w/ "3306"
+  placeholder) + a Connect button (default action, gated) that runs
+  D3 validation and surfaces the failure's alertTitle/alertMessage
+  via `.alert`; on success calls the `onConnect` closure (C3 will pass
+  SAConnectionService there). `formStyle(.grouped)` applied via an
+  availability-gated modifier (macOS 13+; target is 12.0). Like C1b,
+  nothing hosts the view yet — C3 is the host.
+- 14 unit tests in `UnitTests/SAConnectionFormModelTests.swift`:
+  defaults, ObjC round-trip both ways, value-copy isolation,
+  effectiveName matrix (name wins / host / host+db / empty / whitespace
+  name), connect gate (TCP/IP host required incl. whitespace-only,
+  socket always true), validation wiring (hostMissing + pass), and
+  objectWillChange publishing on field mutation.
+- Files were added via Xcode MCP `XcodeWrite` (real Xcode IDs); only
+  the model's second (Unit Tests) membership was a manual pbxproj edit.
+- Remaining C2 scope: socket/SSH/AWS/Vault type switching, SSL options,
+  color index, time-zone picker, favorites save/auto-name parity.
+- Files: `Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift`,
+  `SAConnectionFormView.swift`, `UnitTests/SAConnectionFormModelTests.swift`
 
 **C3. Wire SwiftUI into SAConnectionWindowController + expose in menu**
 - The standalone connection window is the ideal host for SwiftUI views

--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -288,10 +288,13 @@ C2a — TCP/IP form + observable model — ✅ Done
   `SAConnectionInfo` so SwiftUI binds straight into it
   (`$model.info.host`). It funnels the earlier extractions:
   `validate()` → `SAConnectionDetailsValidator` (D3), `effectiveName` →
-  `SAConnectionFormHelpers.generateName` (user name wins, whitespace
-  ignored), `canAttemptConnection` gate (socket always, others need a
-  non-blank host), and ObjC bridging via `init(objc:)` / `apply(to:)`
-  (value-copy semantics — edits don't leak back until applied).
+  `SAConnectionFormHelpers.generateName` (user-entered name wins,
+  whitespace-only names ignored), `canAttemptConnection` gate (socket:
+  always; SSH tunnel: non-blank host OR remote socket path, mirroring
+  the validator; TCP/AWS/Vault: non-blank host — Codex P2 caught the
+  original gate blocking valid remote-socket tunnels), and ObjC
+  bridging via `init(objc:)` / `apply(to:)` (value-copy semantics —
+  edits don't leak back until applied).
 - New `SAConnectionFormView` (SwiftUI, app-target only) renders the
   XIB's TCP/IP tab fields (Name w/ auto-generated-name placeholder,
   Host, Username, Password as SecureField, Database, Port w/ "3306"

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -1,0 +1,94 @@
+//
+//  SAConnectionFormModel.swift
+//  Sequel Ace
+//
+//  Phase C2 of the SwiftUI migration: the observable model behind
+//  SAConnectionFormView. Wraps the value-type SAConnectionInfo so
+//  SwiftUI fields can bind straight into it ($model.info.host), and
+//  funnels the pieces extracted in earlier phases:
+//  - SAConnectionDetailsValidator (D3) for pre-connection validation
+//  - SAConnectionFormHelpers for the auto-generated connection name
+//  - SAConnectionInfoObjC for bridging from/to the ObjC controller world
+//
+//  Pure Foundation + Combine (no AppKit/SwiftUI), so it compiles into
+//  the Unit Tests target and the behaviour is pinned by
+//  SAConnectionFormModelTests.
+//
+
+import Foundation
+import Combine
+
+final class SAConnectionFormModel: ObservableObject {
+
+    /// The connection parameters being edited. SwiftUI binds into this
+    /// directly (e.g. `$model.info.host`) — mutating any field publishes
+    /// a change for the whole model, which is the granularity the form
+    /// needs (the effective name and validation state depend on several
+    /// fields at once).
+    @Published var info: SAConnectionInfo
+
+    init(info: SAConnectionInfo = SAConnectionInfo()) {
+        self.info = info
+    }
+
+    /// Bridge in from the ObjC wrapper (e.g. the controller's current
+    /// details, or a favorite decoded via fromFavoriteDictionary).
+    convenience init(objc: SAConnectionInfoObjC) {
+        self.init(info: objc.info)
+    }
+
+    /// Bridge the edited values back into an ObjC wrapper.
+    func apply(to objc: SAConnectionInfoObjC) {
+        objc.info = info
+    }
+
+    // MARK: - Derived display values
+
+    /// The name shown for this connection: the user-entered name when
+    /// present, otherwise the auto-generated "host[/database]" name the
+    /// AppKit form produces (SAConnectionFormHelpers.generateName), or
+    /// "" when there is not enough information yet.
+    var effectiveName: String {
+        let trimmed = info.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+        return SAConnectionFormHelpers.generateName(type: info.type,
+                                                    host: info.host,
+                                                    database: info.database) ?? ""
+    }
+
+    /// True when the form has the minimum input to attempt a connection
+    /// (used to enable the Connect button before full validation runs).
+    var canAttemptConnection: Bool {
+        switch info.type {
+        case .socket:
+            return true
+        case .tcpIP, .sshTunnel, .awsIAM, .vault:
+            return !info.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    // MARK: - Validation
+
+    /// Runs the D3 pre-connection checks against the current values.
+    /// Returns nil when the details are valid; otherwise the first
+    /// failure, carrying ready-to-display alert strings.
+    func validate() -> SAConnectionValidationFailure? {
+        SAConnectionDetailsValidator.validate(
+            type: info.type,
+            host: info.host,
+            sshHost: info.sshHost,
+            sshRemoteSocketPath: info.sshRemoteSocketPath,
+            useSSL: info.useSSL != 0,
+            sshKeyLocationEnabled: info.sshKeyLocationEnabled != 0,
+            sshKeyLocation: info.sshKeyLocation,
+            sslKeyFileLocationEnabled: info.sslKeyFileLocationEnabled != 0,
+            sslKeyFileLocation: info.sslKeyFileLocation,
+            sslCertificateFileLocationEnabled: info.sslCertificateFileLocationEnabled != 0,
+            sslCertificateFileLocation: info.sslCertificateFileLocation,
+            sslCACertFileLocationEnabled: info.sslCACertFileLocationEnabled != 0,
+            sslCACertFileLocation: info.sslCACertFileLocation
+        )
+    }
+}

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -60,12 +60,20 @@ final class SAConnectionFormModel: ObservableObject {
 
     /// True when the form has the minimum input to attempt a connection
     /// (used to enable the Connect button before full validation runs).
+    /// Mirrors the host rule in SAConnectionDetailsValidator: an SSH
+    /// tunnel that targets a remote socket path doesn't need a MySQL
+    /// host (SAConnectionService connects through the socket instead).
     var canAttemptConnection: Bool {
+        let hasHost = !info.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         switch info.type {
         case .socket:
             return true
-        case .tcpIP, .sshTunnel, .awsIAM, .vault:
-            return !info.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .sshTunnel:
+            let hasRemoteSocket = !info.sshRemoteSocketPath
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            return hasHost || hasRemoteSocket
+        case .tcpIP, .awsIAM, .vault:
+            return hasHost
         }
     }
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -1,0 +1,128 @@
+//
+//  SAConnectionFormView.swift
+//  Sequel Ace
+//
+//  Phase C2 of the SwiftUI migration: a SwiftUI form for editing
+//  connection details, starting with the TCP/IP connection type only
+//  (the ConnectionView.xib standard tab). Binds into
+//  SAConnectionFormModel, which wraps the value-type SAConnectionInfo
+//  and reuses the already-extracted validation (D3) and name
+//  generation helpers.
+//
+//  Like SAFavoritesList (C1b), nothing hosts this view yet — Phase C3
+//  (the standalone connection window) is the intended host, where it
+//  will sit next to the SwiftUI favorites list and drive
+//  SAConnectionService directly. The field set and labels mirror the
+//  XIB's TCP/IP tab; SSL options and the other connection types are
+//  follow-up scope.
+//
+
+import SwiftUI
+
+/// SwiftUI editor for TCP/IP connection details.
+struct SAConnectionFormView: View {
+
+    @ObservedObject var model: SAConnectionFormModel
+
+    /// Invoked when the user submits a form that passed validation —
+    /// the host initiates the connection (C3: via SAConnectionService).
+    var onConnect: (SAConnectionFormModel) -> Void = { _ in }
+
+    /// The first validation failure of the latest submit, surfaced as
+    /// an alert (same strings the AppKit flow shows).
+    @State private var validationFailure: SAConnectionValidationFailure?
+
+    var body: some View {
+        Form {
+            Section {
+                TextField(text: $model.info.name, prompt: Text(namePrompt)) {
+                    Text("Name", comment: "connection view : field label")
+                }
+            }
+
+            Section {
+                TextField(text: $model.info.host) {
+                    Text("Host", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.user) {
+                    Text("Username", comment: "connection view : field label")
+                }
+                SecureField(text: $model.info.password) {
+                    Text("Password", comment: "connection view : field label")
+                }
+            }
+
+            Section {
+                TextField(text: $model.info.database, prompt: Text("optional", comment: "connection view : optional field placeholder")) {
+                    Text("Database", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.port, prompt: Text(verbatim: "3306")) {
+                    Text("Port", comment: "connection view : field label")
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button {
+                        submit()
+                    } label: {
+                        Text("Connect", comment: "connection view : connect button")
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!model.canAttemptConnection)
+                }
+            }
+        }
+        .modifier(SAGroupedFormStyle())
+        .alert(
+            validationFailure?.alertTitle ?? "",
+            isPresented: Binding(
+                get: { validationFailure != nil },
+                set: { if !$0 { validationFailure = nil } }
+            ),
+            presenting: validationFailure
+        ) { _ in
+            Button {
+                validationFailure = nil
+            } label: {
+                Text("OK", comment: "OK button")
+            }
+        } message: { failure in
+            Text(failure.alertMessage)
+        }
+    }
+
+    /// Placeholder for the name field: the auto-generated name the
+    /// connection would get, mirroring the AppKit form's behaviour of
+    /// auto-filling "host[/database]" until the user types their own.
+    private var namePrompt: String {
+        let generated = SAConnectionFormHelpers.generateName(type: model.info.type,
+                                                             host: model.info.host,
+                                                             database: model.info.database)
+        if let generated, !generated.isEmpty {
+            return generated
+        }
+        return NSLocalizedString("Optional Name", comment: "connection view : name field placeholder")
+    }
+
+    private func submit() {
+        if let failure = model.validate() {
+            validationFailure = failure
+            return
+        }
+        onConnect(model)
+    }
+}
+
+/// Applies the grouped form style where available (macOS 13+); on
+/// macOS 12 the default Form rendering is used.
+private struct SAGroupedFormStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 13.0, *) {
+            content.formStyle(.grouped)
+        } else {
+            content
+        }
+    }
+}

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -1,0 +1,155 @@
+//
+//  SAConnectionFormModelTests.swift
+//  Unit Tests
+//
+//  Pins the behaviour of the SwiftUI connection-form model (Phase C2):
+//  ObjC bridging round-trips, effective-name fallback, the
+//  connect-button gate, and the wiring into the D3 validator.
+//
+
+import Combine
+import XCTest
+
+final class SAConnectionFormModelTests: XCTestCase {
+
+    // MARK: - Defaults & bridging
+
+    func testDefaultsMatchBlankConnectionInfo() {
+        let model = SAConnectionFormModel()
+
+        XCTAssertEqual(model.info.type, .tcpIP)
+        XCTAssertEqual(model.info.name, "")
+        XCTAssertEqual(model.info.host, "")
+        XCTAssertEqual(model.info.user, "")
+        XCTAssertEqual(model.info.password, "")
+        XCTAssertEqual(model.info.database, "")
+        XCTAssertEqual(model.info.port, "")
+    }
+
+    func testInitFromObjCWrapperCopiesValues() {
+        let objc = SAConnectionInfoObjC()
+        objc.host = "db.example.com"
+        objc.user = "app"
+        objc.port = "3307"
+
+        let model = SAConnectionFormModel(objc: objc)
+
+        XCTAssertEqual(model.info.host, "db.example.com")
+        XCTAssertEqual(model.info.user, "app")
+        XCTAssertEqual(model.info.port, "3307")
+    }
+
+    func testApplyToObjCWrapperRoundTrips() {
+        let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
+        model.info.database = "shop"
+        model.info.password = "secret"
+
+        let objc = SAConnectionInfoObjC()
+        model.apply(to: objc)
+
+        XCTAssertEqual(objc.host, "db.example.com")
+        XCTAssertEqual(objc.database, "shop")
+        XCTAssertEqual(objc.password, "secret")
+    }
+
+    func testEditsDoNotLeakBackIntoSourceWrapper() {
+        // The model holds a value copy — editing it must not mutate the
+        // wrapper it was created from until apply(to:) is called.
+        let objc = SAConnectionInfoObjC()
+        objc.host = "original"
+
+        let model = SAConnectionFormModel(objc: objc)
+        model.info.host = "edited"
+
+        XCTAssertEqual(objc.host, "original")
+    }
+
+    // MARK: - Effective name
+
+    func testEffectiveNamePrefersUserEnteredName() {
+        let model = SAConnectionFormModel()
+        model.info.name = "Prod"
+        model.info.host = "db.example.com"
+
+        XCTAssertEqual(model.effectiveName, "Prod")
+    }
+
+    func testEffectiveNameFallsBackToGeneratedHostName() {
+        let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
+
+        XCTAssertEqual(model.effectiveName, "db.example.com")
+    }
+
+    func testEffectiveNameAppendsDatabase() {
+        let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
+        model.info.database = "shop"
+
+        XCTAssertEqual(model.effectiveName, "db.example.com/shop")
+    }
+
+    func testEffectiveNameEmptyWithoutHost() {
+        XCTAssertEqual(SAConnectionFormModel().effectiveName, "")
+    }
+
+    func testEffectiveNameIgnoresWhitespaceOnlyName() {
+        let model = SAConnectionFormModel()
+        model.info.name = "   "
+        model.info.host = "db.example.com"
+
+        XCTAssertEqual(model.effectiveName, "db.example.com")
+    }
+
+    // MARK: - Connect gate
+
+    func testCanAttemptConnectionRequiresHostForTCPIP() {
+        let model = SAConnectionFormModel()
+        XCTAssertFalse(model.canAttemptConnection)
+
+        model.info.host = "db.example.com"
+        XCTAssertTrue(model.canAttemptConnection)
+
+        model.info.host = "   "
+        XCTAssertFalse(model.canAttemptConnection)
+    }
+
+    func testCanAttemptConnectionAlwaysTrueForSocket() {
+        let model = SAConnectionFormModel()
+        model.info.type = .socket
+
+        XCTAssertTrue(model.canAttemptConnection)
+    }
+
+    // MARK: - Validation wiring (full rules pinned by D3's own tests)
+
+    func testValidateFailsWithHostMissingForEmptyTCPIPHost() {
+        let failure = SAConnectionFormModel().validate()
+
+        XCTAssertEqual(failure?.kind, .hostMissing)
+        XCTAssertFalse(failure?.alertTitle.isEmpty ?? true)
+        XCTAssertFalse(failure?.alertMessage.isEmpty ?? true)
+    }
+
+    func testValidatePassesWithHostProvided() {
+        let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
+
+        XCTAssertNil(model.validate())
+    }
+
+    // MARK: - Observability
+
+    func testMutatingInfoPublishesChange() {
+        let model = SAConnectionFormModel()
+        var changes = 0
+        let cancellable = model.objectWillChange.sink { changes += 1 }
+
+        model.info.host = "db.example.com"
+        model.info.port = "3307"
+
+        XCTAssertEqual(changes, 2)
+        cancellable.cancel()
+    }
+}

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -122,6 +122,52 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertTrue(model.canAttemptConnection)
     }
 
+    func testCanAttemptConnectionRequiresHostForAWSAndVault() {
+        for type in [SAConnectionType.awsIAM, .vault] {
+            let model = SAConnectionFormModel()
+            model.info.type = type
+            XCTAssertFalse(model.canAttemptConnection, "\(type) without host")
+
+            model.info.host = "db.example.com"
+            XCTAssertTrue(model.canAttemptConnection, "\(type) with host")
+        }
+    }
+
+    func testCanAttemptConnectionForSSHTunnelAcceptsHostOrRemoteSocket() {
+        let model = SAConnectionFormModel()
+        model.info.type = .sshTunnel
+
+        // Neither host nor remote socket: gated.
+        XCTAssertFalse(model.canAttemptConnection)
+
+        // MySQL host alone is enough.
+        model.info.host = "db.example.com"
+        XCTAssertTrue(model.canAttemptConnection)
+
+        // A remote socket path alone is enough too — the validator skips
+        // the host requirement for socket-targeting tunnels and
+        // SAConnectionService connects through the socket.
+        model.info.host = ""
+        model.info.sshRemoteSocketPath = "/var/run/mysqld/mysqld.sock"
+        XCTAssertTrue(model.canAttemptConnection)
+
+        // Whitespace-only values don't count.
+        model.info.sshRemoteSocketPath = "   "
+        XCTAssertFalse(model.canAttemptConnection)
+    }
+
+    func testGateAgreesWithValidatorForRemoteSocketTunnel() {
+        // The P2 regression this pins: a remote-socket SSH favorite must
+        // be submittable — the gate may never be stricter than validate().
+        let model = SAConnectionFormModel()
+        model.info.type = .sshTunnel
+        model.info.sshHost = "bastion.example.com"
+        model.info.sshRemoteSocketPath = "/var/run/mysqld/mysqld.sock"
+
+        XCTAssertTrue(model.canAttemptConnection)
+        XCTAssertNil(model.validate())
+    }
+
     // MARK: - Validation wiring (full rules pinned by D3's own tests)
 
     func testValidateFailsWithHostMissingForEmptyTCPIPHost() {

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -213,8 +213,8 @@
 		50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EA92691AB246B8008D3C4F /* SPDatabaseActionTest.m */; };
 		50F530521ABCF66B002F2C1A /* resetTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 50F530511ABCF66B002F2C1A /* resetTemplate.pdf */; };
 		510247F62FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */; };
-		510247F92FD9F2DD00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */; };
 		510247F82FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F72FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift */; };
+		510247F92FD9F2DD00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */; };
 		5132930C25F586A900D803AD /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5132930925F586A900D803AD /* NotificationToken.swift */; };
 		5132930D25F586A900D803AD /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5132930A25F586A900D803AD /* TabManager.swift */; };
 		513515D2259354BB001E4533 /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513515D1259354BB001E4533 /* NSImageExtensions.swift */; };
@@ -304,6 +304,10 @@
 		51CD0BF9258D06D8009E2484 /* BundleHTMLOutput.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CD0BDB258D06D8009E2484 /* BundleHTMLOutput.xib */; };
 		51D9527625AE2B5300574BEB /* FMDB in Frameworks */ = {isa = PBXBuildFile; productRef = 51D9527525AE2B5300574BEB /* FMDB */; };
 		51DCBEF0257134190098E303 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
+		51EF3E642FDC24EE00EFFF09 /* SAConnectionFormModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF3E632FDC24EE00EFFF09 /* SAConnectionFormModel.swift */; };
+		51EF3E652FDC24EF00EFFF09 /* SAConnectionFormModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF3E632FDC24EE00EFFF09 /* SAConnectionFormModel.swift */; };
+		51EF3E692FDC250300EFFF09 /* SAConnectionFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF3E682FDC250300EFFF09 /* SAConnectionFormView.swift */; };
+		51EF3E6B2FDC251800EFFF09 /* SAConnectionFormModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF3E6A2FDC251800EFFF09 /* SAConnectionFormModelTests.swift */; };
 		51F41FBA25F56A5900594BA5 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51F41FB625F56A5900594BA5 /* MainWindow.xib */; };
 		51F4AFBF24B26665006144D5 /* NSAlertExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */; };
 		5806B76411A991EC00813A88 /* SPDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5806B76311A991EC00813A88 /* SPDocumentController.m */; };
@@ -1075,6 +1079,9 @@
 		51CD0BD8258D06D8009E2484 /* ConnectionView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConnectionView.xib; sourceTree = "<group>"; };
 		51CD0BDA258D06D8009E2484 /* DatabaseProcessList.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DatabaseProcessList.xib; sourceTree = "<group>"; };
 		51CD0BDB258D06D8009E2484 /* BundleHTMLOutput.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BundleHTMLOutput.xib; sourceTree = "<group>"; };
+		51EF3E632FDC24EE00EFFF09 /* SAConnectionFormModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormModel.swift; sourceTree = "<group>"; };
+		51EF3E682FDC250300EFFF09 /* SAConnectionFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormView.swift; sourceTree = "<group>"; };
+		51EF3E6A2FDC251800EFFF09 /* SAConnectionFormModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormModelTests.swift; sourceTree = "<group>"; };
 		51F41FB625F56A5900594BA5 /* MainWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		51F4AFBD24B26665006144D5 /* Sequel-Ace-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sequel-Ace-Bridging-Header.h"; sourceTree = "<group>"; };
 		51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
@@ -1861,6 +1868,8 @@
 				5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */,
 				AAA7A8F76494CE39908140FA /* SPDuplicateImportViewController.swift */,
 				510247F52FD9F2CE00586DEA /* SAFavoriteDeletionPrompt.swift */,
+				51EF3E632FDC24EE00EFFF09 /* SAConnectionFormModel.swift */,
+				51EF3E682FDC250300EFFF09 /* SAConnectionFormView.swift */,
 			);
 			name = "Connection View";
 			path = ConnectionView;
@@ -2524,6 +2533,7 @@
 				5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */,
 				5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */,
 				510247F72FD9F2DC00586DEA /* SAFavoriteDeletionPromptTests.swift */,
+				51EF3E6A2FDC251800EFFF09 /* SAConnectionFormModelTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3187,6 +3197,8 @@
 				F4C0BDAE2E9F4D5E8A1B0102 /* RDSIAMAuthentication.swift in Sources */,
 				F4C0BDAE2E9F4D5E8A1B0103 /* AWSSTSClient.swift in Sources */,
 				F4C0BDAE2E9F4D5E8A1B0104 /* AWSMFATokenDialog.swift in Sources */,
+				51EF3E652FDC24EF00EFFF09 /* SAConnectionFormModel.swift in Sources */,
+				51EF3E6B2FDC251800EFFF09 /* SAConnectionFormModelTests.swift in Sources */,
 				F4C0BDAE2E9F4D5E8A1B0105 /* AWSIAMAuthManager.swift in Sources */,
 				F4C0BDAE2E9F4D5E8A1B0106 /* AWSDirectoryBookmarkManager.swift in Sources */,
 				F4C0BDAE2E9F4D5E8A1B0109 /* OSLog.swift in Sources */,
@@ -3339,10 +3351,12 @@
 				F3A4B8C191E14E7094C9B012 /* RDSIAMAuthentication.swift in Sources */,
 				F3A4B8C191E14E7094C9B013 /* AWSSTSClient.swift in Sources */,
 				F3A4B8C191E14E7094C9B014 /* AWSMFATokenDialog.swift in Sources */,
+				51EF3E692FDC250300EFFF09 /* SAConnectionFormView.swift in Sources */,
 				F3A4B8C191E14E7094C9B015 /* AWSIAMAuthManager.swift in Sources */,
 				F3A4B8C191E14E7094C9B016 /* AWSDirectoryBookmarkManager.swift in Sources */,
 				FA1B2C3D4E5F6A7B8C9D0E11 /* VaultClient.swift in Sources */,
 				FA1B2C3D4E5F6A7B8C9D0E14 /* VaultOIDCHandler.swift in Sources */,
+				51EF3E642FDC24EE00EFFF09 /* SAConnectionFormModel.swift in Sources */,
 				FA1B2C3D4E5F6A7B8C9D0E15 /* VaultAuthManager.swift in Sources */,
 				387BBBA80FBCB6CB00B31746 /* SPTableRelations.m in Sources */,
 				1740FABB0FC4372F00CF3699 /* SPDatabaseData.m in Sources */,


### PR DESCRIPTION
<!-- #changed -->

## Changes:
- First slice of the SwiftUI connection form (Phase C2), following the C1 pattern: build the piece now, host it in C3 (the standalone connection window). **No change to the existing XIB connection flow** — nothing references the new views yet.
- New `SAConnectionFormModel` (ObservableObject, pure Foundation + Combine, compiled into app **and** Unit Tests targets) wraps the value-type `SAConnectionInfo` so SwiftUI binds directly into it (`$model.info.host`). It funnels the pieces extracted in earlier phases instead of duplicating logic:
  - `validate()` → the D3 `SAConnectionDetailsValidator` rules (failure carries the same alert strings the AppKit flow shows)
  - `effectiveName` → `SAConnectionFormHelpers.generateName` fallback ("host[/database]"); a user-entered name wins, whitespace-only names are ignored
  - `canAttemptConnection` gates the Connect button (socket: always; TCP/SSH/AWS/Vault: non-blank host)
  - `init(objc:)` / `apply(to:)` bridge from/to `SAConnectionInfoObjC` with value-copy semantics — edits never leak back into the source wrapper until applied (pinned by a test)
- New `SAConnectionFormView` (SwiftUI, app target only) renders the XIB TCP/IP tab fields: Name (auto-generated name as placeholder), Host, Username, Password (`SecureField`), Database ("optional"), Port ("3306" placeholder), and a default-action Connect button that runs validation and surfaces failures via `.alert`; success invokes an `onConnect` closure that C3 will wire to `SAConnectionService`. `formStyle(.grouped)` is availability-gated (macOS 13+; deployment target is 12.0).
- 14 unit tests in `SAConnectionFormModelTests`: defaults, ObjC round-trips both ways, value-copy isolation, the `effectiveName` matrix, the connect gate (incl. whitespace-only host), validation wiring (`hostMissing` / pass), and `objectWillChange` publishing on field mutation.
- Remaining C2 scope (follow-ups): the other connection types (socket/SSH/AWS/Vault) with type switching, SSL options, color index, time-zone picker, and favorites save parity.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon (build target arm64)
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
- Localizations:
  - [x] English (new strings use NSLocalizedString / Text(comment:) and will flow through Crowdin)
- Xcode Version: 26.5 (17F42)

## Screenshots:
N/A — the view is not hosted anywhere yet (C3 is the intended host), so there is no user-visible change in this PR.

## Additional notes:
- Verified with the full unit-test suite (signed build via Xcode): **574 pass**; the single failure (`SPTableContentColumnFilterTests` — "Could not find PreferenceDefaults.plist") is pre-existing on main and unrelated.
- Project-file entries were added through Xcode itself (real Xcode-assigned IDs); the only manual `project.pbxproj` edit is the model's second (Unit Tests) target membership.
- Built on macOS 26.5 (Tahoe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SwiftUI grouped connection form for TCP/IP setup with fields for name, host, username, password, database, and port.
  * “Connect” button is disabled until the form is ready; on submit, validation failures surface an alert.
  * Added auto-generated connection naming with an optional custom name and macOS grouped form styling.

* **Tests**
  * Added 14 unit tests covering initialization, round-tripping edits, naming rules, validation, and connection gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->