### PR TITLE
Modernization: migrate deprecated keyed-archiver initializers (warnings plan step 4) #infra

### DIFF
--- a/.claude/modernization-followup-plan.md
+++ b/.claude/modernization-followup-plan.md
@@ -1,5 +1,10 @@
 # Sequel Ace Modernization — Follow-up Plan
 
+> Sibling tracks (July 2026): the WebView/deprecation work and the build-warning
+> burn-down live in `.claude/warnings-elimination-plan.md` (steps 0-4 done:
+> print flows on WKWebView, hygiene sweep, ivar-shadow renames, nullability
+> audit, keyed-archiver migration). Agent ground rules live in `AGENTS.md`.
+
 ## What's been done (decoupling branch)
 
 32 commits, 28 files changed, +2630/-959 lines. PR: Sequel-Ace/Sequel-Ace#2375

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,17 @@ Deployment target is macOS 12+.
   `WebView` island is `SPHelpViewerController` (migration planned).
 - **Persisted-format compatibility:** favorites plist, `.spf` documents, and
   NSUserDefaults blobs written by old versions must stay readable. When
-  touching serialization (e.g. migrating the remaining deprecated
-  `NSKeyedArchiver initForWritingWithMutableData:` sites), prove old data
-  still decodes.
-- Known remaining deprecation groups (each deserves its own PR):
-  `NSUserNotification` → UserNotifications.framework (4 files), and the
-  deprecated `NSKeyedArchiver`/`NSKeyedUnarchiver` initializers listed above.
+  touching serialization, prove old data still decodes with a fixture test —
+  see `UnitTests/SAKeyedArchiveCompatTests.swift` for the pattern (embedded
+  legacy blob + wire-format assertion protecting old readers).
+- **Keyed archiving:** use `archivedDataWithRootObject:requiringSecureCoding:`
+  / `unarchivedObjectOfClass(es):fromData:` for session-local data (drag
+  pasteboards etc.); the `.spf` session paths in SPDatabaseDocument
+  deliberately use non-secure keyed archiving under the `"data"` key — that is
+  the cross-version wire format, don't "upgrade" it without a migration plan.
+- Known remaining deprecation group (deserves its own PR):
+  `NSUserNotification` → UserNotifications.framework (4 files). The wider
+  warning burn-down is tracked in `.claude/warnings-elimination-plan.md`.
 
 ## Repo layout (abridged)
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3973,10 +3973,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         if (decryptdata != nil && [decryptdata length]) {
             NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:decryptdata error:nil];
             unarchiver.requiresSecureCoding = NO;
-            NSDictionary *decoded = (NSDictionary *)[unarchiver decodeObjectForKey:@"data"];
+            id decoded = [unarchiver decodeObjectForKey:@"data"];
             [unarchiver finishDecoding];
-            // Leave data nil on failure so the wrong-format/password alert below fires.
-            data = decoded ? [NSMutableDictionary dictionaryWithDictionary:decoded] : nil;
+            // Leave data nil on failure or a non-dictionary root so the
+            // wrong-format/password alert below fires.
+            data = [decoded isKindOfClass:[NSDictionary class]]
+                ? [NSMutableDictionary dictionaryWithDictionary:decoded]
+                : nil;
         }
         if (data == nil) {
             [NSAlert createWarningAlertWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Error while reading connection data file", @"error while reading connection data file")] message:NSLocalizedString(@"Wrong data format or password.", @"wrong data format or password") callback:nil];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -2785,25 +2785,25 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     if (![[spfDocData_temp objectForKey:@"encrypted"] boolValue]) {
 
-        // Convert the content selection to encoded data
+        // Convert the content selection to encoded data. The non-secure keyed
+        // format (object under the "data" key) is the spf wire format older
+        // versions read and write — keep it byte-compatible.
         if ([[spfData objectForKey:@"session"] objectForKey:@"contentSelection"]) {
             NSMutableDictionary *sessionInfo = [NSMutableDictionary dictionaryWithDictionary:[spfData objectForKey:@"session"]];
-            NSMutableData *dataToEncode = [[NSMutableData alloc] init];
-            NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:dataToEncode];
+            NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:NO];
             [archiver encodeObject:[sessionInfo objectForKey:@"contentSelection"] forKey:@"data"];
             [archiver finishEncoding];
-            [sessionInfo setObject:dataToEncode forKey:@"contentSelection"];
+            [sessionInfo setObject:[archiver encodedData] forKey:@"contentSelection"];
             [spfData setObject:sessionInfo forKey:@"session"];
         }
 
         [spfStructure setObject:spfData forKey:@"data"];
     }
     else {
-        NSMutableData *dataToEncrypt = [[NSMutableData alloc] init];
-        NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:dataToEncrypt];
+        NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:NO];
         [archiver encodeObject:spfData forKey:@"data"];
         [archiver finishEncoding];
-        [spfStructure setObject:[dataToEncrypt dataEncryptedWithPassword:[spfDocData_temp objectForKey:@"e_string"]] forKey:@"data"];
+        [spfStructure setObject:[[archiver encodedData] dataEncryptedWithPassword:[spfDocData_temp objectForKey:@"e_string"]] forKey:@"data"];
     }
 
     // Convert to plist
@@ -3950,12 +3950,20 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     if ([[spf objectForKey:@"data"] isKindOfClass:[NSDictionary class]])
         data = [NSMutableDictionary dictionaryWithDictionary:[spf objectForKey:@"data"]];
 
-    // If a content selection data key exists in the session, decode it
+    // If a content selection data key exists in the session, decode it.
+    // Existing spf files were written with non-secure keyed archiving, so the
+    // reader must keep accepting that format.
     if ([[[data objectForKey:@"session"] objectForKey:@"contentSelection"] isKindOfClass:[NSData class]]) {
         NSMutableDictionary *sessionInfo = [NSMutableDictionary dictionaryWithDictionary:[data objectForKey:@"session"]];
-        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:[sessionInfo objectForKey:@"contentSelection"]];
-        [sessionInfo setObject:[unarchiver decodeObjectForKey:@"data"] forKey:@"contentSelection"];
+        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:[sessionInfo objectForKey:@"contentSelection"] error:nil];
+        unarchiver.requiresSecureCoding = NO;
+        id contentSelection = [unarchiver decodeObjectForKey:@"data"];
         [unarchiver finishDecoding];
+        if (contentSelection) {
+            [sessionInfo setObject:contentSelection forKey:@"contentSelection"];
+        } else {
+            [sessionInfo removeObjectForKey:@"contentSelection"];
+        }
         [data setObject:sessionInfo forKey:@"session"];
     }
 
@@ -3963,9 +3971,12 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         NSData *decryptdata = nil;
         decryptdata = [[NSMutableData alloc] initWithData:[(NSData *)[spf objectForKey:@"data"] dataDecryptedWithPassword:encryptpw]];
         if (decryptdata != nil && [decryptdata length]) {
-            NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:decryptdata];
-            data = [NSMutableDictionary dictionaryWithDictionary:(NSDictionary *)[unarchiver decodeObjectForKey:@"data"]];
+            NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:decryptdata error:nil];
+            unarchiver.requiresSecureCoding = NO;
+            NSDictionary *decoded = (NSDictionary *)[unarchiver decodeObjectForKey:@"data"];
             [unarchiver finishDecoding];
+            // Leave data nil on failure so the wrong-format/password alert below fires.
+            data = decoded ? [NSMutableDictionary dictionaryWithDictionary:decoded] : nil;
         }
         if (data == nil) {
             [NSAlert createWarningAlertWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Error while reading connection data file", @"error while reading connection data file")] message:NSLocalizedString(@"Wrong data format or password.", @"wrong data format or password") callback:nil];

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -727,7 +727,9 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	if(row < 0) return NO; //why is that even a signed int when all "indexes" are unsigned!?
 	
 	NSPasteboard *pboard = [info draggingPasteboard];
-	NSArray *draggedItems = [NSKeyedUnarchiver unarchiveObjectWithData:[pboard dataForType:SPSSLCipherPboardTypeName]];
+	NSArray *draggedItems = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSString class], nil]
+	                                                             fromData:[pboard dataForType:SPSSLCipherPboardTypeName]
+	                                                                error:nil];
 	
 	NSUInteger nextInsert = row;
 	for (NSString *item in draggedItems) {
@@ -771,7 +773,7 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 		[items addObject:[sslCiphers objectAtIndex:idx]];
 	}];
 	
-	NSData *arch = [NSKeyedArchiver archivedDataWithRootObject:items];
+	NSData *arch = [NSKeyedArchiver archivedDataWithRootObject:items requiringSecureCoding:YES error:nil];
 	[pboard declareTypes:@[SPSSLCipherPboardTypeName] owner:self];
 	[pboard setData:arch forType:SPSSLCipherPboardTypeName];
 	return YES;

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.m
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.m
@@ -588,10 +588,7 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 
 	[pboard declareTypes:pboardTypes owner:nil];
 
-	NSMutableData *indexdata = [[NSMutableData alloc] init];
-	NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:indexdata];
-	[archiver encodeObject:rows forKey:@"indexdata"];
-	[archiver finishEncoding];
+	NSData *indexdata = [NSKeyedArchiver archivedDataWithRootObject:rows requiringSecureCoding:YES error:nil];
 	[pboard setData:indexdata forType:SPContentFilterPasteboardDragType];
 
 	return YES;
@@ -624,9 +621,10 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 
 	if(row < 1) return NO;
 
-	NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:[[info draggingPasteboard] dataForType:SPContentFilterPasteboardDragType]];
-	NSIndexSet *draggedIndexes = [[NSIndexSet alloc] initWithIndexSet:(NSIndexSet *)[unarchiver decodeObjectForKey:@"indexdata"]];
-	[unarchiver finishDecoding];
+	NSIndexSet *draggedIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSIndexSet class]
+	                                                               fromData:[[info draggingPasteboard] dataForType:SPContentFilterPasteboardDragType]
+	                                                                  error:nil];
+	if (!draggedIndexes) return NO;
 
 	// TODO: still rely on a NSArray but in the future rewrite it to use the NSIndexSet directly
 	NSMutableArray *draggedRows = [[NSMutableArray alloc] initWithCapacity:1];

--- a/Source/Controllers/SubviewControllers/SPNavigatorController.m
+++ b/Source/Controllers/SubviewControllers/SPNavigatorController.m
@@ -1093,10 +1093,7 @@ static NSComparisonResult compareStrings(NSString *s1, NSString *s2, void* conte
 	}
 
 	// Drag the array with schema paths
-	NSMutableData *arraydata = [[NSMutableData alloc] init];
-	NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:arraydata];
-	[archiver encodeObject:draggedItems forKey:@"itemdata"];
-	[archiver finishEncoding];
+	NSData *arraydata = [NSKeyedArchiver archivedDataWithRootObject:draggedItems requiringSecureCoding:YES error:nil];
 	[pboard setData:arraydata forType:SPNavigatorPasteboardDragType];
 
 	if([draggedItems count] == 1) {

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -667,10 +667,7 @@
 
 	[pboard declareTypes:pboardTypes owner:nil];
 
-	NSMutableData *indexdata = [[NSMutableData alloc] init];
-	NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:indexdata];
-	[archiver encodeObject:rows forKey:@"indexdata"];
-	[archiver finishEncoding];
+	NSData *indexdata = [NSKeyedArchiver archivedDataWithRootObject:rows requiringSecureCoding:YES error:nil];
 	[pboard setData:indexdata forType:SPFavoritesPasteboardDragType];
 
 	return YES;
@@ -704,9 +701,10 @@
 
 	if(row < 1) return NO;
 
-	NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:[[info draggingPasteboard] dataForType:SPFavoritesPasteboardDragType]];
-	NSIndexSet *draggedIndexes = [[NSIndexSet alloc] initWithIndexSet:(NSIndexSet *)[unarchiver decodeObjectForKey:@"indexdata"]];
-	[unarchiver finishDecoding];
+	NSIndexSet *draggedIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSIndexSet class]
+	                                                               fromData:[[info draggingPasteboard] dataForType:SPFavoritesPasteboardDragType]
+	                                                                  error:nil];
+	if (!draggedIndexes) return NO;
 
 	// TODO: still rely on a NSArray but in the future rewrite it to use the NSIndexSet directly
 	NSMutableArray *draggedRows = [[NSMutableArray alloc] initWithCapacity:1];

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -3635,9 +3635,9 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		NSUInteger characterIndex = [self characterIndexOfPoint:draggingLocation];
 		[self setSelectedRange:NSMakeRange(characterIndex,0)];
 
-		NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:[pboard dataForType:SPNavigatorPasteboardDragType]];
-		NSArray *draggedItems = [[NSArray alloc] initWithArray:(NSArray *)[unarchiver decodeObjectForKey:@"itemdata"]];
-		[unarchiver finishDecoding];
+		NSArray *draggedItems = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSString class], nil]
+		                                                             fromData:[pboard dataForType:SPNavigatorPasteboardDragType]
+		                                                                error:nil] ?: @[];
 
 		NSMutableString *dragString = [NSMutableString string];
 		NSMutableString *aPath = [NSMutableString string];

--- a/UnitTests/SAKeyedArchiveCompatTests.swift
+++ b/UnitTests/SAKeyedArchiveCompatTests.swift
@@ -1,0 +1,92 @@
+//
+//  SAKeyedArchiveCompatTests.swift
+//  Unit Tests
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import Foundation
+import XCTest
+
+/// Pins the spf session-data wire format across the migration from the
+/// deprecated `initForWritingWithMutableData:` / `initForReadingWithData:`
+/// pair to `initRequiringSecureCoding:` / `initForReadingFromData:error:`
+/// (see SPDatabaseDocument's session save/restore).
+///
+/// The format contract: a non-secure keyed archive with the payload encoded
+/// under the `"data"` key. Files written by old versions must decode with the
+/// new reader, and files written by the new code must remain readable by old
+/// versions (same keyed format, same key).
+final class SAKeyedArchiveCompatTests: XCTestCase {
+
+    /// Generated with the deprecated `NSKeyedArchiver(forWritingWith:)` +
+    /// `encode(_:forKey: "data")` — the exact pattern shipped in releases up
+    /// to and including 5.x. Payload mirrors a session contentSelection dict.
+    private let legacyArchiveBase64 = """
+        YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRkYXRhgAGvEBcLDB0eHyAhIiorLC0zNDU2PD9AQUJHSFUkbnVsbNMNDg8QFhxXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6UREhMUFYACgAOABIAFgAalFxgZGhuAB4ARgBKAE4AUgBBfEBBjb250ZW50U2VsZWN0aW9uWGRhdGFiYXNlXxAdd2luZG93VmVydGljYWxEaXZpZGVyUG9zaXRpb25VdGFibGVVdmlld3PTDQ4PIyYcoiQlgAiACaInKIAKgAuAEFR0eXBlVHJvd3NacHJpbWFyeWtledIODy4yoy8wMYAMgA2ADoAPEAEQBRAq0jc4OTpaJGNsYXNzbmFtZVgkY2xhc3Nlc1dOU0FycmF5ojk7WE5TT2JqZWN00jc4PT5cTlNEaWN0aW9uYXJ5oj07V3Rlc3RfZGIjQGrQAAAAAABZY3VzdG9tZXJz0g4PQzKiREWAFYAWgA9Zc3RydWN0dXJlV2NvbnRlbnQACAARABoAJAApADIANwBJAEwAUQBTAG0AcwB6AIIAjQCUAJoAnACeAKAAogCkAKoArACuALAAsgC0ALYAyQDSAPIA+AD+AQUBCAEKAQwBDwERARMBFQEaAR8BKgEvATMBNQE3ATkBOwE9AT8BQQFGAVEBWgFiAWUBbgFzAYABgwGLAZQBngGjAaYBqAGqAawBtgAAAAAAAAIBAAAAAAAAAEkAAAAAAAAAAAAAAAAAAAG+
+        """
+
+    private var legacyArchive: Data {
+        Data(base64Encoded: legacyArchiveBase64.replacingOccurrences(of: "\n", with: "").trimmingCharacters(in: .whitespaces))!
+    }
+
+    /// The reader pattern now used in SPDatabaseDocument.
+    private func decodeSessionData(_ data: Data) -> Any? {
+        guard let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: data) else { return nil }
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(forKey: "data")
+        unarchiver.finishDecoding()
+        return decoded
+    }
+
+    /// The writer pattern now used in SPDatabaseDocument.
+    private func encodeSessionData(_ payload: Any) -> Data {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: false)
+        archiver.encode(payload, forKey: "data")
+        archiver.finishEncoding()
+        return archiver.encodedData
+    }
+
+    func testLegacyArchiveDecodesWithNewReader() throws {
+        let decoded = try XCTUnwrap(decodeSessionData(legacyArchive) as? [String: Any])
+
+        XCTAssertEqual(decoded["database"] as? String, "test_db")
+        XCTAssertEqual(decoded["table"] as? String, "customers")
+        XCTAssertEqual(decoded["views"] as? [String], ["structure", "content"])
+        XCTAssertEqual(decoded["windowVerticalDividerPosition"] as? Double, 214.5)
+
+        let selection = try XCTUnwrap(decoded["contentSelection"] as? [String: Any])
+        XCTAssertEqual(selection["type"] as? String, "primarykey")
+        XCTAssertEqual(selection["rows"] as? [Int], [1, 5, 42])
+    }
+
+    func testNewWriterRoundTripsThroughNewReader() throws {
+        let payload: [String: Any] = [
+            "database": "roundtrip_db",
+            "contentSelection": ["rows": [7, 9]],
+        ]
+
+        let decoded = try XCTUnwrap(decodeSessionData(encodeSessionData(payload)) as? [String: Any])
+
+        XCTAssertEqual(decoded["database"] as? String, "roundtrip_db")
+        XCTAssertEqual((decoded["contentSelection"] as? [String: Any])?["rows"] as? [Int], [7, 9])
+    }
+
+    func testNewWriterKeepsLegacyWireFormat() throws {
+        // Old app versions read via initForReadingWithData: + decodeObjectForKey:@"data",
+        // which requires a standard NSKeyedArchiver plist with "data" in $top.
+        let plist = try XCTUnwrap(
+            try PropertyListSerialization.propertyList(from: encodeSessionData(["k": "v"]), format: nil) as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["$archiver"] as? String, "NSKeyedArchiver")
+        let top = try XCTUnwrap(plist["$top"] as? [String: Any])
+        XCTAssertNotNil(top["data"], "payload must live under the \"data\" key old readers expect")
+    }
+
+    func testGarbageDataFailsGracefully() {
+        XCTAssertNil(decodeSessionData(Data("definitely not an archive".utf8)))
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		51BC14F825BE135500F1CDC9 /* SPWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BC14F725BE135500F1CDC9 /* SPWindowController.swift */; };
 		51BC150125BE138700F1CDC9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51BC150025BE138700F1CDC9 /* SnapKit */; };
 		51BC150625BE13C400F1CDC9 /* NSViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */; };
+		51BE43D830174A8000AF389C /* SAKeyedArchiveCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */; };
 		51C32B2E2FF6F90C007C2DD3 /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
 		51C397A12FF7BB0100C4C14A /* SAPrintUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C397A22FF7BB0100C4C14A /* SAPrintUtilityTests.swift */; };
 		51C397A32FF7BB0100C4C14A /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
@@ -591,19 +592,19 @@
 		FA1B2C3D4E5F6A7B8C9D0E11 /* VaultClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E01 /* VaultClient.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E12 /* VaultClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E01 /* VaultClient.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E13 /* VaultClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E02 /* VaultClientTests.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1A /* SAVaultCredentialsPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1B /* SAVaultCredentialsPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1C /* SAVaultCredentialsPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E08 /* SAVaultCredentialsPathTests.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1D /* SAVaultRoleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1E /* SAVaultRoleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E20 /* SAVaultRoleListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0B /* SAVaultRoleListController.swift */; };
-		FA1B2C3D4E5F6A7B8C9D0E1F /* SAVaultRoleFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0A /* SAVaultRoleFilterTests.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E14 /* VaultOIDCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E03 /* VaultOIDCHandler.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E15 /* VaultAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E04 /* VaultAuthManager.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E16 /* VaultAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E04 /* VaultAuthManager.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E17 /* VaultAuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E05 /* VaultAuthManagerTests.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E18 /* VaultOIDCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E03 /* VaultOIDCHandler.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E19 /* VaultOIDCHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E06 /* VaultOIDCHandlerTests.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1A /* SAVaultCredentialsPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1B /* SAVaultCredentialsPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1C /* SAVaultCredentialsPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E08 /* SAVaultCredentialsPathTests.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1D /* SAVaultRoleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1E /* SAVaultRoleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E1F /* SAVaultRoleFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0A /* SAVaultRoleFilterTests.swift */; };
+		FA1B2C3D4E5F6A7B8C9D0E20 /* SAVaultRoleListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0B /* SAVaultRoleListController.swift */; };
 		FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */; };
 		FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */; };
 		FD18C8992C3C9B2F002A5D57 /* SAUuidFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */; };
@@ -1097,6 +1098,7 @@
 		51BB84042FDE000200C4C14A /* SAForeignKeyReferenceRuleSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAForeignKeyReferenceRuleSupportTests.swift; sourceTree = "<group>"; };
 		51BC14F725BE135500F1CDC9 /* SPWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowController.swift; sourceTree = "<group>"; };
 		51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtension.swift; sourceTree = "<group>"; };
+		51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAKeyedArchiveCompatTests.swift; sourceTree = "<group>"; };
 		51C04C98261E4CF5001F5554 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		51C04C9D261E4DB6001F5554 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAPrintUtility.swift; sourceTree = "<group>"; };
@@ -1437,15 +1439,15 @@
 		F4C0BDAE2E9F4D5E8A1B0201 /* SecureBookmarkManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBookmarkManagerStub.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E01 /* VaultClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClient.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E02 /* VaultClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClientTests.swift; sourceTree = "<group>"; };
-		FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultCredentialsPath.swift; sourceTree = "<group>"; };
-		FA1B2C3D4E5F6A7B8C9D0E08 /* SAVaultCredentialsPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultCredentialsPathTests.swift; sourceTree = "<group>"; };
-		FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleFilter.swift; sourceTree = "<group>"; };
-		FA1B2C3D4E5F6A7B8C9D0E0B /* SAVaultRoleListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleListController.swift; sourceTree = "<group>"; };
-		FA1B2C3D4E5F6A7B8C9D0E0A /* SAVaultRoleFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleFilterTests.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E03 /* VaultOIDCHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultOIDCHandler.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E04 /* VaultAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAuthManager.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E05 /* VaultAuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAuthManagerTests.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E06 /* VaultOIDCHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultOIDCHandlerTests.swift; sourceTree = "<group>"; };
+		FA1B2C3D4E5F6A7B8C9D0E07 /* SAVaultCredentialsPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultCredentialsPath.swift; sourceTree = "<group>"; };
+		FA1B2C3D4E5F6A7B8C9D0E08 /* SAVaultCredentialsPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultCredentialsPathTests.swift; sourceTree = "<group>"; };
+		FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleFilter.swift; sourceTree = "<group>"; };
+		FA1B2C3D4E5F6A7B8C9D0E0A /* SAVaultRoleFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleFilterTests.swift; sourceTree = "<group>"; };
+		FA1B2C3D4E5F6A7B8C9D0E0B /* SAVaultRoleListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAVaultRoleListController.swift; sourceTree = "<group>"; };
 		FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SATableHeaderView.swift; sourceTree = "<group>"; };
 		FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SQLiteDisplayFormatManager.swift; sourceTree = "<group>"; };
 		FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SAUuidFormatter.swift; sourceTree = "<group>"; };
@@ -2508,7 +2510,7 @@
 			path = MGTemplateEngine;
 			sourceTree = "<group>";
 		};
-		2A37F4AAFDCFA73011CA2CEA = {
+		2A37F4AAFDCFA73011CA2CEA /* sequel-pro */ = {
 			isa = PBXGroup;
 			children = (
 				518E02F227B91FBC007973E3 /* Entitlements */,
@@ -2626,6 +2628,7 @@
 				51EF3E6A2FDC251800EFFF09 /* SAConnectionFormModelTests.swift */,
 				51EA02522FDFF02C00DF6A7B /* SAArchivingTests.swift */,
 				51C397A22FF7BB0100C4C14A /* SAPrintUtilityTests.swift */,
+				51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -2994,7 +2997,7 @@
 				cs,
 				eo,
 			);
-			mainGroup = 2A37F4AAFDCFA73011CA2CEA;
+			mainGroup = 2A37F4AAFDCFA73011CA2CEA /* sequel-pro */;
 			packageReferences = (
 				51D9527425AE2B5300574BEB /* XCRemoteSwiftPackageReference "fmdb" */,
 				51BC14FF25BE138700F1CDC9 /* XCRemoteSwiftPackageReference "SnapKit" */,
@@ -3255,6 +3258,7 @@
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				C812F06F0D4A95968C1B0154 /* SABundleVersionUpdater.swift in Sources */,
+				51BE43D830174A8000AF389C /* SAKeyedArchiveCompatTests.swift in Sources */,
 				B6E4019A9F1C4A8AA0B3D102 /* SALocalNetworkPermissionChecker.swift in Sources */,
 				51C6288C24D196E8006491E9 /* StringExtension.swift in Sources */,
 				1A8B53A52584650700526DED /* SPURLAdditions.m in Sources */,


### PR DESCRIPTION
## Changes:
Step 4 of the warnings elimination plan — retires all 12 deprecated `NSKeyedArchiver`/`NSKeyedUnarchiver` initializer call sites across 6 files, split by data lifetime:

- **Drag-pasteboard round-trips** (same-process, session-local — internal format change is safe): query-favorites reorder, content-filters reorder, navigator→text-view schema-path drags, and SSL-cipher reordering now use `archivedDataWithRootObject:requiringSecureCoding:YES` + `unarchivedObjectOfClass(es):fromData:error:` (the #2447 pattern). Failed decodes now bail out (`return NO` / empty array) instead of proceeding with nil.
- **`.spf` session persistence** (`SPDatabaseDocument`) — the wire format is load-bearing across app versions, so the non-secure keyed archive under the `"data"` key is preserved byte-compatibly; only the deprecated initializers were swapped (`initRequiringSecureCoding:NO` / `initForReadingFromData:error:` + `requiresSecureCoding = NO`). Two robustness improvements: a failed `contentSelection` decode now drops the key instead of throwing on `setObject:nil`, and a failed encrypted-payload decode now leaves `data` nil so the existing "Wrong data format or password" alert actually fires (previously `dictionaryWithDictionary:nil` produced an empty dict that slipped past the check).
- **New `SAKeyedArchiveCompatTests`** pins the `.spf` contract with four tests: a fixture generated by the *deprecated* writer decodes through the new reader; the new writer round-trips; the new writer's output keeps the `$archiver`/`$top["data"]` plist shape old readers require; garbage data fails gracefully.
- **Docs synced for other agents**: AGENTS.md now documents the two archiving regimes (secure for session-local data; the `.spf` format is deliberate — don't "upgrade" it) and points at the fixture-test pattern; `.claude/warnings-elimination-plan.md` step 4 marked done; the modernization roadmap cross-references the warnings plan.

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Localizations:
  - [x] English
- Xcode Version: 26.5

## Screenshots:
N/A

## Additional notes:
- 0 deprecated archiver warnings remain (was 12 sites)
- Full unit suite: 828 tests, 0 failures
- Manual sanity worth doing at some point: drag-reorder query favorites / content filters / SSL ciphers, drag a schema path from the navigator into the query editor, and save+reopen a session `.spf` (plain and encrypted)
- Warning-plan progress: 413 baseline → ~240 after steps 0–4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when saving and opening session files, including older saved data.
  * Invalid or unreadable encrypted session data now triggers the correct error instead of being treated as empty.
  * Drag-and-drop now safely rejects malformed or unexpected payloads.

* **Security**
  * Strengthened drag-and-drop serialization to use secure coding and restrict decoded content to expected types.

* **Tests**
  * Added automated coverage for legacy session-file compatibility, secure/insecure round-trips, and failure on invalid archive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->