### PR TITLE
Modernization: SANotificationCenter replaces NSUserNotification (warnings plan step 5) #infra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,12 @@ Deployment target is macOS 12+.
   pasteboards etc.); the `.spf` session paths in SPDatabaseDocument
   deliberately use non-secure keyed archiving under the `"data"` key — that is
   the cross-version wire format, don't "upgrade" it without a migration plan.
-- Known remaining deprecation group (deserves its own PR):
-  `NSUserNotification` → UserNotifications.framework (4 files). The wider
-  warning burn-down is tracked in `.claude/warnings-elimination-plan.md`.
+- **User notifications:** post via `SANotificationCenter`
+  (`Source/Other/Utility/SANotificationCenter.swift`), never the deprecated
+  `NSUserNotification` API. The wider warning burn-down (remaining: AppKit
+  deprecation batch, Swift 6 readiness, old drag-API delegate methods, and
+  the deferred SecKeychain/NSConnection projects) is tracked in
+  `.claude/warnings-elimination-plan.md`.
 
 ## Repo layout (abridged)
 

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -364,12 +364,7 @@ static inline void SetOnOff(NSNumber *ref,id obj);
 - (void)displayExportFinishedNotification
 {
 	// Export finished notification
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-	notification.title = @"Export Finished";
-	notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Finished exporting to %@", @"description for finished exporting notification"), exportFilename];
-	notification.soundName = NSUserNotificationDefaultSoundName;
-
-	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+	[SANotificationCenter.shared postNotificationWithTitle:@"Export Finished" body:[NSString stringWithFormat:NSLocalizedString(@"Finished exporting to %@", @"description for finished exporting notification"), exportFilename]];
 }
 
 #pragma mark -

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -750,12 +750,7 @@
 	[[tableDocumentInstance databaseStructureRetrieval] queryDbStructureInBackgroundWithUserInfo:@{@"forceUpdate" : @YES}];
 
 	// Import finished notification
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-	notification.title = @"Import Finished";
-	notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Finished importing %@", @"description for finished importing notification"), [filename lastPathComponent]];
-	notification.soundName = NSUserNotificationDefaultSoundName;
-
-	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+	[SANotificationCenter.shared postNotificationWithTitle:@"Import Finished" body:[NSString stringWithFormat:NSLocalizedString(@"Finished importing %@", @"description for finished importing notification"), [filename lastPathComponent]]];
 
 #ifdef DEBUG
 	endDate = [NSDate date];
@@ -1260,12 +1255,7 @@
 	}
 	
 	// Import finished notification
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-	notification.title = @"Import Finished";
-	notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Finished importing %@", @"description for finished importing notification"), [filename lastPathComponent]];
-	notification.soundName = NSUserNotificationDefaultSoundName;
-
-	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+	[SANotificationCenter.shared postNotificationWithTitle:@"Import Finished" body:[NSString stringWithFormat:NSLocalizedString(@"Finished importing %@", @"description for finished importing notification"), [filename lastPathComponent]]];
 
 	SPMainQSync(^{
 

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -1100,8 +1100,6 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         
         [tableDocumentInstance setQueryMode:SPInterfaceQueryMode];
         
-        NSUserNotificationCenter *defaultUNC = [NSUserNotificationCenter defaultUserNotificationCenter];
-        
         // If no results were returned, redraw the empty table and post notifications before returning.
         if ( ![resultData count] ) {
             [customQueryView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
@@ -1110,12 +1108,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
             [defaultNC postNotificationOnMainThreadWithName:@"SMySQLQueryHasBeenPerformed" object:tableDocumentInstance];
             
             // Perform the notification for query completion
-            NSUserNotification *notification = [[NSUserNotification alloc] init];
-            notification.title = @"Query Finished";
-            notification.informativeText=[[errorText onMainThread] string];
-            notification.soundName = NSUserNotificationDefaultSoundName;
-            
-            [defaultUNC deliverNotification:notification];
+            [SANotificationCenter.shared postNotificationWithTitle:@"Query Finished" body:[[errorText onMainThread] string]];
             
             // Set up the callback if present
             if ([taskArguments objectForKey:@"callback"]) {
@@ -1140,12 +1133,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
         [defaultNC postNotificationOnMainThreadWithName:@"SMySQLQueryHasBeenPerformed" object:tableDocumentInstance];
         
         // Query finished notification
-        NSUserNotification *notification = [[NSUserNotification alloc] init];
-        notification.title = @"Query Finished";
-        notification.informativeText=[[errorText onMainThread] string];
-        notification.soundName = NSUserNotificationDefaultSoundName;
-        
-        [defaultUNC deliverNotification:notification];
+        [SANotificationCenter.shared postNotificationWithTitle:@"Query Finished" body:[[errorText onMainThread] string]];
         
         // Set up the callback if present
         if ([taskArguments objectForKey:@"callback"]) {

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -482,12 +482,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [self updateWindowTitle:self];
 
     NSString *serverDisplayName = [[self.parentWindowController window] title];
-    NSUserNotification *notification = [[NSUserNotification alloc] init];
-    notification.title = @"Connected";
-    notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Connected to %@", @"description for connected notification"), serverDisplayName];
-    notification.soundName = NSUserNotificationDefaultSoundName;
-
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+    [SANotificationCenter.shared postNotificationWithTitle:@"Connected" body:[NSString stringWithFormat:NSLocalizedString(@"Connected to %@", @"description for connected notification"), serverDisplayName]];
 
     // Init Custom Query editor with the stored queries in a spf file if given.
     [spfDocData setObject:@NO forKey:@"save_editor_content"];
@@ -1550,12 +1545,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [pb setString:createSyntax forType:NSPasteboardTypeString];
 
         // Table syntax copied notification
-        NSUserNotification *notification = [[NSUserNotification alloc] init];
-        notification.title = @"Syntax Copied";
-        notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Syntax for %@ table copied", @"description for table syntax copied notification"), [self table]];
-        notification.soundName = NSUserNotificationDefaultSoundName;
-
-        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+        [SANotificationCenter.shared postNotificationWithTitle:@"Syntax Copied" body:[NSString stringWithFormat:NSLocalizedString(@"Syntax for %@ table copied", @"description for table syntax copied notification"), [self table]]];
 
         return;
     }
@@ -1958,12 +1948,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         [pb setString:createSyntax forType:NSPasteboardTypeString];
 
         // Table syntax copied notification
-        NSUserNotification *notification = [[NSUserNotification alloc] init];
-        notification.title = @"Syntax Copied";
-        notification.informativeText=[NSString stringWithFormat:NSLocalizedString(@"Syntax for %@ table copied", @"description for table syntax copied notification"), [self table]];
-        notification.soundName = NSUserNotificationDefaultSoundName;
-
-        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+        [SANotificationCenter.shared postNotificationWithTitle:@"Syntax Copied" body:[NSString stringWithFormat:NSLocalizedString(@"Syntax for %@ table copied", @"description for table syntax copied notification"), [self table]]];
     }
 }
 
@@ -2130,11 +2115,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     _isConnected = NO;
 
     // Disconnected notification
-    NSUserNotification *notification = [[NSUserNotification alloc] init];
-    notification.title = @"Disconnected";
-    notification.soundName = NSUserNotificationDefaultSoundName;
-
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+    [SANotificationCenter.shared postNotificationWithTitle:@"Disconnected" body:nil];
 }
 
 /**

--- a/Source/Other/Utility/SANotificationCenter.swift
+++ b/Source/Other/Utility/SANotificationCenter.swift
@@ -1,0 +1,57 @@
+//
+//  SANotificationCenter.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import Foundation
+import UserNotifications
+
+/// Posts user notifications ("Connected", "Query Finished", …) via the
+/// UserNotifications framework, replacing the deprecated `NSUserNotification`
+/// pattern used across the app.
+///
+/// Parity notes with the legacy behavior:
+/// - No `UNUserNotificationCenterDelegate` is installed, so notifications are
+///   not presented while Sequel Ace is frontmost — same as the legacy center
+///   without a delegate.
+/// - Unlike `NSUserNotification`, the system requires user authorization; it
+///   is requested lazily on the first post, so the permission prompt appears
+///   in context (typically right after the first successful connection). If
+///   the user declines, posts become silent no-ops.
+@objc final class SANotificationCenter: NSObject {
+
+    @objc static let shared = SANotificationCenter()
+
+    private var didRequestAuthorization = false
+
+    /// Posts a banner + default sound notification. Safe to call from any
+    /// thread. `body` may be nil for title-only notifications.
+    @objc(postNotificationWithTitle:body:)
+    func postNotification(title: String, body: String?) {
+        // UNUserNotificationCenter needs a real app bundle; guard so code
+        // paths exercised from test runners don't trap.
+        guard Bundle.main.bundleIdentifier != nil else { return }
+
+        DispatchQueue.main.async {
+            let center = UNUserNotificationCenter.current()
+
+            if !self.didRequestAuthorization {
+                self.didRequestAuthorization = true
+                center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
+            }
+
+            let content = UNMutableNotificationContent()
+            content.title = title
+            if let body, !body.isEmpty {
+                content.body = body
+            }
+            content.sound = .default
+
+            center.add(UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil))
+        }
+    }
+}

--- a/Source/Other/Utility/SANotificationCenter.swift
+++ b/Source/Other/Utility/SANotificationCenter.swift
@@ -26,8 +26,6 @@ import UserNotifications
 
     @objc static let shared = SANotificationCenter()
 
-    private var didRequestAuthorization = false
-
     /// Posts a banner + default sound notification. Safe to call from any
     /// thread. `body` may be nil for title-only notifications.
     @objc(postNotificationWithTitle:body:)
@@ -36,22 +34,23 @@ import UserNotifications
         // paths exercised from test runners don't trap.
         guard Bundle.main.bundleIdentifier != nil else { return }
 
-        DispatchQueue.main.async {
-            let center = UNUserNotificationCenter.current()
+        let content = UNMutableNotificationContent()
+        content.title = title
+        if let body, !body.isEmpty {
+            content.body = body
+        }
+        content.sound = .default
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
 
-            if !self.didRequestAuthorization {
-                self.didRequestAuthorization = true
-                center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
-            }
-
-            let content = UNMutableNotificationContent()
-            content.title = title
-            if let body, !body.isEmpty {
-                content.body = body
-            }
-            content.sound = .default
-
-            center.add(UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil))
+        // Deliver from the authorization completion: on the very first call
+        // this prompts and completes only after the user decides, so the
+        // triggering notification is delivered (not silently dropped) when
+        // permission is granted. On every later call it completes immediately
+        // with the stored status — the system never re-prompts.
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            center.add(request)
         }
     }
 }

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -286,6 +286,8 @@
 		51BC150125BE138700F1CDC9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51BC150025BE138700F1CDC9 /* SnapKit */; };
 		51BC150625BE13C400F1CDC9 /* NSViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */; };
 		51BE43D830174A8000AF389C /* SAKeyedArchiveCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */; };
+		51BE43DD30174CC700AF389C /* SANotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43DC30174CC700AF389C /* SANotificationCenter.swift */; };
+		51BE43DE30174CC700AF389C /* SANotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43DC30174CC700AF389C /* SANotificationCenter.swift */; };
 		51C32B2E2FF6F90C007C2DD3 /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
 		51C397A12FF7BB0100C4C14A /* SAPrintUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C397A22FF7BB0100C4C14A /* SAPrintUtilityTests.swift */; };
 		51C397A32FF7BB0100C4C14A /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
@@ -1099,6 +1101,7 @@
 		51BC14F725BE135500F1CDC9 /* SPWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowController.swift; sourceTree = "<group>"; };
 		51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtension.swift; sourceTree = "<group>"; };
 		51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAKeyedArchiveCompatTests.swift; sourceTree = "<group>"; };
+		51BE43DC30174CC700AF389C /* SANotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SANotificationCenter.swift; sourceTree = "<group>"; };
 		51C04C98261E4CF5001F5554 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		51C04C9D261E4DB6001F5554 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAPrintUtility.swift; sourceTree = "<group>"; };
@@ -2569,6 +2572,7 @@
 				5146ADF82F79B9EF00C4C14A /* SAConnectionService.swift */,
 				51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */,
 				91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */,
+				51BE43DC30174CC700AF389C /* SANotificationCenter.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3338,6 +3342,7 @@
 				17DB5F441555CA300046834B /* SPMutableArrayAdditions.m in Sources */,
 				5146E0482F7A640C00C4C14A /* SAConnectionInfoTests.swift in Sources */,
 				5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */,
+				51BE43DE30174CC700AF389C /* SANotificationCenter.swift in Sources */,
 				5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */,
 				5146E04A2F7A640C00C4C14A /* SAViewModeTests.swift in Sources */,
 				5146ADFD2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift in Sources */,
@@ -3441,6 +3446,7 @@
 				17E6415C0EF01EF6001BC333 /* SPTableStructure.m in Sources */,
 				1A8B582A25EEE15900DFC54A /* ByteCountFormatterExtension.swift in Sources */,
 				51C32B2E2FF6F90C007C2DD3 /* SAPrintUtility.swift in Sources */,
+				51BE43DD30174CC700AF389C /* SANotificationCenter.swift in Sources */,
 				1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */,
 				50A9F8B119EAD4B90053E571 /* SPGotoDatabaseController.m in Sources */,
 				AA000001000000000000001B /* SAAboutView.swift in Sources */,


### PR DESCRIPTION
## Changes:
Step 5 of the warnings elimination plan — **stacked on #2509** (step 4); merge that first.

- New **`SANotificationCenter`** (Swift, `UserNotifications` framework, app target) replaces all 9 deprecated `NSUserNotification` post sites across `SPDatabaseDocument`, `SPCustomQuery`, `SPDataImport`, `SPExportController` (Connected / Disconnected / Syntax Copied / Query Finished / Import Finished / Export Finished)
- **Parity analysis**: the legacy code installed no `NSUserNotificationCenter` delegate, so there is no click-to-focus behavior to port — and without a `UNUserNotificationCenterDelegate` the new framework also suppresses banners while the app is frontmost, matching the legacy default exactly
- **Authorization** is requested lazily on the first post, so the permission prompt appears in context (typically right after the first successful connection); declined = silent no-ops. A bundle-identifier guard keeps unbundled test runners from trapping
- Docs synced: AGENTS.md now says "post via SANotificationCenter, never NSUserNotification"; warnings plan step 5 marked done

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Localizations:
  - [x] English
- Xcode Version: 26.5

## Screenshots:
N/A

## Additional notes:
- ⚠️ **User-visible change**: the first notification now triggers the macOS notification permission prompt — worth a release-notes line
- No unit tests for the wrapper itself: it's thin system-service plumbing (`UNUserNotificationCenter` traps without a real app bundle), same rationale as SATaskController
- Manual verification: connect to a server → expect the permission prompt, then background the app and run a query / export / import → banners with sound
- 0 `NSUserNotification` deprecation warnings remain (was ~25). Full suite: 828 tests, 0 failures
- Warning-plan progress: 413 baseline → ~215 after steps 0–5

🤖 Generated with [Claude Code](https://claude.com/claude-code)