### PR TITLE
#fixed Prevent table refresh from adding empty filter rows

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -158,6 +158,7 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
 	IBOutlet NSView *tableContentContainer;
 
 	BOOL showFilterRuleEditor;
+	BOOL ruleEditorVisibilityHasBeenApplied;
 
 	NSDictionary *filtersToRestore;
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -363,6 +363,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	[toggleRuleFilterButton setEnabled:NO];
 	[toggleRuleFilterButton setState:NSControlStateValueOff];
 	[ruleFilterController setColumns:nil];
+	// The next valid table needs an initial visibility application even when it
+	// has the same name as the table whose model was just cleared.
+	ruleEditorVisibilityHasBeenApplied = NO;
 
 	// Disable pagination
 	[paginationPreviousButton setEnabled:NO];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -167,6 +167,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		prefs = [NSUserDefaults standardUserDefaults];
 
 		showFilterRuleEditor = [prefs boolForKey:SPRuleFilterEditorLastVisibilityChoice];
+		ruleEditorVisibilityHasBeenApplied = NO;
 
 		usedQuery = @"";
 
@@ -1404,18 +1405,22 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 - (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate
 {
+	BOOL visibilityWasApplied = ruleEditorVisibilityHasBeenApplied;
 	BOOL wasVisible = showFilterRuleEditor;
 	BOOL editorIsEmpty = [ruleFilterController isEmpty];
-	BOOL shouldAddStarterRule = [SARuleFilterVisibilityPolicy shouldAddStarterRuleWithWasVisible:wasVisible
-	                                                                                 willBeVisible:show
-	                                                                                 editorIsEmpty:editorIsEmpty];
+	BOOL shouldAddStarterRule = [SARuleFilterVisibilityPolicy shouldAddStarterRuleWithVisibilityWasApplied:visibilityWasApplied
+	                                                                                              wasVisible:wasVisible
+	                                                                                           willBeVisible:show
+	                                                                                           editorIsEmpty:editorIsEmpty];
+	showFilterRuleEditor = show;
+	ruleEditorVisibilityHasBeenApplied = YES;
 
 	// we can't change the state of the button here, because the mouse click already changed it
-	if((showFilterRuleEditor = show)) {
+	if(showFilterRuleEditor) {
 		[ruleFilterController setEnabled:YES];
-		// Only an actual hidden-to-visible transition should seed the editor.
-		// Table refreshes reapply the already-visible state after rebuilding
-		// columns; treating that as a fresh open inserts a spurious empty row.
+		// The first application of a saved visible preference and an actual
+		// hidden-to-visible transition should seed the editor. Table refreshes
+		// only reapply the already-visible state and must remain idempotent.
 		if(shouldAddStarterRule) {
 			[[ruleFilterController onMainThread] addFilterExpression];
 			// the sizing will be updated automatically by adding a row

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -1404,11 +1404,19 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 - (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate
 {
+	BOOL wasVisible = showFilterRuleEditor;
+	BOOL editorIsEmpty = [ruleFilterController isEmpty];
+	BOOL shouldAddStarterRule = [SARuleFilterVisibilityPolicy shouldAddStarterRuleWithWasVisible:wasVisible
+	                                                                                 willBeVisible:show
+	                                                                                 editorIsEmpty:editorIsEmpty];
+
 	// we can't change the state of the button here, because the mouse click already changed it
 	if((showFilterRuleEditor = show)) {
 		[ruleFilterController setEnabled:YES];
-		// if it was the user who enabled the filter (indicated by the animation) add an empty row by default
-		if([ruleFilterController isEmpty]) {
+		// Only an actual hidden-to-visible transition should seed the editor.
+		// Table refreshes reapply the already-visible state after rebuilding
+		// columns; treating that as a fresh open inserts a spurious empty row.
+		if(shouldAddStarterRule) {
 			[[ruleFilterController onMainThread] addFilterExpression];
 			// the sizing will be updated automatically by adding a row
 		}

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -109,6 +109,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 - (void)filterRuleEditorPreferredSizeChanged:(NSNotification *)notification;
 - (void)contentViewSizeChanged:(NSNotification *)notification;
 - (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate;
+- (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate tableChanged:(BOOL)tableChanged;
 - (BOOL)_saveRowToTableWithQuery:(NSString*)queryString;
 - (void)_setViewBlankState;
 
@@ -405,6 +406,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	} else {
 		newTableName = [tableDetails objectForKey:@"name"];
 	}
+	BOOL tableChanged = ![selectedTable isEqualToString:newTableName];
 
 	// Ensure the pagination view hides itself if visible, after a tiny delay for smoothness
 	[self performSelector:@selector(setPaginationViewVisibility:) withObject:nil afterDelay:0.1];
@@ -414,7 +416,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 	// Check the supplied table name.  If it matches the old one, a reload is being performed;
 	// reload the data in-place to maintain table state if possible.
-	if ([selectedTable isEqualToString:newTableName]) {
+	if (!tableChanged) {
 		previousTableRowsCount = tableRowsCount;
 
 		// Store the column widths for later restoration
@@ -539,11 +541,11 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 	[ruleFilterController restoreSerializedFilters:filtersToRestore];
 	// hide/show the rule filter editor, based on its previous state (so that it stays visible when switching tables, if someone has enabled it and vice versa)
 	if (showFilterRuleEditor) {
-		[self setRuleEditorVisible:YES animate:YES];
+		[self setRuleEditorVisible:YES animate:YES tableChanged:tableChanged];
 		[toggleRuleFilterButton setState:NSControlStateValueOn];
 	}
 	else {
-		[self setRuleEditorVisible:NO animate:YES];
+		[self setRuleEditorVisible:NO animate:YES tableChanged:tableChanged];
 		[toggleRuleFilterButton setState:NSControlStateValueOff];
 	}
 	[ruleFilterController setEnabled:enableInteraction];
@@ -1405,12 +1407,18 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 - (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate
 {
+	[self setRuleEditorVisible:show animate:animate tableChanged:NO];
+}
+
+- (void)setRuleEditorVisible:(BOOL)show animate:(BOOL)animate tableChanged:(BOOL)tableChanged
+{
 	BOOL visibilityWasApplied = ruleEditorVisibilityHasBeenApplied;
 	BOOL wasVisible = showFilterRuleEditor;
 	BOOL editorIsEmpty = [ruleFilterController isEmpty];
 	BOOL shouldAddStarterRule = [SARuleFilterVisibilityPolicy shouldAddStarterRuleWithVisibilityWasApplied:visibilityWasApplied
 	                                                                                              wasVisible:wasVisible
 	                                                                                           willBeVisible:show
+	                                                                                             tableChanged:tableChanged
 	                                                                                           editorIsEmpty:editorIsEmpty];
 	showFilterRuleEditor = show;
 	ruleEditorVisibilityHasBeenApplied = YES;
@@ -1418,8 +1426,8 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	// we can't change the state of the button here, because the mouse click already changed it
 	if(showFilterRuleEditor) {
 		[ruleFilterController setEnabled:YES];
-		// The first application of a saved visible preference and an actual
-		// hidden-to-visible transition should seed the editor. Table refreshes
+		// First application, an actual hidden-to-visible transition, and a
+		// switch to another table should seed the editor. Same-table refreshes
 		// only reapply the already-visible state and must remain idempotent.
 		if(shouldAddStarterRule) {
 			[[ruleFilterController onMainThread] addFilterExpression];

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -38,9 +38,10 @@ import Cocoa
 /// is only reapplying an already-visible state during table reloads.
 @objc public final class SARuleFilterVisibilityPolicy: NSObject {
     /// A starter rule belongs to the first application of a saved visible
-    /// preference, an explicit hidden-to-visible transition, or a switch to
-    /// another table. Reapplying `visible` while rebuilding the current table
-    /// must be idempotent, even when the transiently rebuilt model is empty.
+    /// preference (including after a blank-state reset), an explicit
+    /// hidden-to-visible transition, or a switch to another table. Reapplying
+    /// `visible` while rebuilding the current table must be idempotent, even
+    /// when the transiently rebuilt model is empty.
     @objc(shouldAddStarterRuleWithVisibilityWasApplied:wasVisible:willBeVisible:tableChanged:editorIsEmpty:)
     public static func shouldAddStarterRule(
         visibilityWasApplied: Bool,

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -38,17 +38,18 @@ import Cocoa
 /// is only reapplying an already-visible state during table reloads.
 @objc public final class SARuleFilterVisibilityPolicy: NSObject {
     /// A starter rule belongs to the first application of a saved visible
-    /// preference or an explicit hidden-to-visible transition. Reapplying
-    /// `visible` while rebuilding the current table must be idempotent, even
-    /// when the transiently rebuilt rule model is empty.
-    @objc(shouldAddStarterRuleWithVisibilityWasApplied:wasVisible:willBeVisible:editorIsEmpty:)
+    /// preference, an explicit hidden-to-visible transition, or a switch to
+    /// another table. Reapplying `visible` while rebuilding the current table
+    /// must be idempotent, even when the transiently rebuilt model is empty.
+    @objc(shouldAddStarterRuleWithVisibilityWasApplied:wasVisible:willBeVisible:tableChanged:editorIsEmpty:)
     public static func shouldAddStarterRule(
         visibilityWasApplied: Bool,
         wasVisible: Bool,
         willBeVisible: Bool,
+        tableChanged: Bool,
         editorIsEmpty: Bool
     ) -> Bool {
-        return (!visibilityWasApplied || !wasVisible) && willBeVisible && editorIsEmpty
+        return (!visibilityWasApplied || !wasVisible || tableChanged) && willBeVisible && editorIsEmpty
     }
 }
 

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -36,16 +36,19 @@ import Cocoa
 
 /// Keeps the rule editor's visibility setter free of model mutations when it
 /// is only reapplying an already-visible state during table reloads.
-@objcMembers public final class SARuleFilterVisibilityPolicy: NSObject {
-    /// A starter rule belongs to an explicit hidden-to-visible transition.
-    /// Reapplying `visible` while rebuilding the current table must be
-    /// idempotent, even when the transiently rebuilt rule model is empty.
+@objc public final class SARuleFilterVisibilityPolicy: NSObject {
+    /// A starter rule belongs to the first application of a saved visible
+    /// preference or an explicit hidden-to-visible transition. Reapplying
+    /// `visible` while rebuilding the current table must be idempotent, even
+    /// when the transiently rebuilt rule model is empty.
+    @objc(shouldAddStarterRuleWithVisibilityWasApplied:wasVisible:willBeVisible:editorIsEmpty:)
     public static func shouldAddStarterRule(
+        visibilityWasApplied: Bool,
         wasVisible: Bool,
         willBeVisible: Bool,
         editorIsEmpty: Bool
     ) -> Bool {
-        return !wasVisible && willBeVisible && editorIsEmpty
+        return (!visibilityWasApplied || !wasVisible) && willBeVisible && editorIsEmpty
     }
 }
 

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -34,6 +34,21 @@ import Cocoa
     func addEmptyFilterRow()
 }
 
+/// Keeps the rule editor's visibility setter free of model mutations when it
+/// is only reapplying an already-visible state during table reloads.
+@objcMembers public final class SARuleFilterVisibilityPolicy: NSObject {
+    /// A starter rule belongs to an explicit hidden-to-visible transition.
+    /// Reapplying `visible` while rebuilding the current table must be
+    /// idempotent, even when the transiently rebuilt rule model is empty.
+    public static func shouldAddStarterRule(
+        wasVisible: Bool,
+        willBeVisible: Bool,
+        editorIsEmpty: Bool
+    ) -> Bool {
+        return !wasVisible && willBeVisible && editorIsEmpty
+    }
+}
+
 /// `NSRuleEditor` subclass that extends the content-tab filter with
 /// drag-and-drop support for the
 /// `SPCellValuePasteboard.pasteboardRowTypeRaw` payload. Dropping a

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -172,6 +172,18 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
     /// model and reapplies `visible`, but that must not create a new rule.
     func testReapplyingVisibleStateDoesNotAddStarterRule() {
         XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: true,
+            wasVisible: true,
+            willBeVisible: true,
+            editorIsEmpty: true
+        ))
+    }
+
+    /// The saved preference is desired state, not proof that visibility has
+    /// already been applied to a table after launch.
+    func testApplyingSavedVisiblePreferenceAddsStarterRule() {
+        XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: false,
             wasVisible: true,
             willBeVisible: true,
             editorIsEmpty: true
@@ -180,6 +192,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
 
     func testOpeningEmptyEditorAddsStarterRule() {
         XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: true,
             wasVisible: false,
             willBeVisible: true,
             editorIsEmpty: true
@@ -188,6 +201,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
 
     func testOpeningPopulatedEditorDoesNotAddStarterRule() {
         XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: true,
             wasVisible: false,
             willBeVisible: true,
             editorIsEmpty: false
@@ -196,6 +210,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
 
     func testHidingEditorDoesNotAddStarterRule() {
         XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: true,
             wasVisible: true,
             willBeVisible: false,
             editorIsEmpty: true

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -165,3 +165,40 @@ final class SACellFilterMergeTests: XCTestCase {
         return (filter["children"] as? [[String: Any]])?.map { $0 as NSDictionary }
     }
 }
+
+final class SARuleFilterVisibilityPolicyTests: XCTestCase {
+
+    /// Regression coverage for #2516: refreshing a table rebuilds the filter
+    /// model and reapplies `visible`, but that must not create a new rule.
+    func testReapplyingVisibleStateDoesNotAddStarterRule() {
+        XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            wasVisible: true,
+            willBeVisible: true,
+            editorIsEmpty: true
+        ))
+    }
+
+    func testOpeningEmptyEditorAddsStarterRule() {
+        XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            wasVisible: false,
+            willBeVisible: true,
+            editorIsEmpty: true
+        ))
+    }
+
+    func testOpeningPopulatedEditorDoesNotAddStarterRule() {
+        XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            wasVisible: false,
+            willBeVisible: true,
+            editorIsEmpty: false
+        ))
+    }
+
+    func testHidingEditorDoesNotAddStarterRule() {
+        XCTAssertFalse(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            wasVisible: true,
+            willBeVisible: false,
+            editorIsEmpty: true
+        ))
+    }
+}

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -202,6 +202,18 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
         ))
     }
 
+    /// Clearing the view invalidates the previous visibility application even
+    /// if the same table name is selected again afterward.
+    func testReselectingTableAfterBlankStateAddsStarterRule() {
+        XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: false,
+            wasVisible: true,
+            willBeVisible: true,
+            tableChanged: false,
+            editorIsEmpty: true
+        ))
+    }
+
     func testOpeningEmptyEditorAddsStarterRule() {
         XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
             visibilityWasApplied: true,

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -175,6 +175,17 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
             visibilityWasApplied: true,
             wasVisible: true,
             willBeVisible: true,
+            tableChanged: false,
+            editorIsEmpty: true
+        ))
+    }
+
+    func testSwitchingTablesWhileVisibleAddsStarterRule() {
+        XCTAssertTrue(SARuleFilterVisibilityPolicy.shouldAddStarterRule(
+            visibilityWasApplied: true,
+            wasVisible: true,
+            willBeVisible: true,
+            tableChanged: true,
             editorIsEmpty: true
         ))
     }
@@ -186,6 +197,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
             visibilityWasApplied: false,
             wasVisible: true,
             willBeVisible: true,
+            tableChanged: true,
             editorIsEmpty: true
         ))
     }
@@ -195,6 +207,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
             visibilityWasApplied: true,
             wasVisible: false,
             willBeVisible: true,
+            tableChanged: false,
             editorIsEmpty: true
         ))
     }
@@ -204,6 +217,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
             visibilityWasApplied: true,
             wasVisible: false,
             willBeVisible: true,
+            tableChanged: true,
             editorIsEmpty: false
         ))
     }
@@ -213,6 +227,7 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
             visibilityWasApplied: true,
             wasVisible: true,
             willBeVisible: false,
+            tableChanged: true,
             editorIsEmpty: true
         ))
     }


### PR DESCRIPTION
## Changes:
- Make same-table rule-editor visibility restoration idempotent so refreshing the table list cannot insert a spurious empty filter row.
- Preserve starter-row behavior for first display, real hidden-to-visible transitions, switches to a different empty table, and reselecting the same table after a blank state.
- Track whether visibility has actually been applied so a saved visible preference—or a cleared table view—still seeds the next editable rule.
- Expose the Swift policy through an explicit Objective-C selector and add deterministic transition coverage.

## Closes following issues:
- Closes: #2516

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.6
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6

## Screenshots:
Not included; this fixes repeated layout growth without changing the intended filter UI.

## Additional notes:
- Root cause: table-list refresh rebuilds the filter model and reapplies the already-visible state. The previous setter treated that restoration as a fresh open and seeded another empty rule.
- Review follow-ups: the policy distinguishes saved desired state from applied visibility and same-table refreshes from table switches. Blanking the content view now invalidates the applied-visibility state so reselecting the same table also restores one editable starter rule.
- Focused `SARuleFilterVisibilityPolicyTests`: 7 passed, 0 failed.
- Full `Unit Tests` target: 854 tests, 794 passed, 60 skipped, 0 failed.
- Manually verified against MySQL 8.0.46: launch with the saved visible preference adds one starter rule; same-table refresh keeps one; switching tables creates one rule using the new table's column; switching databases to blank content and reselecting the same table restores exactly one `alpha_id` rule; and a following refresh keeps exactly one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate starter filter rules from appearing during same-table refreshes.
  * Preserved starter rules on first display, manual reopening, and switches to a different empty table.
* **Tests**
  * Added coverage for filter-editor visibility, saved startup state, table switches, existing content, and hidden states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
