### PR TITLE
#infra Move GitHub tests to native ARM running

### DIFF
--- a/.github/workflows/ci_pr_tests.yml
+++ b/.github/workflows/ci_pr_tests.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Build and run tests
       run: ./Scripts/build.sh tests
       env:
-        DEVELOPER_DIR: '/Applications/Xcode_16.2.app/Contents/Developer'
+        DEVELOPER_DIR: '/Applications/Xcode_16.4.app/Contents/Developer'
         TEST_ARCH: arm64

--- a/.github/workflows/ci_pr_tests.yml
+++ b/.github/workflows/ci_pr_tests.yml
@@ -8,6 +8,18 @@ permissions:
 jobs:
   tests:
     name: Run Tests
+    runs-on: macos-15-intel
+    steps:
+    - name: Checkout the Git repository
+      uses: actions/checkout@v6
+    - name: Build and run tests
+      run: ./Scripts/build.sh tests
+      env:
+        DEVELOPER_DIR: '/Applications/Xcode_16.2.app/Contents/Developer'
+        TEST_ARCH: x86_64
+
+  tests-arm:
+    name: Run Tests (Apple Silicon)
     runs-on: macos-15
     steps:
     - name: Checkout the Git repository
@@ -16,3 +28,4 @@ jobs:
       run: ./Scripts/build.sh tests
       env:
         DEVELOPER_DIR: '/Applications/Xcode_16.2.app/Contents/Developer'
+        TEST_ARCH: arm64

--- a/.github/workflows/ci_pr_tests.yml
+++ b/.github/workflows/ci_pr_tests.yml
@@ -8,18 +8,6 @@ permissions:
 jobs:
   tests:
     name: Run Tests
-    runs-on: macos-15-intel
-    steps:
-    - name: Checkout the Git repository
-      uses: actions/checkout@v6
-    - name: Build and run tests
-      run: ./Scripts/build.sh tests
-      env:
-        DEVELOPER_DIR: '/Applications/Xcode_16.2.app/Contents/Developer'
-        TEST_ARCH: x86_64
-
-  tests-arm:
-    name: Run Tests (Apple Silicon)
     runs-on: macos-15
     steps:
     - name: Checkout the Git repository

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -21,6 +21,7 @@
 set -e
 
 MODE="$1"
+TEST_ARCH="${TEST_ARCH:-x86_64}"
 
 if ! hash xcpretty 2> /dev/null; then
   echo "xcpretty not installed. Try gem install xcpretty"
@@ -29,8 +30,8 @@ if ! hash xcpretty 2> /dev/null; then
 fi
 
 if [ "$MODE" = "tests" ]; then
-  echo "Running Sequel Ace Unit tests"
-  set -o pipefail && xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS,arch=x86_64" test CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
+  echo "Running Sequel Ace Unit tests (${TEST_ARCH})"
+  set -o pipefail && xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS,arch=${TEST_ARCH}" test CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty -c
   success="1"
 fi
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -21,7 +21,7 @@
 set -e
 
 MODE="$1"
-TEST_ARCH="${TEST_ARCH:-arm64}"
+TEST_ARCH="${TEST_ARCH:-$(uname -m)}"
 
 if ! hash xcpretty 2> /dev/null; then
   echo "xcpretty not installed. Try gem install xcpretty"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -21,7 +21,7 @@
 set -e
 
 MODE="$1"
-TEST_ARCH="${TEST_ARCH:-x86_64}"
+TEST_ARCH="${TEST_ARCH:-arm64}"
 
 if ! hash xcpretty 2> /dev/null; then
   echo "xcpretty not installed. Try gem install xcpretty"


### PR DESCRIPTION
## Summary

- our test runner was already arm64, but we were running x86 tests on it. Now we're running arm64 tests on arm64 runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to use the Xcode 16.4 developer directory for test runs.
  * Adjusted build/test scripting to automatically select the appropriate `TEST_ARCH` on the current machine (and use it for `xcodebuild` destinations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->