### PR TITLE
#infra Delete GHCR feasibility probes through Packages API

### DIFF
--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -300,8 +300,8 @@ jobs:
             "orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}" \
             --silent
           remaining_probe_versions="$(
-            gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
-              --jq "map(.[]) | map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\"))) | .[].id"
+            gh api --paginate "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
+              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | .id"
           )"
           [[ -z "${remaining_probe_versions}" ]] || {
             echo "GHCR feasibility probe tag still exists after deletion." >&2

--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -281,7 +281,24 @@ jobs:
           probe_ref="${GHCR_REPOSITORY}:feasibility-${GITHUB_RUN_ID}"
           package_name="${GHCR_REPOSITORY#ghcr.io/sequel-ace/}"
           probe_tag="feasibility-${GITHUB_RUN_ID}"
-          oras manifest delete --force "${probe_ref}"
+          probe_version_rows="$(
+            gh api --paginate "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
+              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | [.id, (.metadata.container.tags | sort | join(\",\"))] | @tsv"
+          )"
+          [[ -n "${probe_version_rows}" && "${probe_version_rows}" != *$'\n'* ]] || {
+            echo "Expected exactly one GHCR package version for the feasibility probe tag." >&2
+            exit 1
+          }
+          IFS=$'\t' read -r probe_version_id probe_version_tags <<< "${probe_version_rows}"
+          [[ "${probe_version_id}" =~ ^[0-9]+$ && "${probe_version_tags}" == "${probe_tag}" ]] || {
+            echo "Refusing to delete a GHCR package version that is not exclusive to the feasibility probe tag." >&2
+            exit 1
+          }
+          gh api --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}" \
+            --silent
           remaining_probe_versions="$(
             gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
               --jq "map(.[]) | map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\"))) | .[].id"

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -450,9 +450,11 @@ It must prove:
 5. A private GHCR push/pull has matching checksums and private visibility.
 
 The GHCR probe is cleanup-sensitive: after the probe step is attempted, a
-separate unconditional cleanup step force-deletes its exact tag without an
-interactive prompt. The workflow preserves any earlier failure and also fails
-unless a paginated package API read-back proves that tag is gone.
+separate unconditional cleanup step finds exactly one package version carrying
+only the run-specific tag and deletes it through GitHub's Packages REST API.
+The workflow preserves any earlier failure and also fails unless a paginated
+package API read-back proves that tag is gone. Do not use the OCI registry
+manifest-delete operation; GHCR reports that operation as unsupported.
 
 The workflow refuses to start unless `SA_RELEASE_AUTOMATION_ENABLED` is already
 `false`, and it does not enable publishing itself. After every gate passes and

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -617,8 +617,9 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes cleanup, '"${probe_version_tags}" == "${probe_tag}"'
     assert_includes cleanup, 'gh api --method DELETE'
     assert_includes cleanup, '"orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}"'
-    assert_includes cleanup, 'gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
-    assert_includes cleanup, 'map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")))'
+    assert_includes cleanup, 'gh api --paginate "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
+    assert_includes cleanup, '.[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | .id'
+    refute_includes cleanup, "--slurp"
     assert_includes cleanup, '[[ -z "${remaining_probe_versions}" ]]'
     refute_includes cleanup, "oras manifest delete"
   end

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -599,7 +599,7 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes workflow[cleanup_probe..], "steps.probe_cleanup_token.outputs.token || github.token"
   end
 
-  def test_feasibility_fails_closed_unless_the_exact_ghcr_probe_tag_is_deleted
+  def test_feasibility_fails_closed_unless_the_exact_ghcr_probe_version_is_deleted_via_rest
     workflow = File.read(repo_path(".github/workflows/release_feasibility.yml"))
     probe = workflow.split("- name: Prove private GHCR round trip and visibility", 2).fetch(1)
                     .split("- name: Delete the exact GHCR feasibility probe", 2).first
@@ -611,11 +611,16 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes cleanup, "if: ${{ always() && steps.ghcr_probe.outcome != 'skipped' }}"
     assert_includes cleanup, 'probe_ref="${GHCR_REPOSITORY}:feasibility-${GITHUB_RUN_ID}"'
     assert_includes cleanup, 'probe_tag="feasibility-${GITHUB_RUN_ID}"'
-    assert_includes cleanup, 'oras manifest delete --force "${probe_ref}"'
+    assert_includes cleanup, "probe_version_rows=\"$("
+    assert_includes cleanup, "Expected exactly one GHCR package version for the feasibility probe tag."
+    assert_includes cleanup, "IFS=$'\\t' read -r probe_version_id probe_version_tags"
+    assert_includes cleanup, '"${probe_version_tags}" == "${probe_tag}"'
+    assert_includes cleanup, 'gh api --method DELETE'
+    assert_includes cleanup, '"orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}"'
     assert_includes cleanup, 'gh api --paginate --slurp "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
     assert_includes cleanup, 'map(select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")))'
     assert_includes cleanup, '[[ -z "${remaining_probe_versions}" ]]'
-    refute_includes cleanup, 'oras manifest delete "${probe_ref}" >/dev/null 2>&1 || true'
+    refute_includes cleanup, "oras manifest delete"
   end
 
   def test_feasibility_binds_a_reusable_alpha_run_to_an_explicit_ancestor_sha


### PR DESCRIPTION
## Changes:
- Replace unsupported GHCR registry manifest deletion with the supported GitHub Packages REST version-deletion endpoint.
- Require exactly one package version carrying only the run-specific feasibility tag before deletion.
- Paginate the post-delete read-back and fail unless the exact tag is absent.
- Update the release runbook and regression coverage.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (release infrastructure only)

## Screenshots:
N/A

## Additional notes:
Feasibility run 31464096745 passed every substantive gate but failed closed during cleanup because GHCR returned `unsupported` for the OCI registry manifest-delete operation. GitHub documents Packages REST as the supported `GITHUB_TOKEN` deletion path for repository-linked granular-permission packages. Publishing remains disabled, and this PR contains no credentials or secret values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of release feasibility probes by deleting the exact package version associated with each probe.
  * Added safeguards to prevent cleanup when multiple or incorrectly tagged versions are found.
  * Added verification that no probe versions remain after cleanup.

* **Documentation**
  * Updated release guidance to reflect the more reliable package cleanup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->