### PR TITLE
#fixed Keep release Bundler config outside worktree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,11 +161,21 @@ jobs:
             /release-archive/ \
             /artifacts/ >> "${exclude_file}"
 
+      - name: Keep Bundler configuration outside the tracked worktree
+        run: |
+          set -euo pipefail
+          bundle_config_directory="$(mktemp -d "${RUNNER_TEMP}/sequel-ace-bundle-config.XXXXXX")"
+          cp .bundle/config "${bundle_config_directory}/config"
+          printf 'BUNDLE_APP_CONFIG=%s\n' "${bundle_config_directory}" >> "${GITHUB_ENV}"
+
       - name: Set up Ruby and locked gems
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: "3.3"
           bundler-cache: true
+
+      - name: Verify Bundler left tracked configuration unchanged
+        run: git diff --exit-code -- .bundle/config
 
       - name: Install checksum-pinned ORAS on Linux
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           bundler-cache: true
 
       - name: Verify Bundler left tracked configuration unchanged
-        run: git diff --exit-code -- .bundle/config
+        run: git diff --quiet -- .bundle/config
 
       - name: Install checksum-pinned ORAS on Linux
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -126,9 +126,8 @@ class WorkflowRecoveryTest < Minitest::Test
     setup = workflow[external_config...ruby_setup]
     assert_includes setup, 'mktemp -d "${RUNNER_TEMP}/sequel-ace-bundle-config.XXXXXX"'
     assert_includes setup, 'cp .bundle/config "${bundle_config_directory}/config"'
-    assert_includes setup, 'BUNDLE_APP_CONFIG=%s'
-    assert_includes setup, '>> "${GITHUB_ENV}"'
-    assert_includes workflow[config_check...preparation], "git diff --exit-code -- .bundle/config"
+    assert_includes setup, %q(printf 'BUNDLE_APP_CONFIG=%s\n' "${bundle_config_directory}" >> "${GITHUB_ENV}")
+    assert_includes workflow[config_check...preparation], "git diff --quiet -- .bundle/config"
   end
 
   def test_ambiguous_app_store_submission_is_polled_before_failure_recording

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -112,6 +112,25 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes feasibility[feasibility_exclusion...feasibility_probe], "/feasibility/"
   end
 
+  def test_release_keeps_bundler_configuration_outside_the_tracked_worktree
+    workflow = File.read(repo_path(".github/workflows/release.yml"))
+    external_config = workflow.index("- name: Keep Bundler configuration outside the tracked worktree")
+    ruby_setup = workflow.index("- name: Set up Ruby and locked gems")
+    config_check = workflow.index("- name: Verify Bundler left tracked configuration unchanged")
+    preparation = workflow.index("- name: Prepare explicit release files")
+
+    assert_operator external_config, :<, ruby_setup
+    assert_operator ruby_setup, :<, config_check
+    assert_operator config_check, :<, preparation
+
+    setup = workflow[external_config...ruby_setup]
+    assert_includes setup, 'mktemp -d "${RUNNER_TEMP}/sequel-ace-bundle-config.XXXXXX"'
+    assert_includes setup, 'cp .bundle/config "${bundle_config_directory}/config"'
+    assert_includes setup, 'BUNDLE_APP_CONFIG=%s'
+    assert_includes setup, '>> "${GITHUB_ENV}"'
+    assert_includes workflow[config_check...preparation], "git diff --exit-code -- .bundle/config"
+  end
+
   def test_ambiguous_app_store_submission_is_polled_before_failure_recording
     workflow = File.read(repo_path(".github/workflows/release_publish.yml"))
     recovery = workflow.split("  recover_publish_failure:", 2).fetch(1)


### PR DESCRIPTION
## Changes:
- Keep Bundler local configuration in a runner-temporary directory before `ruby/setup-ruby` runs.
- Verify dependency setup leaves the tracked `.bundle/config` unchanged without printing future configuration content.
- Add regression coverage for step ordering and the complete external configuration export.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A — release infrastructure only
- `fastlane/test/workflow_recovery_test.rb`: 45 runs, 695 assertions, 0 failures
- Full release-tool suite: 286 runs, 1,522 assertions, 0 failures
- Simulated Bundler local config writes with `BUNDLE_APP_CONFIG` redirected to a temporary directory; tracked `.bundle/config` remained byte-for-byte unchanged

## Screenshots:

N/A — release infrastructure only.

## Additional notes:
- Release run https://github.com/Sequel-Ace/Sequel-Ace/actions/runs/31543708544 passed authorization and Production build reconciliation, then stopped before any PR, tag, release, archive, or Cloud build because `ruby/setup-ruby` had modified the tracked `.bundle/config`.
- CodeRabbit follow-ups now use a quiet worktree check and assert the complete exported configuration path.
- The failed release branch was reconciled and is absent. The approved release plan will be regenerated after this fix merges because `main` will have changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release process by isolating temporary dependency configuration from tracked project settings.
  - Reduced the risk of unintended configuration changes being included in releases.
  - Confirmed that tracked configuration remains unchanged during release preparation.

- **Tests**
  - Added automated checks to verify configuration isolation and release workflow behavior.
  - Increased confidence that releases can be prepared consistently and safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->