### PR TITLE
#fixed Use app-scoped App Store version reads

### DIFF
--- a/fastlane/lib/sequel_ace_release/app_store_connect_client.rb
+++ b/fastlane/lib/sequel_ace_release/app_store_connect_client.rb
@@ -137,8 +137,7 @@ module SequelAceRelease
     end
 
     def app_store_version(app_id:, version:)
-      paginate("/v1/appStoreVersions", {
-        "filter[app]" => app_id,
+      paginate("/v1/apps/#{app_id}/appStoreVersions", {
         "filter[platform]" => "MAC_OS",
         "filter[versionString]" => version,
         "limit" => 10
@@ -146,8 +145,7 @@ module SequelAceRelease
     end
 
     def app_store_versions(app_id:)
-      paginate("/v1/appStoreVersions", {
-        "filter[app]" => app_id,
+      paginate("/v1/apps/#{app_id}/appStoreVersions", {
         "filter[platform]" => "MAC_OS",
         "limit" => 200
       })

--- a/fastlane/test/app_store_connect_client_test.rb
+++ b/fastlane/test/app_store_connect_client_test.rb
@@ -90,6 +90,48 @@ class AppStoreConnectClientTest < Minitest::Test
     assert_equal "/v1/apps/1518036000", transport.requests.first.fetch(:path)
   end
 
+  def test_lists_app_store_versions_through_the_app_scoped_endpoint
+    key = OpenSSL::PKey::EC.generate("prime256v1")
+    transport = FakeTransport.new([
+      http_response(body: {
+        "data" => [{ "id" => "version-id", "type" => "appStoreVersions" }],
+        "links" => { "next" => nil }
+      })
+    ])
+    client = SequelAceRelease::AppStoreConnectClient.new(
+      key_id: "KEY123",
+      private_key: key.to_pem,
+      transport: transport
+    )
+
+    assert_equal "version-id", client.app_store_versions(app_id: "1518036000").first.fetch("id")
+    request = transport.requests.first
+    assert_equal "/v1/apps/1518036000/appStoreVersions", request.fetch(:path)
+    assert_equal "MAC_OS", request.fetch(:query).fetch("filter[platform]")
+    refute request.fetch(:query).key?("filter[app]")
+  end
+
+  def test_finds_an_exact_app_store_version_through_the_app_scoped_endpoint
+    key = OpenSSL::PKey::EC.generate("prime256v1")
+    transport = FakeTransport.new([
+      http_response(body: {
+        "data" => [{ "id" => "version-id", "type" => "appStoreVersions" }],
+        "links" => { "next" => nil }
+      })
+    ])
+    client = SequelAceRelease::AppStoreConnectClient.new(
+      key_id: "KEY123",
+      private_key: key.to_pem,
+      transport: transport
+    )
+
+    assert_equal "version-id", client.app_store_version(app_id: "1518036000", version: "5.3.2").fetch("id")
+    request = transport.requests.first
+    assert_equal "/v1/apps/1518036000/appStoreVersions", request.fetch(:path)
+    assert_equal "5.3.2", request.fetch(:query).fetch("filter[versionString]")
+    refute request.fetch(:query).key?("filter[app]")
+  end
+
   def test_reads_detailed_cloud_run_workflow_commit_and_tag
     key = OpenSSL::PKey::EC.generate("prime256v1")
     transport = FakeTransport.new([

--- a/fastlane/test/app_store_connect_client_test.rb
+++ b/fastlane/test/app_store_connect_client_test.rb
@@ -128,6 +128,7 @@ class AppStoreConnectClientTest < Minitest::Test
     assert_equal "version-id", client.app_store_version(app_id: "1518036000", version: "5.3.2").fetch("id")
     request = transport.requests.first
     assert_equal "/v1/apps/1518036000/appStoreVersions", request.fetch(:path)
+    assert_equal "MAC_OS", request.fetch(:query).fetch("filter[platform]")
     assert_equal "5.3.2", request.fetch(:query).fetch("filter[versionString]")
     refute request.fetch(:query).key?("filter[app]")
   end


### PR DESCRIPTION
## Changes:
- Use Apple’s documented app-scoped App Store version listing endpoint for both exact-version and all-version reads.
- Remove the unsupported collection-level `filter[app]` request that caused the Team API key feasibility gate to fail with `GET_COLLECTION`.
- Add regression coverage for both client methods and their exact request paths/filters.

## Closes following issues:
- Closes: None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [x] 15.x (Sequoia)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - Not applicable; infrastructure-only Ruby change
- `bundle exec rake -f fastlane/Rakefile test` (184 runs, 885 assertions)
- Focused App Store Connect client tests (16 runs, 58 assertions)
- `git diff --check`

## Screenshots:

Not applicable.

## Additional notes:
- Live guarded feasibility run 31425264392 authenticated successfully, passed public artifact verification/launch, and failed closed at Apple’s rejected collection endpoint before creating a disposable PR or GHCR probe.
- No app code, release version/build files, workflow behavior, or credentials are changed.
- Publishing remains disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App Store version lookups for greater accuracy and reliability.
  * Version searches continue to support platform and version filters.
  * Expanded version list results to include up to 200 entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->