### PR TITLE
Modernization: warning hygiene sweep (warnings plan step 1) #infra

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -37,6 +37,20 @@
 #import "Locking.h"
 #import "Conversion.h"
 
+// Class extension: these are implemented in the main @implementation block of
+// SPMySQLConnection.m (declaring them on the PrivateAPI category would make
+// clang warn that the category's @implementation lacks their definitions).
+@interface SPMySQLConnection ()
+
++ (NSArray<NSString *> *)defaultSSLCipherList;
++ (NSArray<NSString *> *)legacySSLCipherList;
++ (NSString *)_defaultSSLCipherListString;
++ (NSString *)_defaultTLSSuiteListString;
++ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
++ (NSString *)_reachabilityProbeHostForHost:(NSString *)host useSocket:(BOOL)useSocket hasProxy:(BOOL)hasProxy;
+
+@end
+
 @interface SPMySQLConnection (PrivateAPI)
 
 - (BOOL)_connect;
@@ -54,12 +68,6 @@
                                  timeZoneIdentifier:(NSString *)timeZoneIdentifier;
 - (void)_validateThreadSetup;
 + (void)_removeThreadVariables:(NSNotification *)aNotification;
-+ (NSArray<NSString *> *)defaultSSLCipherList;
-+ (NSArray<NSString *> *)legacySSLCipherList;
-+ (NSString *)_defaultSSLCipherListString;
-+ (NSString *)_defaultTLSSuiteListString;
-+ (NSArray<NSString *> *)_mergedSSLCipherPreferenceListFromSavedCipherString:(NSString *)savedCipherString disabledMarker:(NSString *)disabledMarker;
-+ (NSString *)_reachabilityProbeHostForHost:(NSString *)host useSocket:(BOOL)useSocket hasProxy:(BOOL)hasProxy;
 
 @end
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoritesListDataSource.swift
@@ -131,7 +131,7 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
     /// Returns the children of `node` that are visible under the current filter.
     /// When no filter is active, returns all children unchanged.
     private func filteredChildren(of node: SPTreeNode) -> [SPTreeNode] {
-        let raw = (node.children ?? []).compactMap { $0 as? SPTreeNode }
+        let raw = node.children ?? []
         guard let visible = visibleNodes else { return raw }
         return raw.filter { visible.contains($0) }
     }
@@ -140,8 +140,8 @@ private let kSPQuickConnectImageWhite = "quick-connect-icon-white.pdf"
     @objc func restoreOutlineViewState(_ node: SPTreeNode, in outlineView: NSOutlineView) {
         guard node.isGroup else { return }
 
-        for child in node.children ?? [] {
-            guard let childNode = child as? SPTreeNode, childNode.isGroup else { continue }
+        for childNode in node.children ?? [] {
+            guard childNode.isGroup else { continue }
 
             // Top-level groups (parent is the synthetic root) live in the source-list
             // section and have no disclosure triangle; they must always be expanded

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -1324,16 +1324,16 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 {
     [AWSIAMAuthManager refreshAWSRegionsIfNeededWithCompletion:^(NSArray<NSString *> *regions) {
         if (!regions || !regions.count) return;
-        if ([awsAvailableRegionValues isEqualToArray:regions]) return;
+        if ([self->awsAvailableRegionValues isEqualToArray:regions]) return;
 
         NSString *currentRegion = [[self awsRegion] copy];
 
         [self willChangeValueForKey:@"awsAvailableRegions"];
-        awsAvailableRegionValues = [regions copy];
+        self->awsAvailableRegionValues = [regions copy];
         [self didChangeValueForKey:@"awsAvailableRegions"];
 
-        if (awsRegionComboBox) {
-            [awsRegionComboBox reloadData];
+        if (self->awsRegionComboBox) {
+            [self->awsRegionComboBox reloadData];
         }
 
         if ([currentRegion length]) {

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.h
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.h
@@ -31,6 +31,7 @@
 #import <Quartz/Quartz.h> // QuickLookUI
 
 @class SABaseFormatter;
+@class SPImageView;
 
 //This is an informal protocol
 @protocol _QLPreviewPanelController
@@ -56,7 +57,7 @@
 	IBOutlet id editSheetProgressBar;
 	IBOutlet id editSheetSegmentControl;
 	IBOutlet id editSheetQuickLookButton;
-	IBOutlet id editImage;
+	IBOutlet SPImageView *editImage;
 	IBOutlet id editTextView;
 	IBOutlet id hexTextView;
 	IBOutlet id jsonTextView;

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -33,6 +33,7 @@
 #import "RegexKitLite.h"
 #import "SPTooltip.h"
 #import "SPGeometryDataView.h"
+#import "SPImageView.h"
 #import "SPCopyTable.h"
 #import "SPWindow.h"
 #include <objc/objc-runtime.h>

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -259,6 +259,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (IBAction)addFilter:(id)sender;
 - (void)_updateButtonStates;
 - (void)_doChangeToRuleEditorData:(void (^)(void))duringBlock;
+- (void)_invokeTarget:(id)aTarget action:(SEL)anAction withObject:(id)object;
 - (void)_invokeFilterTargetActionWithObject:(id)object;
 - (IBAction)_checkboxClicked:(id)sender;
 - (void)_updateCheckedStateUpwardsFromCompoundRow:(NSInteger)row;
@@ -890,12 +891,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		id _target = [[node settings] objectForKey:@"target"];
 		SEL _action = (SEL)[(NSValue *)[[node settings] objectForKey:@"action"] pointerValue];
 		if(_target && _action) {
-			// The registered filter actions are plain void IBAction-style methods,
-			// so there is no returned object for ARC to leak.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-			[_target performSelector:_action withObject:sender];
-#pragma clang diagnostic pop
+			[self _invokeTarget:_target action:_action withObject:sender];
 			return;
 		}
 	}
@@ -1022,17 +1018,24 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 }
 
 /**
- * Invokes the runtime-registered target/action pair (see setTarget:/setAction:).
- * The registered actions are void IBAction-style methods, so there is no
- * returned object for ARC to leak.
+ * Invokes a runtime-registered target/action pair. The registered actions are
+ * void IBAction-style methods, so there is no returned object for ARC to leak.
+ */
+- (void)_invokeTarget:(id)aTarget action:(SEL)anAction withObject:(id)object
+{
+	if(!aTarget || !anAction) return;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+	[aTarget performSelector:anAction withObject:object];
+#pragma clang diagnostic pop
+}
+
+/**
+ * Invokes the controller's filter target/action (see setTarget:/setAction:).
  */
 - (void)_invokeFilterTargetActionWithObject:(id)object
 {
-	if(!target || !action) return;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-	[target performSelector:action withObject:object];
-#pragma clang diagnostic pop
+	[self _invokeTarget:target action:action withObject:object];
 }
 
 - (void)resetFilter {

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -259,6 +259,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (IBAction)addFilter:(id)sender;
 - (void)_updateButtonStates;
 - (void)_doChangeToRuleEditorData:(void (^)(void))duringBlock;
+- (void)_invokeFilterTargetActionWithObject:(id)object;
 - (IBAction)_checkboxClicked:(id)sender;
 - (void)_updateCheckedStateUpwardsFromCompoundRow:(NSInteger)row;
 - (void)_updateCheckedStateForRow:(NSInteger)row to:(NSControlStateValue)newState;
@@ -889,7 +890,12 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 		id _target = [[node settings] objectForKey:@"target"];
 		SEL _action = (SEL)[(NSValue *)[[node settings] objectForKey:@"action"] pointerValue];
 		if(_target && _action) {
+			// The registered filter actions are plain void IBAction-style methods,
+			// so there is no returned object for ARC to leak.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 			[_target performSelector:_action withObject:sender];
+#pragma clang diagnostic pop
 			return;
 		}
 	}
@@ -1012,7 +1018,21 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 
 - (IBAction)filterTable:(id)sender
 {
-	if(target && action) [target performSelector:action withObject:self];
+	[self _invokeFilterTargetActionWithObject:self];
+}
+
+/**
+ * Invokes the runtime-registered target/action pair (see setTarget:/setAction:).
+ * The registered actions are void IBAction-style methods, so there is no
+ * returned object for ARC to leak.
+ */
+- (void)_invokeFilterTargetActionWithObject:(id)object
+{
+	if(!target || !action) return;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+	[target performSelector:action withObject:object];
+#pragma clang diagnostic pop
 }
 
 - (void)resetFilter {
@@ -1025,7 +1045,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	[self _doChangeToRuleEditorData:^{
 		[[self->_modelContainer mutableArrayValueForKey:@"model"] removeAllObjects];
 	}];
-	if(target && action) [target performSelector:action withObject:nil];
+	[self _invokeFilterTargetActionWithObject:nil];
 }
 
 - (IBAction)addFilter:(id)sender
@@ -1060,7 +1080,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 	// - There is no direct way to know whether the action was triggered by the user, so we can only try to exclude all other causes of changes
 	NSInteger newRowCount = [filterRuleEditor numberOfRows];
 	if(!isDoingChangeCausedOutsideOfRuleEditor && previousRowCount > 0 && newRowCount == 0) {
-		if(target && action) [target performSelector:action withObject:nil];
+		[self _invokeFilterTargetActionWithObject:nil];
 	}
 	previousRowCount = newRowCount;
 }

--- a/Source/Other/Vault/VaultAuthManager.swift
+++ b/Source/Other/Vault/VaultAuthManager.swift
@@ -164,7 +164,7 @@ import OSLog
             errorPointer?.pointee = NSError(
                 domain: errorDomain,
                 code: VaultAuthError.invalidConfiguration.rawValue,
-                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.invalidConfiguration.localizedDescription ?? ""]
+                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.invalidConfiguration.localizedDescription]
             )
             return false
         }
@@ -179,7 +179,7 @@ import OSLog
             errorPointer?.pointee = NSError(
                 domain: errorDomain,
                 code: VaultAuthError.loginCancelled.rawValue,
-                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.loginCancelled.localizedDescription ?? ""]
+                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.loginCancelled.localizedDescription]
             )
             return false
         }
@@ -277,7 +277,7 @@ import OSLog
                         errorPointer?.pointee = NSError(
                             domain: errorDomain,
                             code: VaultAuthError.emptyCredentials.rawValue,
-                            userInfo: [NSLocalizedDescriptionKey: VaultAuthError.emptyCredentials.localizedDescription ?? ""]
+                            userInfo: [NSLocalizedDescriptionKey: VaultAuthError.emptyCredentials.localizedDescription]
                         )
                         finishInFlight(); return false
                     }
@@ -315,9 +315,9 @@ import OSLog
             errorPointer?.pointee = NSError(
                 domain: errorDomain,
                 code: authError.rawValue,
-                userInfo: [NSLocalizedDescriptionKey: oidcError.localizedDescription ?? ""]
+                userInfo: [NSLocalizedDescriptionKey: oidcError.localizedDescription]
             )
-            os_log("Vault OIDC login failed: %{public}@", log: log, type: .error, oidcError.localizedDescription ?? "unknown")
+            os_log("Vault OIDC login failed: %{public}@", log: log, type: .error, oidcError.localizedDescription)
             finishInFlight(); return false
         } catch {
             errorPointer?.pointee = NSError(
@@ -351,7 +351,7 @@ import OSLog
             errorPointer?.pointee = NSError(
                 domain: errorDomain,
                 code: VaultAuthError.emptyCredentials.rawValue,
-                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.emptyCredentials.localizedDescription ?? ""]
+                userInfo: [NSLocalizedDescriptionKey: VaultAuthError.emptyCredentials.localizedDescription]
             )
             finishInFlight(); return false
         }


### PR DESCRIPTION
## Changes:
First step of the build-warnings elimination plan — trivial, zero-behavior-change fixes:
- **SPMySQL Private APIs.h**: six class methods (`defaultSSLCipherList`, `legacySSLCipherList`, `_defaultSSLCipherListString`, `_defaultTLSSuiteListString`, `_mergedSSLCipherPreferenceList…`, `_reachabilityProbeHost…`) were declared on the `(PrivateAPI)` category but implemented in the main `@implementation`, so clang warned "method definition not found" for the category. Moved the declarations into a class extension, which is what matches where they're implemented. No code moved, no behavior change.
- **VaultAuthManager.swift**: removed dead `?? ""` / `?? "unknown"` on `localizedDescription`, which is non-optional (6 sites).
- **SAFavoritesListDataSource.swift**: removed two `as? SPTreeNode` casts that always succeed (`children` is already `[SPTreeNode]?` via the `childNodes` redeclaration).
- **SPConnectionController.m**: explicit `self->` for ivar access inside the AWS-regions completion block (implicit-self-retain warning; retaining self there is intended).
- **SPFieldEditorController**: typed the `editImage` outlet as `SPImageView *` (was `id`; the xib instantiates SPImageView) — fixes the null-passed-to-nonnull warning on `setImage:nil`, which was clang resolving the selector against an unrelated nonnull declaration.
- **SPRuleFilterController.m**: the four `performSelector:` calls on the runtime-registered target/action pair now go through one documented helper with a scoped `-Warc-performSelector-leaks` suppression (the registered actions are void IBAction-style methods — nothing for ARC to leak).

Kills ~16 warnings (the four navigator-truncated `performSelector` and second-cast duplicates included). Tracking doc: `.claude/warnings-elimination-plan.md`.

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Localizations:
  - [x] English
- Xcode Version: 26.5

## Screenshots:
N/A

## Additional notes:
- Verified via `xcodebuild`: clean build with all touched files force-recompiled — none of the targeted warnings remain
- Full unit suite: 737 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS region refresh behavior to keep the selected region consistent after available-region updates.
  * Made favorites list filtering/restoring more robust by simplifying child node handling during outline state restoration.
  * Centralized rule editor target/action invocation to improve reliability of filter, reset, and menu actions.
  * Vault authentication error messages now display clearer localized details without vague fallback values.

* **Refactor**
  * Reorganized SSL/TLS-related method declarations and tightened internal header typing for clearer interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->