### PR TITLE
#infra Fix release feasibility launch verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
@@ -381,7 +381,7 @@ jobs:
         id: merge_app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
@@ -670,7 +670,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace

--- a/.github/workflows/release_alpha_retry.yml
+++ b/.github/workflows/release_alpha_retry.yml
@@ -68,7 +68,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace

--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -160,7 +160,7 @@ jobs:
         id: probe_app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
@@ -213,7 +213,7 @@ jobs:
         id: probe_cleanup_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SA_RELEASE_GITHUB_APP_ID }}
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -52,7 +52,6 @@ or creates a GitHub release.
 
    | Name | Value |
    | --- | --- |
-   | `SA_RELEASE_GITHUB_APP_ID` | Dedicated App ID |
    | `SA_RELEASE_GITHUB_APP_PRIVATE_KEY` | Dedicated App PEM |
    | `SA_ASC_KEY_ID` | Dedicated Team ASC key ID with the App Manager role |
    | `SA_ASC_PRIVATE_KEY` | Base64-encoded `.p8` bytes |
@@ -68,10 +67,11 @@ or creates a GitHub release.
    environment. Never copy it to the public App Store webhook relay; that relay
    uses the separate, non-bypass App described below.
 
-7. Add repository variables:
+7. Add protected release-environment variables:
 
    | Name | Initial value |
    | --- | --- |
+   | `SA_RELEASE_GITHUB_APP_CLIENT_ID` | Dedicated release App client ID |
    | `SA_RELEASE_AUTOMATION_ENABLED` | `false` |
    | `SA_WEBHOOK_GITHUB_APP_BOT` | Exact separate webhook-relay App bot login, including `[bot]` |
    | `SA_PRODUCTION_CLOUD_WORKFLOW_ID` | Production Xcode Cloud workflow ID |
@@ -132,8 +132,15 @@ Notarize post-action or the configured **Next Build Number** setting:
 
 - **Production:** scheme `Sequel Ace Release`; start on `production/*` and
   `beta/*` tags; add the built-in Notarize post-action.
-- **Alpha:** scheme `Sequel Ace Beta`; remove the every-`main` trigger; start on
-  `beta/*` tags; add the built-in Notarize post-action.
+- **Alpha:** scheme `Sequel Ace Beta`; remove the every-push-to-`main` trigger;
+  retain manual `main`, schedule `main` nightly at 03:00
+  `America/Los_Angeles`, and start on `beta/*` tags; add the built-in Notarize
+  post-action and internal TestFlight distribution.
+
+Nightly and manual Alpha builds are tester-only App Store Connect deliveries.
+They never create or update a GitHub release and their build numbers remain
+informational. The `beta/*` trigger remains separate because a public beta
+requires both its Production and Alpha artifacts.
 
 After saving both workflows, manually start only Alpha from the current `main`
 commit. Record that Alpha build-run ID for the feasibility workflow. Do not

--- a/fastlane/lib/sequel_ace_release/artifact_verifier.rb
+++ b/fastlane/lib/sequel_ace_release/artifact_verifier.rb
@@ -56,12 +56,7 @@ module SequelAceRelease
         @runner.run("/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", app)
         signature = @runner.run("/usr/bin/codesign", "-d", "--verbose=4", app, allow_failure: true)
         signature_text = [signature.stdout, signature.stderr].join("\n")
-        team = signature_text[/^TeamIdentifier=(.+)$/, 1]
-        authorities = signature_text.scan(/^Authority=(.+)$/).flatten
-        raise ValidationError, "artifact TeamIdentifier #{team || 'missing'} does not match #{Config::TEAM_ID}" unless team == Config::TEAM_ID
-        unless authorities.any? { |authority| authority.include?("Developer ID Application") && authority.include?("Moballo") }
-          raise ValidationError, "artifact is not signed with a Moballo Developer ID Application certificate"
-        end
+        team, authorities = validate_developer_id_signature!(signature_text)
 
         @runner.run("/usr/bin/xcrun", "stapler", "validate", app)
         @runner.run("/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=4", app)
@@ -137,7 +132,10 @@ module SequelAceRelease
       existing = @runner.run("/usr/bin/pgrep", "-x", process_name, allow_failure: true)
       raise ValidationError, "#{process_name} is already running; refusing to quit an unrelated process" if existing.status.success?
 
-      @runner.run("/usr/bin/open", "-n", app)
+      # A GUI app can inherit capture pipes from `open`, keeping Open3 blocked
+      # for the app's entire lifetime. The launch itself produces no evidence;
+      # process identity and liveness are verified independently below.
+      @runner.run("/usr/bin/open", "-n", app, discard_output: true)
       started = true
       sleep(5)
       running = @runner.run("/usr/bin/pgrep", "-x", process_name, allow_failure: true)
@@ -149,11 +147,16 @@ module SequelAceRelease
       process_id = process_ids.first
       raise ValidationError, "launched artifact returned an invalid process identifier" unless process_id.match?(/\A[1-9]\d*\z/)
 
-      expected_command = executable.realpath.to_s
-      unless process_command_matches?(process_command(process_id), expected_command)
+      observed_executable = owned_process_executable(
+        process_command(process_id),
+        app: app,
+        expected_executable: executable
+      )
+      unless observed_executable
         raise ValidationError, "launched process does not belong to the verified artifact"
       end
       owned_process = true
+      verify_translocated_app!(observed_executable, executable) unless observed_executable == executable.realpath
 
       # Apple Events can block indefinitely on Automation consent in hosted runners.
       @runner.run("/bin/kill", "-TERM", process_id)
@@ -163,7 +166,7 @@ module SequelAceRelease
         stopped = !@runner.run("/bin/kill", "-0", process_id, allow_failure: true).status.success?
         return if stopped
         if Time.now >= deadline
-          force_terminate!(process_id, expected_command)
+          force_terminate!(process_id, app, executable, observed_executable)
           raise ValidationError, "artifact did not quit cleanly"
         end
 
@@ -175,10 +178,15 @@ module SequelAceRelease
       end
     end
 
-    def force_terminate!(process_id, expected_command)
+    def force_terminate!(process_id, app, executable, observed_executable)
       command = process_command(process_id)
       return unless command
-      unless process_command_matches?(command, expected_command)
+      current_executable = owned_process_executable(
+        command,
+        app: app,
+        expected_executable: executable
+      )
+      unless current_executable == observed_executable
         raise ValidationError, "launched process identity changed before forced termination"
       end
 
@@ -188,9 +196,14 @@ module SequelAceRelease
         stopped = !@runner.run("/bin/kill", "-0", process_id, allow_failure: true).status.success?
         return if stopped
         if Time.now >= deadline
-          current_command = process_command(process_id)
-          return unless current_command
-          unless process_command_matches?(current_command, expected_command)
+          command = process_command(process_id)
+          return unless command
+          current_executable = owned_process_executable(
+            command,
+            app: app,
+            expected_executable: executable
+          )
+          unless current_executable == observed_executable
             raise ValidationError, "launched process identity changed after forced termination"
           end
           raise ValidationError, "artifact remained running after forced termination"
@@ -201,14 +214,55 @@ module SequelAceRelease
     end
 
     def process_command(process_id)
-      result = @runner.run("/bin/ps", "-p", process_id, "-o", "command=", allow_failure: true)
+      result = @runner.run("/bin/ps", "-ww", "-p", process_id, "-o", "command=", allow_failure: true)
       return nil unless result.status.success?
 
       result.stdout.strip
     end
 
-    def process_command_matches?(command, expected_command)
-      command && (command == expected_command || command.start_with?("#{expected_command} "))
+    def owned_process_executable(command, app:, expected_executable:)
+      return nil unless command
+
+      expected = expected_executable.realpath
+      return expected if command == expected.to_s || command.start_with?("#{expected} ")
+
+      app_relative_executable = [app.basename, "Contents", "MacOS", expected_executable.basename].join("/")
+      uuid = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+      match = command.match(
+        %r{\A(?<path>/private/var/folders/[^/]+/[^/]+/T/AppTranslocation/#{uuid}/d/#{Regexp.escape(app_relative_executable)})(?: .*)?\z}
+      )
+      return nil unless match
+
+      observed = Pathname.new(match[:path])
+      stat = observed.lstat
+      return nil unless stat.file? && !stat.symlink?
+      return nil unless Digest::SHA256.file(observed).hexdigest == Digest::SHA256.file(expected).hexdigest
+
+      observed.realpath
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
+      nil
+    end
+
+    def verify_translocated_app!(observed_executable, expected_executable)
+      observed_app = observed_executable.parent.parent.parent
+      unless observed_app.basename == expected_executable.parent.parent.parent.basename
+        raise ValidationError, "translocated artifact bundle name changed"
+      end
+
+      @runner.run("/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", observed_app)
+      signature = @runner.run("/usr/bin/codesign", "-d", "--verbose=4", observed_app, allow_failure: true)
+      validate_developer_id_signature!([signature.stdout, signature.stderr].join("\n"))
+    end
+
+    def validate_developer_id_signature!(signature_text)
+      team = signature_text[/^TeamIdentifier=(.+)$/, 1]
+      authorities = signature_text.scan(/^Authority=(.+)$/).flatten
+      raise ValidationError, "artifact TeamIdentifier #{team || 'missing'} does not match #{Config::TEAM_ID}" unless team == Config::TEAM_ID
+      unless authorities.any? { |authority| authority.include?("Developer ID Application") && authority.include?("Moballo") }
+        raise ValidationError, "artifact is not signed with a Moballo Developer ID Application certificate"
+      end
+
+      [team, authorities]
     end
 
     def package(app, output_zip)

--- a/fastlane/lib/sequel_ace_release/artifact_verifier.rb
+++ b/fastlane/lib/sequel_ace_release/artifact_verifier.rb
@@ -155,8 +155,8 @@ module SequelAceRelease
       unless observed_executable
         raise ValidationError, "launched process does not belong to the verified artifact"
       end
-      owned_process = true
       verify_translocated_app!(observed_executable, executable) unless observed_executable == executable.realpath
+      owned_process = true
 
       # Apple Events can block indefinitely on Automation consent in hosted runners.
       @runner.run("/bin/kill", "-TERM", process_id)

--- a/fastlane/lib/sequel_ace_release/artifact_verifier.rb
+++ b/fastlane/lib/sequel_ace_release/artifact_verifier.rb
@@ -156,6 +156,14 @@ module SequelAceRelease
         raise ValidationError, "launched process does not belong to the verified artifact"
       end
       verify_translocated_app!(observed_executable, executable) unless observed_executable == executable.realpath
+      current_executable = owned_process_executable(
+        process_command(process_id),
+        app: app,
+        expected_executable: executable
+      )
+      unless current_executable == observed_executable
+        raise ValidationError, "launched process identity changed before graceful termination"
+      end
       owned_process = true
 
       # Apple Events can block indefinitely on Automation consent in hosted runners.

--- a/fastlane/lib/sequel_ace_release/command_runner.rb
+++ b/fastlane/lib/sequel_ace_release/command_runner.rb
@@ -6,8 +6,29 @@ module SequelAceRelease
   class CommandRunner
     Result = Struct.new(:stdout, :stderr, :status, keyword_init: true)
 
-    def run(*command, chdir: Config.repo_root, env: {}, allow_failure: false, stdin_data: nil, redact_arguments: [])
-      stdout, stderr, status = Open3.capture3(env, *command.map(&:to_s), chdir: chdir.to_s, stdin_data: stdin_data)
+    def run(*command, chdir: Config.repo_root, env: {}, allow_failure: false, stdin_data: nil, redact_arguments: [], discard_output: false)
+      if discard_output
+        raise ArgumentError, "stdin_data cannot be combined with discard_output" unless stdin_data.nil?
+
+        process_id = Process.spawn(
+          env,
+          *command.map(&:to_s),
+          chdir: chdir.to_s,
+          in: File::NULL,
+          out: File::NULL,
+          err: File::NULL
+        )
+        _waited_process_id, status = Process.wait2(process_id)
+        stdout = ""
+        stderr = ""
+      else
+        stdout, stderr, status = Open3.capture3(
+          env,
+          *command.map(&:to_s),
+          chdir: chdir.to_s,
+          stdin_data: stdin_data
+        )
+      end
       result = Result.new(stdout: stdout, stderr: stderr, status: status)
       return result if status.success? || allow_failure
 

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -45,7 +45,7 @@ class ArtifactVerifierTest < Minitest::Test
   end
 
   class LaunchRunner
-    attr_reader :commands
+    attr_reader :commands, :options
 
     def initialize(
       pgrep_results: [[false, ""], [true, "4242\n"]],
@@ -53,19 +53,23 @@ class ArtifactVerifierTest < Minitest::Test
       kill_zero_results: [[false, ""]]
     )
       @commands = []
+      @options = []
       @pgrep_results = pgrep_results
       @process_command = process_command
       @kill_zero_results = kill_zero_results
     end
 
-    def run(*command, **_options)
+    def run(*command, **options)
       @commands << command
+      @options << options
       success, stdout = if command.first == "/usr/bin/pgrep"
                           @pgrep_results.shift
                         elsif command.first == "/bin/ps"
                           [true, "#{@process_command}\n"]
                         elsif command.first == "/bin/kill" && command[1] == "-0"
                           @kill_zero_results.shift
+                        elsif command.first == "/usr/bin/codesign" && command.include?("-d")
+                          [true, "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"]
                         else
                           [true, ""]
                         end
@@ -205,10 +209,48 @@ class ArtifactVerifierTest < Minitest::Test
 
     assert_includes runner.commands, ["/bin/kill", "-TERM", "4242"]
     assert_includes runner.commands, ["/usr/bin/pgrep", "-x", "echo"]
-    assert_includes runner.commands, ["/bin/ps", "-p", "4242", "-o", "command="]
+    assert_includes runner.commands, ["/bin/ps", "-ww", "-p", "4242", "-o", "command="]
     assert_includes runner.commands, ["/bin/kill", "-0", "4242"]
+    open_index = runner.commands.index(["/usr/bin/open", "-n", Pathname.new("/tmp/Sequel Ace.app")])
+    assert_equal true, runner.options.fetch(open_index).fetch(:discard_output)
     refute runner.commands.any? { |command| command.first == "/usr/bin/pkill" }
     refute runner.commands.any? { |command| command.first == "/usr/bin/osascript" }
+  end
+
+  def test_launch_accepts_a_matching_signed_app_translocation
+    with_app do |app|
+      with_translocated_copy(app) do |translocated_executable|
+        runner = LaunchRunner.new(process_command: translocated_executable.realpath.to_s)
+        verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
+
+        verifier.stub(:sleep, nil) do
+          verifier.send(:launch_and_quit, app, app.join("Contents/MacOS/Sequel Ace"))
+        end
+
+        assert_includes runner.commands, ["/bin/kill", "-TERM", "4242"]
+        assert runner.commands.any? { |command|
+          command[0, 5] == ["/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2"]
+        }
+      end
+    end
+  end
+
+  def test_launch_rejects_an_app_translocation_with_a_different_executable
+    with_app do |app|
+      with_translocated_copy(app, contents: "different fixture") do |translocated_executable|
+        runner = LaunchRunner.new(process_command: translocated_executable.realpath.to_s)
+        verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
+
+        error = assert_raises(SequelAceRelease::ValidationError) do
+          verifier.stub(:sleep, nil) do
+            verifier.send(:launch_and_quit, app, app.join("Contents/MacOS/Sequel Ace"))
+          end
+        end
+
+        assert_includes error.message, "does not belong"
+        refute runner.commands.any? { |command| command.first == "/bin/kill" }
+      end
+    end
   end
 
   def test_launch_force_terminates_the_verified_pid_after_the_graceful_timeout
@@ -296,5 +338,16 @@ class ArtifactVerifierTest < Minitest::Test
       app.join("Contents/MacOS/Sequel Ace").write("fixture")
       yield app
     end
+  end
+
+  def with_translocated_copy(app, contents: nil)
+    uuid = "01234567-89AB-CDEF-0123-456789ABCDEF"
+    root = Pathname.new(Dir.tmpdir).join("AppTranslocation", uuid)
+    executable = root.join("d", app.basename, "Contents/MacOS/Sequel Ace")
+    FileUtils.mkdir_p(executable.dirname)
+    executable.binwrite(contents || app.join("Contents/MacOS/Sequel Ace").binread)
+    yield executable
+  ensure
+    FileUtils.rm_rf(root) if root
   end
 end

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -360,7 +360,7 @@ class ArtifactVerifierTest < Minitest::Test
         end
 
         assert_includes error.message, expected_error
-        refute runner.commands.any? { |command| command[0, 2] == ["/bin/kill", "-TERM"] }
+        refute runner.commands.any? { |command| command.first == "/bin/kill" }
       end
     end
   end

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -50,13 +50,15 @@ class ArtifactVerifierTest < Minitest::Test
     def initialize(
       pgrep_results: [[false, ""], [true, "4242\n"]],
       process_command: Pathname.new("/bin/echo").realpath.to_s,
-      kill_zero_results: [[false, ""]]
+      kill_zero_results: [[false, ""]],
+      signature_text: "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"
     )
       @commands = []
       @options = []
       @pgrep_results = pgrep_results
       @process_command = process_command
       @kill_zero_results = kill_zero_results
+      @signature_text = signature_text
     end
 
     def run(*command, **options)
@@ -69,7 +71,7 @@ class ArtifactVerifierTest < Minitest::Test
                         elsif command.first == "/bin/kill" && command[1] == "-0"
                           @kill_zero_results.shift
                         elsif command.first == "/usr/bin/codesign" && command.include?("-d")
-                          [true, "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"]
+                          [true, @signature_text]
                         else
                           [true, ""]
                         end
@@ -253,6 +255,18 @@ class ArtifactVerifierTest < Minitest::Test
     end
   end
 
+  def test_launch_rejects_an_app_translocation_signed_by_another_team
+    signature = "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=WRONGTEAM\n"
+
+    assert_rejects_translocated_signature(signature, "TeamIdentifier WRONGTEAM")
+  end
+
+  def test_launch_rejects_an_app_translocation_without_a_moballo_developer_id_authority
+    signature = "Authority=Apple Root CA\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"
+
+    assert_rejects_translocated_signature(signature, "Moballo Developer ID Application")
+  end
+
   def test_launch_force_terminates_the_verified_pid_after_the_graceful_timeout
     runner = LaunchRunner.new(kill_zero_results: [[true, ""], [false, ""]])
     verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
@@ -329,6 +343,27 @@ class ArtifactVerifierTest < Minitest::Test
   end
 
   private
+
+  def assert_rejects_translocated_signature(signature, expected_error)
+    with_app do |app|
+      with_translocated_copy(app) do |translocated_executable|
+        runner = LaunchRunner.new(
+          process_command: translocated_executable.realpath.to_s,
+          signature_text: signature
+        )
+        verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
+
+        error = assert_raises(SequelAceRelease::ValidationError) do
+          verifier.stub(:sleep, nil) do
+            verifier.send(:launch_and_quit, app, app.join("Contents/MacOS/Sequel Ace"))
+          end
+        end
+
+        assert_includes error.message, expected_error
+        refute runner.commands.any? { |command| command[0, 2] == ["/bin/kill", "-TERM"] }
+      end
+    end
+  end
 
   def with_app
     Dir.mktmpdir do |directory|

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -50,13 +50,14 @@ class ArtifactVerifierTest < Minitest::Test
     def initialize(
       pgrep_results: [[false, ""], [true, "4242\n"]],
       process_command: Pathname.new("/bin/echo").realpath.to_s,
+      process_commands: nil,
       kill_zero_results: [[false, ""]],
       signature_text: "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"
     )
       @commands = []
       @options = []
       @pgrep_results = pgrep_results
-      @process_command = process_command
+      @process_commands = Array(process_commands || process_command)
       @kill_zero_results = kill_zero_results
       @signature_text = signature_text
     end
@@ -67,7 +68,8 @@ class ArtifactVerifierTest < Minitest::Test
       success, stdout = if command.first == "/usr/bin/pgrep"
                           @pgrep_results.shift
                         elsif command.first == "/bin/ps"
-                          [true, "#{@process_command}\n"]
+                          process_command = @process_commands.length > 1 ? @process_commands.shift : @process_commands.first
+                          [true, "#{process_command}\n"]
                         elsif command.first == "/bin/kill" && command[1] == "-0"
                           @kill_zero_results.shift
                         elsif command.first == "/usr/bin/codesign" && command.include?("-d")
@@ -267,6 +269,30 @@ class ArtifactVerifierTest < Minitest::Test
     assert_rejects_translocated_signature(signature, "Moballo Developer ID Application")
   end
 
+  def test_launch_revalidates_a_translocated_process_before_signaling
+    with_app do |app|
+      with_translocated_copy(app) do |translocated_executable|
+        runner = LaunchRunner.new(
+          process_commands: [
+            translocated_executable.realpath.to_s,
+            "/Applications/Unrelated.app/Contents/MacOS/Sequel Ace"
+          ]
+        )
+        verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
+
+        error = assert_raises(SequelAceRelease::ValidationError) do
+          verifier.stub(:sleep, nil) do
+            verifier.send(:launch_and_quit, app, app.join("Contents/MacOS/Sequel Ace"))
+          end
+        end
+
+        assert_includes error.message, "identity changed before graceful termination"
+        assert_equal 2, runner.commands.count { |command| command.first == "/bin/ps" }
+        refute runner.commands.any? { |command| command.first == "/bin/kill" }
+      end
+    end
+  end
+
   def test_launch_force_terminates_the_verified_pid_after_the_graceful_timeout
     runner = LaunchRunner.new(kill_zero_results: [[true, ""], [false, ""]])
     verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
@@ -287,7 +313,7 @@ class ArtifactVerifierTest < Minitest::Test
     assert_includes error.message, "did not quit cleanly"
     assert_includes runner.commands, ["/bin/kill", "-TERM", "4242"]
     assert_includes runner.commands, ["/bin/kill", "-KILL", "4242"]
-    assert_equal 2, runner.commands.count { |command| command.first == "/bin/ps" }
+    assert_equal 3, runner.commands.count { |command| command.first == "/bin/ps" }
     assert_equal 2, runner.commands.count { |command| command[0, 2] == ["/bin/kill", "-0"] }
   end
 

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -314,6 +314,9 @@ class ArtifactVerifierTest < Minitest::Test
     assert_includes runner.commands, ["/bin/kill", "-TERM", "4242"]
     assert_includes runner.commands, ["/bin/kill", "-KILL", "4242"]
     assert_equal 3, runner.commands.count { |command| command.first == "/bin/ps" }
+    final_identity_check = runner.commands.rindex(["/bin/ps", "-ww", "-p", "4242", "-o", "command="])
+    forced_termination = runner.commands.index(["/bin/kill", "-KILL", "4242"])
+    assert_operator final_identity_check, :<, forced_termination
     assert_equal 2, runner.commands.count { |command| command[0, 2] == ["/bin/kill", "-0"] }
   end
 

--- a/fastlane/test/command_runner_test.rb
+++ b/fastlane/test/command_runner_test.rb
@@ -3,6 +3,29 @@
 require "test_helper"
 
 class CommandRunnerTest < Minitest::Test
+  def test_can_run_a_gui_launcher_without_capture_pipes
+    result = SequelAceRelease::CommandRunner.new.run(
+      RbConfig.ruby,
+      "-e",
+      '$stdout.write("captured output"); $stderr.write("captured error")',
+      discard_output: true
+    )
+
+    assert result.status.success?
+    assert_empty result.stdout
+    assert_empty result.stderr
+  end
+
+  def test_discard_output_rejects_stdin_data
+    assert_raises(ArgumentError) do
+      SequelAceRelease::CommandRunner.new.run(
+        "/usr/bin/true",
+        discard_output: true,
+        stdin_data: "unexpected"
+      )
+    end
+  end
+
   def test_explicitly_redacts_signed_download_urls_from_failures
     signed_url = "https://download.example.invalid/artifact?signature=secret-value"
     error = assert_raises(SequelAceRelease::CommandError) do

--- a/fastlane/test/command_runner_test.rb
+++ b/fastlane/test/command_runner_test.rb
@@ -4,12 +4,49 @@ require "test_helper"
 
 class CommandRunnerTest < Minitest::Test
   def test_can_run_a_gui_launcher_without_capture_pipes
-    result = SequelAceRelease::CommandRunner.new.run(
-      RbConfig.ruby,
-      "-e",
-      '$stdout.write("captured output"); $stderr.write("captured error")',
-      discard_output: true
-    )
+    child_pid = nil
+    pid_path = nil
+    result = nil
+    runner_thread = nil
+
+    Dir.mktmpdir do |directory|
+      begin
+        pid_path = File.join(directory, "inherited-stream-child.pid")
+        launcher = <<~'RUBY'
+          child_pid = fork do
+            $stdout.write("inherited output")
+            $stderr.write("inherited error")
+            sleep 5
+          end
+          File.write(ARGV.fetch(0), child_pid)
+        RUBY
+
+        runner_thread = Thread.new do
+          SequelAceRelease::CommandRunner.new.run(
+            RbConfig.ruby,
+            "-e",
+            launcher,
+            pid_path,
+            discard_output: true
+          )
+        end
+        runner_thread.report_on_exception = false
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+        sleep(0.01) until File.file?(pid_path) || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        assert File.file?(pid_path), "launcher did not record its descendant"
+        child_pid = Integer(File.read(pid_path))
+        assert runner_thread.join(2), "launcher waited for a descendant holding inherited streams"
+        result = runner_thread.value
+      ensure
+        child_pid ||= Integer(File.read(pid_path)) if pid_path && File.file?(pid_path)
+        begin
+          Process.kill("TERM", child_pid) if child_pid
+        rescue Errno::ESRCH
+          # The child already exited and was reaped by the operating system.
+        end
+        runner_thread&.join(2)
+      end
+    end
 
     assert result.status.success?
     assert_empty result.stdout


### PR DESCRIPTION
## Changes:
- Prevent hosted artifact launch verification from hanging when `open` passes inherited capture pipes to the launched GUI application.
- Preserve exact-process termination safety while accepting Gatekeeper App Translocation only when the translocated executable has the expected bundle path, byte-identical executable digest, valid Developer ID signature, and Moballo team identity.
- Add regression coverage for discarded launcher output, matching and mismatched App Translocation, exact PID termination, and input validation.
- Migrate every release workflow to the supported GitHub App `client-id` input and the protected environment variable `SA_RELEASE_GITHUB_APP_CLIENT_ID`.
- Document the live Alpha policy: manual `main`, nightly `main` at 03:00 America/Los_Angeles, and `beta/*`, with nightly/manual builds remaining internal-TestFlight-only and non-canonical.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - N/A (Ruby/Fastlane and workflow infrastructure only)
- `bundle exec rake -f fastlane/Rakefile test`: 197 runs, 929 assertions, 0 failures, 0 errors, 0 skips.
- Parsed all three changed workflow files with Ruby YAML.
- Re-ran the real `production/5.3.1-20104` public artifact locally: universal arm64/x86_64, Moballo team `NKQ4HJ66PX`, notarization/Gatekeeper validation, successful translocated launch, and clean quit in 8.9 seconds with no remaining Sequel Ace process.

## Screenshots:
- N/A; no app UI or shipped runtime code changes.

## Additional notes:
- Hosted feasibility run https://github.com/Sequel-Ace/Sequel-Ace/actions/runs/31358758700 proved the original failure: `ruby`, `open`, and the launched Sequel Ace process remained alive until cancellation because the GUI app inherited `Open3` capture pipes. The disposable GitHub probe had not yet been created, and guarded cleanup ran.
- Exact Alpha build 30572 on merged `main` completed Archive, Notarize, and internal TestFlight successfully before this follow-up.
- `SA_RELEASE_AUTOMATION_ENABLED` remains `false`. This PR does not dispatch a Production build, create a tag/release, submit to Apple, or enable publishing.
- No Swift, Xcode target membership, app-source code, credentials, approval payloads, or private release state are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved release configuration with protected environment settings and clearer Alpha testing workflows.
  * Added support for running GUI launch commands without capturing output.

* **Bug Fixes**
  * Strengthened application verification during launch and forced termination, including translocated app and signature validation.
  * Updated release automation to use the configured GitHub App client identifier consistently.

* **Documentation**
  * Clarified that Alpha nightly and manual builds are tester-only and do not create GitHub releases or affect canonical build numbering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->