### PR TITLE
#fixed Fix stale bookmark alert handling

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -3229,14 +3229,32 @@
 /* Question to user to see if they would like to re-request access */
 "You have stale secure bookmarks:\n\n%@\n\nWould you like to re-request access now?" = "You have stale secure bookmarks:\n\n%@\n\nWould you like to re-request access now?";
 
+/* single stale bookmark alert message */
+"Sequel Ace found 1 stale secure bookmark. You can continue launching now, or open Files preferences to refresh or revoke it." = "Sequel Ace found 1 stale secure bookmark. You can continue launching now, or open Files preferences to refresh or revoke it.";
+
+/* multiple stale bookmarks alert message */
+"Sequel Ace found %d stale secure bookmarks. You can continue launching now, or open Files preferences to refresh or revoke them." = "Sequel Ace found %d stale secure bookmarks. You can continue launching now, or open Files preferences to refresh or revoke them.";
+
 /* Question to user to see if they would like to request access to missing bookmarks */
 "You have missing secure bookmarks:\n\n%@\n\nWould you like to request access now?" = "You have missing secure bookmarks:\n\n%@\n\nWould you like to request access now?";
+
+/* single missing bookmark alert message */
+"Sequel Ace found 1 missing secure bookmark. You can request access now, or cancel and update it later in Files preferences." = "Sequel Ace found 1 missing secure bookmark. You can request access now, or cancel and update it later in Files preferences.";
+
+/* multiple missing bookmarks alert message */
+"Sequel Ace found %d missing secure bookmarks. You can request access now, or cancel and update them later in Files preferences." = "Sequel Ace found %d missing secure bookmarks. You can request access now, or cancel and update them later in Files preferences.";
 
 /* known hosts advance menu item title */
 "Use known hosts from ssh config (ADVANCED)" = "Use known hosts from ssh config (ADVANCED)";
 
 /* The answer, yes */
 "Yes" = "Yes";
+
+/* open files preferences button */
+"Open Files Preferences" = "Open Files Preferences";
+
+/* request access button */
+"Request Access" = "Request Access";
 
 /* Shown to remind users of their stale bookmarks */
 "A reminder of your stale secure bookmarks:<br /><br />%@<br />" = "A reminder of your stale secure bookmarks:<br /><br />%@<br />";

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2713,7 +2713,7 @@ set_input:
 	// if the string came from another app, paste it literal, tokenfield will take care of any conversions
 	NSString *raw = [pboard stringForType:NSPasteboardTypeString];
 	if(raw) {
-		return @[[raw stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet]	withString:@" "]];
+		return @[[raw sp_stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet]	withString:@" "]];
 	}
 
 	return nil;

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4100,7 +4100,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
                 // This is a binary object being edited as a hex string.
                 // Convert the string back to binary.
                 // Error checking is done in -control:textShouldEndEditing:
-                NSData *data = [NSData dataWithHexString:object];
+                NSData *data = [NSData sp_dataWithHexString:object];
                 if (!data) {
                     NSBeep();
                     return;
@@ -4755,7 +4755,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
           }
           // This is a binary object being edited as a hex string.
           // Convert the string back to binary, checking for errors.
-          if (![NSData dataWithHexString: editor.string]) {
+          if (![NSData sp_dataWithHexString: editor.string]) {
               NSString *title = NSLocalizedString(@"Invalid hexadecimal value", @"table content : editing : error message title when parsing as hex string failed");
               NSString *msg  = NSLocalizedString(
                   @"A valid hex string may only contain the numbers 0-9 and letters A-F (a-f). It can optionally begin with „0x“ and spaces will be ignored.\nAlternatively the syntax X'val' is supported, too.",

--- a/Source/Controllers/Other/SecureBookmarkData.swift
+++ b/Source/Controllers/Other/SecureBookmarkData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class SecureBookmarkData: NSObject {
     let bookmarkData: Data
-    private let options: Double
+    let options: Double
     private let bookmarkURL: URL
 
     init(data: Data, options: Double, url: URL) {

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -270,6 +270,14 @@ import OSLog
             bookmarkCreationOptions = URLBookmarkCreationWithSecurityScope
         }
 
+        guard url.startAccessingSecurityScopedResource() else {
+            Log.error("Error startAccessingSecurityScopedResource while refreshing secure bookmark for: \(url.absoluteString)")
+            return nil
+        }
+        defer {
+            url.stopAccessingSecurityScopedResource()
+        }
+
         do {
             Log.debug("Attempting to refresh secure bookmark for: \(url.absoluteString)")
             let bookmarkData = try url.bookmarkData(options: bookmarkCreationOptions, includingResourceValuesForKeys: nil, relativeTo: nil)

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -341,6 +341,16 @@ import OSLog
         }
     }
 
+    private func hasStaleBookmarkReference(for bookmarkPath: String) -> Bool {
+        guard let normalizedBookmarkPath = normalizedFilePath(forBookmarkPath: bookmarkPath) else {
+            return staleBookmarks.contains(bookmarkPath)
+        }
+
+        return staleBookmarks.contains { staleBookmark in
+            normalizedFilePath(forBookmarkPath: staleBookmark) == normalizedBookmarkPath
+        }
+    }
+
     private func deduplicateStaleBookmarks() {
         var seenBookmarkPaths = Set<String>()
         staleBookmarks = staleBookmarks.filter { bookmarkPath in
@@ -366,12 +376,30 @@ import OSLog
         Log.debug("isForStaleBookmark: \(isForStaleBookmark)")
         Log.debug("isForKnownHostsFile: \(isForKnownHostsFile)")
 
-
         for (index, bookmarkDict) in bookmarks.enumerated() {
             for posibility in possibleMatchingStrings {
-                if bookmarkDict[posibility] != nil {
+                if let existingBookmarkData = bookmarkDict[posibility] {
                     if isForStaleBookmark == false {
                         Log.debug("Existing bookmark for: \(url.absoluteString)")
+                        let hasStaleReference = hasStaleBookmarkReference(for: url.absoluteString) || hasStaleBookmarkReference(for: posibility)
+
+                        if hasStaleReference {
+                            let existingSecureBookmark = SecureBookmark.getDecodedData(encodedData: existingBookmarkData)
+                            guard let refreshedBookmarkData = refreshedEncodedBookmarkData(for: url, storedBookmark: existingSecureBookmark) else {
+                                Log.error("Failed to refresh existing bookmark for: \(url.absoluteString)")
+                                return false
+                            }
+
+                            if bookmarks[safe: index] != nil {
+                                bookmarks[index] = [url.absoluteString: refreshedBookmarkData]
+                            } else {
+                                bookmarks.append([url.absoluteString: refreshedBookmarkData])
+                            }
+
+                            iChangedTheBookmarks = true
+                            prefs.set(bookmarks, forKey: SASecureBookmarks)
+                        }
+
                         if url.startAccessingSecurityScopedResource() {
                             resolvedBookmarks.appendIfNotContains(url)
                         }

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -314,18 +314,7 @@ import OSLog
     }
 
     private func normalizedFilePath(forBookmarkPath bookmarkPath: String) -> String? {
-        let decodedBookmarkPath = bookmarkPath.removingPercentEncoding ?? bookmarkPath
-
-        if let url = URL(string: decodedBookmarkPath), url.isFileURL {
-            return url.standardizedFileURL.path
-        }
-
-        let pathWithoutFileScheme = decodedBookmarkPath.dropPrefix("file://")
-        guard pathWithoutFileScheme.hasPrefix("/") else {
-            return nil
-        }
-
-        return URL(fileURLWithPath: pathWithoutFileScheme).standardizedFileURL.path
+        return SABookmarkPathNormalizer.normalizedFilePath(forBookmarkPath: bookmarkPath)
     }
 
     private func normalizedDirectoryPath(_ path: String) -> String {

--- a/Source/Controllers/Other/SecureBookmarkManager.swift
+++ b/Source/Controllers/Other/SecureBookmarkManager.swift
@@ -61,13 +61,13 @@ import OSLog
 
         })
 
+        staleBookmarks = prefs.array(forKey: SPStaleSecureBookmarks) as? [String] ?? []
+        knownHostsBookmarks = prefs.array(forKey: SPKnownHostsBookmarks) as? [String] ?? []
+
         guard let secureBookmarks = prefs.array(forKey: SASecureBookmarks) as? [[String: Data]], secureBookmarks.isNotEmpty else {
             Log.error("Could not get secureBookmarks from prefs.")
             return
         }
-
-        staleBookmarks = prefs.array(forKey: SPStaleSecureBookmarks) as? [String] ?? []
-        knownHostsBookmarks = prefs.array(forKey: SPKnownHostsBookmarks) as? [String] ?? []
 
         bookmarks = secureBookmarks
 
@@ -177,6 +177,7 @@ import OSLog
 
         // start afresh
         bookmarks.removeAll()
+        resolvedBookmarks.removeAll()
 
         for bookmarkDict in bmCopy {
             for (key, urlData) in bookmarkDict {
@@ -195,24 +196,17 @@ import OSLog
                     //a bookmark might be "stale" because the app hasn't been used
                     //in many months, macOS has been upgraded, the app was
                     //re-installed, the app's preferences .plist file was deleted, etc.
-                        if bookmarkDataIsStale {
-                            Log.error("The bookmark is outdated and needs to be regenerated: key = \(key)")
-                            staleBookmarks.appendIfNotContains(key)
-                        } else {
-                            if let unavailableVolumeRoot = unavailableMountedVolumeRoot(for: urlForBookmark.path) {
-                                Log.info("Skipping bookmark activation for unavailable mounted volume root: \(unavailableVolumeRoot)")
-                                // Keep the bookmark so it can be reactivated later when the volume is available again.
-                                bookmarks.append([key: urlData])
-                                continue
-                            }
+                    if bookmarkDataIsStale {
+                        Log.error("The bookmark is outdated and needs to be regenerated: key = \(key)")
 
-                            Log.info("Resolved bookmark: \(key)")
-                            let res = urlForBookmark.startAccessingSecurityScopedResource()
-                            if res == true {
-                                Log.info("success: startAccessingSecurityScopedResource for: \(key)")
-                                resolvedBookmarks.appendIfNotContains(urlForBookmark)
-                            bookmarks.append([urlForBookmark.absoluteString: urlData])
+                        if let refreshedData = refreshedEncodedBookmarkData(for: urlForBookmark, storedBookmark: spData),
+                           keepResolvedBookmark(urlForBookmark, originalKey: key, bookmarkData: refreshedData) {
+                            Log.info("Successfully refreshed stale bookmark: \(key)")
                         } else {
+                            staleBookmarks.appendIfNotContains(key)
+                        }
+                    } else {
+                        if keepResolvedBookmark(urlForBookmark, originalKey: key, bookmarkData: urlData) == false {
                             Log.error("ERROR: startAccessingSecurityScopedResource for: \(key)")
                             staleBookmarks.appendIfNotContains(key)
                         }
@@ -223,6 +217,9 @@ import OSLog
                 }
             }
         }
+
+        removeStaleBookmarksCoveredByResolvedDirectoryBookmarks()
+        deduplicateStaleBookmarks()
 
         // reset bookmarks
         iChangedTheBookmarks = true
@@ -242,6 +239,117 @@ import OSLog
 
         let volumeRootPath = NSString.path(withComponents: Array(pathComponents.prefix(3)))
         return FileManager.default.fileExists(atPath: volumeRootPath) ? nil : volumeRootPath
+    }
+
+    private func keepResolvedBookmark(_ url: URL, originalKey: String, bookmarkData: Data) -> Bool {
+        if let unavailableVolumeRoot = unavailableMountedVolumeRoot(for: url.path) {
+            Log.info("Skipping bookmark activation for unavailable mounted volume root: \(unavailableVolumeRoot)")
+            // Keep the bookmark so it can be reactivated later when the volume is available again.
+            bookmarks.append([originalKey: bookmarkData])
+            removeStaleBookmarkReferences(for: originalKey)
+            removeStaleBookmarkReferences(for: url.absoluteString)
+            return true
+        }
+
+        Log.info("Resolved bookmark: \(originalKey)")
+        if url.startAccessingSecurityScopedResource() {
+            Log.info("success: startAccessingSecurityScopedResource for: \(originalKey)")
+            resolvedBookmarks.appendIfNotContains(url)
+            bookmarks.append([url.absoluteString: bookmarkData])
+            removeStaleBookmarkReferences(for: originalKey)
+            removeStaleBookmarkReferences(for: url.absoluteString)
+            return true
+        }
+
+        return false
+    }
+
+    private func refreshedEncodedBookmarkData(for url: URL, storedBookmark: SecureBookmarkData) -> Data? {
+        var bookmarkCreationOptions = URL.BookmarkCreationOptions(rawValue: UInt(storedBookmark.options))
+        if bookmarkCreationOptions.isEmpty {
+            bookmarkCreationOptions = URLBookmarkCreationWithSecurityScope
+        }
+
+        do {
+            Log.debug("Attempting to refresh secure bookmark for: \(url.absoluteString)")
+            let bookmarkData = try url.bookmarkData(options: bookmarkCreationOptions, includingResourceValuesForKeys: nil, relativeTo: nil)
+            let refreshedBookmark = SecureBookmark(data: bookmarkData, options: Double(bookmarkCreationOptions.rawValue), url: url)
+
+            guard let encodedData = refreshedBookmark.getEncodedData() else {
+                Log.error("Failed to encode refreshed bookmark for: \(url.absoluteString)")
+                return nil
+            }
+
+            return encodedData
+        } catch {
+            Log.error("Error refreshing secure bookmark for: \(url.absoluteString). Error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func removeStaleBookmarksCoveredByResolvedDirectoryBookmarks() {
+        let resolvedDirectoryPaths = resolvedBookmarks.compactMap { resolvedDirectoryPath(for: $0) }
+        guard resolvedDirectoryPaths.isNotEmpty else {
+            return
+        }
+
+        staleBookmarks.removeAll { staleBookmark in
+            guard let stalePath = normalizedFilePath(forBookmarkPath: staleBookmark) else {
+                return false
+            }
+
+            return resolvedDirectoryPaths.contains { directoryPath in
+                stalePath == directoryPath || stalePath.hasPrefix("\(directoryPath)/")
+            }
+        }
+    }
+
+    private func resolvedDirectoryPath(for url: URL) -> String? {
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            return normalizedDirectoryPath(url.path)
+        }
+
+        return url.hasDirectoryPath ? normalizedDirectoryPath(url.path) : nil
+    }
+
+    private func normalizedFilePath(forBookmarkPath bookmarkPath: String) -> String? {
+        let decodedBookmarkPath = bookmarkPath.removingPercentEncoding ?? bookmarkPath
+
+        if let url = URL(string: decodedBookmarkPath), url.isFileURL {
+            return url.standardizedFileURL.path
+        }
+
+        let pathWithoutFileScheme = decodedBookmarkPath.dropPrefix("file://")
+        guard pathWithoutFileScheme.hasPrefix("/") else {
+            return nil
+        }
+
+        return URL(fileURLWithPath: pathWithoutFileScheme).standardizedFileURL.path
+    }
+
+    private func normalizedDirectoryPath(_ path: String) -> String {
+        let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        return normalizedPath.hasSuffix("/") ? String(normalizedPath.dropLast()) : normalizedPath
+    }
+
+    private func removeStaleBookmarkReferences(for bookmarkPath: String) {
+        guard let normalizedBookmarkPath = normalizedFilePath(forBookmarkPath: bookmarkPath) else {
+            staleBookmarks.removeAll { $0 == bookmarkPath }
+            return
+        }
+
+        staleBookmarks.removeAll { staleBookmark in
+            normalizedFilePath(forBookmarkPath: staleBookmark) == normalizedBookmarkPath
+        }
+    }
+
+    private func deduplicateStaleBookmarks() {
+        var seenBookmarkPaths = Set<String>()
+        staleBookmarks = staleBookmarks.filter { bookmarkPath in
+            let comparablePath = normalizedFilePath(forBookmarkPath: bookmarkPath) ?? bookmarkPath
+            return seenBookmarkPaths.insert(comparablePath).inserted
+        }
     }
 
     /// addBookmark 
@@ -267,6 +375,14 @@ import OSLog
                 if bookmarkDict[posibility] != nil {
                     if isForStaleBookmark == false {
                         Log.debug("Existing bookmark for: \(url.absoluteString)")
+                        if url.startAccessingSecurityScopedResource() {
+                            resolvedBookmarks.appendIfNotContains(url)
+                        }
+                        removeStaleBookmarkReferences(for: url.absoluteString)
+                        removeStaleBookmarksCoveredByResolvedDirectoryBookmarks()
+                        deduplicateStaleBookmarks()
+                        prefs.set(staleBookmarks, forKey: SPStaleSecureBookmarks)
+
                         if isForKnownHostsFile == true {
                             knownHostsBookmarks.appendIfNotContains(url.absoluteString)
                             Log.debug("Updating UserDefaults for SPKnownHostsBookmarks")
@@ -310,6 +426,10 @@ import OSLog
                 Log.debug("staleBookmarks count = \(staleBookmarks.count)")
             }
 
+            removeStaleBookmarkReferences(for: url.absoluteString)
+            removeStaleBookmarksCoveredByResolvedDirectoryBookmarks()
+            deduplicateStaleBookmarks()
+
             if isForKnownHostsFile == true {
                 Log.debug("Adding KnownHostsFile bookmark for: \(url.absoluteString)")
                 knownHostsBookmarks.appendIfNotContains(url.absoluteString)
@@ -336,7 +456,7 @@ import OSLog
     @objc func bookmarkFor(filename: String) -> URL? {
         Log.debug("filename: \(filename)")
 
-        for bookmarkDict in bookmarks {
+        for (index, bookmarkDict) in bookmarks.enumerated() {
             for (key, urlData) in bookmarkDict {
                 Log.info("Bookmark URL = \(key)")
 
@@ -353,11 +473,33 @@ import OSLog
 
                         if bookmarkDataIsStale {
                             Log.error("The bookmark is outdated and needs to be regenerated: key = \(key)")
+                            if let refreshedData = refreshedEncodedBookmarkData(for: urlForBookmark, storedBookmark: spData) {
+                                if urlForBookmark.startAccessingSecurityScopedResource() {
+                                    resolvedBookmarks.appendIfNotContains(urlForBookmark)
+
+                                    if bookmarks[safe: index] != nil {
+                                        bookmarks[index] = [urlForBookmark.absoluteString: refreshedData]
+                                    } else {
+                                        bookmarks.append([urlForBookmark.absoluteString: refreshedData])
+                                    }
+
+                                    removeStaleBookmarkReferences(for: key)
+                                    removeStaleBookmarkReferences(for: urlForBookmark.absoluteString)
+                                    iChangedTheBookmarks = true
+                                    prefs.set(bookmarks, forKey: SASecureBookmarks)
+                                    prefs.set(staleBookmarks, forKey: SPStaleSecureBookmarks)
+                                    return urlForBookmark
+                                }
+                            }
+
                             staleBookmarks.appendIfNotContains(key)
                             prefs.set(staleBookmarks, forKey: SPStaleSecureBookmarks)
                         } else {
                             if urlForBookmark.startAccessingSecurityScopedResource() {
                                 resolvedBookmarks.appendIfNotContains(urlForBookmark)
+                                removeStaleBookmarkReferences(for: key)
+                                removeStaleBookmarkReferences(for: urlForBookmark.absoluteString)
+                                prefs.set(staleBookmarks, forKey: SPStaleSecureBookmarks)
                                 return urlForBookmark
                             } else {
                                 Log.error("Error startAccessingSecurityScopedResource For: key = \(urlForBookmark.absoluteString).")

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -398,21 +398,24 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
                 if(secureBookmarkManager.staleBookmarks.count > staleCount){
                     SPLog(@"staleBookmarks.count: %lu > staleCount: %lu", (unsigned long)secureBookmarkManager.staleBookmarks.count, (unsigned long)staleCount);
 
+                    NSMutableArray<NSString *> *missingBookmarkPaths = [[NSMutableArray alloc] initWithCapacity:errorFileNames.count];
+
+                    for(NSString* missingFile in errorFileNames){
+                        [missingBookmarkPaths addObject:[NSString stringWithFormat:@"file://%@", missingFile]];
+                        SPLog(@"fileNames adding missing file: %@", missingFile.lastPathComponent);
+                    }
+
                     // prompt user to recreate secure bookmarks
-                    if(secureBookmarkManager.staleBookmarks.count > 0){
-
-                        NSMutableString *staleBookmarksString = [[NSMutableString alloc] initWithCapacity:secureBookmarkManager.staleBookmarks.count];
-
-                        for(NSString* staleFile in secureBookmarkManager.staleBookmarks){
-                            [staleBookmarksString appendFormat:@"%@\n", staleFile.lastPathComponent];
-                            SPLog(@"fileNames adding stale file: %@", staleFile.lastPathComponent);
-                        }
-
-                        [staleBookmarksString setString:[staleBookmarksString dropSuffixWithSuffix:@"\n"]];
+                    if(missingBookmarkPaths.count > 0){
 
                         NSView *helpView = [self modifyAndReturnBookmarkHelpView];
 
-                        [NSAlert createAccessoryAlertWithTitle:NSLocalizedString(@"App Sandbox Issue", @"App Sandbox Issue") message:[NSString stringWithFormat:NSLocalizedString(@"You have missing secure bookmarks:\n\n%@\n\nWould you like to request access now?", @"Would you like to request access now?"), staleBookmarksString] accessoryView:helpView primaryButtonTitle:NSLocalizedString(@"Yes", @"Yes")
+                        [NSAlert createScrollableListAccessoryAlertWithTitle:NSLocalizedString(@"App Sandbox Issue", @"App Sandbox Issue")
+                                                                     message:[SABookmarkAlertContent missingBookmarksMessageWithCount:missingBookmarkPaths.count]
+                                                                   listItems:[SABookmarkAlertContent displayNamesForBookmarkPaths:missingBookmarkPaths]
+                                                               accessoryView:helpView
+                                                          primaryButtonTitle:NSLocalizedString(@"Request Access", @"request access button")
+                                                        secondaryButtonTitle:NSLocalizedString(@"Cancel", @"cancel button")
                                           primaryButtonHandler:^{
                             SPLog(@"request access now");
                             [self->errorFileNames removeAllObjects];
@@ -420,7 +423,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
                             [prefCon showWindow:nil];
                             [prefCon displayPreferencePane:prefCon->fileItem];
 
-                        } cancelButtonHandler:^{
+                        } secondaryButtonHandler:^{
                             SPLog(@"No not now");
                         }];
                     }

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -218,22 +218,25 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 
         SPLog(@"We have stale bookmarks");
 
-        NSMutableString *staleBookmarksString = [[NSMutableString alloc] initWithCapacity:secureBookmarkManager.staleBookmarks.count];
+        NSMutableArray<NSString *> *staleBookmarkPaths = [[NSMutableArray alloc] initWithCapacity:secureBookmarkManager.staleBookmarks.count];
 
         for(NSString* staleFile in secureBookmarkManager.staleBookmarks){
-            [staleBookmarksString appendFormat:@"%@\n", staleFile.lastPathComponent];
+            [staleBookmarkPaths addObject:staleFile];
             SPLog(@"fileNames adding stale file: %@", staleFile.lastPathComponent);
         }
 
-        [staleBookmarksString setString:[staleBookmarksString dropSuffixWithSuffix:@"\n"]];
-
-        [NSAlert createAccessoryAlertWithTitle:NSLocalizedString(@"App Sandbox Issue", @"App Sandbox Issue") message:[NSString stringWithFormat:NSLocalizedString(@"You have stale secure bookmarks:\n\n%@\n\nWould you like to re-request access now?", @"Would you like to re-request access now?"), staleBookmarksString] accessoryView:_staleBookmarkHelpView primaryButtonTitle:NSLocalizedString(@"Yes", @"Yes")
+        [NSAlert createScrollableListAccessoryAlertWithTitle:NSLocalizedString(@"App Sandbox Issue", @"App Sandbox Issue")
+                                                     message:[SABookmarkAlertContent staleBookmarksMessageWithCount:secureBookmarkManager.staleBookmarks.count]
+                                                   listItems:[SABookmarkAlertContent displayNamesForBookmarkPaths:staleBookmarkPaths]
+                                               accessoryView:_staleBookmarkHelpView
+                                          primaryButtonTitle:NSLocalizedString(@"Open Files Preferences", @"open files preferences button")
+                                        secondaryButtonTitle:NSLocalizedString(@"Continue", @"continue launching button")
                           primaryButtonHandler:^{
             SPLog(@"re-request access now");
             [self->prefsController showWindow:self];
             [self->prefsController displayPreferencePane:self->prefsController->fileItem];
-        } cancelButtonHandler:^{
-            SPLog(@"No not now");
+        } secondaryButtonHandler:^{
+            SPLog(@"Continue launching with stale bookmarks");
         }];
     }
 

--- a/Source/Other/CategoryAdditions/SPDataAdditions.h
+++ b/Source/Other/CategoryAdditions/SPDataAdditions.h
@@ -43,7 +43,7 @@ typedef NS_OPTIONS(NSUInteger, SPLineTerminator) {
 - (NSData *)dataEncryptedWithKey:(NSData *)aesKey IV:(NSData *)iv;
 - (NSData *)dataDecryptedWithPassword:(NSString *)password;
 - (NSData *)dataDecryptedWithKey:(NSData *)key;
-+ (NSData *)dataWithHexString:(NSString *)hex;
++ (NSData *)sp_dataWithHexString:(NSString *)hex;
 
 - (NSData *)compress;
 - (NSData *)decompress;

--- a/Source/Other/CategoryAdditions/SPDataAdditions.m
+++ b/Source/Other/CategoryAdditions/SPDataAdditions.m
@@ -389,7 +389,7 @@ static void decodeValidHexSequence(const char *inBuffer,uint8_t *outBuffer, NSUI
  * - val cannot contain whitespace (whitespace before/after is ok)
  * - The leading x is case-INsensitive
  */
-+ (NSData *)dataWithHexString:(NSString *)hex
++ (NSData *)sp_dataWithHexString:(NSString *)hex
 {
 	if(!hex) return nil; // no string
 	const char *sourceBytes = [hex UTF8String];

--- a/Source/Other/CategoryAdditions/SPStringAdditions.h
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.h
@@ -75,12 +75,12 @@ static inline id NSMutableAttributedStringAttributeAtIndex(NSMutableAttributedSt
 - (NSString *)stringByRemovingCharactersInSet:(NSCharacterSet *)charSet;
 - (NSString *)stringByRemovingCharactersInSet:(NSCharacterSet *)charSet options:(NSUInteger)mask;
 /**
- * Replace all occurances of any character in set with the replacement string
+ * Replace all occurrences of any character in set with the replacement string
  * @param set    Characters to look for (MUST NOT be nil)
  * @param string A replacement string (can be nil == empty string)
  * @return A string with replacements applied
  */
-- (NSString *)stringByReplacingCharactersInSet:(NSCharacterSet *)set withString:(NSString *)string;
+- (NSString *)sp_stringByReplacingCharactersInSet:(NSCharacterSet *)set withString:(NSString *)string;
 
 - (CGFloat)levenshteinDistanceWithWord:(NSString *)stringB;
 

--- a/Source/Other/CategoryAdditions/SPStringAdditions.m
+++ b/Source/Other/CategoryAdditions/SPStringAdditions.m
@@ -334,7 +334,7 @@ static NSInteger _smallestOf(NSInteger a, NSInteger b, NSInteger c);
 	return lineRangesArray;
 }
 
-- (NSString *)stringByReplacingCharactersInSet:(NSCharacterSet *)set withString:(NSString *)string
+- (NSString *)sp_stringByReplacingCharactersInSet:(NSCharacterSet *)set withString:(NSString *)string
 {
 	NSUInteger len = [self length];
 	NSMutableString *newString = [NSMutableString string];

--- a/Source/Other/Extensions/NSAlertExtension.swift
+++ b/Source/Other/Extensions/NSAlertExtension.swift
@@ -330,14 +330,27 @@ enum SABookmarkPathNormalizer {
         scrollView.widthAnchor.constraint(equalToConstant: accessoryWidth).isActive = true
         scrollView.heightAnchor.constraint(equalToConstant: desiredListHeight).isActive = true
 
+        let helpFittingSize = helpView.fittingSize
+        let helpWidth = min(accessoryWidth, max(helpView.frame.width, helpFittingSize.width))
+        let helpHeight = max(helpView.frame.height, helpFittingSize.height)
+
         helpView.removeFromSuperview()
         helpView.translatesAutoresizingMaskIntoConstraints = false
         helpView.constraints
-            .filter { $0.identifier == "SABookmarkAlertHelpWidth" }
+            .filter { $0.identifier == "SABookmarkAlertHelpWidth" || $0.identifier == "SABookmarkAlertHelpHeight" }
             .forEach { helpView.removeConstraint($0) }
-        let helpWidthConstraint = helpView.widthAnchor.constraint(lessThanOrEqualToConstant: accessoryWidth)
-        helpWidthConstraint.identifier = "SABookmarkAlertHelpWidth"
-        helpWidthConstraint.isActive = true
+
+        if helpWidth > 0 {
+            let helpWidthConstraint = helpView.widthAnchor.constraint(equalToConstant: helpWidth)
+            helpWidthConstraint.identifier = "SABookmarkAlertHelpWidth"
+            helpWidthConstraint.isActive = true
+        }
+
+        if helpHeight > 0 {
+            let helpHeightConstraint = helpView.heightAnchor.constraint(equalToConstant: helpHeight)
+            helpHeightConstraint.identifier = "SABookmarkAlertHelpHeight"
+            helpHeightConstraint.isActive = true
+        }
 
         let stackView = NSStackView(views: [scrollView, helpView])
         stackView.orientation = .vertical

--- a/Source/Other/Extensions/NSAlertExtension.swift
+++ b/Source/Other/Extensions/NSAlertExtension.swift
@@ -8,6 +8,42 @@
 
 import AppKit
 
+enum SABookmarkPathNormalizer {
+    static func normalizedFilePath(forBookmarkPath bookmarkPath: String) -> String? {
+        guard let filePath = filePath(forBookmarkPath: bookmarkPath) else {
+            return nil
+        }
+
+        return URL(fileURLWithPath: filePath).standardizedFileURL.path
+    }
+
+    static func displayName(forBookmarkPath bookmarkPath: String) -> String {
+        let displayPath = filePath(forBookmarkPath: bookmarkPath) ?? (bookmarkPath.removingPercentEncoding ?? bookmarkPath)
+        let lastPathComponent = (displayPath as NSString).lastPathComponent
+        return lastPathComponent.isEmpty ? displayPath : lastPathComponent
+    }
+
+    private static func filePath(forBookmarkPath bookmarkPath: String) -> String? {
+        let fileSchemePrefix = "file://"
+
+        if bookmarkPath.hasPrefix(fileSchemePrefix) {
+            let encodedPath = String(bookmarkPath.dropFirst(fileSchemePrefix.count))
+            guard encodedPath.hasPrefix("/") else {
+                return nil
+            }
+
+            return encodedPath.removingPercentEncoding ?? encodedPath
+        }
+
+        let decodedBookmarkPath = bookmarkPath.removingPercentEncoding ?? bookmarkPath
+        guard decodedBookmarkPath.hasPrefix("/") else {
+            return nil
+        }
+
+        return decodedBookmarkPath
+    }
+}
+
 @objc final class SABookmarkAlertContent: NSObject {
     @objc static func displayNames(forBookmarkPaths bookmarkPaths: [String]) -> [String] {
         return bookmarkPaths.map { displayName(forBookmarkPath: $0) }
@@ -32,16 +68,7 @@ import AppKit
     }
 
     private static func displayName(forBookmarkPath bookmarkPath: String) -> String {
-        let decodedBookmarkPath = bookmarkPath.removingPercentEncoding ?? bookmarkPath
-
-        if let url = URL(string: decodedBookmarkPath), url.isFileURL {
-            let lastPathComponent = url.lastPathComponent
-            return lastPathComponent.isEmpty ? url.path : lastPathComponent
-        }
-
-        let pathWithoutFileScheme = decodedBookmarkPath.dropPrefix("file://")
-        let lastPathComponent = (pathWithoutFileScheme as NSString).lastPathComponent
-        return lastPathComponent.isEmpty ? pathWithoutFileScheme : lastPathComponent
+        return SABookmarkPathNormalizer.displayName(forBookmarkPath: bookmarkPath)
     }
 }
 

--- a/Source/Other/Extensions/NSAlertExtension.swift
+++ b/Source/Other/Extensions/NSAlertExtension.swift
@@ -8,6 +8,43 @@
 
 import AppKit
 
+@objc final class SABookmarkAlertContent: NSObject {
+    @objc static func displayNames(forBookmarkPaths bookmarkPaths: [String]) -> [String] {
+        return bookmarkPaths.map { displayName(forBookmarkPath: $0) }
+    }
+
+    @objc static func staleBookmarksMessage(count: Int) -> String {
+        if count == 1 {
+            return NSLocalizedString("Sequel Ace found 1 stale secure bookmark. You can continue launching now, or open Files preferences to refresh or revoke it.", comment: "single stale bookmark alert message")
+        }
+
+        let format = NSLocalizedString("Sequel Ace found %d stale secure bookmarks. You can continue launching now, or open Files preferences to refresh or revoke them.", comment: "multiple stale bookmarks alert message")
+        return String.localizedStringWithFormat(format, count)
+    }
+
+    @objc static func missingBookmarksMessage(count: Int) -> String {
+        if count == 1 {
+            return NSLocalizedString("Sequel Ace found 1 missing secure bookmark. You can request access now, or cancel and update it later in Files preferences.", comment: "single missing bookmark alert message")
+        }
+
+        let format = NSLocalizedString("Sequel Ace found %d missing secure bookmarks. You can request access now, or cancel and update them later in Files preferences.", comment: "multiple missing bookmarks alert message")
+        return String.localizedStringWithFormat(format, count)
+    }
+
+    private static func displayName(forBookmarkPath bookmarkPath: String) -> String {
+        let decodedBookmarkPath = bookmarkPath.removingPercentEncoding ?? bookmarkPath
+
+        if let url = URL(string: decodedBookmarkPath), url.isFileURL {
+            let lastPathComponent = url.lastPathComponent
+            return lastPathComponent.isEmpty ? url.path : lastPathComponent
+        }
+
+        let pathWithoutFileScheme = decodedBookmarkPath.dropPrefix("file://")
+        let lastPathComponent = (pathWithoutFileScheme as NSString).lastPathComponent
+        return lastPathComponent.isEmpty ? pathWithoutFileScheme : lastPathComponent
+    }
+}
+
 @objc extension NSAlert {
 	/// Creates an alert with primary colored button (also accepts "Enter" key) and cancel button (also accepts escape key), main title and informative subtitle message.
 	/// - Parameters:
@@ -180,6 +217,34 @@ import AppKit
         }
 	}
 
+	/// Creates an alert with a capped scrollable list above the supplied accessory view.
+	/// Use this for long file lists so the alert buttons remain reachable on small displays.
+	@objc(createScrollableListAccessoryAlertWithTitle:message:listItems:accessoryView:primaryButtonTitle:secondaryButtonTitle:primaryButtonHandler:secondaryButtonHandler:)
+	static func createScrollableListAccessoryAlert(title: String,
+												   message: String,
+												   listItems: [String],
+												   accessoryView: NSView,
+												   primaryButtonTitle: String,
+												   secondaryButtonTitle: String,
+												   primaryButtonHandler: (() -> ())? = nil,
+												   secondaryButtonHandler: (() -> ())? = nil) {
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = title
+            alert.informativeText = message
+            alert.accessoryView = scrollableListAccessoryView(listItems: listItems, helpView: accessoryView)
+            alert.addButton(withTitle: primaryButtonTitle)
+            alert.addButton(withTitle: secondaryButtonTitle)
+
+            if alert.runModal() == .alertFirstButtonReturn {
+                primaryButtonHandler?()
+            } else {
+                secondaryButtonHandler?()
+            }
+        }
+	}
+
 	/// Creates an alert with primary colored button (also accepts "Enter" key) and cancel button (also accepts escape key), main title, informative subtitle message and accessory view.
 	/// - Parameters:
 	///   - title: String for title of the alert
@@ -202,4 +267,69 @@ import AppKit
             callback?()
         }
 	}
+
+    @nonobjc static func scrollableListAccessoryView(listItems: [String], helpView: NSView) -> NSView {
+        let visibleFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 900, height: 700)
+        let accessoryWidth = min(520, max(320, visibleFrame.width - 96))
+        let maximumListHeight = min(220, max(96, visibleFrame.height * 0.28))
+        let desiredListHeight = min(maximumListHeight, max(72, CGFloat(listItems.count) * 18 + 18))
+
+        let listTextView = NSTextView()
+        listTextView.string = listItems.joined(separator: "\n")
+        listTextView.font = NSFont.monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        listTextView.isEditable = false
+        listTextView.isSelectable = true
+        listTextView.drawsBackground = false
+        listTextView.textContainerInset = NSSize(width: 8, height: 6)
+        listTextView.textContainer?.lineFragmentPadding = 0
+        listTextView.textContainer?.widthTracksTextView = true
+        listTextView.isVerticallyResizable = true
+        listTextView.isHorizontallyResizable = false
+        listTextView.autoresizingMask = [.width]
+        listTextView.frame = NSRect(x: 0, y: 0, width: accessoryWidth, height: desiredListHeight)
+        listTextView.minSize = NSSize(width: 0, height: desiredListHeight)
+        listTextView.maxSize = NSSize(width: accessoryWidth, height: CGFloat.greatestFiniteMagnitude)
+        listTextView.textContainer?.containerSize = NSSize(width: accessoryWidth, height: CGFloat.greatestFiniteMagnitude)
+
+        let scrollView = NSScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .bezelBorder
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = NSColor.textBackgroundColor
+        scrollView.documentView = listTextView
+        scrollView.widthAnchor.constraint(equalToConstant: accessoryWidth).isActive = true
+        scrollView.heightAnchor.constraint(equalToConstant: desiredListHeight).isActive = true
+
+        helpView.removeFromSuperview()
+        helpView.translatesAutoresizingMaskIntoConstraints = false
+        helpView.constraints
+            .filter { $0.identifier == "SABookmarkAlertHelpWidth" }
+            .forEach { helpView.removeConstraint($0) }
+        let helpWidthConstraint = helpView.widthAnchor.constraint(lessThanOrEqualToConstant: accessoryWidth)
+        helpWidthConstraint.identifier = "SABookmarkAlertHelpWidth"
+        helpWidthConstraint.isActive = true
+
+        let stackView = NSStackView(views: [scrollView, helpView])
+        stackView.orientation = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = 10
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let containerView = NSView(frame: NSRect(x: 0, y: 0, width: accessoryWidth, height: desiredListHeight))
+        containerView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        ])
+
+        containerView.layoutSubtreeIfNeeded()
+        containerView.setFrameSize(containerView.fittingSize)
+        return containerView
+    }
 }

--- a/UnitTests/SAStaleBookmarkAlertContentTests.swift
+++ b/UnitTests/SAStaleBookmarkAlertContentTests.swift
@@ -1,0 +1,62 @@
+//
+//  SAStaleBookmarkAlertContentTests.swift
+//  Unit Tests
+//
+//  Covers the bounded launch-time stale bookmark alert content.
+//
+
+import XCTest
+
+final class SAStaleBookmarkAlertContentTests: XCTestCase {
+
+    func testDisplayNamesDecodeFileURLLastPathComponents() {
+        let displayNames = SABookmarkAlertContent.displayNames(forBookmarkPaths: [
+            "file:///Users/tom/Backups/My%20Backup.sql",
+            "file:///Users/tom/Exports/report.csv"
+        ])
+
+        XCTAssertEqual(displayNames, [
+            "My Backup.sql",
+            "report.csv"
+        ])
+    }
+
+    func testDisplayNamesHandlePlainFilePaths() {
+        let displayNames = SABookmarkAlertContent.displayNames(forBookmarkPaths: [
+            "/Users/tom/Backups/nightly.sql"
+        ])
+
+        XCTAssertEqual(displayNames, ["nightly.sql"])
+    }
+
+    func testStaleBookmarksMessageStaysBoundedForLargeLists() {
+        let message = SABookmarkAlertContent.staleBookmarksMessage(count: 200)
+
+        XCTAssertTrue(message.contains("200"))
+        XCTAssertFalse(message.contains("\n"))
+        XCTAssertLessThan(message.count, 180)
+    }
+
+    func testMissingBookmarksMessageUsesSingularForm() {
+        let message = SABookmarkAlertContent.missingBookmarksMessage(count: 1)
+
+        XCTAssertTrue(message.contains("1 missing secure bookmark"))
+        XCTAssertFalse(message.contains("them"))
+    }
+
+    func testScrollableAccessoryUsesCappedScrollViewForLargeLists() throws {
+        let helpView = NSTextField(labelWithString: "Bookmark help")
+        let listItems = (0..<200).map { "backup-\($0).sql" }
+
+        let accessoryView = NSAlert.scrollableListAccessoryView(listItems: listItems, helpView: helpView)
+        let stackView = try XCTUnwrap(accessoryView.subviews.first as? NSStackView)
+        let scrollView = try XCTUnwrap(stackView.arrangedSubviews.first as? NSScrollView)
+        let heightConstraint = try XCTUnwrap(scrollView.constraints.first { $0.firstAttribute == .height })
+
+        XCTAssertTrue(scrollView.hasVerticalScroller)
+        XCTAssertFalse(scrollView.hasHorizontalScroller)
+        XCTAssertLessThanOrEqual(heightConstraint.constant, 220)
+        XCTAssertGreaterThanOrEqual(heightConstraint.constant, 96)
+        XCTAssertLessThanOrEqual(accessoryView.frame.width, 520)
+    }
+}

--- a/UnitTests/SAStaleBookmarkAlertContentTests.swift
+++ b/UnitTests/SAStaleBookmarkAlertContentTests.swift
@@ -73,4 +73,22 @@ final class SAStaleBookmarkAlertContentTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(heightConstraint.constant, 96)
         XCTAssertLessThanOrEqual(accessoryView.frame.width, 520)
     }
+
+    func testScrollableAccessoryPreservesFixedFrameHelpViewHeight() throws {
+        let helpView = NSView(frame: NSRect(x: 0, y: 0, width: 193, height: 24))
+        let helpButton = NSButton(frame: NSRect(x: -2, y: -2, width: 25, height: 25))
+        let helpLabel = NSTextField(labelWithString: "App Sandbox Info")
+        helpLabel.frame = NSRect(x: 23, y: 0, width: 137, height: 21)
+        helpView.addSubview(helpButton)
+        helpView.addSubview(helpLabel)
+
+        let accessoryView = NSAlert.scrollableListAccessoryView(listItems: ["backup.sql"], helpView: helpView)
+        let stackView = try XCTUnwrap(accessoryView.subviews.first as? NSStackView)
+        let stackedHelpView = try XCTUnwrap(stackView.arrangedSubviews.last)
+        let heightConstraint = try XCTUnwrap(stackedHelpView.constraints.first { $0.identifier == "SABookmarkAlertHelpHeight" })
+        let widthConstraint = try XCTUnwrap(stackedHelpView.constraints.first { $0.identifier == "SABookmarkAlertHelpWidth" })
+
+        XCTAssertEqual(heightConstraint.constant, 24)
+        XCTAssertEqual(widthConstraint.constant, 193)
+    }
 }

--- a/UnitTests/SAStaleBookmarkAlertContentTests.swift
+++ b/UnitTests/SAStaleBookmarkAlertContentTests.swift
@@ -29,6 +29,20 @@ final class SAStaleBookmarkAlertContentTests: XCTestCase {
         XCTAssertEqual(displayNames, ["nightly.sql"])
     }
 
+    func testDisplayNamesDecodeReservedCharactersAfterExtractingFileURLPath() {
+        let displayNames = SABookmarkAlertContent.displayNames(forBookmarkPaths: [
+            "file:///Users/tom/Backups/foo%23bar%3Fbaz.sql"
+        ])
+
+        XCTAssertEqual(displayNames, ["foo#bar?baz.sql"])
+    }
+
+    func testBookmarkPathNormalizerPreservesEncodedReservedCharacters() {
+        let normalizedPath = SABookmarkPathNormalizer.normalizedFilePath(forBookmarkPath: "file:///tmp/foo%23bar%3Fbaz.sql")
+
+        XCTAssertEqual(normalizedPath, "/tmp/foo#bar?baz.sql")
+    }
+
     func testStaleBookmarksMessageStaysBoundedForLargeLists() {
         let message = SABookmarkAlertContent.staleBookmarksMessage(count: 200)
 

--- a/UnitTests/SPDataAdditionsTests.m
+++ b/UnitTests/SPDataAdditionsTests.m
@@ -390,40 +390,40 @@
 {
 	//nil
 	{
-		XCTAssertNil([NSData dataWithHexString:nil], @"nil input");
+		XCTAssertNil([NSData sp_dataWithHexString:nil], @"nil input");
 	}
 	//empty
 	{
-		XCTAssertTrue([[NSData dataWithHexString:@""] length] == 0, @"empty input");
+		XCTAssertTrue([[NSData sp_dataWithHexString:@""] length] == 0, @"empty input");
 	}
 	//single byte 0
 	{
 		const char single[] = {0};
-		XCTAssertEqualObjects([NSData dataWithHexString:@"0"], [NSData dataWithBytes:single length:1], @"single '0'" );
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"0"], [NSData dataWithBytes:single length:1], @"single '0'" );
 	}
 	//empty, with 0x
 	{
-		XCTAssertEqualObjects([NSData dataWithHexString:@" 0x  "], [NSData data], @"empty input after trimming");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@" 0x  "], [NSData data], @"empty input after trimming");
 	}
 	//one lower nibble
 	{
 		const char single[] = { 0xf };
-		XCTAssertEqualObjects([NSData dataWithHexString:@"0xf"], [NSData dataWithBytes:single length:1], @"0x0F");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"0xf"], [NSData dataWithBytes:single length:1], @"0x0F");
 	}
 	//full char, uppercase
 	{
 		const char single[] = { 0xcf };
-		XCTAssertEqualObjects([NSData dataWithHexString:@"CF"], [NSData dataWithBytes:single length:1], @"0xCF");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"CF"], [NSData dataWithBytes:single length:1], @"0xCF");
 	}
 	//regular input
 	{
 		NSString *inp = @"0x de AD Be eF\t0102 0304";
 		const char exp[] = {0xde,0xad,0xbe,0xef,0x01,0x02,0x03,0x04};
-		XCTAssertEqualObjects([NSData dataWithHexString:inp], [NSData dataWithBytes:exp length:sizeof(exp)], @"regular input");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:inp], [NSData dataWithBytes:exp length:sizeof(exp)], @"regular input");
 	}
 	//invalid input
 	{
-		XCTAssertNil([NSData dataWithHexString:@"0xaG"], @"invalid char in input");
+		XCTAssertNil([NSData sp_dataWithHexString:@"0xaG"], @"invalid char in input");
 	}
 }
 
@@ -431,32 +431,32 @@
 {
 	//empty
 	{
-		XCTAssertEqualObjects([NSData dataWithHexString:@"x''"], [NSData data], @"empty mysql hex literal");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"x''"], [NSData data], @"empty mysql hex literal");
 	}
 	//empty, whitespace around, capital x
 	{
-		XCTAssertEqualObjects([NSData dataWithHexString:@"  X''\t  "], [NSData data], @"empty mysql hex literal (2)");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"  X''\t  "], [NSData data], @"empty mysql hex literal (2)");
 	}
 	//nonempty valid, case-insensitive
 	{
 		const char exp[] = {0xde,0xad,0xbe,0xef};
-		XCTAssertEqualObjects([NSData dataWithHexString:@"X'deADBeeF'"], [NSData dataWithBytes:exp length:sizeof(exp)], @"regular input");
+		XCTAssertEqualObjects([NSData sp_dataWithHexString:@"X'deADBeeF'"], [NSData dataWithBytes:exp length:sizeof(exp)], @"regular input");
 	}
 	//bad: uneven
 	{
-		XCTAssertNil([NSData dataWithHexString:@"X'aFF'"],@"uneven length in mysql hex literal");
+		XCTAssertNil([NSData sp_dataWithHexString:@"X'aFF'"],@"uneven length in mysql hex literal");
 	}
 	//bad: whitespace inside literal
 	{
-		XCTAssertNil([NSData dataWithHexString:@"x'0A ff'"], @"whitespace inside mysql hex literal");
+		XCTAssertNil([NSData sp_dataWithHexString:@"x'0A ff'"], @"whitespace inside mysql hex literal");
 	}
 	//bad: non-whitespace after literal
 	{
-		XCTAssertNil([NSData dataWithHexString:@"X'1234'   ."], @"garbage at end");
+		XCTAssertNil([NSData sp_dataWithHexString:@"X'1234'   ."], @"garbage at end");
 	}
 	//bad: non hex char in literal
 	{
-		XCTAssertNil([NSData dataWithHexString:@"x'01äß'"], @"non-hex char in literal");
+		XCTAssertNil([NSData sp_dataWithHexString:@"x'01äß'"], @"non-hex char in literal");
 	}
 }
 

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -939,19 +939,19 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 {
 	{
 		//test against empty string
-		XCTAssertEqualObjects([@"" stringByReplacingCharactersInSet:[NSCharacterSet whitespaceCharacterSet] withString:@"x"], @"", @"replacement on empty string must result in empty string");
+		XCTAssertEqualObjects([@"" sp_stringByReplacingCharactersInSet:[NSCharacterSet whitespaceCharacterSet] withString:@"x"], @"", @"replacement on empty string must result in empty string");
 	}
 	{
 		//test match at begin, middle, end / consecutive matches
-		XCTAssertEqualObjects([@" ab  c " stringByReplacingCharactersInSet:[NSCharacterSet whitespaceCharacterSet] withString:@"_"], @"_ab__c_", @"Testing matches at both end, replacement of consecutive matches");
+		XCTAssertEqualObjects([@" ab  c " sp_stringByReplacingCharactersInSet:[NSCharacterSet whitespaceCharacterSet] withString:@"_"], @"_ab__c_", @"Testing matches at both end, replacement of consecutive matches");
 	}
 	{
 		//test replacement of different characters
-		XCTAssertEqualObjects([@"ab\r\ncd" stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet] withString:@"*"], @"ab**cd", @"Testing replacement of different characters in set");
+		XCTAssertEqualObjects([@"ab\r\ncd" sp_stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet] withString:@"*"], @"ab**cd", @"Testing replacement of different characters in set");
 	}
 	{
 		// nil for replacement char
-		XCTAssertEqualObjects([@"ab\r\ncd" stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet] withString:nil], @"abcd", @"testing replacement with nil");
+		XCTAssertEqualObjects([@"ab\r\ncd" sp_stringByReplacingCharactersInSet:[NSCharacterSet newlineCharacterSet] withString:nil], @"abcd", @"testing replacement with nil");
 	}
 }
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		1A4152F125AF531000B17249 /* GeneralSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4152ED25AF530F00B17249 /* GeneralSwiftTests.swift */; };
 		1A445DAA25BACBE5004E9A77 /* naughty_strings.txt in Resources */ = {isa = PBXBuildFile; fileRef = 1A445DA925BACBE5004E9A77 /* naughty_strings.txt */; };
 		1A4CB03425923C4B00EDF804 /* StringRegexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4CB03325923C4B00EDF804 /* StringRegexExtension.swift */; };
+		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
 		1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4CB03325923C4B00EDF804 /* StringRegexExtension.swift */; };
 		1A4CB06B25926D7C00EDF804 /* StringRegexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4CB03325923C4B00EDF804 /* StringRegexExtension.swift */; };
 		1A4DC22D25DECEA000DA4FE1 /* ProgressWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4DC22C25DECEA000DA4FE1 /* ProgressWindowController.swift */; };
@@ -1019,6 +1020,7 @@
 		5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManagerTests.swift; sourceTree = "<group>"; };
 		5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilder.swift; sourceTree = "<group>"; };
 		5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilderTests.swift; sourceTree = "<group>"; };
+		5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAStaleBookmarkAlertContentTests.swift; sourceTree = "<group>"; };
 		5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcher.swift; sourceTree = "<group>"; };
 		5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcherTests.swift; sourceTree = "<group>"; };
 		5147B00B2F8C000300C4C14A /* SAConnectionDetailsValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDetailsValidator.swift; sourceTree = "<group>"; };
@@ -2541,6 +2543,7 @@
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
+				5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */,
 				5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */,
 				5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */,
 				5147B00E2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift */,
@@ -3253,6 +3256,7 @@
 				CF0000172F8C000600C4C14A /* SPRuleFilterController.m in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
+				0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */,
 				510247F92FD9F2DD00586DEA /* SAFavoriteDeletionPrompt.swift in Sources */,


### PR DESCRIPTION
## Summary

Fixes #2442.

This keeps stale secure-bookmark handling from trapping users behind an oversized modal when the stale list grows large.

- Replace unbounded stale/missing bookmark text with a capped, scrollable alert accessory list so buttons remain reachable on smaller displays.
- Add clearer alert actions: users can continue launching, open Files preferences, request access, or cancel without being blocked by the list height.
- Refresh stale security-scoped bookmark data when macOS resolves it successfully, prune stale entries covered by refreshed directory grants, and deduplicate stale bookmark state.
- Add focused tests for bookmark alert copy, display-name extraction, and scrollable-list sizing.

## Root Cause

The launch and known-hosts preference alerts interpolated every stale filename into `informativeText`. With hundreds or thousands of stale bookmarks, AppKit sized the modal beyond the available screen height, leaving users unable to dismiss it or reach Preferences.

The stale bookmark state could also keep accumulating because resolved stale bookmarks were not refreshed in preferences and stale child entries were not pruned when a valid directory bookmark covered them.

## Validation

Passed:

```sh
git diff --check
plutil -lint sequel-ace.xcodeproj/project.pbxproj
xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination 'platform=macOS' -only-testing:"Unit Tests/SAStaleBookmarkAlertContentTests"
xcodebuild build -project sequel-ace.xcodeproj -scheme "Sequel Ace Debug" -destination 'platform=macOS'
```

Also attempted the full unit-test scheme. It still fails outside this change in existing areas:

- `SPDataAdditionsTests.testDataWithHexString`
- `SPDataAdditionsTests.testDataWithHexStringMySQL`
- `SPTableContentColumnFilterTests.testAutoFillHeuristicControllerDisabledByDefault()` due to missing `PreferenceDefaults.plist` in the loaded test bundle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure bookmark re-resolution flow with refreshed bookmark data, stale tracking, coverage pruning, and deduplication during access re-requests.
  * Enhanced reliability when reactivating stale bookmarks and during filename-token pasting, plus safer binary hex parsing/validation using the new hex helper.
* **New Features**
  * Updated stale/missing secure-bookmark prompts to show scrollable file lists and direct actions into Files preferences.
* **Localization**
  * Added localized messages and button labels for the revised stale/missing secure-bookmark dialogs.
* **Tests**
  * Added/updated unit tests for alert text generation, list layout behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->