### PR TITLE
Modernization: safe deprecation cleanup batch #infra

### DIFF
--- a/Source/Controllers/BundleSupport/SPBundleEditorController.m
+++ b/Source/Controllers/BundleSupport/SPBundleEditorController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPBundleEditorController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPBundleCommandRunner.h"
 #import "SPOutlineView.h"
 #import "SPBundleCommandTextView.h"
@@ -769,7 +770,7 @@
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 
-	[panel setAllowedFileTypes:@[SPUserBundleFileExtensionV2, SPUserBundleFileExtension]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPUserBundleFileExtensionV2], [UTType typeWithFilenameExtension:SPUserBundleFileExtension]]];
 	
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:NO];

--- a/Source/Controllers/BundleSupport/SPBundleEditorController.m
+++ b/Source/Controllers/BundleSupport/SPBundleEditorController.m
@@ -1501,10 +1501,8 @@
 	if(![self saveBundle:bundleDict atPath:draggedFilePath]) return NO;
 
 	// Write data to the pasteboard
-	NSArray *fileList = [NSArray arrayWithObjects:draggedFilePath, nil];
-	// NSPasteboard *pboard = [NSPasteboard pasteboardWithName:NSDragPboard];
-	[pboard declareTypes:@[NSFilenamesPboardType] owner:nil];
-	[pboard setPropertyList:fileList forType:NSFilenamesPboardType];
+	[pboard clearContents];
+	[pboard writeObjects:@[[NSURL fileURLWithPath:draggedFilePath]]];
 
 	// Start the drag operation
 	dragImage = [[NSWorkspace sharedWorkspace] iconForFile:draggedFilePath];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPExportController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPTablesList.h"
 #import "SPTableData.h"
 #import "SPTableContent.h"
@@ -3016,7 +3017,7 @@ set_input:
 	//show open file dialog
 	NSOpenPanel *panel = [NSOpenPanel openPanel];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 	[panel setAllowsOtherFileTypes:YES];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger result) {
@@ -3071,7 +3072,7 @@ set_input:
 	//show save file dialog
 	NSSavePanel *panel = [NSSavePanel savePanel];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:NO];

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesList.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesList.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// SwiftUI favorites sidebar built over the value-type
 /// `SAFavoriteItem` model.
@@ -80,7 +81,7 @@ struct SAFavoriteRow: View {
             Image("quick-connect-icon")
                 .renderingMode(.template)
         case .group:
-            Image(nsImage: NSWorkspace.shared.icon(forFileType: NSFileTypeForHFSTypeCode(OSType(kGenericFolderIcon))))
+            Image(nsImage: NSWorkspace.shared.icon(for: .folder))
                 .resizable()
                 .frame(width: 16, height: 16)
         case .favorite:

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
@@ -9,6 +9,7 @@
 //
 
 import AppKit
+import UniformTypeIdentifiers
 
 // Image name constants (mirrored from SPConnectionController.m)
 private let kSPDatabaseImage = "database-small"
@@ -73,7 +74,7 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
         self.quickConnectCell.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
 
         // Folder icon
-        self.folderImage = NSWorkspace.shared.icon(forFileType: NSFileTypeForHFSTypeCode(OSType(kGenericFolderIcon)))
+        self.folderImage = NSWorkspace.shared.icon(for: .folder)
         self.folderImage.size = NSSize(width: 16, height: 16)
 
         super.init()

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1965,7 +1965,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
             NSButton *revealCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(0, 5, 200, 20)];
             [revealCheckbox setButtonType:NSButtonTypeSwitch];
             [revealCheckbox setTitle:NSLocalizedString(@"Show password", @"Show password checkbox")];
-            [revealCheckbox setState:NSOffState];
+            [revealCheckbox setState:NSControlStateValueOff];
 
             // Use target-action with stored context via associated objects
             objc_setAssociatedObject(revealCheckbox, kOriginalStringKey, clipboardString, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -2015,7 +2015,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
     NSString *redactedString = objc_getAssociatedObject(sender, kRedactedStringKey);
     NSTextField *urlField = objc_getAssociatedObject(sender, kURLFieldKey);
 
-    if (sender.state == NSOnState) {
+    if (sender.state == NSControlStateValueOn) {
         // Show password
         [urlField setStringValue:originalString];
     } else {
@@ -4721,7 +4721,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
         return;
     }
 
-    BOOL shouldReveal = (sender.state == NSOnState);
+    BOOL shouldReveal = (sender.state == NSControlStateValueOn);
     plainField.stringValue = secureField.stringValue ?: @"";
     secureField.hidden = shouldReveal;
     plainField.hidden = !shouldReveal;

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPConnectionController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPDatabaseDocument.h"
 #import "SPAppController.h"
 #import "SPPreferenceController.h"
@@ -2076,7 +2077,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 {
     NSOpenPanel *openPanel = [NSOpenPanel openPanel];
 
-    [openPanel setAllowedFileTypes:@[@"plist"]];
+    [openPanel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:@"plist"]]];
 
     [openPanel beginSheetModalForWindow:[dbDocument parentWindowControllerWindow] completionHandler:^(NSInteger returnCode)
     {

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -30,6 +30,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPCustomQuery.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPSQLParser.h"
 #import "SPDataCellFormatter.h"
 #import "SPDatabaseDocument.h"
@@ -566,7 +567,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
     
-    [panel setAllowedFileTypes:@[SPFileExtensionSQL]];
+    [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
     
     [panel setExtensionHidden:NO];
     [panel setAllowsOtherFileTypes:YES];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -30,6 +30,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPDatabaseDocument.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPConnectionController.h"
 #import "SPTablesList.h"
 #import "SPDatabaseStructure.h"
@@ -1921,7 +1922,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
 
-    [panel setAllowedFileTypes:@[SPFileExtensionSQL]];
+    [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
 
     [panel setExtensionHidden:NO];
     [panel setAllowsOtherFileTypes:YES];
@@ -2478,7 +2479,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
                                                         includeDefaultEntry:NO
                                                               encodingPopUp:&encodingPopUp]];
 
-        [panel setAllowedFileTypes:@[SPFileExtensionSQL]];
+        [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
 
         if (![prefs stringForKey:@"lastSqlFileName"]) {
             [prefs setObject:@"" forKey:@"lastSqlFileName"];
@@ -2505,7 +2506,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         }
 
         // Save current session (open connection windows as SPF file)
-        [panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+        [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 
         [self prepareSaveAccessoryViewWithPanel:panel];
 
@@ -2527,7 +2528,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     else if (sender == nil || [sender tag] == SPMainMenuFileSaveSession) {
 
         // Save current session (open connection windows as SPFS file)
-        [panel setAllowedFileTypes:@[SPBundleFileExtension]];
+        [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPBundleFileExtension]]];
 
         [self prepareSaveAccessoryViewWithPanel:panel];
 

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPEditorPreferencePane.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPPreferenceController.h"
 #import "SPColorWellCell.h"
 #import "SPCategoryAdditions.h"
@@ -137,7 +138,7 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 	
-	[panel setAllowedFileTypes:@[SPColorThemeFileExtension]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPColorThemeFileExtension]]];
 	
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:NO];
@@ -163,7 +164,7 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	[panel setDelegate:self];
 	[panel setCanChooseDirectories:NO];
 	[panel setAllowsMultipleSelection:NO];
-	[panel setAllowedFileTypes:@[SPColorThemeFileExtension, @"tmTheme"]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPColorThemeFileExtension], [UTType typeWithFilenameExtension:@"tmTheme"]]];
 
 	[panel beginSheetModalForWindow:[[self view] window] completionHandler:^(NSInteger returnCode)
 	{

--- a/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPGeneralPreferencePane.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPGeneralPreferencePane.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPPreferenceController.h"
 #import "SPFavoritesController.h"
 #import "SPTreeNode.h"
@@ -55,7 +56,7 @@ static NSString *SPDatabaseImage = @"database-small";
     [super awakeFromNib];
     
 	// Generic folder image for use in the outline view's groups
-	folderImage = [[NSWorkspace sharedWorkspace] iconForFileType:NSFileTypeForHFSTypeCode(kGenericFolderIcon)];
+	folderImage = [[NSWorkspace sharedWorkspace] iconForContentType:UTTypeFolder];
 	
 	[folderImage setSize:NSMakeSize(16, 16)];
 }

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -30,6 +30,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPAppController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPDatabaseDocument.h"
 #import "SPPreferenceController.h"
 #import "SPDataImport.h"
@@ -595,7 +596,7 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
     // it will enabled if user selects a *.sql file
     [encodingPopUp setEnabled:NO];
 
-    [panel setAllowedFileTypes:@[SPFileExtensionDefault, SPFileExtensionSQL, SPBundleFileExtension]];
+    [panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault], [UTType typeWithFilenameExtension:SPFileExtensionSQL], [UTType typeWithFilenameExtension:SPBundleFileExtension]]];
 
     // Check if at least one document exists, if so show a sheet
     if ([self.tabManager activeWindowController]) {

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.m
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPContentFilterManager.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "ImageAndTextCell.h"
 #import "RegexKitLite.h"
 #import "SPQueryController.h"
@@ -330,7 +331,7 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:NO];
@@ -389,7 +390,7 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 	[panel setCanChooseDirectories:NO];
 	[panel setAllowsMultipleSelection:NO];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode)
 	{

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPFieldEditorController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "RegexKitLite.h"
 #import "SPTooltip.h"
 #import "SPGeometryDataView.h"
@@ -576,7 +577,7 @@ typedef enum {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 
 	if ([editSheetSegmentControl selectedSegment] == ImageSegment && [sheetEditData isKindOfClass:[SPMySQLGeometryData class]]) {
-		[panel setAllowedFileTypes:@[@"pdf"]];
+		[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:@"pdf"]]];
 		[panel setAllowsOtherFileTypes:NO];
 	}
 	else {

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPQueryController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPConsoleMessage.h"
 #import "SPAppController.h"
 #import "SPFunctions.h"
@@ -247,7 +248,7 @@ static SPQueryController *sharedQueryController = nil;
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionSQL]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
 
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:YES];

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPQueryFavoriteManager.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "ImageAndTextCell.h"
 #import "SPEncodingPopupAccessory.h"
 #import "SPQueryController.h"
@@ -299,7 +300,7 @@
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 	
-	[panel setAllowedFileTypes:@[SPFileExtensionSQL]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
 	
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:YES];
@@ -322,7 +323,7 @@
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 	
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault]]];
 	
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:NO];
@@ -344,7 +345,7 @@
 	[panel setCanChooseDirectories:NO];
 	[panel setAllowsMultipleSelection:NO];
 
-	[panel setAllowedFileTypes:@[SPFileExtensionDefault, SPFileExtensionSQL]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:SPFileExtensionDefault], [UTType typeWithFilenameExtension:SPFileExtensionSQL]]];
 
 	[panel beginSheetModalForWindow:[self window] completionHandler:^(NSInteger returnCode) {
 		[self importPanelDidEnd:panel returnCode:returnCode contextInfo:NULL];

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -261,10 +261,10 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (void)_doChangeToRuleEditorData:(void (^)(void))duringBlock;
 - (IBAction)_checkboxClicked:(id)sender;
 - (void)_updateCheckedStateUpwardsFromCompoundRow:(NSInteger)row;
-- (void)_updateCheckedStateForRow:(NSInteger)row to:(NSCellStateValue)newState;
-- (void)_updateCheckedStateDownwardsFromCompoundRow:(NSInteger)row to:(NSCellStateValue)newState;
-- (NSCellStateValue)_recalculateCheckboxStatesFromRow:(NSInteger)row;
-- (NSCellStateValue)_checkboxStateForRow:(NSInteger)row;
+- (void)_updateCheckedStateForRow:(NSInteger)row to:(NSControlStateValue)newState;
+- (void)_updateCheckedStateDownwardsFromCompoundRow:(NSInteger)row to:(NSControlStateValue)newState;
+- (NSControlStateValue)_recalculateCheckboxStatesFromRow:(NSInteger)row;
+- (NSControlStateValue)_checkboxStateForRow:(NSInteger)row;
 @end
 
 @implementation SPRuleFilterController
@@ -690,10 +690,10 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (IBAction)_checkboxClicked:(id)sender
 {
 	NSInteger row = [filterRuleEditor rowForDisplayValue:sender];
-	NSCellStateValue newState = [(NSButton *)sender state];
+	NSControlStateValue newState = [(NSButton *)sender state];
 
 	// to have -setState: accept mixed state we have to -setAllowsMixedState:YES in which case the user, too, can cycle all three states m(
-	if(newState == NSMixedState) {
+	if(newState == NSControlStateValueMixed) {
 		[sender setNextState];
 		newState = [(NSButton *)sender state];
 	}
@@ -719,7 +719,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
  * @param newState
  *   The new state to set for all children rows
  */
-- (void)_updateCheckedStateDownwardsFromCompoundRow:(NSInteger)row to:(NSCellStateValue)newState
+- (void)_updateCheckedStateDownwardsFromCompoundRow:(NSInteger)row to:(NSControlStateValue)newState
 {
 	NSIndexSet *subrows = [filterRuleEditor subrowIndexesForRow:row];
 	[subrows enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
@@ -740,7 +740,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
  * @param newState
  *   The new checkbox state to set
  */
-- (void)_updateCheckedStateForRow:(NSInteger)row to:(NSCellStateValue)newState
+- (void)_updateCheckedStateForRow:(NSInteger)row to:(NSControlStateValue)newState
 {
 	NSArray *displayValues = [filterRuleEditor displayValuesForRow:row];
 	RuleNode *firstCriterion = [[filterRuleEditor criteriaForRow:row] objectAtIndex:0];
@@ -767,14 +767,14 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	// stop condition for recursion
 	if(row < 0) return;
 
-	__block NSCellStateValue newState = NSControlStateValueOn;
+	__block NSControlStateValue newState = NSControlStateValueOn;
 	__block NSUInteger countOff = 0;
 	NSIndexSet *subrows = [filterRuleEditor subrowIndexesForRow:row];
 	[subrows enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-		NSCellStateValue subState = [self _checkboxStateForRow:idx];
+		NSControlStateValue subState = [self _checkboxStateForRow:idx];
 		// mixed is easy: if at least one child is mixed, the parent is mixed, too
-		if(subState == NSMixedState) {
-			newState = NSMixedState;
+		if(subState == NSControlStateValueMixed) {
+			newState = NSControlStateValueMixed;
 			*stop = YES;
 			return;
 		}
@@ -784,7 +784,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	}];
 	if(countOff) {
 		// off only happens if all children are off
-		newState = (countOff == [subrows count]) ? NSControlStateValueOff : NSMixedState;
+		newState = (countOff == [subrows count]) ? NSControlStateValueOff : NSControlStateValueMixed;
 	}
 
 	//update ourselves
@@ -805,17 +805,17 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
  *   The resulting state for the given row according to all children (recursive).
  *   This will be:
  *   - `NSControlStateValueOn` if the row either has no children or all children are also checked
- *   - `NSMixedState` if at least one child row is also in mixed state or some (but not all) of the child rows are unchecked
+ *   - `NSControlStateValueMixed` if at least one child row is also in mixed state or some (but not all) of the child rows are unchecked
  *   - `NSControlStateValueOff` if there are child rows and all of them are unchecked
  */
-- (NSCellStateValue)_recalculateCheckboxStatesFromRow:(NSInteger)row
+- (NSControlStateValue)_recalculateCheckboxStatesFromRow:(NSInteger)row
 {
 	NSIndexSet *subrows = [filterRuleEditor subrowIndexesForRow:row];
 
-	__block NSCellStateValue newState = NSControlStateValueOn;
+	__block NSControlStateValue newState = NSControlStateValueOn;
 	__block NSUInteger countOff = 0;
 	[subrows enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-		NSCellStateValue subState;
+		NSControlStateValue subState;
 		if([filterRuleEditor rowTypeForRow:idx] == NSRuleEditorRowTypeCompound) {
 			subState = [self _recalculateCheckboxStatesFromRow:idx];
 			// if the current row is a compound row, update its state from its children
@@ -824,8 +824,8 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		else {
 			subState = [self _checkboxStateForRow:idx];
 		}
-		if(subState == NSMixedState) {
-			newState = NSMixedState;
+		if(subState == NSControlStateValueMixed) {
+			newState = NSControlStateValueMixed;
 		}
 		else if(subState == NSControlStateValueOff) {
 			countOff++;
@@ -833,7 +833,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	}];
 	if(countOff) {
 		// off only happens if all children are off
-		newState = (countOff == [subrows count]) ? NSControlStateValueOff : NSMixedState;
+		newState = (countOff == [subrows count]) ? NSControlStateValueOff : NSControlStateValueMixed;
 	}
 
 	return newState;
@@ -851,7 +851,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
  *   The checkbox state.
  *   Defaults to `NSControlStateValueOn` if no checkbox is found in the row.
  */
-- (NSCellStateValue)_checkboxStateForRow:(NSInteger)row
+- (NSControlStateValue)_checkboxStateForRow:(NSInteger)row
 {
 	NSArray *displayValues = [filterRuleEditor displayValuesForRow:row];
 	RuleNode *firstCriterion = [[filterRuleEditor criteriaForRow:row] objectAtIndex:0];

--- a/Source/Controllers/SubviewControllers/SPServerVariablesController.m
+++ b/Source/Controllers/SubviewControllers/SPServerVariablesController.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPServerVariablesController.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "SPDatabaseDocument.h"
 #import "SPAppController.h"
 
@@ -128,7 +129,7 @@
 {
 	NSSavePanel *panel = [NSSavePanel savePanel];
 	
-	[panel setAllowedFileTypes:@[@"cnf"]];
+	[panel setAllowedContentTypes:@[[UTType typeWithFilenameExtension:@"cnf"]]];
 
 	[panel setExtensionHidden:NO];
 	[panel setAllowsOtherFileTypes:YES];

--- a/Source/Other/CategoryAdditions/SPColorAdditions.m
+++ b/Source/Other/CategoryAdditions/SPColorAdditions.m
@@ -33,14 +33,14 @@
 @implementation NSColor (SPColorAdditions)
 
 /**
- * Convert self by using the NSCalibratedRGBColorSpace color space in a NSString
+ * Convert self by using the generic RGB color space in a NSString
  * #RRGGBBAA or if the alpha value is zero to #RRGGBB
  */
 - (NSString *)rgbHexString
 {
 	CGFloat red, green, blue, alpha;
 	NSString *redHexValue, *greenHexValue, *blueHexValue, *alphaHexValue;
-	NSColor *aColor = [self colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+	NSColor *aColor = [self colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 
 	if(aColor) {
 		[aColor getRed:&red green:&green blue:&blue alpha:&alpha];

--- a/Source/ThirdParty/MGTemplateEngine/MGTemplateStandardFilters.m
+++ b/Source/ThirdParty/MGTemplateEngine/MGTemplateStandardFilters.m
@@ -80,7 +80,7 @@
 									  (unsigned int)(components[2] * 255)];
 				return colorHex;
 #else
-				NSColor *color = [(NSColor *)value colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+				NSColor *color = [(NSColor *)value colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 				if (!color) { // happens if the colorspace couldn't be converted
 					return @"000000"; // black
 				} else {

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -58,8 +58,9 @@
 	}
 
 	// If a filename is available, attempt to read it and pass it to the delegate
-	if ([[[sender draggingPasteboard] propertyListForType:@"NSFilenamesPboardType"] count]) {
-		[delegateForUse processUpdatedImageData:[NSData dataWithContentsOfFile:[[[sender draggingPasteboard] propertyListForType:@"NSFilenamesPboardType"] objectAtIndex:0]]];
+	NSArray *droppedFileURLs = [[sender draggingPasteboard] readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
+	if ([droppedFileURLs count]) {
+		[delegateForUse processUpdatedImageData:[NSData dataWithContentsOfURL:[droppedFileURLs objectAtIndex:0]]];
 		return [super performDragOperation:sender];
 	}
 

--- a/Source/Views/TextViews/SPBundleCommandTextView.m
+++ b/Source/Views/TextViews/SPBundleCommandTextView.m
@@ -608,6 +608,9 @@
 	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] ) {
 		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
+		if([files count] == 0)
+			return [super performDragOperation:sender];
+
 		// Only one file path is allowed
 		if([files count] > 1) {
 			NSLog(@"%@", NSLocalizedString(@"Only one dragged item allowed.",@"Only one dragged item allowed."));

--- a/Source/Views/TextViews/SPBundleCommandTextView.m
+++ b/Source/Views/TextViews/SPBundleCommandTextView.m
@@ -602,11 +602,11 @@
 {
 	NSPasteboard *pboard = [sender draggingPasteboard];
 
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"])
+	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"])
 		return [super performDragOperation:sender];
 
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
-		NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
+	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] ) {
+		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
 		// Only one file path is allowed
 		if([files count] > 1) {
@@ -614,7 +614,7 @@
 			return YES;
 		}
 
-		NSString *filepath = [[pboard propertyListForType:NSFilenamesPboardType] objectAtIndex:0];
+		NSString *filepath = [(NSURL *)[files objectAtIndex:0] path];
 
 		// Set the new insertion point
 		NSPoint draggingLocation = [sender draggingLocation];

--- a/Source/Views/TextViews/SPEditSheetTextView.m
+++ b/Source/Views/TextViews/SPEditSheetTextView.m
@@ -164,12 +164,12 @@
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
 	NSPasteboard *pboard = [sender draggingPasteboard];
 
-	if ([[pboard types] containsObject:NSFilenamesPboardType] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"]) {
+	if ([[pboard types] containsObject:NSPasteboardTypeFileURL] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"]) {
 		return [super performDragOperation:sender];
 	}
 
-	if ([[pboard types] containsObject:NSFilenamesPboardType]) {
-		NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
+	if ([[pboard types] containsObject:NSPasteboardTypeFileURL]) {
+		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
 		// Only one file path is allowed
 		if ([files count] > 1) {
@@ -177,7 +177,7 @@
 			return YES;
 		}
 
-		NSString *filepath = [[pboard propertyListForType:NSFilenamesPboardType] objectAtIndex:0];
+		NSString *filepath = [(NSURL *)[files objectAtIndex:0] path];
 
 		// Set the new insertion point
 		NSPoint draggingLocation = [sender draggingLocation];

--- a/Source/Views/TextViews/SPEditSheetTextView.m
+++ b/Source/Views/TextViews/SPEditSheetTextView.m
@@ -171,6 +171,10 @@
 	if ([[pboard types] containsObject:NSPasteboardTypeFileURL]) {
 		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
+		if ([files count] == 0) {
+			return [super performDragOperation:sender];
+		}
+
 		// Only one file path is allowed
 		if ([files count] > 1) {
 			NSLog(@"%@", NSLocalizedString(@"Only one dragged item allowed.",@"Only one dragged item allowed."));

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3582,6 +3582,9 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] ) {
 		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
+		if([files count] == 0)
+			return [super performDragOperation:sender];
+
 		// Only one file path is allowed
 		if([files count] > 1) {
 			NSLog(@"%@", NSLocalizedString(@"Only one dragged item allowed.",@"Only one dragged item allowed."));

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3576,11 +3576,11 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 {
 	NSPasteboard *pboard = [sender draggingPasteboard];
 
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"])
+	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] && [[pboard types] containsObject:@"CorePasteboardFlavorType 0x54455854"])
 		return [super performDragOperation:sender];
 
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
-		NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
+	if ( [[pboard types] containsObject:NSPasteboardTypeFileURL] ) {
+		NSArray *files = [pboard readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
 
 		// Only one file path is allowed
 		if([files count] > 1) {
@@ -3588,7 +3588,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			return YES;
 		}
 
-		NSString *filepath = [[pboard propertyListForType:NSFilenamesPboardType] objectAtIndex:0];
+		NSString *filepath = [(NSURL *)[files objectAtIndex:0] path];
 		// if (([filenamesAttributes fileHFSTypeCode] == 'clpt' && [filenamesAttributes fileHFSCreatorCode] == 'MACS') || [[filename pathExtension] isEqualToString:@"textClipping"] == YES) {
 		//
 		// }


### PR DESCRIPTION
## Summary

Mechanical batch of deprecation fixes — API renames and 1:1 replacements with no behavior change and no persisted-data compatibility concerns. Deployment target is macOS 12.0, so every replacement API is available unconditionally. Removes ~75 deprecation warning locations.

One commit per API family:

- **`NSCellStateValue` / `NSOnState` / `NSOffState` / `NSMixedState` → `NSControlStateValue*`** — pure rename in `SPRuleFilterController.m` (~32 sites, incl. method signatures) and `SPConnectionController.m` (3 sites). The file already used the modern constants in places.
- **`setAllowedFileTypes:` → `allowedContentTypes`** — 20 sites in 12 files, inline `[UTType typeWithFilenameExtension:…]`. Modules are enabled, so `#import <UniformTypeIdentifiers/...>` auto-links; no project file change. `SPBundleHTMLOutputController.m` is intentionally skipped — it's deleted by the in-flight WKWebView migration branch, and touching it here would create a delete/modify conflict.
- **`iconForFileType:` → `icon(for: .folder)` / `iconForContentType:UTTypeFolder`** — 3 sites fetching the generic folder icon (`SPGeneralPreferencePane.m`, `SAFavoritesList.swift`, `SAFavoritesListDataSource.swift`).
- **`colorUsingColorSpaceName:` → `colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]`** — `SPColorAdditions.m` and vendored `MGTemplateStandardFilters.m`.
- **`NSFilenamesPboardType` → `NSPasteboardTypeFileURL`** — the only commit with behavior surface. Drag-drop readers (`SPTextView`, `SPBundleCommandTextView`, `SPEditSheetTextView`, `SPImageView`) now use `readObjectsForClasses:` with file-URL filtering; the Bundle Editor drag writer uses `clearContents` + `writeObjects:`.

Deliberately **out of scope** (each needs its own design): NSArchiver/NSUnarchiver (years of user prefs in legacy format need a read-legacy/write-keyed compat layer), NSUserNotification, NSConnection (SSH tunnel IPC), SecKeychain, and the remaining legacy WebView consumers (help viewer + print, follow-up to the WKWebView branch).

## Test plan

- [x] Builds clean — zero remaining warnings for the five migrated APIs (unique deprecation locations: ~312 → 286)
- [ ] Save/open panels filter correctly: export (spf), save query (sql), theme import (spTheme/tmTheme), connection import (plist), server variables (cnf)
- [ ] Rule filter checkbox mixed-state behavior unchanged
- [ ] Drag a .sql file onto the query editor; drag an image file onto the field-editor image view
- [ ] Drag a bundle item out of the Bundle Editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized file dialog handling across save, import, and export operations to use current macOS content-type APIs for better compatibility.
  * Updated drag-and-drop handling and pasteboard usage to more robust URL-based APIs for improved reliability.
  * Refreshed folder icons and other UI icon rendering.
  * Modernized color space handling for color exports.
  * Standardized checkbox state management in rule filters for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->