### PR TITLE
#fixed Make changelog temp files portable

### DIFF
--- a/Scripts/generate-changelog.sh
+++ b/Scripts/generate-changelog.sh
@@ -22,9 +22,9 @@ if [[ ! -f "${CHANGELOG_FILE}" ]]; then
   exit 1
 fi
 
-temp_file="$(mktemp -t sequel-ace-changelog)"
-clean_changelog_file="$(mktemp -t sequel-ace-changelog-existing)"
-entries_file="$(mktemp -t sequel-ace-changelog-entries)"
+temp_file="$(mktemp "${TMPDIR:-/tmp}/sequel-ace-changelog.XXXXXX")"
+clean_changelog_file="$(mktemp "${TMPDIR:-/tmp}/sequel-ace-changelog-existing.XXXXXX")"
+entries_file="$(mktemp "${TMPDIR:-/tmp}/sequel-ace-changelog-entries.XXXXXX")"
 trap 'rm -f "${temp_file}" "${clean_changelog_file}" "${entries_file}"' EXIT
 
 find_last_release_ref() {

--- a/fastlane/test/changelog_generation_test.rb
+++ b/fastlane/test/changelog_generation_test.rb
@@ -5,42 +5,44 @@ require "open3"
 
 class ChangelogGenerationTest < Minitest::Test
   def test_repeated_beta_regeneration_keeps_the_complete_version_range
-    Dir.mktmpdir do |directory|
-      git(directory, "init", "--initial-branch=main")
-      git(directory, "config", "user.name", "Release Test")
-      git(directory, "config", "user.email", "release@example.invalid")
-      changelog = File.join(directory, "CHANGELOG.md")
-      File.write(changelog, "# Changelog\n\n## [5.3.1](https://example.invalid/5.3.1)\n\nStable.\n")
-      commit_all(directory, "Initial stable release")
-      git(directory, "tag", "production/5.3.1-20104")
+    with_gnu_compatible_mktemp do |environment|
+      Dir.mktmpdir do |directory|
+        git(directory, "init", "--initial-branch=main")
+        git(directory, "config", "user.name", "Release Test")
+        git(directory, "config", "user.email", "release@example.invalid")
+        changelog = File.join(directory, "CHANGELOG.md")
+        File.write(changelog, "# Changelog\n\n## [5.3.1](https://example.invalid/5.3.1)\n\nStable.\n")
+        commit_all(directory, "Initial stable release")
+        git(directory, "tag", "production/5.3.1-20104")
 
-      File.write(File.join(directory, "first-beta.txt"), "first\n")
-      commit_all(directory, "Fix first beta behavior #fixed")
-      generate_changelog(directory, changelog)
-      commit_all(directory, "Prepare 5.4.0 (20105) release #changed")
-      git(directory, "tag", "beta/5.4.0-20105")
+        File.write(File.join(directory, "first-beta.txt"), "first\n")
+        commit_all(directory, "Fix first beta behavior #fixed")
+        generate_changelog(directory, changelog, environment)
+        commit_all(directory, "Prepare 5.4.0 (20105) release #changed")
+        git(directory, "tag", "beta/5.4.0-20105")
 
-      File.write(File.join(directory, "second-beta.txt"), "second\n")
-      commit_all(directory, "Fix second beta behavior #fixed")
-      generate_changelog(directory, changelog)
+        File.write(File.join(directory, "second-beta.txt"), "second\n")
+        commit_all(directory, "Fix second beta behavior #fixed")
+        generate_changelog(directory, changelog, environment)
 
-      content = File.read(changelog)
-      assert_equal 1, content.scan("Fix first beta behavior").length
-      assert_equal 1, content.scan("Fix second beta behavior").length
-      refute_includes content, "Prepare 5.4.0 (20105) release"
+        content = File.read(changelog)
+        assert_equal 1, content.scan("Fix first beta behavior").length
+        assert_equal 1, content.scan("Fix second beta behavior").length
+        refute_includes content, "Prepare 5.4.0 (20105) release"
+      end
     end
   end
 
   private
 
-  def generate_changelog(directory, changelog)
+  def generate_changelog(directory, changelog, environment = {})
     script = File.expand_path("../../Scripts/generate-changelog.sh", __dir__)
     _stdout, stderr, status = Open3.capture3(
       {
         "CHANGELOG_FILE" => changelog,
         "RANGE_START" => "production/5.3.1-20104",
         "RANGE_END" => "HEAD"
-      },
+      }.merge(environment),
       script,
       "5.4.0",
       chdir: directory
@@ -58,5 +60,28 @@ class ChangelogGenerationTest < Minitest::Test
     raise "git #{arguments.join(' ')} failed: #{stderr}" unless status.success?
 
     stdout.strip
+  end
+
+  def with_gnu_compatible_mktemp
+    Dir.mktmpdir do |binary_directory|
+      fake_mktemp = File.join(binary_directory, "mktemp")
+      File.write(fake_mktemp, <<~'BASH')
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ "${1:-}" == "-t" ]]; then
+          echo "GNU-style mktemp requires an XXXXXX template" >&2
+          exit 64
+        fi
+        [[ "${1:-}" == *XXXXXX* ]] || {
+          echo "mktemp template must contain XXXXXX" >&2
+          exit 64
+        }
+        exec /usr/bin/mktemp "$@"
+      BASH
+      FileUtils.chmod(0o755, fake_mktemp)
+
+      yield("PATH" => "#{binary_directory}:#{ENV.fetch('PATH')}")
+    end
   end
 end


### PR DESCRIPTION
## Changes:
- Replace BSD-only mktemp -t usage in changelog generation with explicit XXXXXX templates accepted by both BSD and GNU mktemp.
- Exercise changelog generation through a GNU-compatible mktemp shim so the Ubuntu runner regression is covered.

## Closes following issues:
- Closes: none

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Not applicable; infrastructure-only shell and Ruby tests
- bash -n Scripts/generate-changelog.sh
- Targeted changelog test: 1 run, 4 assertions, 0 failures
- Full release-tool suite: 286 runs, 1,522 assertions, 0 failures

## Screenshots:
Not applicable.

## Additional notes:
- This fixes the exact failure in guarded release run 31548179090: GNU mktemp rejected the BSD-style template before any release PR, tag, GitHub release, or Xcode Cloud build was created.
- No Swift, Xcode project, app target, or shipped runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog generation to handle temporary files more consistently across environments.
  * Improved compatibility with systems using different temporary-directory configurations.

* **Tests**
  * Expanded changelog-generation coverage to validate temporary-file handling and command arguments.
  * Added environment-aware test execution for more reliable verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->