### PR TITLE
#infra Fail closed on GHCR feasibility probe cleanup

### DIFF
--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -255,6 +255,7 @@ jobs:
             --output feasibility/github-app-probe-cleanup.json
 
       - name: Prove private GHCR round trip and visibility
+        id: ghcr_probe
         env:
           GH_TOKEN: ${{ github.token }}
           GHCR_TOKEN: ${{ github.token }}
@@ -268,6 +269,17 @@ jobs:
           package_name="${GHCR_REPOSITORY#ghcr.io/sequel-ace/}"
           visibility="$(gh api "orgs/Sequel-Ace/packages/container/${package_name}" --jq .visibility)"
           [[ "${visibility}" == "private" ]] || { echo "GHCR release archive package is not private." >&2; exit 1; }
+
+      - name: Delete the exact GHCR feasibility probe
+        if: ${{ always() && steps.ghcr_probe.outcome != 'skipped' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USERNAME: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          probe_ref="${GHCR_REPOSITORY}:feasibility-${GITHUB_RUN_ID}"
+          package_name="${GHCR_REPOSITORY#ghcr.io/sequel-ace/}"
           probe_tag="feasibility-${GITHUB_RUN_ID}"
           oras manifest delete --force "${probe_ref}"
           remaining_probe_versions="$(

--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -268,7 +268,16 @@ jobs:
           package_name="${GHCR_REPOSITORY#ghcr.io/sequel-ace/}"
           visibility="$(gh api "orgs/Sequel-Ace/packages/container/${package_name}" --jq .visibility)"
           [[ "${visibility}" == "private" ]] || { echo "GHCR release archive package is not private." >&2; exit 1; }
-          oras manifest delete "${probe_ref}" >/dev/null 2>&1 || true
+          probe_tag="feasibility-${GITHUB_RUN_ID}"
+          oras manifest delete --force "${probe_ref}"
+          remaining_probe_versions="$(
+            gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
+              --jq "map(.[]) | map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\"))) | .[].id"
+          )"
+          [[ -z "${remaining_probe_versions}" ]] || {
+            echo "GHCR feasibility probe tag still exists after deletion." >&2
+            exit 1
+          }
 
       - name: Confirm publishing remains disabled after all gates pass
         run: |

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -449,6 +449,10 @@ It must prove:
    merge.
 5. A private GHCR push/pull has matching checksums and private visibility.
 
+The GHCR probe is cleanup-sensitive: its exact tag is force-deleted without an
+interactive prompt, and the workflow fails unless a paginated package API
+read-back proves that tag is gone.
+
 The workflow refuses to start unless `SA_RELEASE_AUTOMATION_ENABLED` is already
 `false`, and it does not enable publishing itself. After every gate passes and
 the GitHub/Xcode Cloud UI configuration is reviewed, manually change the

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -449,9 +449,10 @@ It must prove:
    merge.
 5. A private GHCR push/pull has matching checksums and private visibility.
 
-The GHCR probe is cleanup-sensitive: its exact tag is force-deleted without an
-interactive prompt, and the workflow fails unless a paginated package API
-read-back proves that tag is gone.
+The GHCR probe is cleanup-sensitive: after the probe step is attempted, a
+separate unconditional cleanup step force-deletes its exact tag without an
+interactive prompt. The workflow preserves any earlier failure and also fails
+unless a paginated package API read-back proves that tag is gone.
 
 The workflow refuses to start unless `SA_RELEASE_AUTOMATION_ENABLED` is already
 `false`, and it does not enable publishing itself. After every gate passes and

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -599,6 +599,19 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes workflow[cleanup_probe..], "steps.probe_cleanup_token.outputs.token || github.token"
   end
 
+  def test_feasibility_fails_closed_unless_the_exact_ghcr_probe_tag_is_deleted
+    workflow = File.read(repo_path(".github/workflows/release_feasibility.yml"))
+    probe = workflow.split("- name: Prove private GHCR round trip and visibility", 2).fetch(1)
+                    .split("- name: Confirm publishing remains disabled after all gates pass", 2).first
+
+    assert_includes probe, 'probe_tag="feasibility-${GITHUB_RUN_ID}"'
+    assert_includes probe, 'oras manifest delete --force "${probe_ref}"'
+    assert_includes probe, 'gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
+    assert_includes probe, 'map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")))'
+    assert_includes probe, '[[ -z "${remaining_probe_versions}" ]]'
+    refute_includes probe, 'oras manifest delete "${probe_ref}" >/dev/null 2>&1 || true'
+  end
+
   def test_feasibility_binds_a_reusable_alpha_run_to_an_explicit_ancestor_sha
     workflow = File.read(repo_path(".github/workflows/release_feasibility.yml"))
     source_input = workflow.split("      alpha_source_sha:", 2).fetch(1)

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -602,14 +602,20 @@ class WorkflowRecoveryTest < Minitest::Test
   def test_feasibility_fails_closed_unless_the_exact_ghcr_probe_tag_is_deleted
     workflow = File.read(repo_path(".github/workflows/release_feasibility.yml"))
     probe = workflow.split("- name: Prove private GHCR round trip and visibility", 2).fetch(1)
-                    .split("- name: Confirm publishing remains disabled after all gates pass", 2).first
+                    .split("- name: Delete the exact GHCR feasibility probe", 2).first
+    cleanup = workflow.split("- name: Delete the exact GHCR feasibility probe", 2).fetch(1)
+                      .split("- name: Confirm publishing remains disabled after all gates pass", 2).first
 
-    assert_includes probe, 'probe_tag="feasibility-${GITHUB_RUN_ID}"'
-    assert_includes probe, 'oras manifest delete --force "${probe_ref}"'
-    assert_includes probe, 'gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
-    assert_includes probe, 'map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")))'
-    assert_includes probe, '[[ -z "${remaining_probe_versions}" ]]'
-    refute_includes probe, 'oras manifest delete "${probe_ref}" >/dev/null 2>&1 || true'
+    assert_includes probe, "id: ghcr_probe"
+    refute_includes probe, "oras manifest delete"
+    assert_includes cleanup, "if: ${{ always() && steps.ghcr_probe.outcome != 'skipped' }}"
+    assert_includes cleanup, 'probe_ref="${GHCR_REPOSITORY}:feasibility-${GITHUB_RUN_ID}"'
+    assert_includes cleanup, 'probe_tag="feasibility-${GITHUB_RUN_ID}"'
+    assert_includes cleanup, 'oras manifest delete --force "${probe_ref}"'
+    assert_includes cleanup, 'gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
+    assert_includes cleanup, 'map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")))'
+    assert_includes cleanup, '[[ -z "${remaining_probe_versions}" ]]'
+    refute_includes cleanup, 'oras manifest delete "${probe_ref}" >/dev/null 2>&1 || true'
   end
 
   def test_feasibility_binds_a_reusable_alpha_run_to_an_explicit_ancestor_sha


### PR DESCRIPTION
## Changes:
- Make the feasibility probe use noninteractive `oras manifest delete --force` instead of suppressing a prompt failure.
- Read back every GHCR package-version page and fail unless the exact disposable tag is absent.
- Document the cleanup gate and add regression coverage.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (release infrastructure only)

## Screenshots:
N/A

## Additional notes:
The successful feasibility run 31461218890 exposed the defect during independent UI read-back: its private, repository-linked probe tag remained because ORAS attempted to prompt in a noninteractive job and the workflow ignored the error. Publishing remains disabled. No credentials or secret values are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release feasibility checks to ensure temporary package artifacts are force-deleted and fully removed before a release proceeds.
  * Checks now verify deletion through package records and fail safely if any matching artifact remains.

* **Documentation**
  * Clarified artifact cleanup, verification, and failure-handling requirements for release validation.

* **Tests**
  * Added coverage for confirmed cleanup and failed verification scenarios during release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->