### PR TITLE
#fixed Skip the stats-expiry SET that locks ProxySQL connections

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -46,6 +46,7 @@
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;
 - (void)_disconnect;
 - (void)_updateConnectionVariables;
+- (BOOL)_serverIsProxySQL;
 - (void)_restoreConnectionVariables;
 - (void)_restoreSessionStateAfterReconnectWithDatabase:(NSString *)databaseName
                                               encoding:(NSString *)encodingName

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1430,11 +1430,34 @@ asm(".desc ___crashreporter_info__, 0x10");
     // Check the information_schema_stats_expiry timeout - if it's not zero, set it to 0
     // Otherwise, stats page will lag behind reality
     // https://github.com/Sequel-Ace/Sequel-Ace/issues/1206
+    // ProxySQL doesn't track this variable, so the SET pins the connection to its current
+    // hostgroup and a later SELECT that should route elsewhere fails with "locked to
+    // hostgroup". Skip it on ProxySQL; the only cost there is a stats page that can lag.
+    // https://github.com/Sequel-Ace/Sequel-Ace/issues/2006
     if ([variables objectForKey:@"information_schema_stats_expiry"]) {
-        if ([[variables objectForKey:@"information_schema_stats_expiry"] integerValue] != 0) {
+        if ([[variables objectForKey:@"information_schema_stats_expiry"] integerValue] != 0 && ![self _serverIsProxySQL]) {
             [self queryString:@"SET information_schema_stats_expiry=0"];
         }
     }
+}
+
+/**
+ * Returns whether the active connection is served by ProxySQL rather than MySQL or MariaDB directly.
+ */
+- (BOOL)_serverIsProxySQL
+{
+	if (state != SPMySQLConnected && state != SPMySQLConnecting) return NO;
+
+	// ProxySQL answers this exact lowercase query itself with "(ProxySQL)", whatever version it
+	// reports in the handshake. Uppercase keywords or SHOW VARIABLES are forwarded to a backend,
+	// so the query has to match byte for byte to read ProxySQL's own version_comment.
+	SPMySQLResult *theResult = [self queryString:@"select @@version_comment limit 1"];
+	if (![theResult numberOfRows]) return NO;
+
+	[theResult setReturnDataAsStrings:YES];
+	NSString *versionComment = [[theResult getRowAsArray] firstObject];
+
+	return [versionComment isKindOfClass:[NSString class]] && [versionComment rangeOfString:@"ProxySQL"].location != NSNotFound;
 }
 
 /**


### PR DESCRIPTION
## Changes:
- On connect, `_updateConnectionVariables` runs `SET information_schema_stats_expiry=0` (added in #1206 for fresh stats on MySQL 8). ProxySQL doesn't track that variable, so with `mysql-set_query_lock_on_hostgroup=1` it pins the connection to its current hostgroup, and a later read that should route elsewhere fails with `ERROR 9006: connection is locked to hostgroup X but trying to reach hostgroup Y` (#2006). The SET is now skipped on ProxySQL, leaving MySQL and MariaDB unchanged.
- ProxySQL is detected with `select @@version_comment limit 1`, which it answers itself as `(ProxySQL)`. A direct MySQL or MariaDB returns its own version_comment. The only cost on ProxySQL is a stats page that can lag.

## Closes following issues:
- Closes: #2006

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon (M5 Pro)
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] macOS 27.0 (Darwin 27.0.0)
- Localizations:
  - [x] English (no new strings)
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.5

## Screenshots:
N/A, no UI change.

## Additional notes:
- Reproduced locally with ProxySQL 2.5.5 in front of MySQL 8.0, one backend in two hostgroups with reads routed to the second. With the SET the next SELECT fails with the 9006 lock. Without it the SELECT returns rows. The detection query returns `(ProxySQL)` through ProxySQL and `MySQL Community Server - GPL` directly.
- Built and ran the `Unit Tests` scheme on Apple Silicon (Xcode 26.5). All pass except the pre-existing `SPTableContentColumnFilterTests` failure, which fails the same way on `main`. No new unit test for this path, since `_updateConnectionVariables` needs a live server and the test target only covers value conversion.
