### PR TITLE
#added Guard MySQL 8.4 auto-increment column edits

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -1766,6 +1766,9 @@
 /* MySQL connecting very short status message */
 "MySQL connecting..." = "MySQL connecting...";
 
+/* mysql 8.4 invalid auto increment title */
+"AUTO_INCREMENT is unavailable" = "AUTO_INCREMENT is unavailable";
+
 /* mysql error message */
 "MySQL Error" = "MySQL Error";
 
@@ -1780,6 +1783,9 @@
 
 /* mysql help categories */
 "MySQL Help – Categories" = "MySQL Help – Categories";
+
+/* mysql 8.4 invalid auto increment message */
+"MySQL 8.4 and newer only support AUTO_INCREMENT on integer columns. The %@ column type cannot use AUTO_INCREMENT on this server." = "MySQL 8.4 and newer only support AUTO_INCREMENT on integer columns. The %@ column type cannot use AUTO_INCREMENT on this server.";
 
 /* mysql said message */
 "MySQL said:" = "MySQL said:";
@@ -2327,6 +2333,9 @@
 
 /* selected items */
 "selected items" = "selected items";
+
+/* invalid auto increment fallback field type */
+"selected" = "selected";
 
 /* Bundle Editor : Scope=Data-Table : Input source dropdown: 'selected rows as comma-separated' item */
 "Selected Rows (CSV)" = "Selected Rows (CSV)";

--- a/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
+++ b/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@objc final class SAAutoIncrementRuleSupport: NSObject {
+    private static let autoIncrementExtraValues: Set<String> = [
+        "AUTO_INCREMENT",
+        "SERIAL DEFAULT VALUE"
+    ]
+
+    private static let integerFieldTypes: Set<String> = [
+        "TINYINT",
+        "SMALLINT",
+        "MEDIUMINT",
+        "INT",
+        "INTEGER",
+        "BIGINT"
+    ]
+
+    @objc static func isAutoIncrementExtraValue(_ value: Any?) -> Bool {
+        guard let value = value as? String else { return false }
+
+        return autoIncrementExtraValues.contains(normalizedExtraValue(value))
+    }
+
+    @objc static func fieldTypeAllowsAutoIncrement(_ fieldType: String?) -> Bool {
+        return integerFieldTypes.contains(normalizedFieldType(fieldType))
+    }
+
+    private static func normalizedExtraValue(_ value: String) -> String {
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    private static func normalizedFieldType(_ fieldType: String?) -> String {
+        guard var type = fieldType?.trimmingCharacters(in: .whitespacesAndNewlines).uppercased(), !type.isEmpty else {
+            return ""
+        }
+
+        if let lengthStart = type.firstIndex(of: "(") {
+            type = String(type[..<lengthStart])
+        }
+
+        return type.components(separatedBy: .whitespacesAndNewlines).first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
+++ b/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 @objc final class SAAutoIncrementRuleSupport: NSObject {
-    private static let autoIncrementExtraValues: Set<String> = [
+    private static let autoIncrementExtraValue = "AUTO_INCREMENT"
+    private static let mysql84RestrictedExtraValues: Set<String> = [
         "AUTO_INCREMENT",
         "SERIAL DEFAULT VALUE"
     ]
@@ -18,7 +19,14 @@ import Foundation
     @objc static func isAutoIncrementExtraValue(_ value: Any?) -> Bool {
         guard let value = value as? String else { return false }
 
-        return autoIncrementExtraValues.contains(normalizedExtraValue(value))
+        return normalizedExtraValue(value) == autoIncrementExtraValue
+    }
+
+    @objc(isMySQL84AutoIncrementRuleExtraValue:)
+    static func isMySQL84AutoIncrementRuleExtraValue(_ value: Any?) -> Bool {
+        guard let value = value as? String else { return false }
+
+        return mysql84RestrictedExtraValues.contains(normalizedExtraValue(value))
     }
 
     @objc static func fieldTypeAllowsAutoIncrement(_ fieldType: String?) -> Bool {

--- a/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
+++ b/Source/Controllers/MainViewControllers/TableStructure/SAAutoIncrementRuleSupport.swift
@@ -13,7 +13,9 @@ import Foundation
         "MEDIUMINT",
         "INT",
         "INTEGER",
-        "BIGINT"
+        "BIGINT",
+        "BOOL",
+        "BOOLEAN"
     ]
 
     @objc static func isAutoIncrementExtraValue(_ value: Any?) -> Bool {

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -120,6 +120,10 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 - (NSDictionary *)_columnStatsForFieldName:(NSString *)fieldName lengthFunction:(NSString *)lengthFunction;
 - (NSString *)_estimatedOptimizedFieldTypeForField:(NSDictionary *)fieldDefinition failureReason:(NSString **)failureReason;
 - (void)_showOptimizedFieldTypeFallbackTask:(NSDictionary *)context;
+- (BOOL)_serverUsesMySQL84AutoIncrementRules;
+- (BOOL)_isAutoIncrementExtraValue:(id)value;
+- (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType;
+- (void)_showInvalidAutoIncrementAlertForFieldType:(NSString *)fieldType;
 
 #pragma mark - SPTableStructureDelegate
 
@@ -291,6 +295,51 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	for (NSTableColumn *col in [indexesTableView tableColumns]) {
 		[[col dataCell] setFont:tableFont];
 	}
+}
+
+- (BOOL)_serverUsesMySQL84AutoIncrementRules
+{
+	return ![mySQLConnection isMariaDB] && [mySQLConnection serverVersionIsGreaterThanOrEqualTo:8 minorVersion:4 releaseVersion:0];
+}
+
+- (BOOL)_isAutoIncrementExtraValue:(id)value
+{
+	if (![value isKindOfClass:[NSString class]]) return NO;
+	
+	return [[(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].uppercaseString isEqualToString:@"AUTO_INCREMENT"];
+}
+
+- (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType
+{
+	if (![self _serverUsesMySQL84AutoIncrementRules]) return YES;
+	
+	NSString *type = fieldType ? [[fieldType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString] : @"";
+	NSRange lengthRange = [type rangeOfString:@"("];
+	if (lengthRange.location != NSNotFound) {
+		type = [type substringToIndex:lengthRange.location];
+	}
+	type = [[[type componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] firstObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	
+	NSSet *integerTypes = [NSSet setWithObjects:
+		SPMySQLTinyIntType,
+		SPMySQLSmallIntType,
+		SPMySQLMediumIntType,
+		SPMySQLIntType,
+		@"INTEGER",
+		SPMySQLBigIntType,
+		nil];
+	
+	return [integerTypes containsObject:type];
+}
+
+- (void)_showInvalidAutoIncrementAlertForFieldType:(NSString *)fieldType
+{
+	NSString *displayType = [[fieldType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
+	if (![displayType length]) displayType = NSLocalizedString(@"selected", @"invalid auto increment fallback field type");
+	
+	[NSAlert createWarningAlertWithTitle:NSLocalizedString(@"AUTO_INCREMENT is unavailable", @"mysql 8.4 invalid auto increment title")
+								 message:[NSString stringWithFormat:NSLocalizedString(@"MySQL 8.4 and newer only support AUTO_INCREMENT on integer columns. The %@ column type cannot use AUTO_INCREMENT on this server.", @"mysql 8.4 invalid auto increment message"), displayType]
+								callback:nil];
 }
 
 #pragma mark -
@@ -900,6 +949,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	}
 
 	NSDictionary *theRow = [[self activeFieldsSource] safeObjectAtIndex:currentlyEditingRow];
+	
+	if ([self _isAutoIncrementExtraValue:[theRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[theRow objectForKey:@"type"]]) {
+		[self _showInvalidAutoIncrementAlertForFieldType:[theRow objectForKey:@"type"]];
+		return NO;
+	}
 
 	if ([autoIncrementIndex isEqualToString:@"PRIMARY KEY"]) {
 		// If the field isn't set to be unsigned and we're making it the primary key then make it unsigned
@@ -2012,7 +2066,9 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		// Populate Extra suggestion popup button
 		for (id item in extraFieldSuggestions)
 		{
-			if (!(isCurrentExtraAutoIncrement && [item isEqualToString:@"auto_increment"])) {
+			BOOL isAutoIncrementSuggestion = [self _isAutoIncrementExtraValue:item];
+			BOOL shouldHideAutoIncrement = isAutoIncrementSuggestion && (isCurrentExtraAutoIncrement || ![self _fieldTypeAllowsAutoIncrement:[rowData objectForKey:@"type"]]);
+			if (!shouldHideAutoIncrement) {
 				[dataCell addItemWithObjectValue:item];
 			}
 		}
@@ -2070,7 +2126,15 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	else if ([[aTableColumn identifier] isEqualToString:@"Extra"]) {
 		if (![[currentRow objectForKey:@"Extra"] isEqualToString:anObject]) {
 
-			isCurrentExtraAutoIncrement = [[[anObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString] isEqualToString:@"AUTO_INCREMENT"];
+			isCurrentExtraAutoIncrement = [self _isAutoIncrementExtraValue:anObject];
+
+			if (isCurrentExtraAutoIncrement && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
+				isCurrentExtraAutoIncrement = NO;
+				autoIncrementIndex = nil;
+				[self _showInvalidAutoIncrementAlertForFieldType:[currentRow objectForKey:@"type"]];
+				[tableSourceView reloadData];
+				return;
+			}
 
 			if (isCurrentExtraAutoIncrement) {
 				[currentRow setObject:@0 forKey:@"null"];
@@ -2131,6 +2195,13 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	else if ([[aTableColumn identifier] isEqualToString:@"type"]) {
 		if (anObject && [(NSString*)anObject length] && ![(NSString*)anObject hasPrefix:@"--"]) {
 			[currentRow setObject:[(NSString*)anObject uppercaseString] forKey:@"type"];
+
+			if ([self _isAutoIncrementExtraValue:[currentRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
+				[currentRow setObject:@"None" forKey:@"Extra"];
+				isCurrentExtraAutoIncrement = NO;
+				autoIncrementIndex = nil;
+				[self _showInvalidAutoIncrementAlertForFieldType:[currentRow objectForKey:@"type"]];
+			}
 
 			// If type is BLOB or TEXT reset DEFAULT since these field types don't allow a default
 			if ([[currentRow objectForKey:@"type"] hasSuffix:@"TEXT"] ||

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -2072,6 +2072,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	if (aTableView != tableSourceView) return;
 
     NSMutableDictionary *currentRow = [[self activeFieldsSource] safeObjectAtIndex:rowIndex];
+	BOOL wasEditingRow = isEditingRow;
+	BOOL wasEditingNewRow = isEditingNewRow;
+	NSInteger previousEditingRow = currentlyEditingRow;
+	BOOL wasCurrentExtraAutoIncrement = isCurrentExtraAutoIncrement;
+	NSString *previousAutoIncrementIndex = autoIncrementIndex;
 
 	if (!isEditingRow) {
 		[oldRow setDictionary:currentRow];
@@ -2118,8 +2123,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			isCurrentExtraAutoIncrement = [self _isAutoIncrementExtraValue:anObject];
 
 			if ([self _isMySQL84AutoIncrementRuleExtraValue:anObject] && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
-				isCurrentExtraAutoIncrement = NO;
-				autoIncrementIndex = nil;
+				isEditingRow = wasEditingRow;
+				isEditingNewRow = wasEditingNewRow;
+				currentlyEditingRow = previousEditingRow;
+				isCurrentExtraAutoIncrement = wasCurrentExtraAutoIncrement;
+				autoIncrementIndex = previousAutoIncrementIndex;
 				[self _showInvalidAutoIncrementAlertForFieldType:[currentRow objectForKey:@"type"]];
 				[tableSourceView reloadData];
 				return;

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -122,6 +122,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 - (void)_showOptimizedFieldTypeFallbackTask:(NSDictionary *)context;
 - (BOOL)_serverUsesMySQL84AutoIncrementRules;
 - (BOOL)_isAutoIncrementExtraValue:(id)value;
+- (BOOL)_isMySQL84AutoIncrementRuleExtraValue:(id)value;
 - (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType;
 - (void)_showInvalidAutoIncrementAlertForFieldType:(NSString *)fieldType;
 
@@ -305,6 +306,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 - (BOOL)_isAutoIncrementExtraValue:(id)value
 {
 	return [SAAutoIncrementRuleSupport isAutoIncrementExtraValue:value];
+}
+
+- (BOOL)_isMySQL84AutoIncrementRuleExtraValue:(id)value
+{
+	return [SAAutoIncrementRuleSupport isMySQL84AutoIncrementRuleExtraValue:value];
 }
 
 - (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType
@@ -932,7 +938,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 	NSDictionary *theRow = [[self activeFieldsSource] safeObjectAtIndex:currentlyEditingRow];
 	
-	if ([self _isAutoIncrementExtraValue:[theRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[theRow objectForKey:@"type"]]) {
+	if ([self _isMySQL84AutoIncrementRuleExtraValue:[theRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[theRow objectForKey:@"type"]]) {
 		[self _showInvalidAutoIncrementAlertForFieldType:[theRow objectForKey:@"type"]];
 		return NO;
 	}
@@ -2049,7 +2055,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		for (id item in extraFieldSuggestions)
 		{
 			BOOL isAutoIncrementSuggestion = [self _isAutoIncrementExtraValue:item];
-			BOOL shouldHideAutoIncrement = isAutoIncrementSuggestion && (isCurrentExtraAutoIncrement || ![self _fieldTypeAllowsAutoIncrement:[rowData objectForKey:@"type"]]);
+			BOOL isMySQL84RestrictedSuggestion = [self _isMySQL84AutoIncrementRuleExtraValue:item];
+			BOOL shouldHideAutoIncrement = (isAutoIncrementSuggestion && isCurrentExtraAutoIncrement) || (isMySQL84RestrictedSuggestion && ![self _fieldTypeAllowsAutoIncrement:[rowData objectForKey:@"type"]]);
 			if (!shouldHideAutoIncrement) {
 				[dataCell addItemWithObjectValue:item];
 			}
@@ -2110,7 +2117,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 			isCurrentExtraAutoIncrement = [self _isAutoIncrementExtraValue:anObject];
 
-			if (isCurrentExtraAutoIncrement && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
+			if ([self _isMySQL84AutoIncrementRuleExtraValue:anObject] && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
 				isCurrentExtraAutoIncrement = NO;
 				autoIncrementIndex = nil;
 				[self _showInvalidAutoIncrementAlertForFieldType:[currentRow objectForKey:@"type"]];
@@ -2178,7 +2185,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		if (anObject && [(NSString*)anObject length] && ![(NSString*)anObject hasPrefix:@"--"]) {
 			[currentRow setObject:[(NSString*)anObject uppercaseString] forKey:@"type"];
 
-			if ([self _isAutoIncrementExtraValue:[currentRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
+			if ([self _isMySQL84AutoIncrementRuleExtraValue:[currentRow objectForKey:@"Extra"]] && ![self _fieldTypeAllowsAutoIncrement:[currentRow objectForKey:@"type"]]) {
 				[currentRow setObject:@"None" forKey:@"Extra"];
 				isCurrentExtraAutoIncrement = NO;
 				autoIncrementIndex = nil;

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -304,33 +304,14 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 - (BOOL)_isAutoIncrementExtraValue:(id)value
 {
-	if (![value isKindOfClass:[NSString class]]) return NO;
-	
-	NSString *normalized = [[(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
-	return [normalized isEqualToString:@"AUTO_INCREMENT"] || [normalized isEqualToString:@"SERIAL DEFAULT VALUE"];
+	return [SAAutoIncrementRuleSupport isAutoIncrementExtraValue:value];
 }
 
 - (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType
 {
 	if (![self _serverUsesMySQL84AutoIncrementRules]) return YES;
 	
-	NSString *type = fieldType ? [[fieldType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString] : @"";
-	NSRange lengthRange = [type rangeOfString:@"("];
-	if (lengthRange.location != NSNotFound) {
-		type = [type substringToIndex:lengthRange.location];
-	}
-	type = [[[type componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] firstObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-	
-	NSSet *integerTypes = [NSSet setWithObjects:
-		SPMySQLTinyIntType,
-		SPMySQLSmallIntType,
-		SPMySQLMediumIntType,
-		SPMySQLIntType,
-		@"INTEGER",
-		SPMySQLBigIntType,
-		nil];
-	
-	return [integerTypes containsObject:type];
+	return [SAAutoIncrementRuleSupport fieldTypeAllowsAutoIncrement:fieldType];
 }
 
 - (void)_showInvalidAutoIncrementAlertForFieldType:(NSString *)fieldType

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -306,7 +306,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 {
 	if (![value isKindOfClass:[NSString class]]) return NO;
 	
-	return [[(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].uppercaseString isEqualToString:@"AUTO_INCREMENT"];
+	NSString *normalized = [[(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
+	return [normalized isEqualToString:@"AUTO_INCREMENT"] || [normalized isEqualToString:@"SERIAL DEFAULT VALUE"];
 }
 
 - (BOOL)_fieldTypeAllowsAutoIncrement:(NSString *)fieldType

--- a/UnitTests/SAAutoIncrementRuleSupportTests.swift
+++ b/UnitTests/SAAutoIncrementRuleSupportTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+final class SAAutoIncrementRuleSupportTests: XCTestCase {
+    func testRecognizesAutoIncrementExtraValues() {
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("AUTO_INCREMENT"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(" auto_increment\n"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("serial default value"))
+    }
+
+    func testRejectsNonAutoIncrementExtraValues() {
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("DEFAULT_GENERATED"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("on update CURRENT_TIMESTAMP"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(""))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(NSNull()))
+    }
+
+    func testAllowsIntegerFieldTypes() {
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("TINYINT"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("smallint"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("MEDIUMINT(9)"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(" INT(11) UNSIGNED "))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("integer"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("BIGINT(20)\nUNSIGNED"))
+    }
+
+    func testRejectsNonIntegerFieldTypes() {
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(nil))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(""))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("DECIMAL(10,2)"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("DOUBLE"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("FLOAT"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("VARCHAR(255)"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("TIMESTAMP"))
+    }
+}

--- a/UnitTests/SAAutoIncrementRuleSupportTests.swift
+++ b/UnitTests/SAAutoIncrementRuleSupportTests.swift
@@ -1,10 +1,16 @@
 import XCTest
 
 final class SAAutoIncrementRuleSupportTests: XCTestCase {
-    func testRecognizesAutoIncrementExtraValues() {
+    func testRecognizesAutoIncrementExtraValueForIndexPrompt() {
         XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("AUTO_INCREMENT"))
         XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(" auto_increment\n"))
-        XCTAssertTrue(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("serial default value"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("serial default value"))
+    }
+
+    func testRecognizesMySQL84RestrictedAutoIncrementExtraValues() {
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue("AUTO_INCREMENT"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue(" auto_increment\n"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue("serial default value"))
     }
 
     func testRejectsNonAutoIncrementExtraValues() {
@@ -12,6 +18,10 @@ final class SAAutoIncrementRuleSupportTests: XCTestCase {
         XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue("on update CURRENT_TIMESTAMP"))
         XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(""))
         XCTAssertFalse(SAAutoIncrementRuleSupport.isAutoIncrementExtraValue(NSNull()))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue("DEFAULT_GENERATED"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue("on update CURRENT_TIMESTAMP"))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue(""))
+        XCTAssertFalse(SAAutoIncrementRuleSupport.isMySQL84AutoIncrementRuleExtraValue(NSNull()))
     }
 
     func testAllowsIntegerFieldTypes() {

--- a/UnitTests/SAAutoIncrementRuleSupportTests.swift
+++ b/UnitTests/SAAutoIncrementRuleSupportTests.swift
@@ -33,6 +33,11 @@ final class SAAutoIncrementRuleSupportTests: XCTestCase {
         XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("BIGINT(20)\nUNSIGNED"))
     }
 
+    func testAllowsIntegerFieldTypeAliases() {
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement("BOOL"))
+        XCTAssertTrue(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(" boolean "))
+    }
+
     func testRejectsNonIntegerFieldTypes() {
         XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(nil))
         XCTAssertFalse(SAAutoIncrementRuleSupport.fieldTypeAllowsAutoIncrement(""))

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -245,6 +245,9 @@
 		5147B0112F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */; };
 		5147B0122F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */; };
 		5147B0142F8C000400C4C14A /* SAConnectionFormHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */; };
+		51AA84022FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
+		51AA84032FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
+		51AA84052FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84042FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift */; };
 		5147B01A2F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */; };
 		514B40A02F683E3700369718 /* SAAboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001C /* SAAboutWindowController.swift */; };
 		514B40A72F68412000369718 /* License.md in Resources */ = {isa = PBXBuildFile; fileRef = 514B40A62F68412000369718 /* License.md */; };
@@ -1026,6 +1029,8 @@
 		5147B0102F8C000400C4C14A /* SAConnectionFormHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormHelpers.swift; sourceTree = "<group>"; };
 		5147B0132F8C000400C4C14A /* SAConnectionFormHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionFormHelpersTests.swift; sourceTree = "<group>"; };
 		5147B0192F8C000600C4C14A /* SAFavoriteSearchTreeWalker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchTreeWalker.swift; sourceTree = "<group>"; };
+		51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAutoIncrementRuleSupport.swift; sourceTree = "<group>"; };
+		51AA84042FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAutoIncrementRuleSupportTests.swift; sourceTree = "<group>"; };
 		514B40A12F683E7900369718 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		514B40A52F68412000369718 /* Credits.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Credits.md; sourceTree = "<group>"; };
 		514B40A62F68412000369718 /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = License.md; sourceTree = "<group>"; };
@@ -1854,6 +1859,7 @@
 				17E641550EF01EF6001BC333 /* SPTableStructure.m */,
 				17D38F6E1279E23A00672B13 /* SPTableFieldValidation.h */,
 				17D38F6F1279E23A00672B13 /* SPTableFieldValidation.m */,
+				51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */,
 				8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */,
 			);
 			name = "Table Structure";
@@ -2515,6 +2521,7 @@
 				1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */,
 				1AB068B224A3575600E2AAC2 /* SPValidateKeyAndCertFiles.m */,
 				1AE6C1CC25B07E9500880D73 /* SPFunctionsTests.m */,
+				51AA84042FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift */,
 				8AEACADD4B36D9819ADC93DD /* TableSortHelperTests.swift */,
 				FD8099A62C59DCFA0084646F /* SAUuidFormatterTests.swift */,
 				C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */,
@@ -3172,6 +3179,7 @@
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
 				1A4152F125AF531000B17249 /* GeneralSwiftTests.swift in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,
+				51AA84032FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */,
 				FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */,
 				519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */,
 				1A3FA7962495FC2D00B7291A /* SPMainThreadTrampoline.m in Sources */,
@@ -3268,6 +3276,7 @@
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
 				1A9A40D525875EC9009F0E71 /* NSMutableArray-MultipleSort.m in Sources */,
+				51AA84052FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift in Sources */,
 				8AEACED018AABDD8CBB42877 /* TableSortHelperTests.swift in Sources */,
 				96557E151CF87F3F4EA29A47 /* AWSLoginCredentialsProvider.swift in Sources */,
 				11ACD43BE52B0351BBFE518F /* AWSSSOClient.swift in Sources */,
@@ -3551,6 +3560,7 @@
 				9BE765EBBDFD2F121C13D274 /* SPFillView.m in Sources */,
 				9BE76F2B943AFDBA6EDC52BE /* SPHelpViewerController.m in Sources */,
 				9BE765682376A00C82FB93AA /* SPHelpViewerClient.m in Sources */,
+				51AA84022FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */,
 				8AEAC27B5C5B866575ECDB62 /* TableSortHelper.swift in Sources */,
 				44011FFBC7DF57126761313F /* SQLitePinnedTableManager.swift in Sources */,
 				72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */,


### PR DESCRIPTION
## Summary

Adds a MySQL 8.4-specific guard for `AUTO_INCREMENT` column edits in the table structure editor.

- Applies the new validation only when connected to Oracle MySQL 8.4 or newer.
- Leaves MariaDB and older MySQL behavior unchanged.
- Hides the `AUTO_INCREMENT` suggestion for disallowed field types, blocks stale/manual saves, and clears an existing `AUTO_INCREMENT` selection if the field type changes to a disallowed type.
- Allows integer column forms such as `INT`, `INTEGER`, `BIGINT`, and type strings with length or unsigned modifiers.

## Validation

- `xcodebuild -project sequel-ace.xcodeproj -scheme "Sequel Ace Debug" -configuration Debug build CODE_SIGNING_ALLOWED=NO`

Draft because this is one PR in the MySQL 8.4 compatibility series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the table structure editor to enforce MySQL 8.4+ `AUTO_INCREMENT` rules.
  * `AUTO_INCREMENT` is now permitted only for integer column types; incompatible selections are blocked and a warning is shown.
  * Refined `Extra` suggestions and behavior so invalid `Extra`/`type` combinations can’t be saved.
* **Localization**
  * Added localized warning title/message for unavailable/invalid `AUTO_INCREMENT` selections.
* **Tests**
  * Added unit tests covering `AUTO_INCREMENT` rule detection logic (including MySQL 8.4+ restricted cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->