### PR TITLE
#fixed Prevent large field editor close crashes

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -3252,10 +3252,10 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	// now would risk a dealloc while it is still our parent on the stack:
 	(void)(fieldEditor), fieldEditor = nil;
 
+	// This callback only runs for values routed through the field editor sheet.
+	// Re-entering inline editing here makes AppKit lay out the full value before
+	// it can be redirected back to the sheet, which can crash for large text.
 	[[tableContentView window] makeFirstResponder:tableContentView];
-
-	if(row > -1 && column > -1)
-		[tableContentView editColumn:column row:row withEvent:nil select:YES];
 }
 
 - (void)saveViewCellValue:(id)anObject forTableColumn:(NSTableColumn *)aTableColumn row:(NSUInteger)rowIndex


### PR DESCRIPTION
## Changes:
- Keep the table focused after the field editor sheet closes without immediately re-entering inline cell editing.
- Avoid forcing AppKit/TextKit to lay out the full large field value before the table delegate can route it back to the pop-up sheet.

## Closes following issues:
- Closes: #2394

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] Other: 26.5.2
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)
- `Unit Tests` scheme: 764 passed, 60 skipped, 0 failed
- MySQL 8.0.46: opened a 200,000-character `MEDIUMTEXT` value through the pop-up field editor in the patched build

## Screenshots:

N/A — crash-path fix with no visual changes.

## Additional notes:
- Symbolicating the issue's 5.2.1 crash addresses against the official release binary resolves the top app frame to `-[SPTableContent processFieldEditorResult:contextInfo:]` at the post-sheet `editColumn:row:withEvent:select:` call.
- That call was a keyboard-navigation convenience added in 2010; the custom-query field editor already restores table focus without reopening inline editing.
- Desktop automation could open the large-value sheet but could not reliably invoke this legacy sheet's OK/Cancel controls, so the end-to-end close action was not claimed as manually completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when editing large text values in table cells.
  - Prevented the editor from unexpectedly reopening inline after completing an edit.
  - Restored focus to the table view more reliably after editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->