### PR TITLE
#fixed Keep long-running column removal responsive

### DIFF
--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -24,23 +24,33 @@
 
 import AppKit
 
-/// Immutable field-removal details plus task-scoped cancellation state.
+@objc enum SAFieldRemovalQueryResult: Int {
+    case succeeded
+    case cancelled
+    case failed
+}
+
+/// Immutable field-removal details plus sequencing and cancellation state.
 ///
-/// `SPTableStructure` remains responsible for its legacy query and reload
-/// calls; this type keeps the new cross-thread coordination in Swift.
+/// `SPTableStructure` supplies thin bridges for its legacy query, error, and
+/// reload calls; this type owns the cross-thread removal orchestration.
 @objc final class SAFieldRemovalTask: NSObject {
 
     @objc let field: String
-    @objc let removesForeignKey: Bool
+    @objc let foreignKeyName: String?
+    @objc let table: String
+    @objc let database: String
 
     private let stateLock = NSLock()
     private var cancellationRequested = false
     private var queryIsAdmitted = false
 
-    @objc(initWithField:removesForeignKey:)
-    init(field: String, removesForeignKey: Bool) {
+    @objc(initWithField:foreignKeyName:table:database:)
+    init(field: String, foreignKeyName: String?, table: String, database: String) {
         self.field = field
-        self.removesForeignKey = removesForeignKey
+        self.foreignKeyName = foreignKeyName
+        self.table = table
+        self.database = database
         super.init()
     }
 
@@ -63,15 +73,65 @@ import AppKit
         return true
     }
 
+    /// Sequences the optional foreign-key removal and field removal while
+    /// keeping legacy controller operations behind focused callbacks.
+    @objc(runWithForeignKeyQuery:fieldQuery:foreignKeyFailure:fieldFailure:schemaRefresh:completion:)
+    func run(foreignKeyQuery: () -> SAFieldRemovalQueryResult,
+             fieldQuery: () -> SAFieldRemovalQueryResult,
+             foreignKeyFailure: () -> Void,
+             fieldFailure: () -> Void,
+             schemaRefresh: () -> Void,
+             completion: () -> Void) {
+        var previousQueryWasCancelled = false
+        var schemaMayHaveChanged = false
+
+        if foreignKeyName != nil,
+           let result = runQueryIfAllowed(afterPreviousCancellation: false,
+                                          operation: foreignKeyQuery) {
+            switch result {
+            case .succeeded:
+                schemaMayHaveChanged = true
+            case .cancelled:
+                previousQueryWasCancelled = true
+                schemaMayHaveChanged = true
+            case .failed:
+                foreignKeyFailure()
+            }
+        }
+
+        if let result = runQueryIfAllowed(
+            afterPreviousCancellation: previousQueryWasCancelled,
+            operation: fieldQuery
+        ) {
+            switch result {
+            case .succeeded, .cancelled:
+                schemaMayHaveChanged = true
+            case .failed:
+                fieldFailure()
+            }
+        }
+
+        if schemaMayHaveChanged {
+            schemaRefresh()
+        }
+
+        if Thread.isMainThread {
+            completion()
+        } else {
+            DispatchQueue.main.sync(execute: completion)
+        }
+    }
+
     /// Runs a query only while this task remains active and the preceding
     /// query, if any, was not cancelled.
-    @objc(runQueryIfAllowedAfterPreviousCancellation:operation:)
-    func runQueryIfAllowed(afterPreviousCancellation queryWasCancelled: Bool,
-                           operation: () -> Void) -> Bool {
+    private func runQueryIfAllowed(
+        afterPreviousCancellation queryWasCancelled: Bool,
+        operation: () -> SAFieldRemovalQueryResult
+    ) -> SAFieldRemovalQueryResult? {
         stateLock.lock()
         guard !queryWasCancelled, !cancellationRequested else {
             stateLock.unlock()
-            return false
+            return nil
         }
         queryIsAdmitted = true
         stateLock.unlock()
@@ -81,8 +141,7 @@ import AppKit
             queryIsAdmitted = false
             stateLock.unlock()
         }
-        operation()
-        return true
+        return operation()
     }
 }
 

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -33,7 +33,9 @@ import AppKit
     @objc let field: String
     @objc let removesForeignKey: Bool
 
-    private let cancellationProgress = Progress(totalUnitCount: 1)
+    private let stateLock = NSLock()
+    private var cancellationRequested = false
+    private var queryIsAdmitted = false
 
     @objc(initWithField:removesForeignKey:)
     init(field: String, removesForeignKey: Bool) {
@@ -43,7 +45,17 @@ import AppKit
     }
 
     @objc func cancel() {
-        cancellationProgress.cancel()
+        stateLock.lock()
+        cancellationRequested = true
+        stateLock.unlock()
+    }
+
+    /// Whether cancellation must keep reaching for a query that won admission
+    /// immediately before the cancellation request.
+    var cancellationRequiresQueryCancellation: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return cancellationRequested && queryIsAdmitted
     }
 
     /// Runs a query only while this task remains active and the preceding
@@ -51,10 +63,19 @@ import AppKit
     @objc(runQueryIfAllowedAfterPreviousCancellation:operation:)
     func runQueryIfAllowed(afterPreviousCancellation queryWasCancelled: Bool,
                            operation: () -> Void) -> Bool {
-        guard !queryWasCancelled, !cancellationProgress.isCancelled else {
+        stateLock.lock()
+        guard !queryWasCancelled, !cancellationRequested else {
+            stateLock.unlock()
             return false
         }
+        queryIsAdmitted = true
+        stateLock.unlock()
 
+        defer {
+            stateLock.lock()
+            queryIsAdmitted = false
+            stateLock.unlock()
+        }
         operation()
         return true
     }
@@ -70,7 +91,8 @@ import AppKit
     /// Invoked when the user clicks the cancel button, after the per-task
     /// cancellation callback has recorded the request. The document cancels
     /// the running query (directly, or via the database-structure connection
-    /// for speed).
+    /// for speed). This may be invoked again while a field-removal query that
+    /// won admission concurrently with cancellation is still unwinding.
     func taskControllerDidRequestCancellation()
 }
 
@@ -335,9 +357,32 @@ import AppKit
             callbackObject.perform(callbackSelector)
         }
 
+        requestQueryCancellation(
+            retryingWhile: taskCancellationCallbackObject as? SAFieldRemovalTask
+        )
+    }
+
+    private func requestQueryCancellation(retryingWhile fieldRemovalTask: SAFieldRemovalTask?) {
         // The document cancels the running query (using the database-structure
         // connection where available, for speed - no connection overhead).
         delegate?.taskControllerDidRequestCancellation()
+
+        // Query admission and cancellation are serialized by the task's state
+        // lock. If the query won admission first but has not yet made the
+        // connection busy, keep retrying until cancellation reaches it or the
+        // operation returns. A query cannot be admitted after cancel() wins.
+        guard let fieldRemovalTask,
+              fieldRemovalTask.cancellationRequiresQueryCancellation else {
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self, weak fieldRemovalTask] in
+            guard let self, let fieldRemovalTask,
+                  fieldRemovalTask.cancellationRequiresQueryCancellation else {
+                return
+            }
+            self.requestQueryCancellation(retryingWhile: fieldRemovalTask)
+        }
     }
 
     // MARK: - Query-execution timer

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -50,12 +50,17 @@ import AppKit
         stateLock.unlock()
     }
 
-    /// Whether cancellation must keep reaching for a query that won admission
-    /// immediately before the cancellation request.
-    var cancellationRequiresQueryCancellation: Bool {
+    /// Cancels an admitted query while preventing it from completing its
+    /// transition to subsequent connection work. The cancellation closure
+    /// must not call back into this task.
+    fileprivate func cancelAdmittedQuery(_ cancellation: () -> Void) -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return cancellationRequested && queryIsAdmitted
+        guard cancellationRequested, queryIsAdmitted else {
+            return false
+        }
+        cancellation()
+        return true
     }
 
     /// Runs a query only while this task remains active and the preceding
@@ -363,22 +368,25 @@ import AppKit
     }
 
     private func requestQueryCancellation(retryingWhile fieldRemovalTask: SAFieldRemovalTask?) {
-        // The document cancels the running query (using the database-structure
-        // connection where available, for speed - no connection overhead).
-        delegate?.taskControllerDidRequestCancellation()
+        guard let fieldRemovalTask else {
+            delegate?.taskControllerDidRequestCancellation()
+            return
+        }
 
-        // Query admission and cancellation are serialized by the task's state
-        // lock. If the query won admission first but has not yet made the
-        // connection busy, keep retrying until cancellation reaches it or the
-        // operation returns. A query cannot be admitted after cancel() wins.
-        guard let fieldRemovalTask,
-              fieldRemovalTask.cancellationRequiresQueryCancellation else {
+        // Query admission, completion, and each cancellation attempt are
+        // serialized by the task's state lock. If the query won admission
+        // first but has not yet made the connection busy, keep retrying until
+        // cancellation reaches it or the operation returns. Holding the lock
+        // across the delegate call also prevents a queued retry from racing
+        // with the following schema-reload query.
+        guard fieldRemovalTask.cancelAdmittedQuery({
+            delegate?.taskControllerDidRequestCancellation()
+        }) else {
             return
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self, weak fieldRemovalTask] in
-            guard let self, let fieldRemovalTask,
-                  fieldRemovalTask.cancellationRequiresQueryCancellation else {
+            guard let self, let fieldRemovalTask else {
                 return
             }
             self.requestQueryCancellation(retryingWhile: fieldRemovalTask)

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -24,127 +24,6 @@
 
 import AppKit
 
-@objc enum SAFieldRemovalQueryResult: Int {
-    case succeeded
-    case cancelled
-    case failed
-}
-
-/// Immutable field-removal details plus sequencing and cancellation state.
-///
-/// `SPTableStructure` supplies thin bridges for its legacy query, error, and
-/// reload calls; this type owns the cross-thread removal orchestration.
-@objc final class SAFieldRemovalTask: NSObject {
-
-    @objc let field: String
-    @objc let foreignKeyName: String?
-    @objc let table: String
-    @objc let database: String
-
-    private let stateLock = NSLock()
-    private var cancellationRequested = false
-    private var queryIsAdmitted = false
-
-    @objc(initWithField:foreignKeyName:table:database:)
-    init(field: String, foreignKeyName: String?, table: String, database: String) {
-        self.field = field
-        self.foreignKeyName = foreignKeyName
-        self.table = table
-        self.database = database
-        super.init()
-    }
-
-    @objc func cancel() {
-        stateLock.lock()
-        cancellationRequested = true
-        stateLock.unlock()
-    }
-
-    /// Cancels an admitted query while preventing it from completing its
-    /// transition to subsequent connection work. The cancellation closure
-    /// must not call back into this task.
-    fileprivate func cancelAdmittedQuery(_ cancellation: () -> Void) -> Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-        guard cancellationRequested, queryIsAdmitted else {
-            return false
-        }
-        cancellation()
-        return true
-    }
-
-    /// Sequences the optional foreign-key removal and field removal while
-    /// keeping legacy controller operations behind focused callbacks.
-    @objc(runWithForeignKeyQuery:fieldQuery:foreignKeyFailure:fieldFailure:schemaRefresh:completion:)
-    func run(foreignKeyQuery: () -> SAFieldRemovalQueryResult,
-             fieldQuery: () -> SAFieldRemovalQueryResult,
-             foreignKeyFailure: () -> Void,
-             fieldFailure: () -> Void,
-             schemaRefresh: () -> Void,
-             completion: () -> Void) {
-        var previousQueryWasCancelled = false
-        var schemaMayHaveChanged = false
-
-        if foreignKeyName != nil,
-           let result = runQueryIfAllowed(afterPreviousCancellation: false,
-                                          operation: foreignKeyQuery) {
-            switch result {
-            case .succeeded:
-                schemaMayHaveChanged = true
-            case .cancelled:
-                previousQueryWasCancelled = true
-                schemaMayHaveChanged = true
-            case .failed:
-                foreignKeyFailure()
-            }
-        }
-
-        if let result = runQueryIfAllowed(
-            afterPreviousCancellation: previousQueryWasCancelled,
-            operation: fieldQuery
-        ) {
-            switch result {
-            case .succeeded, .cancelled:
-                schemaMayHaveChanged = true
-            case .failed:
-                fieldFailure()
-            }
-        }
-
-        if schemaMayHaveChanged {
-            schemaRefresh()
-        }
-
-        if Thread.isMainThread {
-            completion()
-        } else {
-            DispatchQueue.main.sync(execute: completion)
-        }
-    }
-
-    /// Runs a query only while this task remains active and the preceding
-    /// query, if any, was not cancelled.
-    private func runQueryIfAllowed(
-        afterPreviousCancellation queryWasCancelled: Bool,
-        operation: () -> SAFieldRemovalQueryResult
-    ) -> SAFieldRemovalQueryResult? {
-        stateLock.lock()
-        guard !queryWasCancelled, !cancellationRequested else {
-            stateLock.unlock()
-            return nil
-        }
-        queryIsAdmitted = true
-        stateLock.unlock()
-
-        defer {
-            stateLock.lock()
-            queryIsAdmitted = false
-            stateLock.unlock()
-        }
-        return operation()
-    }
-}
-
 /// Hooks the task controller needs back from its host document — things it
 /// cannot own because they belong to the document's wider lifecycle.
 @objc protocol SATaskControllerDelegate: AnyObject {
@@ -156,7 +35,8 @@ import AppKit
     /// cancellation callback has recorded the request. The document cancels
     /// the running query (directly, or via the database-structure connection
     /// for speed). This may be invoked again while a field-removal query that
-    /// won admission concurrently with cancellation is still unwinding.
+    /// won admission concurrently with cancellation is still unwinding; those
+    /// retries are delivered from the task's background cancellation queue.
     func taskControllerDidRequestCancellation()
 }
 
@@ -421,34 +301,12 @@ import AppKit
             callbackObject.perform(callbackSelector)
         }
 
-        requestQueryCancellation(
-            retryingWhile: taskCancellationCallbackObject as? SAFieldRemovalTask
-        )
-    }
-
-    private func requestQueryCancellation(retryingWhile fieldRemovalTask: SAFieldRemovalTask?) {
-        guard let fieldRemovalTask else {
-            delegate?.taskControllerDidRequestCancellation()
-            return
-        }
-
-        // Query admission, completion, and each cancellation attempt are
-        // serialized by the task's state lock. If the query won admission
-        // first but has not yet made the connection busy, keep retrying until
-        // cancellation reaches it or the operation returns. Holding the lock
-        // across the delegate call also prevents a queued retry from racing
-        // with the following schema-reload query.
-        guard fieldRemovalTask.cancelAdmittedQuery({
-            delegate?.taskControllerDidRequestCancellation()
-        }) else {
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self, weak fieldRemovalTask] in
-            guard let self, let fieldRemovalTask else {
-                return
+        if let fieldRemovalTask = taskCancellationCallbackObject as? SAFieldRemovalTask {
+            fieldRemovalTask.requestQueryCancellation { [weak self] in
+                self?.delegate?.taskControllerDidRequestCancellation()
             }
-            self.requestQueryCancellation(retryingWhile: fieldRemovalTask)
+        } else {
+            delegate?.taskControllerDidRequestCancellation()
         }
     }
 

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -24,6 +24,42 @@
 
 import AppKit
 
+/// Immutable field-removal details plus task-scoped cancellation state.
+///
+/// `SPTableStructure` remains responsible for its legacy query and reload
+/// calls; this type keeps the new cross-thread coordination in Swift.
+@objc final class SAFieldRemovalTask: NSObject {
+
+    @objc let field: String
+    @objc let removesForeignKey: Bool
+
+    private let cancellationProgress = Progress(totalUnitCount: 1)
+
+    @objc(initWithField:removesForeignKey:)
+    init(field: String, removesForeignKey: Bool) {
+        self.field = field
+        self.removesForeignKey = removesForeignKey
+        super.init()
+    }
+
+    @objc func cancel() {
+        cancellationProgress.cancel()
+    }
+
+    /// Runs a query only while this task remains active and the preceding
+    /// query, if any, was not cancelled.
+    @objc(runQueryIfAllowedAfterPreviousCancellation:operation:)
+    func runQueryIfAllowed(afterPreviousCancellation queryWasCancelled: Bool,
+                           operation: () -> Void) -> Bool {
+        guard !queryWasCancelled, !cancellationProgress.isCancelled else {
+            return false
+        }
+
+        operation()
+        return true
+    }
+}
+
 /// Hooks the task controller needs back from its host document — things it
 /// cannot own because they belong to the document's wider lifecycle.
 @objc protocol SATaskControllerDelegate: AnyObject {

--- a/Source/Controllers/MainViewControllers/SATaskController.swift
+++ b/Source/Controllers/MainViewControllers/SATaskController.swift
@@ -67,10 +67,10 @@ import AppKit
     /// The window the progress panel should be centred over / parented to.
     func taskParentWindow() -> NSWindow?
 
-    /// Invoked when the user clicks the cancel button. The document cancels
+    /// Invoked when the user clicks the cancel button, after the per-task
+    /// cancellation callback has recorded the request. The document cancels
     /// the running query (directly, or via the database-structure connection
-    /// for speed). The per-task cancellation callback is invoked separately
-    /// by the controller after this returns.
+    /// for speed).
     func taskControllerDidRequestCancellation()
 }
 
@@ -324,18 +324,20 @@ import AppKit
 
         taskCancelButton.isEnabled = false
 
-        // The document cancels the running query (using the database-structure
-        // connection where available, for speed - no connection overhead).
-        delegate?.taskControllerDidRequestCancellation()
-
         // The callback selector is documented (on enableTaskCancellation) to be
         // a no-argument, void-returning method; guard against a non-responding
-        // object rather than crashing.
+        // object rather than crashing. Record task-scoped cancellation before
+        // asking the connection to cancel so a worker cannot start its next
+        // query in between those two actions.
         if let callbackObject = taskCancellationCallbackObject,
            let callbackSelector = taskCancellationCallbackSelector,
            callbackObject.responds(to: callbackSelector) {
             callbackObject.perform(callbackSelector)
         }
+
+        // The document cancels the running query (using the database-structure
+        // connection where available, for speed - no connection overhead).
+        delegate?.taskControllerDidRequestCancellation()
     }
 
     // MARK: - Query-execution timer

--- a/Source/Controllers/MainViewControllers/TableRelations/SAForeignKeyReferenceRuleSupport.swift
+++ b/Source/Controllers/MainViewControllers/TableRelations/SAForeignKeyReferenceRuleSupport.swift
@@ -60,3 +60,159 @@ import Foundation
         return Int(String(describing: value).trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
     }
 }
+
+@objc enum SAFieldRemovalQueryResult: Int {
+    case succeeded
+    case cancelled
+    case failed
+}
+
+/// Immutable field-removal details plus sequencing and cancellation state.
+///
+/// `SPTableStructure` supplies thin bridges for its legacy query, error, and
+/// reload calls; this type owns the cross-thread removal orchestration.
+@objc final class SAFieldRemovalTask: NSObject {
+
+    @objc let field: String
+    @objc let foreignKeyName: String?
+    @objc let table: String
+    @objc let database: String
+
+    private static let initialCancellationRetryDelay: TimeInterval = 0.025
+    private static let maximumCancellationRetryDelay: TimeInterval = 1
+
+    private let stateLock = NSLock()
+    private let cancellationQueue = DispatchQueue(
+        label: "com.sequel-ace.field-removal-query-cancellation",
+        qos: .userInitiated
+    )
+    private var cancellationRequested = false
+    private var queryIsAdmitted = false
+
+    @objc(initWithField:foreignKeyName:table:database:)
+    init(field: String, foreignKeyName: String?, table: String, database: String) {
+        self.field = field
+        self.foreignKeyName = foreignKeyName
+        self.table = table
+        self.database = database
+        super.init()
+    }
+
+    @objc func cancel() {
+        stateLock.lock()
+        cancellationRequested = true
+        stateLock.unlock()
+    }
+
+    /// Keeps cancellation attempts off the main queue and backs them off while
+    /// an admitted query remains active.
+    func requestQueryCancellation(_ cancellation: @escaping () -> Void) {
+        scheduleCancellationAttempt(
+            after: 0,
+            nextRetryDelay: Self.initialCancellationRetryDelay,
+            cancellation: cancellation
+        )
+    }
+
+    /// Sequences the optional foreign-key removal and field removal while
+    /// keeping legacy controller operations behind focused callbacks.
+    @objc(runWithForeignKeyQuery:fieldQuery:foreignKeyFailure:fieldFailure:schemaRefresh:completion:)
+    func run(foreignKeyQuery: () -> SAFieldRemovalQueryResult,
+             fieldQuery: () -> SAFieldRemovalQueryResult,
+             foreignKeyFailure: () -> Void,
+             fieldFailure: () -> Void,
+             schemaRefresh: () -> Void,
+             completion: () -> Void) {
+        var previousQueryWasCancelled = false
+        var schemaMayHaveChanged = false
+
+        if foreignKeyName != nil,
+           let result = runQueryIfAllowed(afterPreviousCancellation: false,
+                                          operation: foreignKeyQuery) {
+            switch result {
+            case .succeeded:
+                schemaMayHaveChanged = true
+            case .cancelled:
+                previousQueryWasCancelled = true
+                schemaMayHaveChanged = true
+            case .failed:
+                foreignKeyFailure()
+            }
+        }
+
+        if let result = runQueryIfAllowed(
+            afterPreviousCancellation: previousQueryWasCancelled,
+            operation: fieldQuery
+        ) {
+            switch result {
+            case .succeeded, .cancelled:
+                schemaMayHaveChanged = true
+            case .failed:
+                fieldFailure()
+            }
+        }
+
+        if schemaMayHaveChanged {
+            schemaRefresh()
+        }
+
+        if Thread.isMainThread {
+            completion()
+        } else {
+            DispatchQueue.main.sync(execute: completion)
+        }
+    }
+
+    /// Cancels an admitted query while preventing it from completing its
+    /// transition to subsequent connection work. The cancellation closure
+    /// must not call back into this task.
+    private func cancelAdmittedQuery(_ cancellation: () -> Void) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard cancellationRequested, queryIsAdmitted else {
+            return false
+        }
+        cancellation()
+        return true
+    }
+
+    private func scheduleCancellationAttempt(
+        after delay: TimeInterval,
+        nextRetryDelay: TimeInterval,
+        cancellation: @escaping () -> Void
+    ) {
+        cancellationQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self, cancelAdmittedQuery(cancellation) else {
+                return
+            }
+
+            scheduleCancellationAttempt(
+                after: nextRetryDelay,
+                nextRetryDelay: min(nextRetryDelay * 2, Self.maximumCancellationRetryDelay),
+                cancellation: cancellation
+            )
+        }
+    }
+
+    /// Runs a query only while this task remains active and the preceding
+    /// query, if any, was not cancelled.
+    private func runQueryIfAllowed(
+        afterPreviousCancellation queryWasCancelled: Bool,
+        operation: () -> SAFieldRemovalQueryResult
+    ) -> SAFieldRemovalQueryResult? {
+        stateLock.lock()
+        guard !queryWasCancelled, !cancellationRequested else {
+            stateLock.unlock()
+            return nil
+        }
+        queryIsAdmitted = true
+        stateLock.unlock()
+
+        defer {
+            stateLock.lock()
+            queryIsAdmitted = false
+            stateLock.unlock()
+        }
+        return operation()
+    }
+}

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1576,6 +1576,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 {
 	@autoreleasepool {
 		NSString *field = [removalDetails objectForKey:@"field"];
+		BOOL shouldRemoveField = YES;
 
 		// Remove the foreign key before the field if required
 		if ([[removalDetails objectForKey:@"removeForeignKey"] boolValue]) {
@@ -1594,6 +1595,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 
 			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
+			shouldRemoveField = ![self->mySQLConnection lastQueryWasCancelled];
 
 			// Check for errors, but only if the query wasn't cancelled
 			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
@@ -1604,29 +1606,31 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 		}
 
-		// Remove field
-		[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
-																[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
+		if (shouldRemoveField) {
+			// Remove field
+			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
+																	[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
 
-		// Check for errors, but only if the query wasn't cancelled
-		if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
-			NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-			[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
-			[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
-																  field,
-																  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
+			// Check for errors, but only if the query wasn't cancelled
+			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
+				NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
+				[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
+				[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
+																	  field,
+																	  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
 
-			[[self onMainThread] showErrorSheetWith:errorDictionary];
-		}
-		else {
-			[self->tableDataInstance resetAllData];
+				[[self onMainThread] showErrorSheetWith:errorDictionary];
+			}
+			else {
+				[self->tableDataInstance resetAllData];
 
-			// Refresh relevant views
-			[self->tableDocumentInstance setStatusRequiresReload:YES];
-			[self->tableDocumentInstance setContentRequiresReload:YES];
-			[self->tableDocumentInstance setRelationsRequiresReload:YES];
+				// Refresh relevant views
+				[self->tableDocumentInstance setStatusRequiresReload:YES];
+				[self->tableDocumentInstance setContentRequiresReload:YES];
+				[self->tableDocumentInstance setRelationsRequiresReload:YES];
 
-			[self loadTable:self->selectedTable];
+				[self loadTable:self->selectedTable];
+			}
 		}
 
 		SPMainQSync(^{

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -113,7 +113,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	TableSortHelper *fieldsSortHelper;
 }
 
-- (void)_removeFieldAndForeignKey:(NSNumber *)removeForeignKey;
+- (void)_removeFieldAndForeignKey:(NSDictionary *)removalDetails;
 - (NSString *)_buildPartialColumnDefinitionString:(NSDictionary *)theRow;
 - (BOOL)filterFieldsWithString:(NSString *)filterString;
 - (BOOL)sort:(NSMutableArray *)data withDescriptor:(NSSortDescriptor *)descriptor;
@@ -713,19 +713,23 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 		[self->tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Removing field...", @"removing field task status message")];
 
-		NSNumber *removeKey = [NSNumber numberWithBool:hasForeignKey];
+		// Capture the AppKit selection before handing the operation to the background thread.
+		NSDictionary *removalDetails = @{
+			@"field": field,
+			@"removeForeignKey": [NSNumber numberWithBool:hasForeignKey]
+		};
 
 		if ([NSThread isMainThread]) {
 			[NSThread detachNewThreadWithName:SPCtxt(@"SPTableStructure field and key removal task", self->tableDocumentInstance)
 									   target:self
 									 selector:@selector(_removeFieldAndForeignKey:)
-									   object:removeKey];
+									   object:removalDetails];
 
 			[self->tableDocumentInstance enableTaskCancellationWithTitle:NSLocalizedString(@"Cancel", @"cancel button")
 													callbackObject:self
 												  callbackFunction:NULL];
 		} else {
-			[self _removeFieldAndForeignKey:removeKey];
+			[self _removeFieldAndForeignKey:removalDetails];
 		}
 	} cancelButtonHandler:nil];
 }
@@ -1568,69 +1572,70 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 /**
  * Removes a field from the current table and the dependent foreign key if specified.
  */
-- (void)_removeFieldAndForeignKey:(NSNumber *)removeForeignKey
+- (void)_removeFieldAndForeignKey:(NSDictionary *)removalDetails
 {
-	SPMainQSync(^{
-		@autoreleasepool {
-			// Remove the foreign key before the field if required
-			if ([removeForeignKey boolValue]) {
-				NSString *relationName = @"";
-				NSString *field = [[[self activeFieldsSource] safeObjectAtIndex:[self->tableSourceView selectedRow]] safeObjectForKey:@"name"];
+	@autoreleasepool {
+		NSString *field = [removalDetails objectForKey:@"field"];
 
-				// Get the foreign key name
-				for (NSDictionary *constraint in [self->tableDataInstance getConstraints])
+		// Remove the foreign key before the field if required
+		if ([[removalDetails objectForKey:@"removeForeignKey"] boolValue]) {
+			NSString *relationName = @"";
+
+			// Get the foreign key name
+			for (NSDictionary *constraint in [self->tableDataInstance getConstraints])
+			{
+				for (NSString *column in [constraint safeObjectForKey:@"columns"])
 				{
-					for (NSString *column in [constraint safeObjectForKey:@"columns"])
-					{
-						if ([column isEqualToString:field]) {
-							relationName = [constraint safeObjectForKey:@"name"];
-							break;
-						}
+					if ([column isEqualToString:field]) {
+						relationName = [constraint safeObjectForKey:@"name"];
+						break;
 					}
-				}
-
-				[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
-
-				// Check for errors, but only if the query wasn't cancelled
-				if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
-					NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-					[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
-					[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
-					[[self onMainThread] showErrorSheetWith:errorDictionary];
 				}
 			}
 
-			// Remove field
-			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
-																	[self->selectedTable backtickQuotedString], [[[[self activeFieldsSource] safeObjectAtIndex:[self->tableSourceView selectedRow]] safeObjectForKey:@"name"] backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
+			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
 
 			// Check for errors, but only if the query wasn't cancelled
 			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
 				NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-				[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
-				[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
-																	  [[[self activeFieldsSource] objectAtIndex:[self->tableSourceView selectedRow]] objectForKey:@"name"],
-																	  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
-
+				[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
+				[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
 				[[self onMainThread] showErrorSheetWith:errorDictionary];
 			}
-			else {
-				[self->tableDataInstance resetAllData];
+		}
 
-				// Refresh relevant views
-				[self->tableDocumentInstance setStatusRequiresReload:YES];
-				[self->tableDocumentInstance setContentRequiresReload:YES];
-				[self->tableDocumentInstance setRelationsRequiresReload:YES];
+		// Remove field
+		[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
+																[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
 
-				[self loadTable:self->selectedTable];
-			}
+		// Check for errors, but only if the query wasn't cancelled
+		if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
+			NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
+			[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
+			[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
+																  field,
+																  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
 
+			[[self onMainThread] showErrorSheetWith:errorDictionary];
+		}
+		else {
+			[self->tableDataInstance resetAllData];
+
+			// Refresh relevant views
+			[self->tableDocumentInstance setStatusRequiresReload:YES];
+			[self->tableDocumentInstance setContentRequiresReload:YES];
+			[self->tableDocumentInstance setRelationsRequiresReload:YES];
+
+			[self loadTable:self->selectedTable];
+		}
+
+		SPMainQSync(^{
 			[self->tableDocumentInstance endTask];
 
 			// Preserve focus on table for keyboard navigation
 			[[self->tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:self->tableSourceView];
-		}
-	});
+		});
+	}
 }
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -113,7 +113,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	TableSortHelper *fieldsSortHelper;
 }
 
-- (void)_removeFieldAndForeignKey:(NSDictionary *)removalDetails;
+- (void)_removeFieldAndForeignKey:(SAFieldRemovalTask *)removalTask;
 - (NSString *)_buildPartialColumnDefinitionString:(NSDictionary *)theRow;
 - (BOOL)filterFieldsWithString:(NSString *)filterString;
 - (BOOL)sort:(NSMutableArray *)data withDescriptor:(NSSortDescriptor *)descriptor;
@@ -714,24 +714,19 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		[self->tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Removing field...", @"removing field task status message")];
 
 		// Capture the AppKit selection before handing the operation to the background thread.
-		NSProgress *cancellationToken = [NSProgress progressWithTotalUnitCount:1];
-		NSDictionary *removalDetails = @{
-			@"field": field,
-			@"removeForeignKey": [NSNumber numberWithBool:hasForeignKey],
-			@"cancellationToken": cancellationToken
-		};
+		SAFieldRemovalTask *removalTask = [[SAFieldRemovalTask alloc] initWithField:field removesForeignKey:hasForeignKey];
 
 		if ([NSThread isMainThread]) {
 			[NSThread detachNewThreadWithName:SPCtxt(@"SPTableStructure field and key removal task", self->tableDocumentInstance)
 									   target:self
 									 selector:@selector(_removeFieldAndForeignKey:)
-									   object:removalDetails];
+									   object:removalTask];
 
 			[self->tableDocumentInstance enableTaskCancellationWithTitle:NSLocalizedString(@"Cancel", @"cancel button")
-													callbackObject:cancellationToken
+													callbackObject:removalTask
 												  callbackFunction:@selector(cancel)];
 		} else {
-			[self _removeFieldAndForeignKey:removalDetails];
+			[self _removeFieldAndForeignKey:removalTask];
 		}
 	} cancelButtonHandler:nil];
 }
@@ -1574,15 +1569,14 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 /**
  * Removes a field from the current table and the dependent foreign key if specified.
  */
-- (void)_removeFieldAndForeignKey:(NSDictionary *)removalDetails
+- (void)_removeFieldAndForeignKey:(SAFieldRemovalTask *)removalTask
 {
 	@autoreleasepool {
-		NSString *field = [removalDetails objectForKey:@"field"];
-		NSProgress *cancellationToken = [removalDetails objectForKey:@"cancellationToken"];
-		BOOL shouldRemoveField = ![cancellationToken isCancelled];
+		NSString *field = [removalTask field];
+		BOOL previousQueryWasCancelled = NO;
 
 		// Remove the foreign key before the field if required
-		if ([[removalDetails objectForKey:@"removeForeignKey"] boolValue] && shouldRemoveField) {
+		if ([removalTask removesForeignKey]) {
 			NSString *relationName = @"";
 
 			// Get the foreign key name
@@ -1597,23 +1591,29 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 				}
 			}
 
-			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
-			shouldRemoveField = ![cancellationToken isCancelled] && ![self->mySQLConnection lastQueryWasCancelled];
+			BOOL didRunForeignKeyQuery = [removalTask runQueryIfAllowedAfterPreviousCancellation:NO operation:^{
+				[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
+			}];
 
-			// Check for errors, but only if the query wasn't cancelled
-			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
-				NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-				[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
-				[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
-				[[self onMainThread] showErrorSheetWith:errorDictionary];
+			if (didRunForeignKeyQuery) {
+				previousQueryWasCancelled = [self->mySQLConnection lastQueryWasCancelled];
+
+				// Check for errors, but only if the query wasn't cancelled
+				if ([self->mySQLConnection queryErrored] && !previousQueryWasCancelled) {
+					NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
+					[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
+					[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
+					[[self onMainThread] showErrorSheetWith:errorDictionary];
+				}
 			}
 		}
 
-		if (shouldRemoveField && ![cancellationToken isCancelled]) {
-			// Remove field
+		BOOL didRunFieldQuery = [removalTask runQueryIfAllowedAfterPreviousCancellation:previousQueryWasCancelled operation:^{
 			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
 																	[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
+		}];
 
+		if (didRunFieldQuery) {
 			// Check for errors, but only if the query wasn't cancelled
 			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
 				NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -688,6 +688,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 	BOOL hasForeignKey = NO;
 	NSString *referencedTable = @"";
+	NSString *foreignKeyName = nil;
 
 	// Check to see whether the user is attempting to remove a field that has foreign key constraints and thus
 	// would result in an error if not dropped before removing the field.
@@ -698,6 +699,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			if ([column isEqualToString:field]) {
 				hasForeignKey = YES;
 				referencedTable = [constraint objectForKey:@"ref_table"];
+				foreignKeyName = [constraint objectForKey:@"name"] ?: @"";
 				break;
 			}
 		}
@@ -714,7 +716,10 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		[self->tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Removing field...", @"removing field task status message")];
 
 		// Capture the AppKit selection before handing the operation to the background thread.
-		SAFieldRemovalTask *removalTask = [[SAFieldRemovalTask alloc] initWithField:field removesForeignKey:hasForeignKey];
+		SAFieldRemovalTask *removalTask = [[SAFieldRemovalTask alloc] initWithField:field
+																 foreignKeyName:foreignKeyName
+																		  table:self->selectedTable
+																	   database:[self->tableDocumentInstance database]];
 
 		if ([NSThread isMainThread]) {
 			[NSThread detachNewThreadWithName:SPCtxt(@"SPTableStructure field and key removal task", self->tableDocumentInstance)
@@ -1572,69 +1577,38 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 - (void)_removeFieldAndForeignKey:(SAFieldRemovalTask *)removalTask
 {
 	@autoreleasepool {
-		NSString *field = [removalTask field];
-		BOOL previousQueryWasCancelled = NO;
-		BOOL schemaMayHaveChanged = NO;
-
-		// Remove the foreign key before the field if required
-		if ([removalTask removesForeignKey]) {
-			NSString *relationName = @"";
-
-			// Get the foreign key name
-			for (NSDictionary *constraint in [self->tableDataInstance getConstraints])
-			{
-				for (NSString *column in [constraint safeObjectForKey:@"columns"])
-				{
-					if ([column isEqualToString:field]) {
-						relationName = [constraint safeObjectForKey:@"name"];
-						break;
-					}
-				}
+		SAFieldRemovalQueryResult (^queryResult)(void) = ^SAFieldRemovalQueryResult {
+			if ([self->mySQLConnection lastQueryWasCancelled]) {
+				return SAFieldRemovalQueryResultCancelled;
 			}
+			return [self->mySQLConnection queryErrored] ? SAFieldRemovalQueryResultFailed : SAFieldRemovalQueryResultSucceeded;
+		};
 
-			BOOL didRunForeignKeyQuery = [removalTask runQueryIfAllowedAfterPreviousCancellation:NO operation:^{
-				[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
-			}];
-
-			if (didRunForeignKeyQuery) {
-				previousQueryWasCancelled = [self->mySQLConnection lastQueryWasCancelled];
-				BOOL foreignKeyQueryErrored = [self->mySQLConnection queryErrored];
-
-				// Check for errors, but only if the query wasn't cancelled
-				if (foreignKeyQueryErrored && !previousQueryWasCancelled) {
-					NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-					[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
-					[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
-					[[self onMainThread] showErrorSheetWith:errorDictionary];
-				}
-				else if (!foreignKeyQueryErrored) {
-					schemaMayHaveChanged = YES;
-				}
-			}
-		}
-
-		BOOL didRunFieldQuery = [removalTask runQueryIfAllowedAfterPreviousCancellation:previousQueryWasCancelled operation:^{
+		[removalTask runWithForeignKeyQuery:^SAFieldRemovalQueryResult {
+			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@",
+																		   [[removalTask table] backtickQuotedString],
+																		   [[removalTask foreignKeyName] backtickQuotedString]]
+									 assertingDatabase:[removalTask database]];
+			return queryResult();
+		} fieldQuery:^SAFieldRemovalQueryResult {
 			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
-																	[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
-		}];
-
-		if (didRunFieldQuery) {
-			// Check for errors, but only if the query wasn't cancelled
-			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
-				NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
-				[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
-				[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
-																	  field,
-																	  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
-
-				[[self onMainThread] showErrorSheetWith:errorDictionary];
-			}
-			else {
-				schemaMayHaveChanged = YES;
-			}
-		}
-
-		if (schemaMayHaveChanged) {
+																	   [[removalTask table] backtickQuotedString],
+																	   [[removalTask field] backtickQuotedString]]
+									 assertingDatabase:[removalTask database]];
+			return queryResult();
+		} foreignKeyFailure:^{
+			NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
+			[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
+			[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), [removalTask foreignKeyName], [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
+			[[self onMainThread] showErrorSheetWith:errorDictionary];
+		} fieldFailure:^{
+			NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
+			[errorDictionary setObject:NSLocalizedString(@"Error", @"error") forKey:@"title"];
+			[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"Couldn't delete field %@.\nMySQL said: %@", @"message of panel when field cannot be deleted"),
+																  [removalTask field],
+																  [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
+			[[self onMainThread] showErrorSheetWith:errorDictionary];
+		} schemaRefresh:^{
 			[self->tableDataInstance resetAllData];
 
 			// Refresh relevant views
@@ -1642,15 +1616,13 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			[self->tableDocumentInstance setContentRequiresReload:YES];
 			[self->tableDocumentInstance setRelationsRequiresReload:YES];
 
-			[self loadTable:self->selectedTable];
-		}
-
-		SPMainQSync(^{
+			[self loadTable:[removalTask table]];
+		} completion:^{
 			[self->tableDocumentInstance endTask];
 
 			// Preserve focus on table for keyboard navigation
 			[[self->tableDocumentInstance parentWindowControllerWindow] makeFirstResponder:self->tableSourceView];
-		});
+		}];
 	}
 }
 

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1574,6 +1574,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	@autoreleasepool {
 		NSString *field = [removalTask field];
 		BOOL previousQueryWasCancelled = NO;
+		BOOL schemaMayHaveChanged = NO;
 
 		// Remove the foreign key before the field if required
 		if ([removalTask removesForeignKey]) {
@@ -1597,13 +1598,17 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 
 			if (didRunForeignKeyQuery) {
 				previousQueryWasCancelled = [self->mySQLConnection lastQueryWasCancelled];
+				BOOL foreignKeyQueryErrored = [self->mySQLConnection queryErrored];
 
 				// Check for errors, but only if the query wasn't cancelled
-				if ([self->mySQLConnection queryErrored] && !previousQueryWasCancelled) {
+				if (foreignKeyQueryErrored && !previousQueryWasCancelled) {
 					NSMutableDictionary *errorDictionary = [NSMutableDictionary dictionary];
 					[errorDictionary setObject:NSLocalizedString(@"Unable to delete relation", @"error deleting relation message") forKey:@"title"];
 					[errorDictionary setObject:[NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to delete the relation '%@'.\n\nMySQL said: %@", @"error deleting relation informative message"), relationName, [self->mySQLConnection lastErrorMessage]] forKey:@"message"];
 					[[self onMainThread] showErrorSheetWith:errorDictionary];
+				}
+				else if (!foreignKeyQueryErrored) {
+					schemaMayHaveChanged = YES;
 				}
 			}
 		}
@@ -1625,15 +1630,19 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 				[[self onMainThread] showErrorSheetWith:errorDictionary];
 			}
 			else {
-				[self->tableDataInstance resetAllData];
-
-				// Refresh relevant views
-				[self->tableDocumentInstance setStatusRequiresReload:YES];
-				[self->tableDocumentInstance setContentRequiresReload:YES];
-				[self->tableDocumentInstance setRelationsRequiresReload:YES];
-
-				[self loadTable:self->selectedTable];
+				schemaMayHaveChanged = YES;
 			}
+		}
+
+		if (schemaMayHaveChanged) {
+			[self->tableDataInstance resetAllData];
+
+			// Refresh relevant views
+			[self->tableDocumentInstance setStatusRequiresReload:YES];
+			[self->tableDocumentInstance setContentRequiresReload:YES];
+			[self->tableDocumentInstance setRelationsRequiresReload:YES];
+
+			[self loadTable:self->selectedTable];
 		}
 
 		SPMainQSync(^{

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -714,9 +714,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		[self->tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Removing field...", @"removing field task status message")];
 
 		// Capture the AppKit selection before handing the operation to the background thread.
+		NSProgress *cancellationToken = [NSProgress progressWithTotalUnitCount:1];
 		NSDictionary *removalDetails = @{
 			@"field": field,
-			@"removeForeignKey": [NSNumber numberWithBool:hasForeignKey]
+			@"removeForeignKey": [NSNumber numberWithBool:hasForeignKey],
+			@"cancellationToken": cancellationToken
 		};
 
 		if ([NSThread isMainThread]) {
@@ -726,8 +728,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 									   object:removalDetails];
 
 			[self->tableDocumentInstance enableTaskCancellationWithTitle:NSLocalizedString(@"Cancel", @"cancel button")
-													callbackObject:self
-												  callbackFunction:NULL];
+													callbackObject:cancellationToken
+												  callbackFunction:@selector(cancel)];
 		} else {
 			[self _removeFieldAndForeignKey:removalDetails];
 		}
@@ -1576,10 +1578,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 {
 	@autoreleasepool {
 		NSString *field = [removalDetails objectForKey:@"field"];
-		BOOL shouldRemoveField = YES;
+		NSProgress *cancellationToken = [removalDetails objectForKey:@"cancellationToken"];
+		BOOL shouldRemoveField = ![cancellationToken isCancelled];
 
 		// Remove the foreign key before the field if required
-		if ([[removalDetails objectForKey:@"removeForeignKey"] boolValue]) {
+		if ([[removalDetails objectForKey:@"removeForeignKey"] boolValue] && shouldRemoveField) {
 			NSString *relationName = @"";
 
 			// Get the foreign key name
@@ -1595,7 +1598,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 
 			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP FOREIGN KEY %@", [self->selectedTable backtickQuotedString], [relationName backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];
-			shouldRemoveField = ![self->mySQLConnection lastQueryWasCancelled];
+			shouldRemoveField = ![cancellationToken isCancelled] && ![self->mySQLConnection lastQueryWasCancelled];
 
 			// Check for errors, but only if the query wasn't cancelled
 			if ([self->mySQLConnection queryErrored] && ![self->mySQLConnection lastQueryWasCancelled]) {
@@ -1606,7 +1609,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			}
 		}
 
-		if (shouldRemoveField) {
+		if (shouldRemoveField && ![cancellationToken isCancelled]) {
 			// Remove field
 			[self->mySQLConnection queryString:[NSString stringWithFormat:@"ALTER TABLE %@ DROP %@",
 																	[self->selectedTable backtickQuotedString], [field backtickQuotedString]] assertingDatabase:[self->tableDocumentInstance database]];

--- a/UnitTests/GeneralSwiftTests.swift
+++ b/UnitTests/GeneralSwiftTests.swift
@@ -113,40 +113,4 @@ private final class GeneralSwiftTests: XCTestCase {
 
         print(newHistMutArray)
     }
-
-    func testFieldRemovalTaskCancellationBeforeQueryAdmission() {
-        let task = SAFieldRemovalTask(field: "obsolete", removesForeignKey: false)
-        var operationRan = false
-
-        task.cancel()
-        let queryWasAdmitted = task.runQueryIfAllowed(afterPreviousCancellation: false) {
-            operationRan = true
-        }
-
-        XCTAssertFalse(queryWasAdmitted)
-        XCTAssertFalse(operationRan)
-    }
-
-    func testFieldRemovalTaskKeepsAdmittedQueryObservableUntilItReturns() {
-        let task = SAFieldRemovalTask(field: "obsolete", removesForeignKey: true)
-        let operationStarted = expectation(description: "query operation started")
-        let operationFinished = expectation(description: "query operation finished")
-        let allowOperationToFinish = DispatchSemaphore(value: 0)
-
-        DispatchQueue.global(qos: .userInitiated).async {
-            _ = task.runQueryIfAllowed(afterPreviousCancellation: false) {
-                operationStarted.fulfill()
-                allowOperationToFinish.wait()
-            }
-            operationFinished.fulfill()
-        }
-
-        wait(for: [operationStarted], timeout: 2)
-        task.cancel()
-        XCTAssertTrue(task.cancellationRequiresQueryCancellation)
-
-        allowOperationToFinish.signal()
-        wait(for: [operationFinished], timeout: 2)
-        XCTAssertFalse(task.cancellationRequiresQueryCancellation)
-    }
 }

--- a/UnitTests/GeneralSwiftTests.swift
+++ b/UnitTests/GeneralSwiftTests.swift
@@ -113,4 +113,40 @@ private final class GeneralSwiftTests: XCTestCase {
 
         print(newHistMutArray)
     }
+
+    func testFieldRemovalTaskCancellationBeforeQueryAdmission() {
+        let task = SAFieldRemovalTask(field: "obsolete", removesForeignKey: false)
+        var operationRan = false
+
+        task.cancel()
+        let queryWasAdmitted = task.runQueryIfAllowed(afterPreviousCancellation: false) {
+            operationRan = true
+        }
+
+        XCTAssertFalse(queryWasAdmitted)
+        XCTAssertFalse(operationRan)
+    }
+
+    func testFieldRemovalTaskKeepsAdmittedQueryObservableUntilItReturns() {
+        let task = SAFieldRemovalTask(field: "obsolete", removesForeignKey: true)
+        let operationStarted = expectation(description: "query operation started")
+        let operationFinished = expectation(description: "query operation finished")
+        let allowOperationToFinish = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = task.runQueryIfAllowed(afterPreviousCancellation: false) {
+                operationStarted.fulfill()
+                allowOperationToFinish.wait()
+            }
+            operationFinished.fulfill()
+        }
+
+        wait(for: [operationStarted], timeout: 2)
+        task.cancel()
+        XCTAssertTrue(task.cancellationRequiresQueryCancellation)
+
+        allowOperationToFinish.signal()
+        wait(for: [operationFinished], timeout: 2)
+        XCTAssertFalse(task.cancellationRequiresQueryCancellation)
+    }
 }

--- a/UnitTests/SAForeignKeyReferenceRuleSupportTests.swift
+++ b/UnitTests/SAForeignKeyReferenceRuleSupportTests.swift
@@ -51,3 +51,216 @@ final class SAForeignKeyReferenceRuleSupportTests: XCTestCase {
         return Set(columns.compactMap { $0 as? String })
     }
 }
+
+final class SAFieldRemovalTaskTests: XCTestCase {
+    func testSuccessfulRemovalRunsBothQueriesThenRefreshes() {
+        let task = makeTask()
+        var events: [String] = []
+
+        task.run(
+            foreignKeyQuery: {
+                events.append("foreign key query")
+                return .succeeded
+            },
+            fieldQuery: {
+                events.append("field query")
+                return .succeeded
+            },
+            foreignKeyFailure: {
+                XCTFail("A successful foreign-key query must not report a failure")
+            },
+            fieldFailure: {
+                XCTFail("A successful field query must not report a failure")
+            },
+            schemaRefresh: {
+                events.append("schema refresh")
+            },
+            completion: {
+                events.append("completion")
+            }
+        )
+
+        XCTAssertEqual(events, [
+            "foreign key query",
+            "field query",
+            "schema refresh",
+            "completion"
+        ])
+    }
+
+    func testFailuresAdvanceInOrderWithoutRefreshing() {
+        let task = makeTask()
+        var events: [String] = []
+
+        task.run(
+            foreignKeyQuery: {
+                events.append("foreign key query")
+                return .failed
+            },
+            fieldQuery: {
+                events.append("field query")
+                return .failed
+            },
+            foreignKeyFailure: {
+                events.append("foreign key failure")
+            },
+            fieldFailure: {
+                events.append("field failure")
+            },
+            schemaRefresh: {
+                XCTFail("Failed queries must not refresh schema state")
+            },
+            completion: {
+                events.append("completion")
+            }
+        )
+
+        XCTAssertEqual(events, [
+            "foreign key query",
+            "foreign key failure",
+            "field query",
+            "field failure",
+            "completion"
+        ])
+    }
+
+    func testCancellationBeforeAdmissionSkipsQueries() {
+        let task = makeTask()
+        var didComplete = false
+
+        task.cancel()
+        task.run(
+            foreignKeyQuery: {
+                XCTFail("Cancellation must prevent foreign-key query admission")
+                return .failed
+            },
+            fieldQuery: {
+                XCTFail("Cancellation must prevent field query admission")
+                return .failed
+            },
+            foreignKeyFailure: {
+                XCTFail("A skipped foreign-key query must not report a failure")
+            },
+            fieldFailure: {
+                XCTFail("A skipped field query must not report a failure")
+            },
+            schemaRefresh: {
+                XCTFail("No schema refresh is needed when no query was admitted")
+            },
+            completion: {
+                didComplete = true
+            }
+        )
+
+        XCTAssertTrue(didComplete)
+    }
+
+    func testCancelledForeignKeyQuerySkipsFieldAndRefreshesPossibleChanges() {
+        let task = makeTask()
+        var events: [String] = []
+
+        task.run(
+            foreignKeyQuery: {
+                events.append("foreign key query")
+                return .cancelled
+            },
+            fieldQuery: {
+                XCTFail("A cancelled foreign-key query must prevent the field query")
+                return .failed
+            },
+            foreignKeyFailure: {
+                XCTFail("Cancellation must not be reported as a query failure")
+            },
+            fieldFailure: {
+                XCTFail("The skipped field query must not report a failure")
+            },
+            schemaRefresh: {
+                events.append("schema refresh")
+            },
+            completion: {
+                events.append("completion")
+            }
+        )
+
+        XCTAssertEqual(events, [
+            "foreign key query",
+            "schema refresh",
+            "completion"
+        ])
+    }
+
+    func testAdmittedQueryCancellationRunsOffMainAndCannotReachRefreshQuery() {
+        let task = makeTask(foreignKeyName: nil)
+        let queryStarted = expectation(description: "field query started")
+        let cancellationAttempted = expectation(description: "query cancellation attempted")
+        let taskCompleted = expectation(description: "field removal task completed")
+        let cancellationAfterRefresh = expectation(description: "no cancellation after schema refresh")
+        cancellationAfterRefresh.isInverted = true
+
+        let allowQueryToFinish = DispatchSemaphore(value: 0)
+        let stateLock = NSLock()
+        var refreshStarted = false
+        var cancellationWasReported = false
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            task.run(
+                foreignKeyQuery: {
+                    XCTFail("A task without a foreign key must skip that query")
+                    return .failed
+                },
+                fieldQuery: {
+                    queryStarted.fulfill()
+                    allowQueryToFinish.wait()
+                    return .cancelled
+                },
+                foreignKeyFailure: {
+                    XCTFail("A skipped foreign-key query must not report a failure")
+                },
+                fieldFailure: {
+                    XCTFail("Cancellation must not be reported as a field failure")
+                },
+                schemaRefresh: {
+                    stateLock.lock()
+                    refreshStarted = true
+                    stateLock.unlock()
+                },
+                completion: {
+                    XCTAssertTrue(Thread.isMainThread)
+                    taskCompleted.fulfill()
+                }
+            )
+        }
+
+        wait(for: [queryStarted], timeout: 2)
+        task.cancel()
+        task.requestQueryCancellation {
+            XCTAssertFalse(Thread.isMainThread)
+
+            stateLock.lock()
+            let didStartRefresh = refreshStarted
+            let shouldReportFirstAttempt = !cancellationWasReported
+            cancellationWasReported = true
+            stateLock.unlock()
+
+            if didStartRefresh {
+                cancellationAfterRefresh.fulfill()
+            }
+            if shouldReportFirstAttempt {
+                cancellationAttempted.fulfill()
+                allowQueryToFinish.signal()
+            }
+        }
+
+        wait(for: [cancellationAttempted, taskCompleted], timeout: 2)
+        wait(for: [cancellationAfterRefresh], timeout: 0.1)
+    }
+
+    private func makeTask(foreignKeyName: String? = "fk_child_parent") -> SAFieldRemovalTask {
+        SAFieldRemovalTask(
+            field: "parent_id",
+            foreignKeyName: foreignKeyName,
+            table: "child",
+            database: "test"
+        )
+    }
+}


### PR DESCRIPTION
## Changes:
- Keep field and dependent foreign-key removal queries on the existing worker thread instead of synchronously dispatching the full operation onto AppKit's main queue.
- Snapshot the selected field before detaching so the background task does not read from the table view.
- Keep immutable removal details and persistent cancellation gating in the `SAFieldRemovalTask` Swift type; the legacy controller supplies only its existing query and reload bridges.
- Run query-cancellation retries on a dedicated background queue with exponential backoff while serializing cancellation against query completion and schema refresh.
- Cover the shared Swift state machine with focused success, failure, pre-admission cancellation, foreign-key cancellation, and cancellation/reload race tests.
- Return to the main queue only for task completion and first-responder restoration, preserving existing error and reload behavior.

## Closes following issues:
- Closes: #2503

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

## Screenshots:
Not applicable; this changes task responsiveness without changing the UI.

## Additional notes:
The regression was caused by `_removeFieldAndForeignKey:` wrapping both `ALTER TABLE` calls in `SPMainQSync`. A long-running column drop therefore occupied the main queue even though the caller had detached a worker thread.

Validation:
- `Sequel Ace Debug` build passed.
- Full `Unit Tests` suite passed: 829 tests discovered, 769 passed, 60 expected skips, 0 failures.
- Xcode static analysis completed successfully with no finding on the changed path.
- Live MySQL 8.0.46 regression: held a metadata lock while the GUI issued `ALTER TABLE ... DROP removable_col`; the task timer continued updating, the app menu remained responsive, and Cancel terminated the waiting query while preserving the column.
- Live MySQL 8.0.46 foreign-key cancellation regression: blocked `DROP FOREIGN KEY` with a metadata lock, cancelled it in the GUI, and verified no subsequent `DROP COLUMN` began while both the column and constraint remained intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field deletion reliability by capturing the selected field and foreign-key presence on the main thread before running database updates.
  * Foreign keys are dropped (when applicable) before the field, with more consistent error dialogs if operations fail.
  * After the update, the table view refreshes and keyboard focus is restored so you can continue navigating without interruption.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->