### PR TITLE
#fixed Prevent hosted release artifact launch hangs

### DIFF
--- a/fastlane/lib/sequel_ace_release/artifact_verifier.rb
+++ b/fastlane/lib/sequel_ace_release/artifact_verifier.rb
@@ -132,20 +132,13 @@ module SequelAceRelease
       existing = @runner.run("/usr/bin/pgrep", "-x", process_name, allow_failure: true)
       raise ValidationError, "#{process_name} is already running; refusing to quit an unrelated process" if existing.status.success?
 
-      # A GUI app can inherit capture pipes from `open`, keeping Open3 blocked
-      # for the app's entire lifetime. The launch itself produces no evidence;
-      # process identity and liveness are verified independently below.
-      @runner.run("/usr/bin/open", "-n", app, discard_output: true)
+      # LaunchServices can keep `open` alive for the GUI app's entire lifetime
+      # on hosted runners. Spawn the already-verified executable directly so
+      # launch is asynchronous and its exact process identity is known.
+      process_id = @runner.spawn(executable, chdir: app.parent).to_s
+      raise ValidationError, "launched artifact returned an invalid process identifier" unless process_id.match?(/\A[1-9]\d*\z/)
       started = true
       sleep(5)
-      running = @runner.run("/usr/bin/pgrep", "-x", process_name, allow_failure: true)
-      raise ValidationError, "artifact did not remain running after launch" unless running.status.success?
-
-      process_ids = running.stdout.lines.map(&:strip).reject(&:empty?)
-      raise ValidationError, "expected exactly one launched artifact process, found #{process_ids.length}" unless process_ids.length == 1
-
-      process_id = process_ids.first
-      raise ValidationError, "launched artifact returned an invalid process identifier" unless process_id.match?(/\A[1-9]\d*\z/)
 
       observed_executable = owned_process_executable(
         process_command(process_id),

--- a/fastlane/lib/sequel_ace_release/command_runner.rb
+++ b/fastlane/lib/sequel_ace_release/command_runner.rb
@@ -6,6 +6,23 @@ module SequelAceRelease
   class CommandRunner
     Result = Struct.new(:stdout, :stderr, :status, keyword_init: true)
 
+    def spawn(*command, chdir: Config.repo_root, env: {})
+      raise ArgumentError, "command is required" if command.empty?
+
+      program, *arguments = command.map(&:to_s)
+      process_id = Process.spawn(
+        env,
+        [program, program],
+        *arguments,
+        chdir: chdir.to_s,
+        in: File::NULL,
+        out: File::NULL,
+        err: File::NULL
+      )
+      Process.detach(process_id)
+      process_id
+    end
+
     def run(*command, chdir: Config.repo_root, env: {}, allow_failure: false, stdin_data: nil, redact_arguments: [], discard_output: false)
       if discard_output
         raise ArgumentError, "stdin_data cannot be combined with discard_output" unless stdin_data.nil?

--- a/fastlane/lib/sequel_ace_release/command_runner.rb
+++ b/fastlane/lib/sequel_ace_release/command_runner.rb
@@ -21,6 +21,8 @@ module SequelAceRelease
       )
       Process.detach(process_id)
       process_id
+    rescue SystemCallError => e
+      raise CommandError, "command could not be started (#{e.class.name}, errno #{e.errno})"
     end
 
     def run(*command, chdir: Config.repo_root, env: {}, allow_failure: false, stdin_data: nil, redact_arguments: [], discard_output: false)

--- a/fastlane/test/artifact_verifier_test.rb
+++ b/fastlane/test/artifact_verifier_test.rb
@@ -45,21 +45,31 @@ class ArtifactVerifierTest < Minitest::Test
   end
 
   class LaunchRunner
-    attr_reader :commands, :options
+    attr_reader :commands, :options, :spawn_commands, :spawn_options
 
     def initialize(
-      pgrep_results: [[false, ""], [true, "4242\n"]],
+      pgrep_results: [[false, ""]],
       process_command: Pathname.new("/bin/echo").realpath.to_s,
       process_commands: nil,
       kill_zero_results: [[false, ""]],
+      spawn_pid: 4242,
       signature_text: "Authority=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)\nTeamIdentifier=#{SequelAceRelease::Config::TEAM_ID}\n"
     )
       @commands = []
       @options = []
+      @spawn_commands = []
+      @spawn_options = []
       @pgrep_results = pgrep_results
       @process_commands = Array(process_commands || process_command)
       @kill_zero_results = kill_zero_results
+      @spawn_pid = spawn_pid
       @signature_text = signature_text
+    end
+
+    def spawn(*command, **options)
+      @spawn_commands << command
+      @spawn_options << options
+      @spawn_pid
     end
 
     def run(*command, **options)
@@ -215,8 +225,9 @@ class ArtifactVerifierTest < Minitest::Test
     assert_includes runner.commands, ["/usr/bin/pgrep", "-x", "echo"]
     assert_includes runner.commands, ["/bin/ps", "-ww", "-p", "4242", "-o", "command="]
     assert_includes runner.commands, ["/bin/kill", "-0", "4242"]
-    open_index = runner.commands.index(["/usr/bin/open", "-n", Pathname.new("/tmp/Sequel Ace.app")])
-    assert_equal true, runner.options.fetch(open_index).fetch(:discard_output)
+    assert_includes runner.spawn_commands, [Pathname.new("/bin/echo")]
+    assert_equal Pathname.new("/tmp"), runner.spawn_options.first.fetch(:chdir)
+    refute runner.commands.any? { |command| command.first == "/usr/bin/open" }
     refute runner.commands.any? { |command| command.first == "/usr/bin/pkill" }
     refute runner.commands.any? { |command| command.first == "/usr/bin/osascript" }
   end
@@ -320,8 +331,8 @@ class ArtifactVerifierTest < Minitest::Test
     assert_equal 2, runner.commands.count { |command| command[0, 2] == ["/bin/kill", "-0"] }
   end
 
-  def test_launch_refuses_to_terminate_when_more_than_one_process_matches
-    runner = LaunchRunner.new(pgrep_results: [[false, ""], [true, "4242\n4243\n"]])
+  def test_launch_refuses_to_start_when_the_executable_is_already_running
+    runner = LaunchRunner.new(pgrep_results: [[true, "4242\n"]])
     verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
 
     error = assert_raises(SequelAceRelease::ValidationError) do
@@ -334,7 +345,26 @@ class ArtifactVerifierTest < Minitest::Test
       end
     end
 
-    assert_includes error.message, "exactly one"
+    assert_includes error.message, "already running"
+    assert_empty runner.spawn_commands
+    refute runner.commands.any? { |command| command.first == "/bin/kill" }
+  end
+
+  def test_launch_rejects_an_invalid_spawned_process_identifier
+    runner = LaunchRunner.new(spawn_pid: 0)
+    verifier = SequelAceRelease::ArtifactVerifier.new(runner: runner)
+
+    error = assert_raises(SequelAceRelease::ValidationError) do
+      verifier.stub(:sleep, nil) do
+        verifier.send(
+          :launch_and_quit,
+          Pathname.new("/tmp/Sequel Ace.app"),
+          Pathname.new("/bin/echo")
+        )
+      end
+    end
+
+    assert_includes error.message, "invalid process identifier"
     refute runner.commands.any? { |command| command.first == "/bin/kill" }
   end
 

--- a/fastlane/test/command_runner_test.rb
+++ b/fastlane/test/command_runner_test.rb
@@ -34,16 +34,18 @@ class CommandRunnerTest < Minitest::Test
   end
 
   def test_spawn_wraps_system_call_failures_without_exposing_the_command
-    missing_command = File.join(Dir.tmpdir, "missing-spawn-command-secret-value")
+    Dir.mktmpdir do |directory|
+      missing_command = File.join(directory, "missing-spawn-command-secret-value")
 
-    error = assert_raises(SequelAceRelease::CommandError) do
-      SequelAceRelease::CommandRunner.new.spawn(missing_command)
+      error = assert_raises(SequelAceRelease::CommandError) do
+        SequelAceRelease::CommandRunner.new.spawn(missing_command)
+      end
+
+      assert_includes error.message, "Errno::ENOENT"
+      assert_includes error.message, "errno"
+      refute_includes error.message, missing_command
+      refute_includes error.message, "secret-value"
     end
-
-    assert_includes error.message, "Errno::ENOENT"
-    assert_includes error.message, "errno"
-    refute_includes error.message, missing_command
-    refute_includes error.message, "secret-value"
   end
 
   def test_can_run_a_gui_launcher_without_capture_pipes

--- a/fastlane/test/command_runner_test.rb
+++ b/fastlane/test/command_runner_test.rb
@@ -3,6 +3,36 @@
 require "test_helper"
 
 class CommandRunnerTest < Minitest::Test
+  def test_can_spawn_a_long_running_gui_process_without_waiting
+    process_id = nil
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    Dir.mktmpdir do |directory|
+      executable = File.join(directory, "long running ; child")
+      File.write(executable, "#!#{RbConfig.ruby}\nsleep 10\n")
+      File.chmod(0o700, executable)
+
+      begin
+        process_id = SequelAceRelease::CommandRunner.new.spawn(executable)
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+
+        assert_operator process_id, :>, 0
+        assert_operator elapsed, :<, 2
+        assert Process.kill(0, process_id)
+      ensure
+        begin
+          Process.kill("TERM", process_id) if process_id
+        rescue Errno::ESRCH
+          # The child already exited and was reaped by the detached waiter.
+        end
+      end
+    end
+  end
+
+  def test_spawn_requires_a_command
+    assert_raises(ArgumentError) { SequelAceRelease::CommandRunner.new.spawn }
+  end
+
   def test_can_run_a_gui_launcher_without_capture_pipes
     child_pid = nil
     pid_path = nil

--- a/fastlane/test/command_runner_test.rb
+++ b/fastlane/test/command_runner_test.rb
@@ -33,6 +33,19 @@ class CommandRunnerTest < Minitest::Test
     assert_raises(ArgumentError) { SequelAceRelease::CommandRunner.new.spawn }
   end
 
+  def test_spawn_wraps_system_call_failures_without_exposing_the_command
+    missing_command = File.join(Dir.tmpdir, "missing-spawn-command-secret-value")
+
+    error = assert_raises(SequelAceRelease::CommandError) do
+      SequelAceRelease::CommandRunner.new.spawn(missing_command)
+    end
+
+    assert_includes error.message, "Errno::ENOENT"
+    assert_includes error.message, "errno"
+    refute_includes error.message, missing_command
+    refute_includes error.message, "secret-value"
+  end
+
   def test_can_run_a_gui_launcher_without_capture_pipes
     child_pid = nil
     pid_path = nil


### PR DESCRIPTION
## Changes:
- launch the already verified app executable asynchronously and retain its exact PID, avoiding the hosted-runner hang caused by waiting on `/usr/bin/open`
- force argv-form direct execution so spaces and shell metacharacters in artifact paths are never interpreted as command syntax
- preserve the existing preflight, exact executable identity, translocation, graceful termination, forced termination, and unrelated-process protections
- add focused regressions for asynchronous execution, metacharacter-bearing executable paths, invalid PIDs, and exact spawned-process handling

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (Ruby/Fastlane infrastructure only)

## Screenshots:

N/A; no UI changes.

## Additional notes:
- `bundle exec rake -f fastlane/Rakefile test`: 181 runs, 868 assertions, 0 failures, 0 errors
- Verified the public `production/5.3.1-20104` `Sequel-Ace-5.3.1.zip`: universal arm64/x86_64, Moballo Developer ID team `NKQ4HJ66PX`, stapled/notarized, Gatekeeper accepted, launched, remained alive, terminated, and left no residual Sequel Ace process
- A targeted Codex Security pass reproduced and caught the single-string `Process.spawn` command-injection form in the first draft. This PR contains the argv-form remediation and regression coverage.
- Publishing remains disabled; this change cannot start or publish a Production release by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable launching for more reliable startup and process validation.
  * Prevented invalid process identifiers from being used for process signaling.
  * Added safeguards against launching executables that are already running.
  * Improved handling of launch failures without exposing sensitive command details.

* **Tests**
  * Expanded coverage for asynchronous process launching, invalid commands, startup failures, and process ID validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->