### PR TITLE
Preserve SSH config port when field is empty #fixed

### DIFF
--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -94,8 +94,12 @@ struct SAConnectionInfo {
     /// OpenSSH can resolve the port from its configuration; invalid values fail.
     var sshPortOverride: Int? {
         let trimmedPort = sshPort.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedPort.isEmpty else { return 0 }
-        guard let port = Int(trimmedPort), (1...65535).contains(port) else { return nil }
+        guard !trimmedPort.isEmpty else {
+            return 0
+        }
+        guard let port = Int(trimmedPort), (1...65535).contains(port) else {
+            return nil
+        }
         return port
     }
 

--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -357,6 +357,11 @@ struct SAConnectionInfo {
         set { info.sshPort = newValue }
     }
 
+    /// The explicit command-line port override, or zero to defer to the SSH configuration.
+    var sshPortOverride: Int {
+        Int(info.sshPort) ?? 0
+    }
+
     @objc var sshRemoteSocketPath: String {
         get { info.sshRemoteSocketPath }
         set { info.sshRemoteSocketPath = newValue }

--- a/Source/Model/SAConnectionInfo.swift
+++ b/Source/Model/SAConnectionInfo.swift
@@ -89,6 +89,16 @@ struct SAConnectionInfo {
     var sshKeyLocationEnabled: Int = 0
     var sshKeyLocation: String = ""
     var sshPort: String = ""
+
+    /// The explicit command-line port override. A blank value returns zero so
+    /// OpenSSH can resolve the port from its configuration; invalid values fail.
+    var sshPortOverride: Int? {
+        let trimmedPort = sshPort.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPort.isEmpty else { return 0 }
+        guard let port = Int(trimmedPort), (1...65535).contains(port) else { return nil }
+        return port
+    }
+
     var sshRemoteSocketPath: String = ""
 
     // MARK: Keychain
@@ -355,11 +365,6 @@ struct SAConnectionInfo {
     @objc var sshPort: String {
         get { info.sshPort }
         set { info.sshPort = newValue }
-    }
-
-    /// The explicit command-line port override, or zero to defer to the SSH configuration.
-    var sshPortOverride: Int {
-        Int(info.sshPort) ?? 0
     }
 
     @objc var sshRemoteSocketPath: String {

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -455,7 +455,7 @@ import Foundation
         attemptID: UInt64,
         completion: @escaping (SPSSHTunnel?, String?) -> Void
     ) {
-        let sshPort = Int(info.sshPort) ?? 22
+        let sshPort = info.sshPortOverride
         let remoteSocketPath = info.sshRemoteSocketPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let useRemoteSocket = !remoteSocketPath.isEmpty
         let mysqlPort = useRemoteSocket ? 0 : (Int(info.port) ?? 3306)

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -455,7 +455,16 @@ import Foundation
         attemptID: UInt64,
         completion: @escaping (SPSSHTunnel?, String?) -> Void
     ) {
-        let sshPort = info.sshPortOverride
+        guard let sshPort = info.info.sshPortOverride else {
+            completion(
+                nil,
+                NSLocalizedString(
+                    "Enter an SSH port between 1 and 65535, or leave it blank to use the SSH configuration.",
+                    comment: "Invalid SSH port error"
+                )
+            )
+            return
+        }
         let remoteSocketPath = info.sshRemoteSocketPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let useRemoteSocket = !remoteSocketPath.isEmpty
         let mysqlPort = useRemoteSocket ? 0 : (Int(info.port) ?? 3306)

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -62,6 +62,20 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(info.sshPassword, "sshpass")
     }
 
+    func testEmptySSHPortDefersToSSHConfiguration() {
+        let info = SAConnectionInfoObjC()
+        info.sshPort = ""
+
+        XCTAssertEqual(info.sshPortOverride, 0)
+    }
+
+    func testExplicitSSHPortOverridesSSHConfiguration() {
+        let info = SAConnectionInfoObjC()
+        info.sshPort = "2222"
+
+        XCTAssertEqual(info.sshPortOverride, 2222)
+    }
+
     func testAWSIAMInfoSetup() {
         let info = SAConnectionInfoObjC()
         info.type = .awsIAM

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 // MARK: - Connection Info Parameter Mapping Tests
 
-/// Tests that SAConnectionInfoObjC correctly stores and retrieves all
-/// connection parameters that SAConnectionService will consume.
+/// Tests connection parameter storage and the pure Swift mappings that
+/// SAConnectionService consumes.
 final class SAConnectionInfoMappingTests: XCTestCase {
 
     func testTCPIPInfoSetup() {
@@ -62,18 +62,33 @@ final class SAConnectionInfoMappingTests: XCTestCase {
         XCTAssertEqual(info.sshPassword, "sshpass")
     }
 
-    func testEmptySSHPortDefersToSSHConfiguration() {
-        let info = SAConnectionInfoObjC()
-        info.sshPort = ""
+    func testBlankSSHPortDefersToSSHConfiguration() {
+        for sshPort in ["", " \n\t "] {
+            var info = SAConnectionInfo()
+            info.sshPort = sshPort
 
-        XCTAssertEqual(info.sshPortOverride, 0)
+            XCTAssertEqual(info.sshPortOverride, 0, "SSH port: \(sshPort.debugDescription)")
+        }
     }
 
-    func testExplicitSSHPortOverridesSSHConfiguration() {
-        let info = SAConnectionInfoObjC()
-        info.sshPort = "2222"
+    func testValidSSHPortOverridesSSHConfiguration() {
+        let ports = [("1", 1), ("2222", 2222), (" 2222 ", 2222), ("65535", 65535)]
 
-        XCTAssertEqual(info.sshPortOverride, 2222)
+        for (sshPort, expectedPort) in ports {
+            var info = SAConnectionInfo()
+            info.sshPort = sshPort
+
+            XCTAssertEqual(info.sshPortOverride, expectedPort, "SSH port: \(sshPort)")
+        }
+    }
+
+    func testInvalidSSHPortIsRejected() {
+        for sshPort in ["0", "-1", "65536", "not-a-port"] {
+            var info = SAConnectionInfo()
+            info.sshPort = sshPort
+
+            XCTAssertNil(info.sshPortOverride, "SSH port: \(sshPort)")
+        }
     }
 
     func testAWSIAMInfoSetup() {


### PR DESCRIPTION
## Changes:
- Preserve the SSH tunnel API's zero-port sentinel when the SSH Port field is empty, allowing OpenSSH to use the selected config file's Port directive.
- Accept explicit SSH ports from 1 through 65535 as command-line overrides, and reject malformed or out-of-range values before tunnel creation.
- Add pure Swift regression coverage for blank, valid, and invalid SSH port mappings.

## Closes following issues:
- Closes: #2513

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - 26.6 (17F113)
- Focused SAConnectionInfoMappingTests: 26 passed, 0 failed
- Full Unit Tests scheme: 790 passed, 60 skipped, 0 failed
- Sequel Ace Debug build: passed
- OpenSSH config-resolution check: config Port 2222 is retained without -p and overridden when -p 22 is supplied

## Screenshots:
- Not applicable; no visual changes.

## Additional notes:
- SPSSHTunnel already omits the -p argument when initialized with port 0. When neither the field nor SSH config sets a port, OpenSSH still defaults to port 22. This restores the sentinel used by the legacy connection path before the Swift service extraction.
- A live end-to-end SSH/MySQL connection was not run because no issue-specific remote test host was available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom SSH port for connections.
  * Port values are trimmed and validated against the allowed range of 1–65535.
  * Blank SSH port values defer to SSH configuration; invalid explicit values display a localized validation error.

* **Tests**
  * Added coverage for blank, whitespace-only, valid, and invalid SSH port values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

