### PR TITLE
#fixed Restore Keychain password handoff for SSH connections

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -531,7 +531,8 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
     // unset on SPMySQLConnection and is requested from its delegate at connect time.
     SAConnectionInfoObjC *info = [self _buildConnectionInfo];
     BOOL deferMySQLPasswordToDelegate = [SAConnectionInfoObjC shouldDeferMySQLPasswordToDelegateForInfo:info
-                                                                                                   password:[self password] ?: @""];
+                                                                                                   password:[self password] ?: @""
+                                                                                         delegateAvailable:self.connectionService.mySQLDelegate != nil];
 
     // Resolve explicit passwords and generated credentials before entering the service.
     NSString *resolvedPassword = deferMySQLPasswordToDelegate ? nil : [self _resolvedMySQLPassword];

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -496,7 +496,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
     // for increased security.
     if (connectionKeychainItemName && !isTestingConnection) {
         if ([[keychain getPasswordForName:connectionKeychainItemName account:connectionKeychainItemAccount] isEqualToString:[self password]]) {
-            [self setPassword:@"SequelAceSecretPassword"];
+            [self setPassword:[SAConnectionInfoObjC keychainPasswordPlaceholder]];
 
             [[standardPasswordField undoManager] removeAllActionsWithTarget:standardPasswordField];
             [[socketPasswordField undoManager] removeAllActionsWithTarget:socketPasswordField];
@@ -506,7 +506,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
 
     if (connectionSSHKeychainItemName && !isTestingConnection) {
         if ([[keychain getPasswordForName:connectionSSHKeychainItemName account:connectionSSHKeychainItemAccount] isEqualToString:[self sshPassword]]) {
-            [self setSshPassword:@"SequelAceSecretPassword"];
+            [self setSshPassword:[SAConnectionInfoObjC keychainPasswordPlaceholder]];
             [[sshSSHPasswordField undoManager] removeAllActionsWithTarget:sshSSHPasswordField];
         }
     }
@@ -527,14 +527,19 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
         }
     }
 
-    // Resolve passwords (handles keychain marker and AWS IAM token)
-    NSString *resolvedPassword = [self _resolvedMySQLPassword];
-    if (!resolvedPassword) return; // AWS IAM error already shown
+    // Preserve the legacy Keychain handoff: an unchanged saved password stays
+    // unset on SPMySQLConnection and is requested from its delegate at connect time.
+    SAConnectionInfoObjC *info = [self _buildConnectionInfo];
+    BOOL deferMySQLPasswordToDelegate = [SAConnectionInfoObjC shouldDeferMySQLPasswordToDelegateForInfo:info
+                                                                                                   password:[self password] ?: @""];
+
+    // Resolve explicit passwords and generated credentials before entering the service.
+    NSString *resolvedPassword = deferMySQLPasswordToDelegate ? nil : [self _resolvedMySQLPassword];
+    if (!resolvedPassword && !deferMySQLPasswordToDelegate) return; // AWS IAM error already shown
 
     NSString *resolvedSSHPassword = [self _resolvedSSHPassword];
 
-    // Build connection info and preferences
-    SAConnectionInfoObjC *info = [self _buildConnectionInfo];
+    // Build connection preferences
     SAConnectionPreferences *preferences = [SAConnectionPreferences fromUserDefaults];
 
     // Update progress text
@@ -3579,7 +3584,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
     }
 
     // Keychain marker: if password matches the marker, fetch from keychain
-    if (connectionKeychainItemName && [[self password] isEqualToString:@"SequelAceSecretPassword"]) {
+    if (connectionKeychainItemName && [[self password] isEqualToString:[SAConnectionInfoObjC keychainPasswordPlaceholder]]) {
         NSString *keychainPassword = [keychain getPasswordForName:connectionKeychainItemName account:connectionKeychainItemAccount];
         return keychainPassword ?: @"";
     }
@@ -3594,7 +3599,7 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
  */
 - (NSString *)_resolvedSSHPassword
 {
-    if (connectionSSHKeychainItemName && [[self sshPassword] isEqualToString:@"SequelAceSecretPassword"]) {
+    if (connectionSSHKeychainItemName && [[self sshPassword] isEqualToString:[SAConnectionInfoObjC keychainPasswordPlaceholder]]) {
         return @""; // Tunnel will use keychain names from SAConnectionInfoObjC
     }
     return [self sshPassword] ?: @"";

--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -150,11 +150,16 @@ struct SAConnectionInfo {
     }
 
     /// Returns whether SPMySQLConnection should request the saved password from its delegate.
-    @objc(shouldDeferMySQLPasswordToDelegateForInfo:password:)
+    @objc(shouldDeferMySQLPasswordToDelegateForInfo:password:delegateAvailable:)
     class func shouldDeferMySQLPasswordToDelegate(
         for info: SAConnectionInfoObjC,
-        password: String
+        password: String,
+        delegateAvailable: Bool
     ) -> Bool {
+        guard delegateAvailable else {
+            return false
+        }
+
         guard info.type != .awsIAM, info.type != .vault else {
             return false
         }

--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -106,6 +106,8 @@ struct SAConnectionInfo {
 /// ObjC code can create, populate, and pass this object; Swift code can read `.info` to get the value type.
 @objc class SAConnectionInfoObjC: NSObject {
 
+    @objc static let keychainPasswordPlaceholder = "SequelAceSecretPassword"
+
     var info: SAConnectionInfo
 
     @objc override init() {
@@ -145,6 +147,20 @@ struct SAConnectionInfo {
         @unknown default:
             return fallbackHost
         }
+    }
+
+    /// Returns whether SPMySQLConnection should request the saved password from its delegate.
+    @objc(shouldDeferMySQLPasswordToDelegateForInfo:password:)
+    class func shouldDeferMySQLPasswordToDelegate(
+        for info: SAConnectionInfoObjC,
+        password: String
+    ) -> Bool {
+        guard info.type != .awsIAM, info.type != .vault else {
+            return false
+        }
+
+        return !info.connectionKeychainItemName.isEmpty
+            && password == keychainPasswordPlaceholder
     }
 
     // MARK: Basic Connection

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -204,7 +204,7 @@ import Foundation
     @objc func connect(
         with info: SAConnectionInfoObjC,
         preferences: SAConnectionPreferences,
-        password: String,
+        password: String?,
         sshPassword: String,
         parentWindow: NSWindow?,
         completion: @escaping (SAConnectionResult) -> Void
@@ -267,7 +267,7 @@ import Foundation
     private func connectMySQL(
         info: SAConnectionInfoObjC,
         preferences: SAConnectionPreferences,
-        password: String,
+        password: String?,
         tunnel: SPSSHTunnel?,
         attemptID: UInt64,
         completion: @escaping (SAConnectionResult) -> Void
@@ -304,7 +304,9 @@ import Foundation
                 break
             }
 
-            conn.password = password
+            if let password {
+                conn.password = password
+            }
             conn.allowDataLocalInfile = info.allowDataLocalInfile != 0
             conn.enableClearTextPlugin = info.enableClearTextPlugin != 0
             conn.requestServerPublicKey = info.requestServerPublicKey != 0

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -144,7 +144,20 @@ final class SAConnectionInfoMappingTests: XCTestCase {
 
         XCTAssertTrue(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
             for: info,
-            password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+            password: SAConnectionInfoObjC.keychainPasswordPlaceholder,
+            delegateAvailable: true
+        ))
+    }
+
+    func testUnchangedKeychainPasswordWithoutDelegateIsPassedDirectly() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.connectionKeychainItemName = "Favorite password"
+
+        XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
+            for: info,
+            password: SAConnectionInfoObjC.keychainPasswordPlaceholder,
+            delegateAvailable: false
         ))
     }
 
@@ -155,7 +168,8 @@ final class SAConnectionInfoMappingTests: XCTestCase {
 
         XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
             for: info,
-            password: "temporary override"
+            password: "temporary override",
+            delegateAvailable: true
         ))
     }
 
@@ -165,7 +179,8 @@ final class SAConnectionInfoMappingTests: XCTestCase {
 
         XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
             for: info,
-            password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+            password: SAConnectionInfoObjC.keychainPasswordPlaceholder,
+            delegateAvailable: true
         ))
     }
 
@@ -177,7 +192,8 @@ final class SAConnectionInfoMappingTests: XCTestCase {
 
             XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
                 for: info,
-                password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+                password: SAConnectionInfoObjC.keychainPasswordPlaceholder,
+                delegateAvailable: true
             ))
         }
     }

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -137,6 +137,51 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(info.connectionSSHKeychainItemAccount, "tunnel@jump")
     }
 
+    func testUnchangedKeychainPasswordIsDeferredToConnectionDelegate() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.connectionKeychainItemName = "Favorite password"
+
+        XCTAssertTrue(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
+            for: info,
+            password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+        ))
+    }
+
+    func testExplicitPasswordOverrideIsPassedDirectly() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+        info.connectionKeychainItemName = "Favorite password"
+
+        XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
+            for: info,
+            password: "temporary override"
+        ))
+    }
+
+    func testPasswordWithoutKeychainItemIsPassedDirectly() {
+        let info = SAConnectionInfoObjC()
+        info.type = .sshTunnel
+
+        XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
+            for: info,
+            password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+        ))
+    }
+
+    func testGeneratedCredentialsAreNeverDeferredToConnectionDelegate() {
+        for connectionType in [SAConnectionType.awsIAM, .vault] {
+            let info = SAConnectionInfoObjC()
+            info.type = connectionType
+            info.connectionKeychainItemName = "Favorite password"
+
+            XCTAssertFalse(SAConnectionInfoObjC.shouldDeferMySQLPasswordToDelegate(
+                for: info,
+                password: SAConnectionInfoObjC.keychainPasswordPlaceholder
+            ))
+        }
+    }
+
     func testSpecialSettingsForService() {
         let info = SAConnectionInfoObjC()
         info.allowDataLocalInfile = 1


### PR DESCRIPTION
## Changes:
- Restore the 5.2.1 credential contract for unchanged Keychain-backed favorites: leave `SPMySQLConnection.password` unset so its delegate supplies the saved password at connect time.
- Keep explicitly entered passwords, Test Connection credentials, AWS IAM tokens, and Vault credentials on the existing direct-assignment path.
- Resolve unchanged Keychain passwords directly when no MySQL delegate is installed, including the standalone connection window.
- Add focused coverage for unchanged Keychain credentials, explicit overrides, missing Keychain items, and generated credential types.

## Closes following issues:
- Closes: #2488

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] Other: macOS 26.5.1
- Localizations:
  - No localization changes
- Xcode Version:
  - Xcode 26.6 (17F113)
  - `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:"Unit Tests/SAConnectionInfoMappingTests"` (23 tests, 0 failures)
  - `xcodebuild test -project sequel-ace.xcodeproj -scheme "Unit Tests" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (742 tests, 58 skipped performance tests, 0 failures)

## Screenshots:
- n/a

## Additional notes:
- Root cause: the 5.3 Swift connection-service rewrite changed unchanged saved-favorite authentication from delegate-time Keychain retrieval to eagerly materializing and assigning the password before `SPMySQLConnection.connect()`. This restores the established 5.2.1 handoff without reverting the connection-service rewrite.
- This deliberately does not change SSH host resolution. For the issue's primary `127.0.0.1` reproducer, the local client endpoint and remote tunnel target were already identical before and after the rewrite.
- No Sequel Ace app or external database service was launched for this pass; validation is contained to the focused and full unit suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced connection setup to support deferring MySQL password retrieval to the later connection workflow when appropriate.
  * Standardized the placeholder password used for both SQL and SSH password fields.
* **Bug Fixes**
  * Prevented early connection aborts when a MySQL password is temporarily unavailable.
  * Ensured deferral rules correctly disable placeholder handling for credential-generation connection types.
  * Updated connection service to accept an optional password during setup.
* **Tests**
  * Added unit tests covering password deferral, explicit override, missing keychain configuration, and type-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
