### PR TITLE
#infra Handle empty GHCR probe cleanup

### DIFF
--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -299,10 +299,24 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}" \
             --silent
-          remaining_probe_versions="$(
-            gh api --paginate "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100" \
-              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | .id"
-          )"
+          package_endpoint="orgs/Sequel-Ace/packages/container/${package_name}"
+          set +e
+          package_readback_headers="$(gh api --include --silent "${package_endpoint}" 2>&1)"
+          package_readback_exit=$?
+          set -e
+          package_readback_status="$(awk 'NR == 1 { print $2 }' <<< "${package_readback_headers}")"
+          if [[ "${package_readback_exit}" -eq 0 && "${package_readback_status}" == "200" ]]; then
+            remaining_probe_versions="$(
+              gh api --paginate "${package_endpoint}/versions?per_page=100" \
+                --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | .id"
+            )"
+          elif [[ "${package_readback_exit}" -ne 0 && "${package_readback_status}" == "404" ]]; then
+            # Deleting the package's final version removes the empty package.
+            remaining_probe_versions=""
+          else
+            echo "Unexpected GHCR package read-back status ${package_readback_status:-unavailable}." >&2
+            exit 1
+          fi
           [[ -z "${remaining_probe_versions}" ]] || {
             echo "GHCR feasibility probe tag still exists after deletion." >&2
             exit 1

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -453,8 +453,11 @@ The GHCR probe is cleanup-sensitive: after the probe step is attempted, a
 separate unconditional cleanup step finds exactly one package version carrying
 only the run-specific tag and deletes it through GitHub's Packages REST API.
 The workflow preserves any earlier failure and also fails unless a paginated
-package API read-back proves that tag is gone. Do not use the OCI registry
-manifest-delete operation; GHCR reports that operation as unsupported.
+package API read-back proves that tag is gone. When the probe was the package's
+final version, GitHub removes the now-empty package; an exact `404` read-back
+after the successful version DELETE is therefore also accepted. Every other
+read-back failure remains fatal. Do not use the OCI registry manifest-delete
+operation; GHCR reports that operation as unsupported.
 
 The workflow refuses to start unless `SA_RELEASE_AUTOMATION_ENABLED` is already
 `false`, and it does not enable publishing itself. After every gate passes and

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -617,8 +617,15 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes cleanup, '"${probe_version_tags}" == "${probe_tag}"'
     assert_includes cleanup, 'gh api --method DELETE'
     assert_includes cleanup, '"orgs/Sequel-Ace/packages/container/${package_name}/versions/${probe_version_id}"'
-    assert_includes cleanup, 'gh api --paginate "orgs/Sequel-Ace/packages/container/${package_name}/versions?per_page=100"'
+    assert_includes cleanup, 'package_endpoint="orgs/Sequel-Ace/packages/container/${package_name}"'
+    assert_includes cleanup, 'package_readback_headers="$(gh api --include --silent "${package_endpoint}" 2>&1)"'
+    assert_includes cleanup, %q!package_readback_status="$(awk 'NR == 1 { print $2 }' <<< "${package_readback_headers}")"!
+    assert_includes cleanup, '"${package_readback_exit}" -eq 0 && "${package_readback_status}" == "200"'
+    assert_includes cleanup, 'gh api --paginate "${package_endpoint}/versions?per_page=100"'
     assert_includes cleanup, '.[] | select(any(.metadata.container.tags[]?; . == \"${probe_tag}\")) | .id'
+    assert_includes cleanup, '"${package_readback_exit}" -ne 0 && "${package_readback_status}" == "404"'
+    assert_includes cleanup, 'remaining_probe_versions=""'
+    assert_includes cleanup, 'Unexpected GHCR package read-back status ${package_readback_status:-unavailable}.'
     refute_includes cleanup, "--slurp"
     assert_includes cleanup, '[[ -z "${remaining_probe_versions}" ]]'
     refute_includes cleanup, "oras manifest delete"


### PR DESCRIPTION
## Changes

- Accept an exact package `404` only after successfully deleting the uniquely tagged GHCR feasibility version, covering the case where that was the package’s final version.
- Continue paginated version readback when the package remains and fail closed on every other HTTP/CLI outcome.
- Document and regression-test both cleanup states.

## Closes following issues

None.

## Tested

- Apple Silicon Mac, macOS 26.6, Homebrew Ruby 4.0.6
- `bundle exec ruby -I fastlane/lib:fastlane/test fastlane/test/workflow_recovery_test.rb` — 44 runs, 660 assertions
- `bundle exec rake -f fastlane/Rakefile test` — 285 runs, 1487 assertions
- Workflow YAML parse, Ruby syntax, `git diff --check`, and live `gh api --include --silent` 200/404 status extraction

## Screenshots

Not applicable; infrastructure only.

## Additional notes

Final feasibility run 31466303929 passed all existing gates. Independent cleanup then exposed that GitHub removes an empty package after its last version is deleted, so the old leaked probe had masked this clean-package branch. Release publishing remains disabled and no Xcode Cloud build was started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release feasibility cleanup to correctly handle packages removed after their final version is deleted.
  * Cleanup now accepts valid package responses and expected “not found” responses while reporting other failures clearly.

* **Tests**
  * Expanded workflow recovery coverage for successful, removed-package, and unexpected response scenarios.

* **Documentation**
  * Updated release guidance to reflect the revised cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->