### PR TITLE
Modernization: AppKit deprecation batch 3 (warnings plan step 7) #infra

### DIFF
--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -2665,7 +2665,7 @@ set_input:
 {
 	if (IS_TOKEN(representedObject)) return NSDefaultTokenStyle;
 
-	return NSPlainTextTokenStyle;
+	return NSTokenStyleNone;
 }
 
 - (BOOL)tokenField:(NSTokenField *)tokenField writeRepresentedObjects:(NSArray *)objects toPasteboard:(NSPasteboard *)pboard

--- a/Source/Controllers/DataImport/SPFieldMapperController.m
+++ b/Source/Controllers/DataImport/SPFieldMapperController.m
@@ -130,8 +130,7 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 	// Ask HansJB for more info.
 	NSPathControl *pc = [[NSPathControl alloc] initWithFrame:NSZeroRect];
 	[pc setURL:[NSURL fileURLWithPath:sourcePath]];
-	if([pc pathComponentCells])
-		[fileSourcePath setPathComponentCells:[pc pathComponentCells]];
+	[fileSourcePath setPathItems:[pc pathItems]];
 	[fileSourcePath setDoubleAction:@selector(goBackToFileChooserFromPathControl:)];
 
 	[onupdateTextView setDelegate:theDelegate];

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3303,10 +3303,8 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
         SPMainToolbarTableRelations,
         SPMainToolbarTableTriggers,
         SPMainToolbarUserManager,
-        NSToolbarCustomizeToolbarItemIdentifier,
         NSToolbarFlexibleSpaceItemIdentifier,
-        NSToolbarSpaceItemIdentifier,
-        NSToolbarSeparatorItemIdentifier
+        NSToolbarSpaceItemIdentifier
     ];
 }
 

--- a/Source/Controllers/Other/GitHubReleaseManager.swift
+++ b/Source/Controllers/Other/GitHubReleaseManager.swift
@@ -80,7 +80,7 @@ import OSLog
             self.Log.debug("urlRequest: \(urlRequest)")
         }
         .validate() // check response code etc
-        .responseJSON { [self] response in
+        .responseData { [self] response in
             switch response.result {
             case .success:
                 Log.info("Validation Successful")
@@ -91,9 +91,7 @@ import OSLog
                         return
                     }
 
-                    let json = try JSONSerialization.jsonObject(with: responseData, options: JSONSerialization.ReadingOptions())
-                    let jsonData = try JSONSerialization.data(withJSONObject: json, options: .fragmentsAllowed)
-                    let gitHub = try GitHub(data: jsonData)
+                    let gitHub = try GitHub(data: responseData)
 
                     var releasesArray = gitHub.sorted(by: { (element0: GitHubElement, element1: GitHubElement) -> Bool in
                         element0 > element1

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -565,7 +565,7 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 			[check setTitle:NSLocalizedString(@"Enable Filter", @"table Content : rule filter editor : row : enable filter expression checkbox")];
 			[check setToolTip:NSLocalizedString(@"When unchecked this filter expression will not be applied", @"table Content : rule filter editor : row : enable filter expression checkbox : tooltip")];
 			// see +checkboxWithTitle:target:action: in 10.12+
-			[check setButtonType:NSSwitchButton];
+			[check setButtonType:NSButtonTypeSwitch];
 			[check setBezelStyle:NSBezelStyleRegularSquare];
 			[check setBordered:NO];
 			[check setImagePosition:NSImageOnly];

--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -269,12 +269,9 @@ static CGFloat slow_in_out (CGFloat t)
 	[self setHidesOnDeactivate:YES];
 	[self setIgnoresMouseEvents:YES];
 
-	WKPreferences *prefs = [WKPreferences new];
-	prefs.javaScriptEnabled = YES;
-	
 	/* Create a configuration for our preferences */
 	WKWebViewConfiguration *conf = [WKWebViewConfiguration new];
-	conf.preferences = prefs;
+	conf.defaultWebpagePreferences.allowsContentJavaScript = YES;
 	conf.applicationNameForUserAgent = @"SequelPro Tooltip";
 	
 	wkWebView = [[WKWebView alloc] initWithFrame:NSZeroRect configuration:conf];

--- a/Source/Other/Utility/SAImageRenderer.swift
+++ b/Source/Other/Utility/SAImageRenderer.swift
@@ -1,0 +1,48 @@
+//
+//  SAImageRenderer.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import AppKit
+
+/// Renders `NSImageRep`s into bitmap-backed PNG data.
+///
+/// Replaces the deprecated `lockFocus` + `initWithFocusedViewRect:` snapshot
+/// pattern: the rep is drawn into an explicit bitmap graphics context instead
+/// of a focused NSImage. Used for image drag conversions where the dragged
+/// representation (e.g. PICT) has no direct bitmap form.
+@objc final class SAImageRenderer: NSObject {
+
+    /// PNG data for `imageRep` rendered at its natural size, or nil when the
+    /// rep has no drawable size or fails to draw.
+    @objc(pngDataForImageRep:)
+    static func pngData(for imageRep: NSImageRep) -> Data? {
+        let size = imageRep.size
+        guard size.width >= 1, size.height >= 1 else { return nil }
+
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(ceil(size.width)),
+            pixelsHigh: Int(ceil(size.height)),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .calibratedRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let context = NSGraphicsContext(bitmapImageRep: bitmap) else { return nil }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        let drawn = imageRep.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard drawn else { return nil }
+        return bitmap.representation(using: .png, properties: [:])
+    }
+}

--- a/Source/ThirdParty/Views/YRKSpinningProgressIndicator.m
+++ b/Source/ThirdParty/Views/YRKSpinningProgressIndicator.m
@@ -90,7 +90,7 @@
 	else
 		rectMaxSize = size.width;
 
-	CGContextRef currentContext = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+	CGContextRef currentContext = [[NSGraphicsContext currentContext] CGContext];
 	[NSGraphicsContext saveGraphicsState];
 
 	if (_shadow) [_shadow set];
@@ -113,7 +113,7 @@
 		CGFloat lineStart = 0.234375f * rectMaxSize; // should be 7.5 for 32x32
 		CGFloat lineEnd = 0.421875f * rectMaxSize;  // should be 13.5 for 32x32
 		[path setLineWidth:lineWidth];
-		[path setLineCapStyle:NSRoundLineCapStyle];
+		[path setLineCapStyle:NSLineCapStyleRound];
 		[path moveToPoint:NSMakePoint(0,lineStart)];
 		[path lineToPoint:NSMakePoint(0,lineEnd)];
 
@@ -252,7 +252,7 @@
 
 - (void)setStyle:(NSProgressIndicatorStyle)style
 {
-    if (NSProgressIndicatorSpinningStyle != style) {
+    if (NSProgressIndicatorStyleSpinning != style) {
         NSAssert(NO, @"Non-spinning styles not available.");
     }
 }

--- a/Source/Views/Controls/SPColorSelectorView.m
+++ b/Source/Views/Controls/SPColorSelectorView.m
@@ -296,7 +296,7 @@ enum trackingAreaIDs
 				[NSColor colorWithCalibratedWhite:1.0 alpha:0.0], 0.6, nil];
 	circlePath = [NSBezierPath bezierPathWithOvalInRect:NSInsetRect(dotRect, 1.0, 1.0)];
 	[circlePath appendBezierPath:[NSBezierPath bezierPathWithOvalInRect:NSMakeRect(dotRect.origin.x+1.0, dotRect.origin.y-2.0, dotRect.size.width-2.0, dotRect.size.height)]];
-	[circlePath setWindingRule:NSEvenOddWindingRule];
+	[circlePath setWindingRule:NSWindingRuleEvenOdd];
 	[grad drawInBezierPath:circlePath angle:-90.0];
 	
 	// top center gloss
@@ -313,7 +313,7 @@ enum trackingAreaIDs
 	NSGradient *grad3 = [[NSGradient alloc] initWithStartingColor:[NSColor colorWithCalibratedWhite:0.0 alpha:0.12]
 											 endingColor:[NSColor colorWithCalibratedWhite:0.0 alpha:0.46]];
 	[circlePath appendBezierPath:[NSBezierPath bezierPathWithOvalInRect:NSInsetRect(dotRect, 1.0, 1.0)]];
-	[circlePath setWindingRule:NSEvenOddWindingRule];
+	[circlePath setWindingRule:NSWindingRuleEvenOdd];
 	[grad3 drawInBezierPath:circlePath angle:-90.0];
 }
 

--- a/Source/Views/Controls/SPComboPopupButton.m
+++ b/Source/Views/Controls/SPComboPopupButton.m
@@ -89,7 +89,7 @@
 {
 	NSRect boundsRect = [self bounds];
 	CGFloat boundingLinePosition = boundsRect.origin.x + boundsRect.size.width - lineOffset - 0.5;
-	CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+	CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
 	CGFloat heightIndent = ([self isFlipped] ? 4.f : -4.f);
 
 	// Allow the NSPopupButton to draw the majority of the button, with one exception:

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -31,6 +31,8 @@
 
 #import "SPImageView.h"
 
+#import "sequel-ace-Swift.h"
+
 @implementation SPImageView
 
 /**
@@ -88,26 +90,7 @@
 		NSData *pngData = nil;
 		NSPICTImageRep *draggedImage = [[NSPICTImageRep alloc] initWithData:[[sender draggingPasteboard] dataForType:@"NSPICTPboardType"]];
 		if (draggedImage) {
-			// Render the PICT into a bitmap-backed context; replaces the
-			// deprecated lockFocus + initWithFocusedViewRect: snapshot.
-			NSRect bounds = [draggedImage boundingBox];
-			NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
-			                                                                           pixelsWide:(NSInteger)ceil(bounds.size.width)
-			                                                                           pixelsHigh:(NSInteger)ceil(bounds.size.height)
-			                                                                        bitsPerSample:8
-			                                                                      samplesPerPixel:4
-			                                                                             hasAlpha:YES
-			                                                                             isPlanar:NO
-			                                                                       colorSpaceName:NSCalibratedRGBColorSpace
-			                                                                          bytesPerRow:0
-			                                                                         bitsPerPixel:0];
-			if (bitmapImageRep) {
-				[NSGraphicsContext saveGraphicsState];
-				[NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithBitmapImageRep:bitmapImageRep]];
-				[draggedImage drawInRect:NSMakeRect(0, 0, bounds.size.width, bounds.size.height)];
-				[NSGraphicsContext restoreGraphicsState];
-				pngData = [bitmapImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
-			}
+			pngData = [SAImageRenderer pngDataForImageRep:draggedImage];
 		}
 		if (pngData) {
 			[delegateForUse processUpdatedImageData:pngData];

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -75,7 +75,7 @@
 		NSData *pngData = nil;
 		NSBitmapImageRep *draggedImage = [[NSBitmapImageRep alloc] initWithData:[[sender draggingPasteboard] dataForType:@"NSTIFFPboardType"]];
 		if (draggedImage) {
-			pngData = [draggedImage representationUsingType:NSPNGFileType properties:@{}];
+			pngData = [draggedImage representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
 		}
 		if (pngData) {
 			[delegateForUse processUpdatedImageData:pngData];
@@ -88,14 +88,26 @@
 		NSData *pngData = nil;
 		NSPICTImageRep *draggedImage = [[NSPICTImageRep alloc] initWithData:[[sender draggingPasteboard] dataForType:@"NSPICTPboardType"]];
 		if (draggedImage) {
-			NSImage *convertImage = [[NSImage alloc] initWithSize:[draggedImage size]];
-			[convertImage lockFocus];
-			[draggedImage drawInRect:[draggedImage boundingBox]];
-			NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithFocusedViewRect:[draggedImage boundingBox]];
+			// Render the PICT into a bitmap-backed context; replaces the
+			// deprecated lockFocus + initWithFocusedViewRect: snapshot.
+			NSRect bounds = [draggedImage boundingBox];
+			NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
+			                                                                           pixelsWide:(NSInteger)ceil(bounds.size.width)
+			                                                                           pixelsHigh:(NSInteger)ceil(bounds.size.height)
+			                                                                        bitsPerSample:8
+			                                                                      samplesPerPixel:4
+			                                                                             hasAlpha:YES
+			                                                                             isPlanar:NO
+			                                                                       colorSpaceName:NSCalibratedRGBColorSpace
+			                                                                          bytesPerRow:0
+			                                                                         bitsPerPixel:0];
 			if (bitmapImageRep) {
-				pngData = [bitmapImageRep representationUsingType:NSPNGFileType properties:@{}];
+				[NSGraphicsContext saveGraphicsState];
+				[NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithBitmapImageRep:bitmapImageRep]];
+				[draggedImage drawInRect:NSMakeRect(0, 0, bounds.size.width, bounds.size.height)];
+				[NSGraphicsContext restoreGraphicsState];
+				pngData = [bitmapImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
 			}
-			[convertImage unlockFocus];
 		}
 		if (pngData) {
 			[delegateForUse processUpdatedImageData:pngData];

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -1207,7 +1207,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 	}
 
 	// This will scale the view to fit the page without centering it.
-	[[NSPrintInfo sharedPrintInfo] setHorizontalPagination:NSFitPagination];
+	[[NSPrintInfo sharedPrintInfo] setHorizontalPagination:NSPrintingPaginationModeFit];
 	[[NSPrintInfo sharedPrintInfo] setHorizontallyCentered:NO];
 	[[NSPrintInfo sharedPrintInfo] setVerticallyCentered:NO];
 
@@ -1306,8 +1306,8 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 	if (rtf)
 	{
-		[pb declareTypes:@[NSRTFPboardType] owner:self];
-		[pb setData:rtf forType:NSRTFPboardType];
+		[pb declareTypes:@[NSPasteboardTypeRTF] owner:self];
+		[pb setData:rtf forType:NSPasteboardTypeRTF];
 	}
 }
 

--- a/UnitTests/SAImageRendererTests.swift
+++ b/UnitTests/SAImageRendererTests.swift
@@ -1,0 +1,79 @@
+//
+//  SAImageRendererTests.swift
+//  Unit Tests
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import AppKit
+import XCTest
+
+/// Pins the bitmap-render path that replaced the deprecated
+/// `lockFocus` + `initWithFocusedViewRect:` snapshot in SPImageView's image
+/// drag conversion.
+///
+/// A note on fixtures: the drag path this serves converts PICT
+/// representations, but PICT *encoders* were removed from macOS long ago
+/// (QuickDraw), so a genuine PICT blob cannot be synthesized here. The tests
+/// exercise the identical rendering code through a bitmap-backed rep —
+/// `NSPICTImageRep` drawing itself is AppKit's responsibility either way.
+final class SAImageRendererTests: XCTestCase {
+
+    /// A solid-colour source rep drawn through the same context machinery.
+    private func makeSolidRep(width: Int, height: Int, color: NSColor) -> NSImageRep {
+        let source = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .calibratedRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        )!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: source)
+        color.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        return source
+    }
+
+    func testRendersRepToPNGWithMatchingSizeAndContent() throws {
+        let source = makeSolidRep(width: 24, height: 16, color: .red)
+
+        let pngData = try XCTUnwrap(SAImageRenderer.pngData(for: source))
+
+        // PNG magic bytes
+        XCTAssertEqual([UInt8](pngData.prefix(4)), [0x89, 0x50, 0x4E, 0x47])
+
+        let decoded = try XCTUnwrap(NSBitmapImageRep(data: pngData))
+        XCTAssertEqual(decoded.pixelsWide, 24)
+        XCTAssertEqual(decoded.pixelsHigh, 16)
+
+        let center = try XCTUnwrap(decoded.colorAt(x: 12, y: 8)?.usingColorSpace(.genericRGB))
+        XCTAssertEqual(center.redComponent, 1.0, accuracy: 0.05)
+        XCTAssertEqual(center.greenComponent, 0.0, accuracy: 0.05)
+        XCTAssertEqual(center.blueComponent, 0.0, accuracy: 0.05)
+        XCTAssertEqual(center.alphaComponent, 1.0, accuracy: 0.05)
+    }
+
+    func testNonIntegralSizeRoundsUp() throws {
+        let source = makeSolidRep(width: 10, height: 10, color: .blue)
+        source.size = NSSize(width: 10.4, height: 10.6)
+
+        let pngData = try XCTUnwrap(SAImageRenderer.pngData(for: source))
+        let decoded = try XCTUnwrap(NSBitmapImageRep(data: pngData))
+
+        XCTAssertEqual(decoded.pixelsWide, 11)
+        XCTAssertEqual(decoded.pixelsHigh, 11)
+    }
+
+    func testZeroSizedRepReturnsNil() {
+        XCTAssertNil(SAImageRenderer.pngData(for: NSImageRep()))
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -288,6 +288,9 @@
 		51BE43D830174A8000AF389C /* SAKeyedArchiveCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */; };
 		51BE43DD30174CC700AF389C /* SANotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43DC30174CC700AF389C /* SANotificationCenter.swift */; };
 		51BE43DE30174CC700AF389C /* SANotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE43DC30174CC700AF389C /* SANotificationCenter.swift */; };
+		51BE68DC3017550E00AF389C /* SAImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE68DB3017550E00AF389C /* SAImageRenderer.swift */; };
+		51BE68DD3017550E00AF389C /* SAImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE68DB3017550E00AF389C /* SAImageRenderer.swift */; };
+		51BE68E23017552B00AF389C /* SAImageRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE68E13017552B00AF389C /* SAImageRendererTests.swift */; };
 		51C32B2E2FF6F90C007C2DD3 /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
 		51C397A12FF7BB0100C4C14A /* SAPrintUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C397A22FF7BB0100C4C14A /* SAPrintUtilityTests.swift */; };
 		51C397A32FF7BB0100C4C14A /* SAPrintUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */; };
@@ -1102,6 +1105,8 @@
 		51BC150525BE13C400F1CDC9 /* NSViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtension.swift; sourceTree = "<group>"; };
 		51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAKeyedArchiveCompatTests.swift; sourceTree = "<group>"; };
 		51BE43DC30174CC700AF389C /* SANotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SANotificationCenter.swift; sourceTree = "<group>"; };
+		51BE68DB3017550E00AF389C /* SAImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAImageRenderer.swift; sourceTree = "<group>"; };
+		51BE68E13017552B00AF389C /* SAImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAImageRendererTests.swift; sourceTree = "<group>"; };
 		51C04C98261E4CF5001F5554 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		51C04C9D261E4DB6001F5554 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAPrintUtility.swift; sourceTree = "<group>"; };
@@ -2573,6 +2578,7 @@
 				51C32B2D2FF6F90C007C2DD3 /* SAPrintUtility.swift */,
 				91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */,
 				51BE43DC30174CC700AF389C /* SANotificationCenter.swift */,
+				51BE68DB3017550E00AF389C /* SAImageRenderer.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2633,6 +2639,7 @@
 				51EA02522FDFF02C00DF6A7B /* SAArchivingTests.swift */,
 				51C397A22FF7BB0100C4C14A /* SAPrintUtilityTests.swift */,
 				51BE43D730174A8000AF389C /* SAKeyedArchiveCompatTests.swift */,
+				51BE68E13017552B00AF389C /* SAImageRendererTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3261,6 +3268,7 @@
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
+				51BE68DD3017550E00AF389C /* SAImageRenderer.swift in Sources */,
 				C812F06F0D4A95968C1B0154 /* SABundleVersionUpdater.swift in Sources */,
 				51BE43D830174A8000AF389C /* SAKeyedArchiveCompatTests.swift in Sources */,
 				B6E4019A9F1C4A8AA0B3D102 /* SALocalNetworkPermissionChecker.swift in Sources */,
@@ -3349,6 +3357,7 @@
 				5146E0522F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
 				5146E0532F7A640C00C4C14A /* SADatabaseListManagerTests.swift in Sources */,
 				C3A2875D9BB7411F87F05EA2 /* SPCustomQuerySQLClassifier.swift in Sources */,
+				51BE68E23017552B00AF389C /* SAImageRendererTests.swift in Sources */,
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
@@ -3432,6 +3441,7 @@
 				C3A2875D9BB7411F87F05EA0 /* SPCustomQuery+Explain.swift in Sources */,
 				C3A2875D9BB7411F87F05EA1 /* SPCustomQuerySQLClassifier.swift in Sources */,
 				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
+				51BE68DC3017550E00AF389C /* SAImageRenderer.swift in Sources */,
 				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
 				CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */,
 				CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,


### PR DESCRIPTION
## Changes:
Step 7 of the warnings elimination plan — **stacked on #2510** (which stacks on #2509); merge those first. Same shape as the merged batches #2441/#2443.

20 deprecated sites across 10 files:
- **Mechanical renames**: `NSPNGFileType`→`NSBitmapImageFileTypePNG` (SPImageView), `NSEvenOddWindingRule`→`NSWindingRuleEvenOdd` (SPColorSelectorView ×2), `NSFitPagination`→`NSPrintingPaginationModeFit` + `NSRTFPboardType`→`NSPasteboardTypeRTF` (SPTextView), `NSRoundLineCapStyle`/`NSProgressIndicatorSpinningStyle`/`graphicsPort` (YRKSpinningProgressIndicator, vendored), `graphicsPort`→`CGContext` (SPComboPopupButton), `NSSwitchButton`→`NSButtonTypeSwitch` (SPRuleFilterController), `NSPlainTextTokenStyle`→`NSTokenStyleNone` (SPExportController), `pathComponentCells`→`pathItems` (SPFieldMapperController)
- **Deleted**: `NSToolbarCustomizeToolbarItemIdentifier` / `NSToolbarSeparatorItemIdentifier` from the allowed-toolbar-items array — ignored by AppKit since 10.7
- **Structural (3)**:
  - `SPTooltip`: `defaultWebpagePreferences.allowsContentJavaScript` replaces `WKPreferences.javaScriptEnabled`
  - `GitHubReleaseManager`: Alamofire `responseData` + direct `GitHub(data:)` Codable decode replaces `responseJSON` (removed in Alamofire 6); the old JSONSerialization parse→re-serialize roundtrip was a no-op and is gone
  - `SPImageView`: the PICT drag conversion renders into a bitmap-backed `NSGraphicsContext` instead of `lockFocus` + `initWithFocusedViewRect:` — which also retires a `lockFocus` use that deprecates at macOS 14

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Localizations:
  - [x] English
- Xcode Version: 26.5

## Screenshots:
N/A

## Additional notes:
- All 20 targeted deprecation warnings gone; full suite 828 tests, 0 failures
- Manual sanity (low risk): hover a tooltip, check-for-updates from the menu, drag an image into the field editor, toggle a rule-filter checkbox
- Warning-plan progress: 413 baseline → ~195 after steps 0–5 + 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)