### PR TITLE
#fixed Round-trip SSH remote socket connection URLs

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -2171,6 +2171,8 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
         if ([details objectForKey:@"ssh_user"]) [favorite setObject:[details objectForKey:@"ssh_user"] forKey:SPFavoriteSSHUserKey];
         if ([details objectForKey:@"ssh_keyLocationEnabled"]) [favorite setObject:[details objectForKey:@"ssh_keyLocationEnabled"] forKey:SPFavoriteSSHKeyLocationEnabledKey];
         if ([details objectForKey:@"ssh_keyLocation"]) [favorite setObject:[details objectForKey:@"ssh_keyLocation"] forKey:SPFavoriteSSHKeyLocationKey];
+        id sshRemoteSocketPath = [details objectForKey:SPFavoriteSSHRemoteSocketPathKey] ?: [details objectForKey:@"ssh_remote_socket_path"];
+        if (sshRemoteSocketPath) [favorite setObject:sshRemoteSocketPath forKey:SPFavoriteSSHRemoteSocketPathKey];
     }
     else if (typeTag == SPAWSIAMConnection) {
         if ([details objectForKey:@"aws_region"]) [favorite setObject:[details objectForKey:@"aws_region"] forKey:@"awsRegion"];
@@ -2356,15 +2358,18 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
                 NSString *existingSSHHost = [favoriteDict objectForKey:SPFavoriteSSHHostKey] ?: @"";
                 NSString *existingSSHUser = [favoriteDict objectForKey:SPFavoriteSSHUserKey] ?: @"";
                 NSString *existingSSHPort = [favoriteDict objectForKey:SPFavoriteSSHPortKey] ?: @"";
+                NSString *existingSSHRemoteSocketPath = [favoriteDict objectForKey:SPFavoriteSSHRemoteSocketPathKey] ?: @"";
 
                 // Check both URL keys (from connection string) and favorite keys (from plist import)
                 NSString *newSSHHost = [modeFields objectForKey:@"ssh_host"] ?: [modeFields objectForKey:SPFavoriteSSHHostKey] ?: @"";
                 NSString *newSSHUser = [modeFields objectForKey:@"ssh_user"] ?: [modeFields objectForKey:SPFavoriteSSHUserKey] ?: @"";
                 NSString *newSSHPort = [modeFields objectForKey:@"ssh_port"] ?: [modeFields objectForKey:SPFavoriteSSHPortKey] ?: @"";
+                NSString *newSSHRemoteSocketPath = [modeFields objectForKey:@"ssh_remote_socket_path"] ?: [modeFields objectForKey:SPFavoriteSSHRemoteSocketPathKey] ?: @"";
 
                 if (![existingSSHHost isEqualToString:newSSHHost] ||
                     ![existingSSHUser isEqualToString:newSSHUser] ||
-                    ![existingSSHPort isEqualToString:newSSHPort]) {
+                    ![existingSSHPort isEqualToString:newSSHPort] ||
+                    ![existingSSHRemoteSocketPath isEqualToString:newSSHRemoteSocketPath]) {
                     continue;
                 }
             }

--- a/Source/Model/ConnectionStringParser.swift
+++ b/Source/Model/ConnectionStringParser.swift
@@ -29,7 +29,7 @@ import Foundation
     /// Valid query parameters for mysql:// URLs
     @objc public static let validQueryParameters: [String] = [
         "type", "socket",
-        "ssh_host", "ssh_port", "ssh_user", "ssh_password", "ssh_keyLocationEnabled", "ssh_keyLocation",
+        "ssh_host", "ssh_port", "ssh_user", "ssh_password", "ssh_keyLocationEnabled", "ssh_keyLocation", "ssh_remote_socket_path",
         "aws_region", "aws_profile",
         "autoConnect", "enable_cleartext_plugin", "get_server_public_key", "request_server_public_key"
     ]
@@ -128,6 +128,10 @@ import Foundation
                 case "ssh_keyLocation":
                     details["ssh_keyLocation"] = value
 
+                case "ssh_remote_socket_path":
+                    details["ssh_remote_socket_path"] = value
+                    details["sshRemoteSocketPath"] = value
+
                 case "aws_region":
                     details["aws_region"] = value
 
@@ -154,7 +158,8 @@ import Foundation
             let hasAWSIAMIndicators = (details["aws_profile"] as? String)?.isEmpty == false ||
                                      (details["aws_region"] as? String)?.isEmpty == false
             let hasSocketIndicators = (details["socket"] as? String)?.isEmpty == false
-            let hasSSHIndicators = (details["ssh_host"] as? String)?.isEmpty == false
+            let hasSSHIndicators = (details["ssh_host"] as? String)?.isEmpty == false ||
+                                   (details["ssh_remote_socket_path"] as? String)?.isEmpty == false
 
             if hasAWSIAMIndicators {
                 details["type"] = "SPAWSIAMConnection"

--- a/Source/Model/SAConnectionInfo+ConnectionString.swift
+++ b/Source/Model/SAConnectionInfo+ConnectionString.swift
@@ -71,6 +71,9 @@ extension SAConnectionInfo {
                 queryItems.append(URLQueryItem(name: "ssh_keyLocationEnabled", value: "1"))
                 queryItems.append(URLQueryItem(name: "ssh_keyLocation", value: sshKeyLocation))
             }
+            if !sshRemoteSocketPath.isEmpty {
+                queryItems.append(URLQueryItem(name: "ssh_remote_socket_path", value: sshRemoteSocketPath))
+            }
 
         case .awsIAM:
             queryItems.append(URLQueryItem(name: "type", value: "aws_iam"))
@@ -211,6 +214,9 @@ extension SPFavoriteNode {
 
             // Note: SSH key paths are excluded by default as they are local to the machine
             // If needed, use toConnectionString(includePassword:includeSSHKeyPath:) with includeSSHKeyPath: true
+            if let sshRemoteSocketPath = favoriteDict[SPFavoriteSSHRemoteSocketPathKey] as? String, !sshRemoteSocketPath.isEmpty {
+                queryItems.append(URLQueryItem(name: "ssh_remote_socket_path", value: sshRemoteSocketPath))
+            }
         }
         else if typeValue == 3 { // SPAWSIAMConnection
             queryItems.append(URLQueryItem(name: "type", value: "aws_iam"))

--- a/UnitTests/SAConnectionStringTests.swift
+++ b/UnitTests/SAConnectionStringTests.swift
@@ -72,6 +72,21 @@ final class SAConnectionStringTests: XCTestCase {
         XCTAssertTrue(connectionString.contains("ssh_port=2222"))
     }
 
+    func testSSHTunnelConnectionStringIncludesRemoteSocketPath() throws {
+        var info = SAConnectionInfo()
+        info.type = .sshTunnel
+        info.host = "127.0.0.1"
+        info.user = "dbuser"
+        info.sshHost = "bastion.example.com"
+        info.sshUser = "ubuntu"
+        info.sshRemoteSocketPath = "/var/run/mysqld/mysqld.sock"
+
+        let connectionString = try XCTUnwrap(info.toConnectionString(includePassword: false))
+
+        XCTAssertTrue(connectionString.contains("type=ssh"))
+        XCTAssertTrue(connectionString.contains("ssh_remote_socket_path=/var/run/mysqld/mysqld.sock"))
+    }
+
     func testSSHKeyPathExcludedByDefault() throws {
         var info = SAConnectionInfo()
         info.type = .sshTunnel
@@ -135,6 +150,24 @@ final class SAConnectionStringTests: XCTestCase {
 
         XCTAssertTrue(result.success)
         XCTAssertEqual((result.details["requestServerPublicKey"] as? NSNumber)?.boolValue, true)
+    }
+
+    func testConnectionStringParsesSSHRemoteSocketPath() throws {
+        let url = try XCTUnwrap(URL(string: "mysql://dbuser@127.0.0.1?ssh_host=bastion.example.com&ssh_user=ubuntu&ssh_remote_socket_path=%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock"))
+        let result = ConnectionStringParser.parse(url)
+
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.details["type"] as? String, "SPSSHTunnelConnection")
+        XCTAssertEqual(result.details["ssh_remote_socket_path"] as? String, "/var/run/mysqld/mysqld.sock")
+        XCTAssertEqual(result.details["sshRemoteSocketPath"] as? String, "/var/run/mysqld/mysqld.sock")
+    }
+
+    func testConnectionStringInfersSSHTunnelFromRemoteSocketPath() throws {
+        let url = try XCTUnwrap(URL(string: "mysql://dbuser@127.0.0.1?ssh_remote_socket_path=%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock"))
+        let result = ConnectionStringParser.parse(url)
+
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.details["type"] as? String, "SPSSHTunnelConnection")
     }
 
     func testEmptyHostDefaultsToLocalhost() throws {

--- a/docs/get-started/connect-via-url.md
+++ b/docs/get-started/connect-via-url.md
@@ -48,6 +48,7 @@ These query parameters are currently supported:
 - `ssh_password`
 - `ssh_keyLocation`
 - `ssh_keyLocationEnabled` (set to `1` to enable key-based auth; `0` or omission keeps password auth)
+- `ssh_remote_socket_path`
 - `socket`
 - `aws_profile`
 - `aws_region`
@@ -61,10 +62,10 @@ When `type` is omitted, Sequel Ace infers mode in this order:
 
 1. AWS IAM if `aws_profile` or `aws_region` is present
 2. Socket if `socket` is present
-3. SSH if `ssh_host` is present
+3. SSH if `ssh_host` or `ssh_remote_socket_path` is present
 4. TCP/IP otherwise
 
-If both `socket` and `ssh_host` are present without `type`, Socket mode is used.
+If `socket` is present with `ssh_host` or `ssh_remote_socket_path` but no `type`, Socket mode is used.
 If `ssh_keyLocation` is provided but `ssh_keyLocationEnabled` is not `1`, Sequel Ace still uses password auth.
 
 Examples:
@@ -75,6 +76,9 @@ open 'mysql://db_user:db_password@127.0.0.1:3306/my_database?ssh_host=ssh.exampl
 
 # SSH connection using key auth
 open 'mysql://db_user:db_password@127.0.0.1:3306/my_database?ssh_host=ssh.example.com&ssh_port=22&ssh_user=ssh_user&ssh_keyLocation=%2FUsers%2Fyou%2F.ssh%2Fid_rsa&ssh_keyLocationEnabled=1'
+
+# SSH connection to a remote Unix socket on the SSH host
+open 'mysql://db_user:db_password@127.0.0.1/my_database?ssh_host=ssh.example.com&ssh_port=22&ssh_user=ssh_user&ssh_remote_socket_path=%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock'
 
 # `ssh_keyLocation` without enabling key auth still uses password auth
 open 'mysql://db_user:db_password@127.0.0.1:3306/my_database?ssh_host=ssh.example.com&ssh_port=22&ssh_user=ssh_user&ssh_keyLocation=%2FUsers%2Fyou%2F.ssh%2Fid_rsa&ssh_keyLocationEnabled=0'
@@ -106,6 +110,7 @@ If any unsupported query parameter is included, Sequel Ace shows an error and do
 - If no host is provided, Sequel Ace uses `127.0.0.1`.
 - The first path segment is treated as the database name.
 - For socket URLs, use the `socket` query parameter for the Unix socket path. Socket files must be inside Sequel Ace's container path due to macOS sandboxing.
+- For SSH remote socket URLs, use `ssh_remote_socket_path` for the Unix socket path on the SSH host.
 - AWS IAM URLs require Sequel Ace to already have sandbox access to your `~/.aws` directory. Grant access from the **AWS IAM** tab first.
 - If you use `ssh_keyLocation`, Sequel Ace must already have sandbox access to that key path. Grant access in **Sequel Ace → Preferences → Files** (add the key file or its containing folder).
 - `enable_cleartext_plugin=1` lets the MySQL client transmit the password unobscured to plugins that require it (typically PAM or LDAP back-ends). Only enable it on TLS-encrypted or SSH-tunneled connections.


### PR DESCRIPTION
## Summary

Fixes a 5.3.0 regression where SSH remote socket paths are saved in favorites and sessions, but are lost when a connection is copied, parsed, or imported via a `mysql://` connection URL.

## Root cause

PR #2406 added `sshRemoteSocketPath` to the SSH connection model and persistence path. PR #2398 added connection URL copy/import support, but the new remote socket field was not added to the URL parser, URL generator, import mapping, duplicate-favorite comparison, or URL docs. A favorite using an SSH remote Unix socket could therefore be copied/imported as a normal host/port SSH tunnel, or treated as a duplicate of a different SSH favorite.

## Changes

- Adds `ssh_remote_socket_path` as the URL query parameter for SSH remote socket paths.
- Emits the parameter when generating connection URLs from `SAConnectionInfo` and `SPFavoriteNode`.
- Parses the parameter into both the URL key and the existing favorite key so ObjC import code preserves it.
- Includes the remote socket path in duplicate SSH favorite comparisons.
- Updates the connection URL documentation.
- Adds unit coverage for generation, parsing, and SSH type inference from the remote socket parameter.

## Validation

- `git diff --check`
- `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
  - 737 tests executed, 58 skipped, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `ssh_remote_socket_path` in connection URLs and SSH tunnel connections.
  * Connection strings can now include and preserve remote Unix socket paths for SSH-based setups.
  * Documentation now includes an example and guidance for using remote socket paths.

* **Bug Fixes**
  * Improved SSH tunnel duplicate detection during favorites import by comparing remote socket paths too.
  * Connection type detection now correctly recognizes SSH tunnel connections when only a remote socket path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->