### PR TITLE
Percent-encode the MySQL online-help topic in the search URL

### DIFF
--- a/Source/Controllers/SubviewControllers/HelpViewer/SAHelpViewerOnlineURLBuilder.swift
+++ b/Source/Controllers/SubviewControllers/HelpViewer/SAHelpViewerOnlineURLBuilder.swift
@@ -80,12 +80,13 @@ import Foundation
         // percent-encoding the topic — same approach as mariaDBOnlineHelpURL.
         var queryAllowedCharacters = CharacterSet.urlQueryAllowed
         queryAllowedCharacters.remove(charactersIn: "&=+?#")
-        let encodedSearchString = searchString.addingPercentEncoding(withAllowedCharacters: queryAllowedCharacters) ?? ""
-        let urlString = "https://dev.mysql.com/doc/search/?d=\(documentID)&p=1&q=\(encodedSearchString)"
-
-        guard urlString.isNotEmpty else {
+        // `addingPercentEncoding` returns nil only for a malformed topic (e.g. an
+        // unpaired UTF-16 surrogate). Treat that as "no searchable URL" rather
+        // than silently producing a generic empty-`q` search.
+        guard let encodedSearchString = searchString.addingPercentEncoding(withAllowedCharacters: queryAllowedCharacters) else {
             return nil
         }
+        let urlString = "https://dev.mysql.com/doc/search/?d=\(documentID)&p=1&q=\(encodedSearchString)"
 
         return URL(string: urlString)
     }
@@ -104,7 +105,9 @@ import Foundation
         if !trimmedTopic.isEmpty {
             var queryAllowedCharacters = CharacterSet.urlQueryAllowed
             queryAllowedCharacters.remove(charactersIn: "&=+?#")
-            let encodedTopic = trimmedTopic.addingPercentEncoding(withAllowedCharacters: queryAllowedCharacters) ?? ""
+            guard let encodedTopic = trimmedTopic.addingPercentEncoding(withAllowedCharacters: queryAllowedCharacters) else {
+                return nil
+            }
 
             return URL(string: "https://mariadb.com/docs?q=\(encodedTopic)")
         }

--- a/Source/Controllers/SubviewControllers/HelpViewer/SAHelpViewerOnlineURLBuilder.swift
+++ b/Source/Controllers/SubviewControllers/HelpViewer/SAHelpViewerOnlineURLBuilder.swift
@@ -74,10 +74,16 @@ import Foundation
 
     static func mysqlOnlineHelpURL(forTopic topic: String?, documentID: Int) -> URL? {
         let searchString = topic ?? ""
-        let urlString = "https://dev.mysql.com/doc/search/?d=\(documentID)&p=1&q=\(searchString)"
-            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        // `urlQueryAllowed` leaves the query delimiters `&`, `=`, `+`, `?`, `#`
+        // unescaped, so a topic containing any of them would be spliced into the
+        // URL structure (truncating/mangling the `q` value). Remove them before
+        // percent-encoding the topic — same approach as mariaDBOnlineHelpURL.
+        var queryAllowedCharacters = CharacterSet.urlQueryAllowed
+        queryAllowedCharacters.remove(charactersIn: "&=+?#")
+        let encodedSearchString = searchString.addingPercentEncoding(withAllowedCharacters: queryAllowedCharacters) ?? ""
+        let urlString = "https://dev.mysql.com/doc/search/?d=\(documentID)&p=1&q=\(encodedSearchString)"
 
-        guard let urlString, !urlString.isEmpty else {
+        guard urlString.isNotEmpty else {
             return nil
         }
 

--- a/UnitTests/SAHelpViewerOnlineURLBuilderTests.swift
+++ b/UnitTests/SAHelpViewerOnlineURLBuilderTests.swift
@@ -48,17 +48,18 @@ final class SAHelpViewerOnlineURLBuilderTests: XCTestCase {
     }
 
     func testMySQLOnlineHelpURLPercentEncodesQueryDelimitersInTopic() {
-        // Topics containing query delimiters (`&`, `=`, `+`) must be percent-encoded
-        // so they survive as the `q` value instead of being spliced into the URL
-        // structure — regression: a bare `&`/`=` truncated the query, `+` read as a space.
+        // Topics containing query delimiters (`&`, `=`, `+`, `?`, `#`) must be
+        // percent-encoded so they survive as the `q` value instead of being spliced
+        // into the URL structure — regression: a bare `&`/`=` truncated the query,
+        // `+` read as a space, `?`/`#` opened a query/fragment.
         let combined = SAHelpViewerOnlineURLBuilder.onlineHelpURL(
-            forTopic: "a&b=c+d",
+            forTopic: "a&b=c+d?e#f",
             serverVersionString: "8.4.0",
             mysqlMajorVersion: 8,
             mysqlMinorVersion: 4,
             mysqlReleaseVersion: 0
         )
-        XCTAssertEqual(combined?.absoluteString, "https://dev.mysql.com/doc/search/?d=371&p=1&q=a%26b%3Dc%2Bd")
+        XCTAssertEqual(combined?.absoluteString, "https://dev.mysql.com/doc/search/?d=371&p=1&q=a%26b%3Dc%2Bd%3Fe%23f")
 
         let plusOnly = SAHelpViewerOnlineURLBuilder.mysqlOnlineHelpURL(forTopic: "a+b", documentID: 12)
         XCTAssertEqual(plusOnly?.absoluteString, "https://dev.mysql.com/doc/search/?d=12&p=1&q=a%2Bb")
@@ -69,9 +70,13 @@ final class SAHelpViewerOnlineURLBuilderTests: XCTestCase {
         XCTAssertEqual(withSpace?.absoluteString, "https://dev.mysql.com/doc/search/?d=201&p=1&q=GRANT%20%26%20REVOKE")
 
         // Round-trip: the escaped value must parse back as a single `q` item equal to
-        // the original topic — i.e. the delimiter did not split the query.
-        let parsed = URLComponents(url: URL(string: combined?.absoluteString ?? "")!, resolvingAgainstBaseURL: false)
-        XCTAssertEqual(parsed?.queryItems?.first { $0.name == "q" }?.value, "a&b=c+d")
+        // the original topic — i.e. the delimiters did not split the query.
+        guard let combined else {
+            XCTFail("Expected a MySQL help URL for the delimiter topic")
+            return
+        }
+        let parsed = URLComponents(url: combined, resolvingAgainstBaseURL: false)
+        XCTAssertEqual(parsed?.queryItems?.first { $0.name == "q" }?.value, "a&b=c+d?e#f")
     }
 
     func testMariaDBVersionDetectionUsesCachedVersionString() {

--- a/UnitTests/SAHelpViewerOnlineURLBuilderTests.swift
+++ b/UnitTests/SAHelpViewerOnlineURLBuilderTests.swift
@@ -47,6 +47,33 @@ final class SAHelpViewerOnlineURLBuilderTests: XCTestCase {
         XCTAssertEqual(url?.absoluteString, "https://dev.mysql.com/doc/search/?d=515&p=1&q=CREATE%20TABLE")
     }
 
+    func testMySQLOnlineHelpURLPercentEncodesQueryDelimitersInTopic() {
+        // Topics containing query delimiters (`&`, `=`, `+`) must be percent-encoded
+        // so they survive as the `q` value instead of being spliced into the URL
+        // structure — regression: a bare `&`/`=` truncated the query, `+` read as a space.
+        let combined = SAHelpViewerOnlineURLBuilder.onlineHelpURL(
+            forTopic: "a&b=c+d",
+            serverVersionString: "8.4.0",
+            mysqlMajorVersion: 8,
+            mysqlMinorVersion: 4,
+            mysqlReleaseVersion: 0
+        )
+        XCTAssertEqual(combined?.absoluteString, "https://dev.mysql.com/doc/search/?d=371&p=1&q=a%26b%3Dc%2Bd")
+
+        let plusOnly = SAHelpViewerOnlineURLBuilder.mysqlOnlineHelpURL(forTopic: "a+b", documentID: 12)
+        XCTAssertEqual(plusOnly?.absoluteString, "https://dev.mysql.com/doc/search/?d=12&p=1&q=a%2Bb")
+
+        // A topic mixing a space with a delimiter: the space still encodes to `%20`
+        // alongside the now-escaped delimiter.
+        let withSpace = SAHelpViewerOnlineURLBuilder.mysqlOnlineHelpURL(forTopic: "GRANT & REVOKE", documentID: 201)
+        XCTAssertEqual(withSpace?.absoluteString, "https://dev.mysql.com/doc/search/?d=201&p=1&q=GRANT%20%26%20REVOKE")
+
+        // Round-trip: the escaped value must parse back as a single `q` item equal to
+        // the original topic — i.e. the delimiter did not split the query.
+        let parsed = URLComponents(url: URL(string: combined?.absoluteString ?? "")!, resolvingAgainstBaseURL: false)
+        XCTAssertEqual(parsed?.queryItems?.first { $0.name == "q" }?.value, "a&b=c+d")
+    }
+
     func testMariaDBVersionDetectionUsesCachedVersionString() {
         XCTAssertTrue(SAHelpViewerOnlineURLBuilder.isMariaDBServerVersion("10.11.8-MariaDB"))
         XCTAssertTrue(SAHelpViewerOnlineURLBuilder.isMariaDBServerVersion("11.4.5-mariadb-ubu2404"))


### PR DESCRIPTION
## Summary
A MySQL online-help lookup whose topic contains `&`, `=`, `+`, `?`, or `#` now builds a correct, percent-encoded search URL instead of a malformed/truncated one.

## Root cause
`SAHelpViewerOnlineURLBuilder` concatenated the topic into the query string using `urlQueryAllowed`, which leaves `&=+` unescaped, so they were interpreted as URL structure — `a&b=c+d` produced `q=a&b=c+d`, truncating the query.

## Changes
- `Source/Controllers/SubviewControllers/HelpViewer/SAHelpViewerOnlineURLBuilder.swift` — percent-encode the topic, removing `&=+?#` from `urlQueryAllowed` (mirroring the existing MariaDB path). `+` now travels as `%2B` (avoids form-encoding space ambiguity).
- `UnitTests/SAHelpViewerOnlineURLBuilderTests.swift` — red→green: `a&b=c+d` → `q=a%26b%3Dc%2Bd`; `a+b` → `q=a%2Bb`; `GRANT & REVOKE` with a space; plus a `URLComponents` round-trip oracle.

## Test plan
- [x] `./Scripts/build.sh tests` — 851 tests, 0 failures.
- [x] Plain topics (no special chars) are unchanged — existing URL tests stay green.

This change was developed with AI assistance (Claude Code); every changed line was reviewed and understood.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed online MySQL help links so special characters in topic names no longer alter URL query parameters.
  * Improved handling of topics containing spaces and other reserved characters.
  * Corrected invalid topic handling for MySQL and MariaDB help links.

* **Tests**
  * Added regression coverage to verify that encoded help topics remain a single query value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->