### PR TITLE
fix(json-formatter): Prevent NSRangeException crash on tab indent

### DIFF
--- a/Source/Other/Parsing/SPJSONFormatter.m
+++ b/Source/Other/Parsing/SPJSONFormatter.m
@@ -87,11 +87,11 @@ static char GetNextANSIChar(SPJSONTokenizerState *stateInfo);
         [tabs appendString:indentString];
       
       NSInteger myIdLevel = idLevel;
-      while(myIdLevel > [tabs length]) {
+      while(myIdLevel > 32) {
         [formatted appendString:tabs];
-        myIdLevel -= [tabs length];
+        myIdLevel -= 32;
       }
-      [formatted appendString:[tabs substringWithRange:NSMakeRange(0, myIdLevel*indentWidth)]];
+      [formatted appendString:[tabs substringWithRange:NSMakeRange(0, myIdLevel * [indentString length])]];
       needIndent = NO;
     }
     

--- a/UnitTests/SPJSONFormatterTests.m
+++ b/UnitTests/SPJSONFormatterTests.m
@@ -87,6 +87,29 @@
 			XCTAssertEqualObjects([SPJSONFormatter stringByFormattingString:[pair objectAtIndex:0]], [pair objectAtIndex:1], @"%@", [pair objectAtIndex:2]);
 		}
 	}
+	
+	// Test with tabs and indentWidth = 2
+	{
+		NSString *unf = @"{\"a\":{\"b\":1}}";
+		NSString *fmt = @"{\n\t\"a\": {\n\t\t\"b\": 1\n\t}\n}";
+		NSString *res = [SPJSONFormatter stringByFormattingString:unf useSoftIndent:NO indentWidth:2];
+		XCTAssertEqualObjects(res, fmt, @"formatting with tabs and indentWidth=2 should work");
+	}
+	
+	// Test with spaces and indentWidth = 4
+	{
+		NSString *unf = @"{\"a\":{\"b\":1}}";
+		NSString *fmt = @"{\n    \"a\": {\n        \"b\": 1\n    }\n}";
+		NSString *res = [SPJSONFormatter stringByFormattingString:unf useSoftIndent:YES indentWidth:4];
+		XCTAssertEqualObjects(res, fmt, @"formatting with 4 spaces should work");
+	}
+
+	// Test with extreme nesting (> 32)
+	{
+		NSString *unf = @"[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[null]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]";
+		NSString *res = [SPJSONFormatter stringByFormattingString:unf useSoftIndent:YES indentWidth:2];
+		XCTAssertNotNil(res, @"formatting 35 levels of nesting with soft indent should not crash");
+	}
 }
 
 - (void)testUnformatting


### PR DESCRIPTION
- Fix out-of-bounds crash when formatting JSON with tabs and indentWidth > 1
- Correct indentation buffer slicing to scale by actual indentString length
- Add unit tests for custom indentation widths and deep nesting

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- Fixed an out-of-bounds `NSRangeException` crash when formatting JSON strings with hard tab indentation (`useSoftIndent = NO`) and `indentWidth > 1`.
- Corrected the indentation buffer slicing logic in `SPJSONFormatter.m` to scale by the actual character length of `indentString` (1 for tab, `indentWidth` for spaces) rather than always multiplying by `indentWidth`.
- Fixed the buffer overflow comparison logic to compare levels against the maximum pool size (`32`) instead of comparing levels with string character length.
- Added unit tests in `SPJSONFormatterTests.m` covering custom indentation configurations (tabs vs spaces, different widths) and extreme nesting levels (>32) to prevent regressions.
## Closes following issues:
- Closes: None (Fixed a runtime crash observed in local debugging logs)
## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - Xcode 26.5 (Build 17F42)
  
## Screenshots:
## Additional notes:
Run the `Unit Tests` scheme locally. All unit tests related to `SPJSONFormatter` passed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON formatter to reliably handle deeply nested structures (35+ nesting levels) without crashes.

* **Tests**
  * Added test coverage for JSON formatting with configurable indentation (tabs and spaces).
  * Added regression test for extreme nesting depth scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->