### PR TITLE
#infra Make performance tests opt in to speed up CI

### DIFF
--- a/UnitTests/GeneralSwiftTests.swift
+++ b/UnitTests/GeneralSwiftTests.swift
@@ -8,11 +8,30 @@
 
 import XCTest
 
+private enum PerformanceTestOptIn {
+    static let environmentVariable = "SEQUEL_ACE_RUN_PERFORMANCE_TESTS"
+    static let skipMessage = "Set \(environmentVariable)=1 to run performance measurement tests."
+
+    static var isEnabled: Bool {
+        #if SEQUEL_ACE_RUN_PERFORMANCE_TESTS
+        return true
+        #else
+        guard let value = ProcessInfo.processInfo.environment[environmentVariable]?.lowercased() else {
+            return false
+        }
+
+        return value == "1" || value == "true" || value == "yes"
+        #endif
+    }
+}
+
 // added private so that this class is not in the generated -Swift.h
 private final class GeneralSwiftTests: XCTestCase {
 
     // 0.242s
     func testPerformanceComponents() throws {
+        try XCTSkipUnless(PerformanceTestOptIn.isEnabled, PerformanceTestOptIn.skipMessage)
+
         // This is an example of a performance test case.
 
         let str = "My name is JIMMY"
@@ -28,6 +47,8 @@ private final class GeneralSwiftTests: XCTestCase {
 
     // 0.131s
     func testPerformanceSplit() throws {
+        try XCTSkipUnless(PerformanceTestOptIn.isEnabled, PerformanceTestOptIn.skipMessage)
+
         // This is an example of a performance test case.
 
         let str = "My name is JIMMY"
@@ -43,6 +64,8 @@ private final class GeneralSwiftTests: XCTestCase {
 
     // 0.103s
     func testPerformanceEnumerateSubstrings() throws {
+        try XCTSkipUnless(PerformanceTestOptIn.isEnabled, PerformanceTestOptIn.skipMessage)
+
         // This is an example of a performance test case.
 
         let str = "SELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT COUNT(*) FROM `HKWarningsLog`;"
@@ -68,6 +91,8 @@ private final class GeneralSwiftTests: XCTestCase {
 
     // 0.114 s 
     func testPerformanceSeparatedIntoLines() throws {
+        try XCTSkipUnless(PerformanceTestOptIn.isEnabled, PerformanceTestOptIn.skipMessage)
+
         // This is an example of a performance test case.
 
         let str = "SELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT * FROM `HKWarningsLog` LIMIT 1000;\nSELECT COUNT(*) FROM `HKWarningsLog`;"

--- a/UnitTests/SPArrayAdditions.m
+++ b/UnitTests/SPArrayAdditions.m
@@ -31,6 +31,7 @@
 //0.0259
 - (void)testPerformance_NormalNSArrayObjectAtIndex {
     // this is on main thread
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 10000;
@@ -48,6 +49,7 @@
 // 0.0264
 - (void)testPerformance_safeObjectAtIndex {
     // this is on main thread
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 10000;
@@ -123,6 +125,7 @@
 
 //0.668 s
 - (void)testPerformance_FirstObjectPassingTest_Last {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 100;
@@ -147,6 +150,7 @@
 
 // 0.0274 s
 - (void)testPerformance_FirstObjectPassingTest_First {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 100;

--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -10,6 +10,7 @@
 
 #import <XCTest/XCTest.h>
 #import "SPDateAdditions.h"
+#import "SPTestingUtils.h"
 #import "sequel-ace-Swift.h"
 
 @interface SPDateAdditionsTests : XCTestCase
@@ -28,6 +29,7 @@
 
 - (void)testPerformanceMonotonicTimeInterval {
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -47,6 +49,7 @@
 //0.9s - twice as slow as the Obj C static
 - (void)testPerformanceFormatWithFormat {
 	// This is an example of a performance test case.
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 
@@ -71,6 +74,7 @@
 // 0.5s
 - (void)testPerformanceDescriptionWithCalendarFormat {
 	// This is an example of a performance test case.
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 

--- a/UnitTests/SPFunctionsTests.m
+++ b/UnitTests/SPFunctionsTests.m
@@ -301,6 +301,7 @@
 
 // 0.0354 s
 - (void)testPerformanceIsEmptyString {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -317,6 +318,7 @@
 }
 //0.0118 s
 - (void)testPerformanceIsEmptyString2{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -334,6 +336,7 @@
 
 // 0.0105 s
 - (void)testPerformanceIsEmptyStringOldSchool {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -353,6 +356,7 @@
 
 //0.0438 s
 - (void)testPerformanceIsEmptySet {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -370,6 +374,7 @@
 
 // 0.0121 s
 - (void)testPerformanceIsEmptySet2{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -387,6 +392,7 @@
 
 //0.0104 s
 - (void)testPerformanceIsEmptySetOldSchool {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -406,6 +412,7 @@
 
 //0.00845 s
 - (void)testPerformanceIsEmptySetOldSchool2{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -425,6 +432,7 @@
 
 // 0.0292 s
 - (void)testPerformanceNormalForLoop {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 

--- a/UnitTests/SPMutableArrayAdditionsTests.m
+++ b/UnitTests/SPMutableArrayAdditionsTests.m
@@ -123,6 +123,7 @@
 
 - (void)testPerformance_withPairedMutableArrays {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		NSMutableArray *testArray = [NSMutableArray arrayWithObjects:@"o" ,@"n" ,@"m" ,@"l" ,@"k" ,@"j" ,@"i" ,@"h" ,@"g" ,@"f" ,@"e" ,@"d" ,@"c" ,@"b" ,@"a", nil];
@@ -139,6 +140,7 @@
 
 - (void)testPerformance_sortArrayUsingSelector {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		NSMutableArray *testArray = [NSMutableArray arrayWithObjects:@"o" ,@"n" ,@"m" ,@"l" ,@"k" ,@"j" ,@"i" ,@"h" ,@"g" ,@"f" ,@"e" ,@"d" ,@"c" ,@"b" ,@"a", nil];
@@ -184,6 +186,7 @@
 //0.0271s
 - (void)testPerformanceSafeReplaceObjectAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
 
         NSMutableArray *randomArray = [SPTestingUtils randomHistArray];
@@ -202,6 +205,7 @@
 //0.0262s
 - (void)testPerformanceReplaceObjectAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         NSMutableArray *randomArray = [SPTestingUtils randomHistArray];
 
@@ -235,6 +239,7 @@
 // 0.0272s
 - (void)testPerformanceRemoveObjectAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         NSMutableArray *randomArray = [SPTestingUtils randomHistArray];
 
@@ -249,6 +254,7 @@
 //0.0289s
 - (void)testPerformanceSafeRemoveObjectAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         NSMutableArray *randomArray = [SPTestingUtils randomHistArray];
 
@@ -262,6 +268,7 @@
 
 // 0.761 s
 - (void)testPerformanceReverse {
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
 
         NSMutableArray *randomArray = [SPTestingUtils randomHistArray];

--- a/UnitTests/SPPointerArrayAdditionsTests.m
+++ b/UnitTests/SPPointerArrayAdditionsTests.m
@@ -51,6 +51,7 @@
 //0.00328s
 - (void)testPerformanceSafeReplacePointerAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         NSPointerArray *randomPointerArray = [SPTestingUtils randomPointerArray];
 
@@ -66,6 +67,7 @@
 //0.00327s
 - (void)testPerformanceReplacePointerAtIndex {
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         NSPointerArray *randomPointerArray = [SPTestingUtils randomPointerArray];
 

--- a/UnitTests/SPStringAdditionsTests.m
+++ b/UnitTests/SPStringAdditionsTests.m
@@ -116,6 +116,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // 5.2 s 
 - (void)testPerformance_stringForByteSize {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 100000;
@@ -131,6 +132,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 - (void)testPerformance_stringForByteSizeSwift {
     // this is on main thread
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
 
         NSString *tmp = [[NSString alloc] init];
@@ -147,6 +149,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // obj c static - 0.241s
 - (void)testPerformance_stringForByteSizeObjCStatic {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 10000;
@@ -161,6 +164,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // 0.0383s
 - (void)testPerformance_stringByMatchingRegexSearch {
     // this is on main thread
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 1;
@@ -181,6 +185,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // 0.175s - 4 times slower than regexkit
 - (void)testPerformance_captureGroupForRegex {
     // this is on main thread
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         int const iterations = 1;
@@ -201,6 +206,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 - (void)testPerformance_RegexSearch {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1;
@@ -222,6 +228,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 - (void)testPerformance_StringWithString {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -239,6 +246,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // this cast method is twice as fast as stringWithString above
 - (void)testPerformance_cast {
 	
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -256,6 +264,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 // this "unsafe" cast method is twice as fast as cast above
 - (void)testPerformance_cast2 {
 	
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -272,6 +281,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 - (void)testnumberLiterals{
 
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -285,6 +295,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // 0.198s
 - (void)testSafeSubstringWithRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -301,6 +312,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 //0.19s
 - (void)testSubstringWithRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -349,6 +361,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 //0.133 s
 - (void)testPerformanceDateStringFromUnixTimestamp{
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         double epoch = 1641629299;
@@ -369,6 +382,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 //0.273 s
 - (void)testPerformanceDateStringFromUnixTimestamp2{
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
         NSString *epochStr = @"1641629299";
@@ -411,6 +425,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 - (void)testPerformanceIsUnixTimeStamp{
 
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -434,6 +449,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 - (void)testPerformanceIsUnixTimeStamp2{
 
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -463,6 +479,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // 0.95 s
 - (void)testSHA256Perf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 100000;
 
@@ -556,6 +573,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // 1.39 s
 - (void)testMutAttrStringSafeDeleteCharactersInRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -577,6 +595,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 //1.34 s
 - (void)testMutAttrStringDeleteCharactersInRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -629,6 +648,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 //0.328 s
 - (void)testSafeDeleteCharactersInRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
         
@@ -647,6 +667,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 //0.33 s
 - (void)testDeleteCharactersInRangePerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -702,6 +723,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // 0.145 s
 - (void)testContainsPerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 
@@ -717,6 +739,7 @@ static NSRange RangeFromArray(NSArray *a,NSUInteger idx);
 
 // 0.13 s
 - (void)testContainsStringPerf{
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         int const iterations = 1000000;
 

--- a/UnitTests/SPSyncTests.m
+++ b/UnitTests/SPSyncTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "SPFunctions.h"
 #import "SPMainThreadTrampoline.h"
+#import "SPTestingUtils.h"
 
 @interface SPSyncTests : XCTestCase
 
@@ -27,6 +28,7 @@
 
 - (void)testPerformance_get_main_window_on_main {
 
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -48,6 +50,7 @@
 
 - (void)testPerformance_get_main_window_SPMainQSync {
 
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -72,6 +75,7 @@
 - (void)testPerformance_dispatch_sync {
 	
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -96,6 +100,7 @@
 // DOESN'T WORK
 - (void)testPerformance_onMainThread {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;
@@ -118,6 +123,7 @@
 
 - (void)testPerformance_SPMainQSync {
 	// this is on main thread
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 		int const iterations = 1000000;

--- a/UnitTests/SPTestingUtils.h
+++ b/UnitTests/SPTestingUtils.h
@@ -9,6 +9,31 @@
 #ifndef SPTestingUtils_h
 #define SPTestingUtils_h
 
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#ifndef SEQUEL_ACE_RUN_PERFORMANCE_TESTS
+#define SEQUEL_ACE_RUN_PERFORMANCE_TESTS 0
+#endif
+
+static inline BOOL SARunPerformanceTests(void)
+{
+#if SEQUEL_ACE_RUN_PERFORMANCE_TESTS
+	return YES;
+#else
+	NSString *value = [[[[NSProcessInfo processInfo] environment] objectForKey:@"SEQUEL_ACE_RUN_PERFORMANCE_TESTS"] lowercaseString];
+	return [value isEqualToString:@"1"] || [value isEqualToString:@"true"] || [value isEqualToString:@"yes"];
+#endif
+}
+
+#define SASkipUnlessPerformanceTestsEnabled() \
+	do { \
+		if (!SARunPerformanceTests()) { \
+			XCTSkip(@"Set SEQUEL_ACE_RUN_PERFORMANCE_TESTS=1 to run performance measurement tests."); \
+			return; \
+		} \
+	} while (0)
+
 @interface SPTestingUtils : NSObject
 
 + (NSMutableArray *)randomHistArray;

--- a/UnitTests/SPURLAdditionsTests.m
+++ b/UnitTests/SPURLAdditionsTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "SPFunctions.h"
 #import "SPConstants.h"
+#import "SPTestingUtils.h"
 
 @interface SPURLAdditionsTests : XCTestCase
 
@@ -347,6 +348,7 @@
 // 0.15 s
 - (void)testPerformanceSwizzle{
     // This is an example of a performance test case.
+    SASkipUnlessPerformanceTestsEnabled();
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
 
@@ -362,6 +364,7 @@
 // 0.161 s
 - (void)testPerformanceNoSwizzle{
 	// This is an example of a performance test case.
+	SASkipUnlessPerformanceTestsEnabled();
 	[self measureBlock:^{
 		// Put the code you want to measure the time of here.
 


### PR DESCRIPTION
## Summary

- Adds a shared opt-in guard for XCTest performance measurement tests.
- Skips all current `measure` / `measureBlock` tests by default, including 54 Obj-C `measureBlock` sites and 4 Swift `measure` sites.
- Leaves `Scripts/build.sh` untouched so this PR does not conflict with #2457's ARM runner changes.

## Notes

The normal PR test path still compiles and discovers the tests, but the expensive timing loops are skipped unless explicitly opted in. Async correctness tests that use timeouts are untouched.

To run the measurement tests from the command line, pass the Obj-C and Swift test compile flags to `xcodebuild`:

```sh
xcodebuild test \
  -project sequel-ace.xcodeproj \
  -scheme "Unit Tests" \
  -destination "platform=macOS,arch=x86_64" \
  "GCC_PREPROCESSOR_DEFINITIONS=\$(inherited) SEQUEL_ACE_RUN_PERFORMANCE_TESTS=1" \
  "OTHER_SWIFT_FLAGS=\$(inherited) -D SEQUEL_ACE_RUN_PERFORMANCE_TESTS" \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO
```

When running from Xcode, setting the test process environment variable `SEQUEL_ACE_RUN_PERFORMANCE_TESTS=1` also enables the guarded measurements.

## Validation

- `bash -n Scripts/build.sh`
- `git diff --check`
- Confirmed guard coverage: 54 Obj-C `measureBlock` calls / 54 Obj-C guards; 4 Swift `measure` calls / 4 Swift guards.
- Confirmed merge simulation with #2457 has no `Scripts/build.sh` conflict markers.
- Default focused run skips measurement test:
  - `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS,arch=x86_64" -only-testing:"Unit Tests/SPFunctionsTests/testPerformanceIsEmptyString" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Opt-in focused Obj-C measurement run executes measurement:
  - `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS,arch=x86_64" -only-testing:"Unit Tests/SPFunctionsTests/testPerformanceIsEmptyString" "GCC_PREPROCESSOR_DEFINITIONS=\$(inherited) SEQUEL_ACE_RUN_PERFORMANCE_TESTS=1" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Opt-in Swift compile flag check passes:
  - `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination "platform=macOS,arch=x86_64" -only-testing:"Unit Tests/SAViewModeTests/testTabIndexes" "OTHER_SWIFT_FLAGS=\$(inherited) -D SEQUEL_ACE_RUN_PERFORMANCE_TESTS" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conditional skipping of performance tests across the test suite. Performance benchmarks can now be optionally enabled via environment configuration, allowing developers to run faster test cycles when detailed performance analysis is not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->