### PR TITLE
Modernization: nullability audit of SPDatabaseDocument.h (warnings plan step 3) #infra

### DIFF
--- a/Source/Controllers/MCP/SPAppController+MCP.swift
+++ b/Source/Controllers/MCP/SPAppController+MCP.swift
@@ -265,9 +265,10 @@ extension SPAppController: SPMCPDataSource {
                 guard let conn = c, conn.isConnected() else { continue }
                 var info: [String: Any] = [:]
                 info["id"] = mcpDocumentID(doc)
-                let displayName = doc.displayName() ?? ""
-                info["name"] = displayName.isEmpty ? (doc.host() ?? "") : displayName
-                if let host = doc.host(), !host.isEmpty { info["host"] = host }
+                let displayName = doc.displayName()
+                info["name"] = displayName.isEmpty ? doc.host() : displayName
+                let host = doc.host()
+                if !host.isEmpty { info["host"] = host }
                 if let db = doc.database(), !db.isEmpty { info["database"] = db }
                 info["active"] = (front != nil && doc == front)
                 result.append(info)

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -62,6 +62,8 @@
 
 #import <SPMySQL/SPMySQLConnectionDelegate.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The SPDatabaseDocument class controls the primary database view window.
  */
@@ -222,24 +224,27 @@
 	int64_t instanceId;
 }
 
-@property (nonatomic, strong) IBOutlet NSView *saveConnectionAccessory;
-@property (nonatomic, strong) IBOutlet NSButton *saveConnectionIncludeData;
-@property (nonatomic, strong) IBOutlet NSButton *saveConnectionIncludeQuery;
-@property (nonatomic, strong) IBOutlet NSButton *saveConnectionSavePassword;
-@property (nonatomic, strong) IBOutlet id saveConnectionSavePasswordAlert;
-@property (nonatomic, strong) IBOutlet NSButton *saveConnectionEncrypt;
-@property (nonatomic, strong) IBOutlet NSButton *saveConnectionAutoConnect;
-@property (nonatomic, strong) IBOutlet NSSecureTextField *saveConnectionEncryptString;
+// Outlets of the save-connection accessory view, loaded on demand — nil until
+// the accessory nib has been loaded.
+@property (nonatomic, strong, nullable) IBOutlet NSView *saveConnectionAccessory;
+@property (nonatomic, strong, nullable) IBOutlet NSButton *saveConnectionIncludeData;
+@property (nonatomic, strong, nullable) IBOutlet NSButton *saveConnectionIncludeQuery;
+@property (nonatomic, strong, nullable) IBOutlet NSButton *saveConnectionSavePassword;
+@property (nonatomic, strong, nullable) IBOutlet id saveConnectionSavePasswordAlert;
+@property (nonatomic, strong, nullable) IBOutlet NSButton *saveConnectionEncrypt;
+@property (nonatomic, strong, nullable) IBOutlet NSButton *saveConnectionAutoConnect;
+@property (nonatomic, strong, nullable) IBOutlet NSSecureTextField *saveConnectionEncryptString;
 
-@property (nonatomic, strong) NSTableView *dbTablesTableView;
-@property (readwrite, strong) NSURL *sqlFileURL;
+@property (nonatomic, strong, nullable) NSTableView *dbTablesTableView;
+@property (readwrite, strong, nullable) NSURL *sqlFileURL;
 @property (readwrite) NSStringEncoding sqlFileEncoding;
 @property (readwrite) BOOL isProcessing;
-@property (readwrite, copy) NSString *processID;
+@property (readwrite, copy, nullable) NSString *processID;
 @property (readonly, nonatomic, strong) NSToolbar *mainToolbar;
 
-@property (nonatomic, weak, readonly) SPWindowController *parentWindowController;
-@property (readonly, strong) SPServerSupport *serverSupport;
+@property (nonatomic, weak, readonly, nullable) SPWindowController *parentWindowController;
+// nil until a connection has been established.
+@property (readonly, strong, nullable) SPServerSupport *serverSupport;
 @property (readonly, strong) SPDatabaseStructure *databaseStructureRetrieval;
 @property (readonly, strong) SPDataImport *tableDumpInstance;
 @property (readonly, strong) SPTablesList *tablesListInstance;
@@ -248,7 +253,7 @@
 
 @property (readonly) int64_t instanceId;
 @property (readonly, strong) SPSplitView *contentViewSplitter;
-@property (strong) IBOutlet NSButton *multipleLineEditingButton;
+@property (strong, nullable) IBOutlet NSButton *multipleLineEditingButton;
 
 - (instancetype)initWithWindowController:(SPWindowController *)windowController;
 
@@ -261,16 +266,16 @@
 
 // Connection callback and methods
 - (void)setConnection:(SPMySQLConnection *)theConnection;
-- (SPMySQLConnection *)getConnection;
+- (nullable SPMySQLConnection *)getConnection;
 
 // Database methods
 - (IBAction)chooseDatabase:(id)sender;
-- (void)selectDatabase:(NSString *)aDatabase item:(NSString *)anItem;
-- (IBAction)makeTableListFilterHaveFocus:(id)sender;
-- (NSArray *)allDatabaseNames;
-- (NSArray *)allSystemDatabaseNames;
-- (NSDictionary *)getDbStructure;
-- (NSArray *)allSchemaKeys;
+- (void)selectDatabase:(NSString *)aDatabase item:(nullable NSString *)anItem;
+- (IBAction)makeTableListFilterHaveFocus:(nullable id)sender;
+- (nullable NSArray *)allDatabaseNames;
+- (nullable NSArray *)allSystemDatabaseNames;
+- (nullable NSDictionary *)getDbStructure;
+- (nullable NSArray *)allSchemaKeys;
 
 // Task progress and notification methods
 - (void)startTaskWithDescription:(nonnull NSString *)description;
@@ -294,8 +299,8 @@
 - (void)detectDatabaseEncoding;
 - (BOOL)supportsEncoding;
 - (void)updateEncodingMenuWithSelectedEncoding:(NSNumber *)encodingTag;
-- (NSNumber *)encodingTagFromMySQLEncoding:(NSString *)mysqlEncoding;
-- (NSString *)mysqlEncodingFromEncodingTag:(NSNumber *)encodingTag;
+- (nullable NSNumber *)encodingTagFromMySQLEncoding:(NSString *)mysqlEncoding;
+- (nullable NSString *)mysqlEncodingFromEncodingTag:(NSNumber *)encodingTag;
 
 // Table methods
 - (IBAction)saveCreateSyntax:(id)sender;
@@ -306,7 +311,7 @@
 // Other methods
 - (IBAction)closeSheet:(id)sender;
 - (IBAction)closePanelSheet:(id)sender;
-- (IBAction)validateSaveConnectionAccessory:(id)sender;
+- (IBAction)validateSaveConnectionAccessory:(nullable id)sender;
 - (IBAction)closePasswordSheet:(id)sender;
 - (IBAction)copyChecksumFromSheet:(id)sender;
 
@@ -318,8 +323,8 @@
 
 - (void)refreshCurrentDatabase;
 
-- (void)saveConnectionPanelDidEnd:(NSSavePanel *)panel returnCode:(NSInteger)returnCode contextInfo:(NSString *)contextInfo;
-- (BOOL)saveDocumentWithFilePath:(NSString *)fileName inBackground:(BOOL)saveInBackground onlyPreferences:(BOOL)saveOnlyPreferences contextInfo:(NSDictionary*)contextInfo;
+- (void)saveConnectionPanelDidEnd:(NSSavePanel *)panel returnCode:(NSInteger)returnCode contextInfo:(nullable NSString *)contextInfo;
+- (BOOL)saveDocumentWithFilePath:(nullable NSString *)fileName inBackground:(BOOL)saveInBackground onlyPreferences:(BOOL)saveOnlyPreferences contextInfo:(nullable NSDictionary*)contextInfo;
 - (void)setIsSavedInBundle:(BOOL)savedInBundle;
 - (void)setFileURL:(NSURL *)fileURL;
 - (void)connect;
@@ -327,14 +332,14 @@
 // Accessor methods
 - (NSString *)host;
 - (NSString *)name;
-- (NSString *)database;
+- (nullable NSString *)database;
 - (NSString *)port;
-- (NSString *)mySQLVersion;
+- (nullable NSString *)mySQLVersion;
 - (NSString *)user;
 - (NSString *)connectionID;
 - (NSString *)tabTitleForTooltip;
 - (BOOL)isSaveInBundle;
-- (NSURL *)fileURL;
+- (nullable NSURL *)fileURL;
 - (NSString *)displayName;
 - (NSUndoManager *)undoManager;
 - (NSArray *)allTableNames;
@@ -348,14 +353,14 @@
 
 // Menu methods
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem;
-- (IBAction)saveConnectionSheet:(id)sender;
+- (IBAction)saveConnectionSheet:(nullable id)sender;
 - (BOOL)isCustomQuerySelected;
 - (IBAction)showConnectionDebugMessages:(id)sender;
 
 // Toolbar methods
 - (void)updateWindowTitle:(id)sender;
-- (NSString *)selectedToolbarItemIdentifier;
-- (NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag;
+- (nullable NSString *)selectedToolbarItemIdentifier;
+- (nullable NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag;
 
 // Tab methods
 - (BOOL)parentTabShouldClose;
@@ -363,7 +368,7 @@
 - (void)setIsProcessing:(BOOL)value;
 - (BOOL)isProcessing;
 
-- (NSWindow *)parentWindowControllerWindow;
+- (nullable NSWindow *)parentWindowControllerWindow;
 
 // Scripting
 - (void)handleSchemeCommand:(NSDictionary*)commandDict;
@@ -385,7 +390,7 @@
 #pragma mark - SPDatabaseViewController
 
 // Accessors
-- (NSString *)table;
+- (nullable NSString *)table;
 - (SPTableType)tableType;
 
 - (BOOL)structureLoaded;
@@ -398,7 +403,7 @@
 - (void)setRelationsRequiresReload:(BOOL)reload;
 
 // Table control
-- (void)loadTable:(NSString *)aTable ofType:(SPTableType)aTableType;
+- (void)loadTable:(nullable NSString *)aTable ofType:(SPTableType)aTableType;
 
 - (NSView *)databaseView;
 
@@ -457,8 +462,8 @@
 
 - (void)focusOnTableContentFilter;
 - (void)showFilterTable;
-- (void)copyCreateTableSyntax:(SPDatabaseDocument *)sender;
-- (void)showCreateTableSyntax:(SPDatabaseDocument *)sender;
+- (void)copyCreateTableSyntax:(nullable SPDatabaseDocument *)sender;
+- (void)showCreateTableSyntax:(nullable SPDatabaseDocument *)sender;
 - (void)checkTable;
 - (void)repairTable;
 - (void)analyzeTable;
@@ -471,3 +476,5 @@
 - (void)showMySQLHelp;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.swift
@@ -66,21 +66,21 @@ extension SPDatabaseDocument {
 
         // Restore accessory view settings if possible
         if let save_password = sessionData?["save_password"] as? Bool {
-            saveConnectionSavePassword.state = save_password ? .on : .off
+            saveConnectionSavePassword?.state = save_password ? .on : .off
         }
         if let auto_connect = sessionData?["auto_connect"] as? Bool {
-            saveConnectionAutoConnect.state = auto_connect ? .on : .off
+            saveConnectionAutoConnect?.state = auto_connect ? .on : .off
         }
         if let encrypted = sessionData?["encrypted"] as? Bool {
-            saveConnectionEncrypt.state = encrypted ? .on : .off
+            saveConnectionEncrypt?.state = encrypted ? .on : .off
         }
         if let include_session = sessionData?["include_session"] as? Bool {
-            saveConnectionIncludeData.state = include_session ? .on : .off
+            saveConnectionIncludeData?.state = include_session ? .on : .off
         }
         if let save_editor_content = sessionData?["save_editor_content"] as? Bool {
-            saveConnectionIncludeQuery.state = save_editor_content ? .on : .off
+            saveConnectionIncludeQuery?.state = save_editor_content ? .on : .off
         } else {
-            saveConnectionIncludeQuery.state = .on
+            saveConnectionIncludeQuery?.state = .on
         }
     }
 }

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -498,7 +498,12 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 	// arbitrary declaration (e.g. a CGColorRef-returning property).
 	NSColor *newColor = [(NSColorPanel *)sender color];
 
-	[prefs setObject:[SAArchiving archivedDataForColor:newColor] forKey:[editorColors objectAtIndex:colorRow]];
+	// Archiving should never fail for an NSColor, but setObject:nil would
+	// throw; on failure keep the previously stored colour instead.
+	NSData *colorData = [SAArchiving archivedDataForColor:newColor];
+	if (colorData) {
+		[prefs setObject:colorData forKey:[editorColors objectAtIndex:colorRow]];
+	}
 
 	if ([[editorColors objectAtIndex:colorRow] isEqualTo:SPCustomQueryEditorBackgroundColor]) {
 		[colorSettingTableView setBackgroundColor:newColor];

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -493,11 +493,15 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 - (void)colorChanged:(id)sender
 {
 	if (![[NSColorPanel sharedColorPanel] isVisible]) return;
-	
-	[prefs setObject:[SAArchiving archivedDataForColor:[sender color]] forKey:[editorColors objectAtIndex:colorRow]];
+
+	// The sender is untyped; without the cast clang resolves -color against an
+	// arbitrary declaration (e.g. a CGColorRef-returning property).
+	NSColor *newColor = [(NSColorPanel *)sender color];
+
+	[prefs setObject:[SAArchiving archivedDataForColor:newColor] forKey:[editorColors objectAtIndex:colorRow]];
 
 	if ([[editorColors objectAtIndex:colorRow] isEqualTo:SPCustomQueryEditorBackgroundColor]) {
-		[colorSettingTableView setBackgroundColor:[sender color]];
+		[colorSettingTableView setBackgroundColor:newColor];
 	}
 
 	[colorSettingTableView reloadData];

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.h
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.h
@@ -34,6 +34,8 @@
 @class SPContentFilterManager;
 @class SPRuleFilterDropBox;
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSString * const SPRuleFilterHeightChangedNotification;
 
 @interface SPRuleFilterController : NSObject {
@@ -88,7 +90,7 @@ NSString * const SPRuleFilterHeightChangedNotification;
  *
  * MUST BE CALLED ON THE UI THREAD!
  */
-- (void)setColumns:(NSArray *)dataColumns;
+- (void)setColumns:(nullable NSArray *)dataColumns;
 
 /**
  * Converts the current filter expression displayed in the UI into an
@@ -103,7 +105,7 @@ NSString * const SPRuleFilterHeightChangedNotification;
  *
  * MUST BE CALLED ON THE UI THREAD!
  */
-- (NSString *)sqlWhereExpressionWithBinary:(BOOL)isBINARY error:(NSError **)err;
+- (nullable NSString *)sqlWhereExpressionWithBinary:(BOOL)isBINARY error:(NSError **)err;
 
 /**
  * Returns the current filter configuration in a serialized form that can be exported and
@@ -123,7 +125,7 @@ NSString * const SPRuleFilterHeightChangedNotification;
  *
  * MUST BE CALLED ON THE UI THREAD!
  */
-- (void)restoreSerializedFilters:(NSDictionary *)serialized;
+- (void)restoreSerializedFilters:(nullable NSDictionary *)serialized;
 
 /**
  * Create a serialized filter from a given column, operator and operand.
@@ -230,10 +232,12 @@ NSString * const SPRuleFilterHeightChangedNotification;
  *
  * SHOULD be called on the UI thread, or results may be inconsistent!
  */
-@property (unsafe_unretained, nonatomic) id target;
-@property (assign, nonatomic) SEL action;
+@property (unsafe_unretained, nonatomic, nullable) id target;
+@property (assign, nonatomic, nullable) SEL action;
 
 - (BOOL)isEnabled;
 - (void)setEnabled:(BOOL)enabled;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -62,7 +62,7 @@ private extension SPWindowController {
         databaseDocument.updateWindowTitle(self)
 
         window?.contentView?.addSubview(databaseDocument.databaseView())
-        databaseDocument.databaseView()?.frame = window?.contentView?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 400)
+        databaseDocument.databaseView().frame = window?.contentView?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 400)
 
         if #available(macOS 10.13, *) {
             window?.tab.accessoryView = tabAccessoryView

--- a/Source/Model/TreeNodes/SPFavoriteNode.h
+++ b/Source/Model/TreeNodes/SPFavoriteNode.h
@@ -30,6 +30,8 @@
 
 #import "SPNamedNode.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @class SPFavoriteNode SPFavoriteNode.h
  *
@@ -45,7 +47,7 @@
 /**
  * @property nodeFavorite The actual favorite dictionary
  */
-@property (readwrite, strong) NSMutableDictionary *nodeFavorite;
+@property (readwrite, strong, nullable) NSMutableDictionary *nodeFavorite;
 
 - (instancetype)initWithDictionary:(NSMutableDictionary *)dictionary;
 
@@ -57,3 +59,5 @@
 @interface SPFavoriteNode (ConnectionString)
 - (NSString * _Nullable)toConnectionString:(BOOL)includePassword;
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Changes:
Step 3 of the warnings elimination plan — eliminates all ~77 `-Wnullability-completeness` warnings (the largest single group) by auditing three headers rather than blanket-annotating:

- **SPDatabaseDocument.h**, **SPRuleFilterController.h**, **SPFavoriteNode.h** wrapped in `NS_ASSUME_NONNULL`, with `nullable` applied only where the implementation proves it:
  - Returns that can be nil: `database`/`table` (nil before selection), `mySQLVersion`/`getConnection`/`serverSupport` (nil before connect), `fileURL` (nil when untitled), the navigator-backed `getDbStructure`/`allSchemaKeys`, encoding-map lookups, `selectedToolbarItemIdentifier`, `parentWindowControllerWindow`, `sqlWhereExpressionWithBinary:error:` (nil on error, per its own doc)
  - Params that accept nil: `loadTable:` (documented nil-clears-views), `selectDatabase:item:`, save-panel contexts (`saveDocumentWithFilePath:nil` is a real call), `setColumns:`/`restoreSerializedFilters:` (nil-guarded), and the action senders Swift invokes with nil
  - The on-demand save-accessory outlets and `processID`/`sqlFileURL` are nullable; nib-backed instances and init-created objects keep the nonnull default
- **Swift fix-ups** from the now-precise imports: optional-chained accessory outlets in SPDatabaseDocument.swift, non-optional `displayName()`/`host()` in the MCP extension, `databaseView()` in SPWindowController
- **Bonus fixes surfaced by the audit**:
  - Both pre-existing protocol-optionality warnings against `SADatabaseDocumentProviding` (`contentViewSplitter`, `parentWindowControllerWindow`) are resolved
  - `SPEditorPreferencePane.colorChanged:` called `-color` on an untyped `id` sender, which clang resolved against a `CGColorRef`-returning declaration — now typed via `NSColorPanel` cast

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Localizations:
  - [x] English
- Xcode Version: 26.5

## Screenshots:
N/A

## Additional notes:
- Verified by full rebuild with forced recompiles: nullability-completeness 0 (was ~77 unique / 148 raw), null-passed-to-nonnull 0, protocol-optionality 0, no new warnings
- Full unit suite: 756 tests, 0 failures
- Warning-plan progress: 413 baseline → ~250 after steps 0–3
- Nullability is advisory for ObjC callers (warnings only); the behavioral surface of this change is the Swift optionality, and all Swift call sites were updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection details handling when display names or hosts are missing.
  - Prevented crashes when restoring saved connection settings if some optional controls aren’t available.
  - Improved editor color preference saving to avoid overwriting the last valid color when the archive fails.
- **Refactor**
  - Updated interface null-handling across database, filters, favorites, and UI components for more reliable optional data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->