### PR TITLE
#fixed Ensure release tags trigger Xcode Cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,15 +272,27 @@ jobs:
       - name: Reconcile the authoritative Production Cloud build
         id: reconcile
         env:
+          SA_GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           SA_ASC_KEY_ID: ${{ secrets.SA_ASC_KEY_ID }}
           SA_ASC_ISSUER_ID: ${{ secrets.SA_ASC_ISSUER_ID }}
           SA_ASC_PRIVATE_KEY: ${{ secrets.SA_ASC_PRIVATE_KEY }}
           SA_ASC_PRIVATE_KEY_BASE64: "1"
+          RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          recovery_args=()
+          if [[ "${RELEASE_MODE}" == "resume" ]]; then
+            recovery_args+=(
+              --recover-release-channel "${RELEASE_CHANNEL}"
+              --recover-release-version "${RELEASE_VERSION}"
+            )
+          fi
           bundle exec ruby fastlane/bin/sa-release reconcile-build \
             --cloud-next-build "${{ inputs.production_cloud_next_build }}" \
             --workflow-id "${{ vars.SA_PRODUCTION_CLOUD_WORKFLOW_ID }}" \
+            "${recovery_args[@]}" \
             --output reconciliation.json
           ruby -rjson -e 'value = JSON.parse(File.read("reconciliation.json")); File.open(ENV.fetch("GITHUB_OUTPUT"), "a") { |file| file.puts("build=#{value.fetch("target_build")}"); file.puts("reason=#{value.fetch("reason")}"); file.puts("source_release_commit_sha=#{value["source_release_commit_sha"]}") if value["source_release_commit_sha"] }'
 
@@ -315,21 +327,22 @@ jobs:
             build: manifest.fetch("canonical_build"),
             iteration: manifest.fetch("iteration")
           )
-          resume_without_pr = ENV.fetch("RECONCILIATION_REASON") == "resume_after_merge"
+          recovery_reason = ENV.fetch("RECONCILIATION_REASON")
+          resume_without_pr = %w[resume_after_merge resume_after_tag].include?(recovery_reason)
           dispatch_main_advanced = ENV.fetch("DISPATCH_MAIN_SHA") != ENV.fetch("APPROVED_MAIN_SHA")
           if dispatch_main_advanced && !resume_without_pr
-            raise SequelAceRelease::ValidationError, "an advanced main is allowed only for merged-but-untagged recovery"
+            raise SequelAceRelease::ValidationError, "an advanced main is allowed only for exact release recovery"
           end
           if resume_without_pr
-            raise SequelAceRelease::ValidationError, "merged-but-untagged recovery requires mode=resume" unless ENV.fetch("RELEASE_MODE") == "resume"
+            raise SequelAceRelease::ValidationError, "exact release recovery requires mode=resume" unless ENV.fetch("RELEASE_MODE") == "resume"
             source_release_commit_sha = ENV.fetch("SOURCE_RELEASE_COMMIT_SHA")
             unless source_release_commit_sha.match?(/\A[0-9a-f]{40,64}\z/i)
-              raise SequelAceRelease::ValidationError, "merged-but-untagged recovery is missing its exact release commit"
+              raise SequelAceRelease::ValidationError, "release recovery is missing its exact release commit"
             end
             raise SequelAceRelease::ValidationError, "approved recovery SHA is not the release commit" unless source_release_commit_sha == ENV.fetch("APPROVED_MAIN_SHA")
             current = SequelAceRelease::VersionFiles.new.current
             expected = { "version" => ENV.fetch("EXPECTED_VERSION"), "build" => Integer(ENV.fetch("EXPECTED_BUILD")) }
-            raise SequelAceRelease::ValidationError, "merged release source does not match #{expected}" unless current == expected
+            raise SequelAceRelease::ValidationError, "recovered release source does not match #{expected}" unless current == expected
             heading = "## [#{expected.fetch('version')}]"
             raise SequelAceRelease::ValidationError, "merged release changelog is missing #{heading}" unless File.read("CHANGELOG.md").include?(heading)
           end
@@ -433,10 +446,14 @@ jobs:
           SA_ASC_ISSUER_ID: ${{ secrets.SA_ASC_ISSUER_ID }}
           SA_ASC_PRIVATE_KEY: ${{ secrets.SA_ASC_PRIVATE_KEY }}
           SA_ASC_PRIVATE_KEY_BASE64: "1"
+          SA_GITHUB_TOKEN: ${{ steps.merge_app_token.outputs.token || steps.app_token.outputs.token }}
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
           APPROVED_BASE_SHA: ${{ steps.plan.outputs.base_sha }}
           CHANGELOG_BASE_TAG: ${{ steps.plan.outputs.changelog_base_tag }}
           APPROVED_CHANGELOG_BASE_SHA: ${{ steps.plan.outputs.changelog_base_sha }}
+          RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           git fetch --force --prune --no-recurse-submodules origin '+refs/tags/*:refs/tags/*'
@@ -451,11 +468,19 @@ jobs:
             exit 1
           }
           source_build="$(ruby -rjson -e 'puts JSON.parse(File.read(ARGV.fetch(0))).fetch("current_source").fetch("build")' release-plan.json)"
+          recovery_args=()
+          if [[ "${RELEASE_MODE}" == "resume" ]]; then
+            recovery_args+=(
+              --recover-release-channel "${RELEASE_CHANNEL}"
+              --recover-release-version "${RELEASE_VERSION}"
+            )
+          fi
           bundle exec ruby fastlane/bin/sa-release reconcile-build \
             --source-build "${source_build}" \
             --cloud-next-build "${{ inputs.production_cloud_next_build }}" \
             --workflow-id "${{ vars.SA_PRODUCTION_CLOUD_WORKFLOW_ID }}" \
             --expected-target-build "${{ steps.reconcile.outputs.build }}" \
+            "${recovery_args[@]}" \
             --output pre-merge-reconciliation.json
           mv pre-merge-reconciliation.json reconciliation.json
           bundle exec ruby -I fastlane/lib -rsequel_ace_release -rjson <<'RUBY'
@@ -491,13 +516,14 @@ jobs:
           RESUME_WITHOUT_PR: ${{ steps.release_context.outputs.resume_without_pr }}
           MERGED_SHA: ${{ steps.merge.outputs.sha }}
           SOURCE_RELEASE_COMMIT_SHA: ${{ steps.release_context.outputs.source_release_commit_sha }}
+          RECONCILIATION_REASON: ${{ steps.reconcile.outputs.reason }}
         run: |
           set -euo pipefail
           ruby -rjson <<'RUBY'
           if ENV.fetch("RESUME_WITHOUT_PR") == "true"
             sha = ENV.fetch("SOURCE_RELEASE_COMMIT_SHA")
             validation = JSON.parse(File.read("release-target-validation.json"))
-            evidence = { "release_recovery" => { "reason" => "resume_after_merge", "source_sha" => sha, "live_main_validation" => validation } }
+            evidence = { "release_recovery" => { "reason" => ENV.fetch("RECONCILIATION_REASON"), "source_sha" => sha, "live_main_validation" => validation } }
           else
             sha = ENV.fetch("MERGED_SHA")
             raise "release merge did not return a commit SHA" if sha.empty?

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -131,6 +131,13 @@ Git-reference API before it publishes the prerelease. Do not let the Releases
 API synthesize a missing tag: that path can publish a release without emitting
 the tag-change event Xcode Cloud needs. An existing tag is reusable only when
 it is a lightweight ref that resolves directly to the exact release commit.
+Prerelease creation is idempotent: an existing release is reused only when its
+tag, title, body, draft flag, and prerelease flag exactly match the approved
+release. If explicit tag creation succeeds but GitHub has no release behind
+that tag, a newly approved `mode=resume` plan against the exact release commit
+reuses the same canonical build. The recovery validates the missing release
+and, if Cloud already consumed the tag, binds the exact Production workflow,
+tag, commit, and run before recreating the prerelease; it never bumps or retags.
 `.github/workflows/release_publish.yml` runs immediately after a successful
 handoff and at minutes 11 and 41 each hour. Its Linux job performs one exact
 Cloud-status read and exits; it starts the protected macOS verification job only
@@ -328,6 +335,13 @@ informational):
   Before any recovery mutation and again immediately before tagging, GitHub must
   prove that exact commit is still an ancestor of live `main` and that no
   protected release file changed after it.
+- Resume after tag: if the exact lightweight release tag resolves to the newest
+  release-preparation commit but its GitHub release is absent, `mode=resume`
+  reuses the source build. Cloud may either still report that build as next or
+  have exactly one run for it; the latter must identify the Production
+  workflow, exact tag, exact commit, and no later Production run. Any existing
+  GitHub release, mismatched tag/run, App Store build ahead of source, or Cloud
+  advancement beyond that one exact run aborts recovery.
 - Stop: `N` regresses, an intervening Production run is absent, histories
   conflict, or the eventual Cloud build does not exactly match the tag/build.
 

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -126,6 +126,11 @@ package-manager install.
 `.github/workflows/release.yml` deliberately stops after the exact merge, tag,
 prerelease, and `cloud_running` manifest have been pushed to private GHCR. It
 does not keep a macOS runner alive while Xcode Cloud builds or Apple notarizes.
+The release tool creates and verifies the lightweight Git tag through GitHub's
+Git-reference API before it publishes the prerelease. Do not let the Releases
+API synthesize a missing tag: that path can publish a release without emitting
+the tag-change event Xcode Cloud needs. An existing tag is reusable only when
+it is a lightweight ref that resolves directly to the exact release commit.
 `.github/workflows/release_publish.yml` runs immediately after a successful
 handoff and at minutes 11 and 41 each hour. Its Linux job performs one exact
 Cloud-status read and exits; it starts the protected macOS verification job only
@@ -162,7 +167,8 @@ public API does not expose the built-in
 Notarize post-action or the configured **Next Build Number** setting:
 
 - **Production:** scheme `Sequel Ace Release`; start on `production/*` and
-  `beta/*` tags; add the built-in Notarize post-action.
+  `beta/*` tags; allow manual starts for only those same tag prefixes (not
+  branches or pull requests); add the built-in Notarize post-action.
 - **Alpha:** scheme `Sequel Ace Beta`; remove the every-push-to-`main` trigger;
   retain manual `main`, schedule `main` nightly at 03:00
   `America/Los_Angeles`, and start on `beta/*` tags; add the built-in Notarize
@@ -176,6 +182,13 @@ requires both its Production and Alpha artifacts.
 After saving both workflows, manually start only Alpha from the current `main`
 commit. Record that Alpha build-run ID for the feasibility workflow. Do not
 manually start Production during setup.
+
+When changing Xcode Cloud start conditions through the App Store Connect API,
+read the complete workflow first and send every start-condition field that must
+remain enabled in the same update. Apple treats those attributes as a set; a
+partial update that supplies only `manualTagStartCondition` can clear the
+existing `tagStartCondition`. Always read back both conditions before creating
+a release tag.
 
 `.github/workflows/release_finalize.yml` checks for Production prereleases at
 minute 17 every six hours and also supports an authorized manual recovery run.

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -133,7 +133,9 @@ the tag-change event Xcode Cloud needs. An existing tag is reusable only when
 it is a lightweight ref that resolves directly to the exact release commit.
 Prerelease creation is idempotent: an existing release is reused only when its
 tag, title, body, draft flag, and prerelease flag exactly match the approved
-release. If explicit tag creation succeeds but GitHub has no release behind
+release. The direct-commit tag ref is revalidated immediately before and after
+both prerelease creation and reuse so a moved tag cannot be accepted. If
+explicit tag creation succeeds but GitHub has no release behind
 that tag, a newly approved `mode=resume` plan against the exact release commit
 reuses the same canonical build. The recovery validates the missing release
 and, if Cloud already consumed the tag, binds the exact Production workflow,

--- a/fastlane/lib/sequel_ace_release/build_reconciler.rb
+++ b/fastlane/lib/sequel_ace_release/build_reconciler.rb
@@ -21,7 +21,8 @@ module SequelAceRelease
     def reconcile(
       source_build:, highest_tag_build:, highest_asc_build:, cloud_next_build:,
       cloud_runs:, source_tagged:, source_release_commit_sha: nil,
-      expected_target_build: nil
+      expected_target_build: nil, recover_release_tag: nil,
+      production_workflow_id: nil
     )
       source = positive_integer(source_build, "source build")
       tag = nonnegative_integer(highest_tag_build, "highest tag build")
@@ -33,6 +34,20 @@ module SequelAceRelease
       indexed_runs = Array(cloud_runs).each_with_object({}) do |run, result|
         number = integer_or_nil(run["number"] || run[:number])
         result[number] = stringify_keys(run) if number
+      end
+
+      if recover_release_tag
+        return validate_expected_target!(recover_tagged_release(
+          source: source,
+          tag: tag,
+          asc: asc,
+          observed_cloud_next: observed_cloud_next,
+          indexed_runs: indexed_runs,
+          source_tagged: source_tagged,
+          source_release_commit_sha: source_release_commit_sha,
+          recover_release_tag: recover_release_tag,
+          production_workflow_id: production_workflow_id
+        ), expected_target_build)
       end
 
       if observed_cloud_next == source && !source_tagged && source > [tag, asc].max
@@ -99,6 +114,64 @@ module SequelAceRelease
     end
 
     private
+
+    def recover_tagged_release(
+      source:, tag:, asc:, observed_cloud_next:, indexed_runs:, source_tagged:,
+      source_release_commit_sha:, recover_release_tag:, production_workflow_id:
+    )
+      release_commit = validate_commit_sha!(source_release_commit_sha)
+      unless recover_release_tag.to_s.match?(%r{\A(?:production|beta)/\d+\.\d+\.\d+-#{source}\z})
+        raise ValidationError, "tag-only recovery does not match source build #{source}"
+      end
+      raise ValidationError, "tag-only recovery requires the exact canonical source tag" unless source_tagged && tag == source
+      if asc > source
+        raise ValidationError, "App Store Connect build #{asc} is ahead of tag-only recovery build #{source}"
+      end
+      unless production_workflow_id.to_s.match?(/\A[0-9A-F-]{36}\z/i)
+        raise ValidationError, "tag-only recovery requires the exact Production workflow ID"
+      end
+      if observed_cloud_next < source || observed_cloud_next > source + 1
+        raise ValidationError,
+              "Xcode Cloud next build #{observed_cloud_next} is incompatible with tag-only recovery build #{source}"
+      end
+
+      later_runs = indexed_runs.keys.select { |number| number > source }
+      unless later_runs.empty?
+        raise ValidationError,
+              "Production Xcode Cloud advanced beyond tag-only recovery build #{source}: #{later_runs.sort.join(', ')}"
+      end
+
+      source_run = indexed_runs[source]
+      if asc == source && source_run.nil?
+        raise ValidationError,
+              "App Store Connect build #{source} has no exact Production run for tag-only recovery"
+      end
+      if source_run
+        required = %w[id execution_progress source_commit git_reference workflow_id]
+        missing = required.select { |key| source_run[key].to_s.empty? }
+        unless missing.empty?
+          raise ValidationError,
+                "Production Xcode Cloud build #{source} is missing tag-only recovery evidence: #{missing.join(', ')}"
+        end
+        unless source_run["source_commit"].to_s.downcase == release_commit &&
+               source_run["git_reference"] == recover_release_tag &&
+               source_run["workflow_id"] == production_workflow_id
+          raise ValidationError, "Production Xcode Cloud build #{source} does not match the tag-only recovery identity"
+        end
+      elsif observed_cloud_next != source
+        raise ValidationError,
+              "Xcode Cloud advanced past tag-only recovery build #{source} without its exact Production run"
+      end
+
+      Result.new(
+        target_build: source,
+        observed_cloud_next_build: observed_cloud_next,
+        baseline: source,
+        reason: "resume_after_tag",
+        skipped_runs: [],
+        source_release_commit_sha: release_commit
+      )
+    end
 
     def validate_commit_sha!(value)
       return value.to_s.downcase if Config.valid_git_sha?(value)

--- a/fastlane/lib/sequel_ace_release/cli.rb
+++ b/fastlane/lib/sequel_ace_release/cli.rb
@@ -438,13 +438,17 @@ module SequelAceRelease
         target_sha: options[:target_sha],
         protected_paths: release_paths
       )
+      tag = client.create_or_validate_release_tag(
+        tag: naming.tag,
+        target_sha: options[:target_sha]
+      )
       release = client.create_release(
         tag: naming.tag,
         target_sha: options[:target_sha],
         title: naming.title,
         body: options[:body]
       )
-      emit({ "naming" => naming.to_h, "target_validation" => target_validation, "release" => release }, options[:output])
+      emit({ "naming" => naming.to_h, "target_validation" => target_validation, "tag" => tag, "release" => release }, options[:output])
     end
 
     def github_validate_release_target(arguments)

--- a/fastlane/lib/sequel_ace_release/cli.rb
+++ b/fastlane/lib/sequel_ace_release/cli.rb
@@ -187,6 +187,8 @@ module SequelAceRelease
         value.on("--cloud-runs FILE") { |item| options[:cloud_runs] = read_json(item) }
         value.on("--workflow-id ID") { |item| options[:workflow_id] = item }
         value.on("--source-tagged") { options[:source_tagged] = true }
+        value.on("--recover-release-channel CHANNEL") { |item| options[:recover_release_channel] = item }
+        value.on("--recover-release-version VERSION") { |item| options[:recover_release_version] = item }
         value.on("--output FILE") { |item| options[:output] = item }
       end
       parser.parse!(arguments)
@@ -206,6 +208,14 @@ module SequelAceRelease
       source_tags = git.tags("production/*-#{source_build}") + git.tags("beta/*-#{source_build}")
       source_tagged = options.fetch(:source_tagged, false) || source_tags.any?
       source_release_commit_sha = git.latest_commit_changing_all(release_paths)
+      recovery_tag = recover_release_tag(
+        options: options,
+        git: git,
+        source_build: source_build,
+        source_release_commit_sha: source_release_commit_sha,
+        runs: runs,
+        app_store_client: asc_client
+      )
 
       result = BuildReconciler.new.reconcile(
         source_build: source_build,
@@ -215,7 +225,9 @@ module SequelAceRelease
         cloud_runs: runs,
         source_tagged: source_tagged,
         source_release_commit_sha: source_release_commit_sha,
-        expected_target_build: options[:expected_target_build]
+        expected_target_build: options[:expected_target_build],
+        recover_release_tag: recovery_tag,
+        production_workflow_id: options[:workflow_id]
       )
       emit(result.to_h.merge("production_cloud_runs" => runs), options[:output])
     end
@@ -442,7 +454,7 @@ module SequelAceRelease
         tag: naming.tag,
         target_sha: options[:target_sha]
       )
-      release = client.create_release(
+      release = client.create_or_validate_release(
         tag: naming.tag,
         target_sha: options[:target_sha],
         title: naming.title,
@@ -1109,6 +1121,39 @@ module SequelAceRelease
 
     def highest_build_from_tags(tags)
       tags.filter_map { |tag| tag[%r{\A(?:production|beta)/\d+\.\d+\.\d+-([1-9]\d*)\z}, 1]&.to_i }.max || 0
+    end
+
+    def recover_release_tag(options:, git:, source_build:, source_release_commit_sha:, runs:, app_store_client:)
+      channel = options[:recover_release_channel]
+      version = options[:recover_release_version]
+      return nil if channel.nil? && version.nil?
+      if channel.to_s.empty? || version.to_s.empty?
+        raise ValidationError, "tag-only recovery requires both release channel and version"
+      end
+
+      naming = ReleaseNaming.new(channel: channel, version: version, build: source_build, iteration: 1)
+      tag = naming.tag
+      return nil unless git.tag_exists?(tag)
+      unless Config.valid_git_sha?(source_release_commit_sha) && git.sha("refs/tags/#{tag}") == source_release_commit_sha
+        raise IntegrityError, "tag-only recovery tag does not resolve to the exact release preparation commit"
+      end
+
+      begin
+        github_client.release_by_tag(tag)
+        return nil
+      rescue APIError => error
+        raise unless error.message.include?("HTTP 404")
+      end
+      if options[:workflow_id].to_s.empty? || app_store_client.nil?
+        raise ValidationError, "tag-only recovery requires Production Xcode Cloud access"
+      end
+
+      run = Array(runs).find { |candidate| candidate["number"].to_i == source_build }
+      if run
+        details = app_store_client.build_run(run.fetch("id"))
+        run.replace(run.merge(details))
+      end
+      tag
     end
 
     def release_pull_request_body(naming, release_body)

--- a/fastlane/lib/sequel_ace_release/github_client.rb
+++ b/fastlane/lib/sequel_ace_release/github_client.rb
@@ -322,6 +322,44 @@ module SequelAceRelease
       })
     end
 
+    def create_or_validate_release(tag:, target_sha:, title:, body:)
+      validate_commit_sha!(target_sha, "release target SHA")
+      begin
+        existing = release_by_tag(tag)
+        return validate_release_response!(
+          existing,
+          tag: tag,
+          title: title,
+          body: body,
+          created: false
+        )
+      rescue APIError => error
+        raise unless error.message.include?("HTTP 404")
+      end
+
+      begin
+        created = create_release(tag: tag, target_sha: target_sha, title: title, body: body)
+      rescue APIError => creation_error
+        # GitHub can accept the write while the client loses the response. Read
+        # the canonical tag endpoint before surfacing the original error so a
+        # retry cannot create or misclassify a second release.
+        begin
+          existing = release_by_tag(tag)
+          return validate_release_response!(
+            existing,
+            tag: tag,
+            title: title,
+            body: body,
+            created: false
+          )
+        rescue APIError
+          raise creation_error
+        end
+      end
+
+      validate_release_response!(created, tag: tag, title: title, body: body, created: true)
+    end
+
     def create_or_validate_release_tag(tag:, target_sha:)
       validate_commit_sha!(target_sha, "release target SHA")
       expected_ref = "refs/tags/#{tag}"
@@ -471,6 +509,22 @@ module SequelAceRelease
       unless response.is_a?(Hash) && response["ref"] == expected_ref &&
              response.dig("object", "type") == "commit" && response.dig("object", "sha") == target_sha
         raise IntegrityError, "release tag does not resolve directly to the exact release commit"
+      end
+
+      response.merge("created" => created)
+    end
+
+    def validate_release_response!(response, tag:, title:, body:, created:)
+      expected = {
+        "tag_name" => tag,
+        "name" => title,
+        "body" => body,
+        "draft" => false,
+        "prerelease" => true
+      }
+      actual = expected.keys.to_h { |key| [key, response[key]] } if response.is_a?(Hash)
+      unless response.is_a?(Hash) && response["id"].is_a?(Integer) && response["id"].positive? && actual == expected
+        raise IntegrityError, "GitHub release does not match the exact approved prerelease"
       end
 
       response.merge("created" => created)

--- a/fastlane/lib/sequel_ace_release/github_client.rb
+++ b/fastlane/lib/sequel_ace_release/github_client.rb
@@ -324,40 +324,53 @@ module SequelAceRelease
 
     def create_or_validate_release(tag:, target_sha:, title:, body:)
       validate_commit_sha!(target_sha, "release target SHA")
+      validate_exact_release_tag!(tag: tag, target_sha: target_sha)
+
+      existing = nil
       begin
         existing = release_by_tag(tag)
-        return validate_release_response!(
+      rescue APIError => error
+        raise unless error.message.include?("HTTP 404")
+      end
+      if existing
+        validated = validate_release_response!(
           existing,
           tag: tag,
           title: title,
           body: body,
           created: false
         )
-      rescue APIError => error
-        raise unless error.message.include?("HTTP 404")
+        validate_exact_release_tag!(tag: tag, target_sha: target_sha)
+        return validated
       end
 
+      validate_exact_release_tag!(tag: tag, target_sha: target_sha)
       begin
         created = create_release(tag: tag, target_sha: target_sha, title: title, body: body)
       rescue APIError => creation_error
         # GitHub can accept the write while the client loses the response. Read
         # the canonical tag endpoint before surfacing the original error so a
         # retry cannot create or misclassify a second release.
+        validate_exact_release_tag!(tag: tag, target_sha: target_sha)
         begin
           existing = release_by_tag(tag)
-          return validate_release_response!(
-            existing,
-            tag: tag,
-            title: title,
-            body: body,
-            created: false
-          )
         rescue APIError
           raise creation_error
         end
+        validated = validate_release_response!(
+          existing,
+          tag: tag,
+          title: title,
+          body: body,
+          created: false
+        )
+        validate_exact_release_tag!(tag: tag, target_sha: target_sha)
+        return validated
       end
 
-      validate_release_response!(created, tag: tag, title: title, body: body, created: true)
+      validated = validate_release_response!(created, tag: tag, title: title, body: body, created: true)
+      validate_exact_release_tag!(tag: tag, target_sha: target_sha)
+      validated
     end
 
     def create_or_validate_release_tag(tag:, target_sha:)
@@ -504,6 +517,12 @@ module SequelAceRelease
     end
 
     private
+
+    def validate_exact_release_tag!(tag:, target_sha:)
+      expected_ref = "refs/tags/#{tag}"
+      response = request!("GET", "/repos/#{@repository}/git/ref/tags/#{URI.encode_www_form_component(tag)}")
+      validate_release_tag_response!(response, expected_ref: expected_ref, target_sha: target_sha, created: false)
+    end
 
     def validate_release_tag_response!(response, expected_ref:, target_sha:, created:)
       unless response.is_a?(Hash) && response["ref"] == expected_ref &&

--- a/fastlane/lib/sequel_ace_release/github_client.rb
+++ b/fastlane/lib/sequel_ace_release/github_client.rb
@@ -322,6 +322,31 @@ module SequelAceRelease
       })
     end
 
+    def create_or_validate_release_tag(tag:, target_sha:)
+      validate_commit_sha!(target_sha, "release target SHA")
+      expected_ref = "refs/tags/#{tag}"
+
+      begin
+        existing = request!("GET", "/repos/#{@repository}/git/ref/tags/#{URI.encode_www_form_component(tag)}")
+        return validate_release_tag_response!(existing, expected_ref: expected_ref, target_sha: target_sha, created: false)
+      rescue APIError => error
+        raise unless error.message.include?("HTTP 404")
+      end
+
+      begin
+        created = request!("POST", "/repos/#{@repository}/git/refs", body: {
+          "ref" => expected_ref,
+          "sha" => target_sha
+        })
+      rescue APIError => error
+        raise unless error.message.include?("HTTP 422")
+
+        raced = request!("GET", "/repos/#{@repository}/git/ref/tags/#{URI.encode_www_form_component(tag)}")
+        return validate_release_tag_response!(raced, expected_ref: expected_ref, target_sha: target_sha, created: false)
+      end
+      validate_release_tag_response!(created, expected_ref: expected_ref, target_sha: target_sha, created: true)
+    end
+
     def validate_release_target!(target_sha:, protected_paths:)
       validate_commit_sha!(target_sha, "release target SHA")
       current_main = ref_sha
@@ -441,6 +466,15 @@ module SequelAceRelease
     end
 
     private
+
+    def validate_release_tag_response!(response, expected_ref:, target_sha:, created:)
+      unless response.is_a?(Hash) && response["ref"] == expected_ref &&
+             response.dig("object", "type") == "commit" && response.dig("object", "sha") == target_sha
+        raise IntegrityError, "release tag does not resolve directly to the exact release commit"
+      end
+
+      response.merge("created" => created)
+    end
 
     def verified_commit_evidence(commit)
       validate_commit_sha!(commit.fetch("oid"), "created release commit SHA")

--- a/fastlane/test/build_reconciler_test.rb
+++ b/fastlane/test/build_reconciler_test.rb
@@ -155,6 +155,106 @@ class BuildReconcilerTest < Minitest::Test
     assert_equal "normal_increment", result.reason
   end
 
+  def test_tag_only_recovery_reuses_the_source_build_before_cloud_consumes_it
+    result = reconcile(
+      source_build: 20_105,
+      highest_tag_build: 20_105,
+      highest_asc_build: 20_104,
+      cloud_next_build: 20_105,
+      source_tagged: true,
+      source_release_commit_sha: "a" * 40,
+      recover_release_tag: "production/5.4.0-20105",
+      production_workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE"
+    )
+
+    assert_equal 20_105, result.target_build
+    assert_equal "resume_after_tag", result.reason
+    assert_equal "a" * 40, result.source_release_commit_sha
+  end
+
+  def test_tag_only_recovery_reuses_the_exact_consumed_cloud_run
+    result = reconcile(
+      source_build: 20_105,
+      highest_tag_build: 20_105,
+      highest_asc_build: 20_105,
+      cloud_next_build: 20_106,
+      source_tagged: true,
+      source_release_commit_sha: "a" * 40,
+      recover_release_tag: "production/5.4.0-20105",
+      production_workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE",
+      cloud_runs: [{
+        "id" => "run-20105",
+        "number" => 20_105,
+        "execution_progress" => "COMPLETE",
+        "completion_status" => "SUCCEEDED",
+        "source_commit" => "a" * 40,
+        "git_reference" => "production/5.4.0-20105",
+        "workflow_id" => "DB2243BC-F641-472D-995E-3C9198C235DE"
+      }]
+    )
+
+    assert_equal 20_105, result.target_build
+    assert_equal "resume_after_tag", result.reason
+  end
+
+  def test_tag_only_recovery_rejects_cloud_advancement_without_the_exact_run
+    error = assert_raises(SequelAceRelease::ValidationError) do
+      reconcile(
+        source_build: 20_105,
+        highest_tag_build: 20_105,
+        cloud_next_build: 20_106,
+        source_tagged: true,
+        source_release_commit_sha: "a" * 40,
+        recover_release_tag: "production/5.4.0-20105",
+        production_workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE"
+      )
+    end
+
+    assert_includes error.message, "without its exact Production run"
+  end
+
+  def test_tag_only_recovery_rejects_an_app_store_build_without_the_exact_run
+    error = assert_raises(SequelAceRelease::ValidationError) do
+      reconcile(
+        source_build: 20_105,
+        highest_tag_build: 20_105,
+        highest_asc_build: 20_105,
+        cloud_next_build: 20_105,
+        source_tagged: true,
+        source_release_commit_sha: "a" * 40,
+        recover_release_tag: "production/5.4.0-20105",
+        production_workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE"
+      )
+    end
+
+    assert_includes error.message, "has no exact Production run"
+  end
+
+  def test_tag_only_recovery_rejects_a_mismatched_cloud_identity
+    error = assert_raises(SequelAceRelease::ValidationError) do
+      reconcile(
+        source_build: 20_105,
+        highest_tag_build: 20_105,
+        cloud_next_build: 20_106,
+        source_tagged: true,
+        source_release_commit_sha: "a" * 40,
+        recover_release_tag: "production/5.4.0-20105",
+        production_workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE",
+        cloud_runs: [{
+          "id" => "run-20105",
+          "number" => 20_105,
+          "execution_progress" => "COMPLETE",
+          "completion_status" => "SUCCEEDED",
+          "source_commit" => "b" * 40,
+          "git_reference" => "production/5.4.0-20105",
+          "workflow_id" => "DB2243BC-F641-472D-995E-3C9198C235DE"
+        }]
+      )
+    end
+
+    assert_includes error.message, "does not match the tag-only recovery identity"
+  end
+
   def test_regression_aborts
     assert_raises(SequelAceRelease::ValidationError) do
       reconcile(source_build: 20_105, cloud_next_build: 20_104)

--- a/fastlane/test/cli_build_reconciliation_test.rb
+++ b/fastlane/test/cli_build_reconciliation_test.rb
@@ -36,4 +36,76 @@ class CliBuildReconciliationTest < Minitest::Test
     assert_equal 1, status
     assert_includes error.string, "canonical release tag build 20106 is ahead of source build 20105"
   end
+
+  def test_tag_only_recovery_validates_the_missing_release_and_enriches_its_cloud_run
+    commit = "a" * 40
+    tag = "production/5.4.0-20105"
+    git = Object.new
+    git.define_singleton_method(:tag_exists?) { |candidate| candidate == tag }
+    git.define_singleton_method(:sha) { |_ref| commit }
+    github = Object.new
+    github.define_singleton_method(:release_by_tag) do |_candidate|
+      raise SequelAceRelease::APIError, "GitHub API returned HTTP 404: Not Found"
+    end
+    apple = Object.new
+    apple.define_singleton_method(:build_run) do |run_id|
+      raise "wrong run" unless run_id == "run-20105"
+
+      {
+        "workflow_id" => "DB2243BC-F641-472D-995E-3C9198C235DE",
+        "git_reference" => tag,
+        "source_commit" => commit
+      }
+    end
+    runs = [{ "id" => "run-20105", "number" => 20_105 }]
+    cli = SequelAceRelease::CLI.new(out: StringIO.new, err: StringIO.new, env: {})
+
+    recovered = cli.stub(:github_client, github) do
+      cli.send(
+        :recover_release_tag,
+        options: {
+          recover_release_channel: "production",
+          recover_release_version: "5.4.0",
+          workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE"
+        },
+        git: git,
+        source_build: 20_105,
+        source_release_commit_sha: commit,
+        runs: runs,
+        app_store_client: apple
+      )
+    end
+
+    assert_equal tag, recovered
+    assert_equal tag, runs.first.fetch("git_reference")
+    assert_equal commit, runs.first.fetch("source_commit")
+  end
+
+  def test_tag_only_recovery_is_not_selected_when_the_prerelease_exists
+    commit = "a" * 40
+    git = Object.new
+    git.define_singleton_method(:tag_exists?) { |_candidate| true }
+    git.define_singleton_method(:sha) { |_ref| commit }
+    github = Object.new
+    github.define_singleton_method(:release_by_tag) { |_candidate| { "id" => 100 } }
+    cli = SequelAceRelease::CLI.new(out: StringIO.new, err: StringIO.new, env: {})
+
+    recovered = cli.stub(:github_client, github) do
+      cli.send(
+        :recover_release_tag,
+        options: {
+          recover_release_channel: "production",
+          recover_release_version: "5.4.0",
+          workflow_id: "DB2243BC-F641-472D-995E-3C9198C235DE"
+        },
+        git: git,
+        source_build: 20_105,
+        source_release_commit_sha: commit,
+        runs: [],
+        app_store_client: Object.new
+      )
+    end
+
+    assert_nil recovered
+  end
 end

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -48,6 +48,85 @@ class GitHubClientTest < Minitest::Test
     assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases/latest", transport.requests.first[:path]
   end
 
+  def test_creates_the_lightweight_release_tag_before_publishing_the_release
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => target_sha }
+      }),
+      http_response(body: { "id" => 100, "tag_name" => tag })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    tag_result = client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
+    release = client.create_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+
+    assert_equal true, tag_result.fetch("created")
+    assert_equal tag, release.fetch("tag_name")
+    assert_equal ["GET", "POST", "POST"], transport.requests.map { |request| request.fetch(:method) }
+    assert_equal "/repos/Sequel-Ace/Sequel-Ace/git/refs", transport.requests.fetch(1).fetch(:path)
+    assert_equal({ "ref" => "refs/tags/#{tag}", "sha" => target_sha }, transport.requests.fetch(1).fetch(:body))
+    assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(2).fetch(:path)
+  end
+
+  def test_reuses_only_an_existing_lightweight_tag_at_the_exact_release_commit
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => target_sha }
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    result = client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
+
+    assert_equal false, result.fetch("created")
+    assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_validates_the_winning_tag_when_creation_races_another_request
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(status: 422, body: { "message" => "Reference already exists" }),
+      http_response(body: {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => target_sha }
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    result = client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
+
+    assert_equal false, result.fetch("created")
+    assert_equal ["GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_rejects_a_conflicting_or_annotated_release_tag_before_publishing
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "tag", "sha" => "b" * 40 }
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal 1, transport.requests.length
+  end
+
   def test_accepts_an_exact_release_target_that_remains_an_unchanged_main_ancestor
     target_sha = "a" * 40
     current_main = "b" * 40

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -57,19 +57,96 @@ class GitHubClientTest < Minitest::Test
         "ref" => "refs/tags/#{tag}",
         "object" => { "type" => "commit", "sha" => target_sha }
       }),
-      http_response(body: { "id" => 100, "tag_name" => tag })
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: {
+        "id" => 100,
+        "tag_name" => tag,
+        "name" => "5.4.0",
+        "body" => "Notes",
+        "draft" => false,
+        "prerelease" => true
+      })
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
 
     tag_result = client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
-    release = client.create_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+    release = client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
 
     assert_equal true, tag_result.fetch("created")
+    assert_equal true, release.fetch("created")
     assert_equal tag, release.fetch("tag_name")
-    assert_equal ["GET", "POST", "POST"], transport.requests.map { |request| request.fetch(:method) }
+    assert_equal ["GET", "POST", "GET", "POST"], transport.requests.map { |request| request.fetch(:method) }
     assert_equal "/repos/Sequel-Ace/Sequel-Ace/git/refs", transport.requests.fetch(1).fetch(:path)
     assert_equal({ "ref" => "refs/tags/#{tag}", "sha" => target_sha }, transport.requests.fetch(1).fetch(:body))
-    assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(2).fetch(:path)
+    assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(3).fetch(:path)
+  end
+
+  def test_reuses_only_an_exact_existing_prerelease
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: {
+        "id" => 100,
+        "tag_name" => tag,
+        "name" => "5.4.0",
+        "body" => "Notes",
+        "draft" => false,
+        "prerelease" => true
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    release = client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+
+    assert_equal false, release.fetch("created")
+    assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_recovers_when_github_accepts_release_but_the_create_response_is_lost
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    exact_release = {
+      "id" => 100,
+      "tag_name" => tag,
+      "name" => "5.4.0",
+      "body" => "Notes",
+      "draft" => false,
+      "prerelease" => true
+    }
+    transport = FakeTransport.new([
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(status: 502, body: { "message" => "Bad Gateway" }),
+      http_response(body: exact_release)
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    release = client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+
+    assert_equal false, release.fetch("created")
+    assert_equal ["GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_rejects_an_existing_release_with_different_approved_content
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: {
+        "id" => 100,
+        "tag_name" => tag,
+        "name" => "5.4.0",
+        "body" => "Different notes",
+        "draft" => false,
+        "prerelease" => true
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+    end
+
+    assert_includes error.message, "exact approved prerelease"
+    assert_equal 1, transport.requests.length
   end
 
   def test_reuses_only_an_existing_lightweight_tag_at_the_exact_release_commit

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -82,6 +82,15 @@ class GitHubClientTest < Minitest::Test
     assert_equal "/repos/Sequel-Ace/Sequel-Ace/git/refs", transport.requests.fetch(1).fetch(:path)
     assert_equal({ "ref" => "refs/tags/#{tag}", "sha" => target_sha }, transport.requests.fetch(1).fetch(:body))
     assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(5).fetch(:path)
+    assert_equal({
+      "tag_name" => tag,
+      "target_commitish" => target_sha,
+      "name" => "5.4.0",
+      "body" => "Notes",
+      "draft" => false,
+      "prerelease" => true,
+      "make_latest" => "false"
+    }, transport.requests.fetch(5).fetch(:body))
   end
 
   def test_reuses_only_an_exact_existing_prerelease
@@ -277,13 +286,32 @@ class GitHubClientTest < Minitest::Test
     assert_equal ["GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
   end
 
-  def test_rejects_a_conflicting_or_annotated_release_tag_before_publishing
+  def test_rejects_an_annotated_release_tag_before_publishing
     target_sha = "a" * 40
     tag = "production/5.4.0-20105"
     transport = FakeTransport.new([
       http_response(body: {
         "ref" => "refs/tags/#{tag}",
         "object" => { "type" => "tag", "sha" => "b" * 40 }
+      })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release_tag(tag: tag, target_sha: target_sha)
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal 1, transport.requests.length
+  end
+
+  def test_rejects_a_conflicting_lightweight_release_tag_before_publishing
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => "b" * 40 }
       })
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -57,7 +57,9 @@ class GitHubClientTest < Minitest::Test
         "ref" => "refs/tags/#{tag}",
         "object" => { "type" => "commit", "sha" => target_sha }
       }),
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(body: {
         "id" => 100,
         "tag_name" => tag,
@@ -65,7 +67,8 @@ class GitHubClientTest < Minitest::Test
         "body" => "Notes",
         "draft" => false,
         "prerelease" => true
-      })
+      }),
+      http_response(body: release_tag_response(tag, target_sha))
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
 
@@ -75,16 +78,17 @@ class GitHubClientTest < Minitest::Test
     assert_equal true, tag_result.fetch("created")
     assert_equal true, release.fetch("created")
     assert_equal tag, release.fetch("tag_name")
-    assert_equal ["GET", "POST", "GET", "POST"], transport.requests.map { |request| request.fetch(:method) }
+    assert_equal ["GET", "POST", "GET", "GET", "GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
     assert_equal "/repos/Sequel-Ace/Sequel-Ace/git/refs", transport.requests.fetch(1).fetch(:path)
     assert_equal({ "ref" => "refs/tags/#{tag}", "sha" => target_sha }, transport.requests.fetch(1).fetch(:body))
-    assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(3).fetch(:path)
+    assert_equal "/repos/Sequel-Ace/Sequel-Ace/releases", transport.requests.fetch(5).fetch(:path)
   end
 
   def test_reuses_only_an_exact_existing_prerelease
     target_sha = "a" * 40
     tag = "production/5.4.0-20105"
     transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(body: {
         "id" => 100,
         "tag_name" => tag,
@@ -92,14 +96,15 @@ class GitHubClientTest < Minitest::Test
         "body" => "Notes",
         "draft" => false,
         "prerelease" => true
-      })
+      }),
+      http_response(body: release_tag_response(tag, target_sha))
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
 
     release = client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
 
     assert_equal false, release.fetch("created")
-    assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
+    assert_equal ["GET", "GET", "GET"], transport.requests.map { |request| request.fetch(:method) }
   end
 
   def test_recovers_when_github_accepts_release_but_the_create_response_is_lost
@@ -114,22 +119,57 @@ class GitHubClientTest < Minitest::Test
       "prerelease" => true
     }
     transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(status: 502, body: { "message" => "Bad Gateway" }),
-      http_response(body: exact_release)
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(body: exact_release),
+      http_response(body: release_tag_response(tag, target_sha))
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
 
     release = client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
 
     assert_equal false, release.fetch("created")
-    assert_equal ["GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
+    assert_equal ["GET", "GET", "GET", "POST", "GET", "GET", "GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_rejects_ambiguous_release_recovery_when_the_tag_moves
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    exact_release = {
+      "id" => 100,
+      "tag_name" => tag,
+      "name" => "5.4.0",
+      "body" => "Notes",
+      "draft" => false,
+      "prerelease" => true
+    }
+    transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(status: 502, body: { "message" => "Bad Gateway" }),
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(body: exact_release),
+      http_response(body: release_tag_response(tag, "b" * 40))
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal ["GET", "GET", "GET", "POST", "GET", "GET", "GET"], transport.requests.map { |request| request.fetch(:method) }
   end
 
   def test_rejects_an_existing_release_with_different_approved_content
     target_sha = "a" * 40
     tag = "production/5.4.0-20105"
     transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
       http_response(body: {
         "id" => 100,
         "tag_name" => tag,
@@ -146,7 +186,59 @@ class GitHubClientTest < Minitest::Test
     end
 
     assert_includes error.message, "exact approved prerelease"
-    assert_equal 1, transport.requests.length
+    assert_equal 2, transport.requests.length
+  end
+
+  def test_rejects_a_release_when_its_tag_moves_during_reuse
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(body: {
+        "id" => 100,
+        "tag_name" => tag,
+        "name" => "5.4.0",
+        "body" => "Notes",
+        "draft" => false,
+        "prerelease" => true
+      }),
+      http_response(body: release_tag_response(tag, "b" * 40))
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal ["GET", "GET", "GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_rejects_a_new_release_when_its_tag_moves_during_creation
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(status: 404, body: { "message" => "Not Found" }),
+      http_response(body: release_tag_response(tag, target_sha)),
+      http_response(body: {
+        "id" => 100,
+        "tag_name" => tag,
+        "name" => "5.4.0",
+        "body" => "Notes",
+        "draft" => false,
+        "prerelease" => true
+      }),
+      http_response(body: release_tag_response(tag, "b" * 40))
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.create_or_validate_release(tag: tag, target_sha: target_sha, title: "5.4.0", body: "Notes")
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal ["GET", "GET", "GET", "POST", "GET"], transport.requests.map { |request| request.fetch(:method) }
   end
 
   def test_reuses_only_an_existing_lightweight_tag_at_the_exact_release_commit
@@ -851,6 +943,13 @@ class GitHubClientTest < Minitest::Test
   end
 
   private
+
+  def release_tag_response(tag, sha)
+    {
+      "ref" => "refs/tags/#{tag}",
+      "object" => { "type" => "commit", "sha" => sha }
+    }
+  end
 
   def inspected_commit_response(sha:, parent:, signed: true)
     http_response(body: {

--- a/fastlane/test/github_release_creation_test.rb
+++ b/fastlane/test/github_release_creation_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GitHubReleaseCreationTest < Minitest::Test
+  class Client
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def validate_release_target!(target_sha:, protected_paths:)
+      raise "wrong target" unless target_sha == "a" * 40
+      raise "missing protected paths" if protected_paths.empty?
+
+      @events << :validate_target
+      { "target_sha" => target_sha }
+    end
+
+    def create_or_validate_release_tag(tag:, target_sha:)
+      raise "wrong tag" unless tag == "production/5.4.0-20105"
+      raise "wrong target" unless target_sha == "a" * 40
+
+      @events << :create_tag
+      {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => target_sha },
+        "created" => true
+      }
+    end
+
+    def create_release(tag:, target_sha:, title:, body:)
+      raise "tag was not created first" unless @events == %i[validate_target create_tag]
+      raise "wrong tag" unless tag == "production/5.4.0-20105"
+      raise "wrong target" unless target_sha == "a" * 40
+      raise "wrong title" unless title == "5.4.0 (20105) - Release Candidate 1"
+      raise "wrong body" unless body == "Approved notes"
+
+      @events << :publish_release
+      { "id" => 100, "tag_name" => tag }
+    end
+  end
+
+  def test_cli_creates_the_exact_tag_before_publishing_the_prerelease
+    client = Client.new
+    output = StringIO.new
+    cli = SequelAceRelease::CLI.new(out: output, err: StringIO.new, env: {})
+
+    Dir.mktmpdir do |directory|
+      body = File.join(directory, "release-body.md")
+      File.write(body, "Approved notes")
+      status = cli.stub(:github_client, client) do
+        cli.run([
+          "github-create-release",
+          "--channel", "production",
+          "--version", "5.4.0",
+          "--build", "20105",
+          "--iteration", "1",
+          "--target-sha", "a" * 40,
+          "--body", body
+        ])
+      end
+
+      assert_equal 0, status
+    end
+
+    assert_equal %i[validate_target create_tag publish_release], client.events
+    result = JSON.parse(output.string)
+    assert_equal true, result.dig("tag", "created")
+    assert_equal 100, result.dig("release", "id")
+  end
+end

--- a/fastlane/test/github_release_creation_test.rb
+++ b/fastlane/test/github_release_creation_test.rb
@@ -30,7 +30,7 @@ class GitHubReleaseCreationTest < Minitest::Test
       }
     end
 
-    def create_release(tag:, target_sha:, title:, body:)
+    def create_or_validate_release(tag:, target_sha:, title:, body:)
       raise "tag was not created first" unless @events == %i[validate_target create_tag]
       raise "wrong tag" unless tag == "production/5.4.0-20105"
       raise "wrong target" unless target_sha == "a" * 40
@@ -38,7 +38,7 @@ class GitHubReleaseCreationTest < Minitest::Test
       raise "wrong body" unless body == "Approved notes"
 
       @events << :publish_release
-      { "id" => 100, "tag_name" => tag }
+      { "id" => 100, "tag_name" => tag, "created" => true }
     end
   end
 

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -803,6 +803,20 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes context, 'source_release_commit_sha == ENV.fetch("APPROVED_MAIN_SHA")'
   end
 
+  def test_tag_without_release_resume_is_reconciled_before_skipping_the_pr
+    workflow = File.read(repo_path(".github/workflows/release.yml"))
+    context = workflow.split("- name: Resolve naming and the merged-but-untagged recovery path", 2).fetch(1)
+                      .split("- name: Validate the recovered release target against live main", 2).first
+    target = workflow.split("- name: Resolve the exact release target commit", 2).fetch(1)
+                     .split("- name: Create the tag-backed GitHub prerelease", 2).first
+
+    assert_equal 2, workflow.scan('--recover-release-channel "${RELEASE_CHANNEL}"').length
+    assert_equal 2, workflow.scan('--recover-release-version "${RELEASE_VERSION}"').length
+    assert_equal 2, workflow.scan('"${recovery_args[@]}"').length
+    assert_includes context, "%w[resume_after_merge resume_after_tag].include?(recovery_reason)"
+    assert_includes target, 'ENV.fetch("RECONCILIATION_REASON")'
+  end
+
   private
 
   def repo_path(relative_path)


### PR DESCRIPTION
## Changes:
- Create and validate the exact lightweight Git tag through the Git-reference API before publishing a prerelease, so Xcode Cloud receives a real tag-change event instead of relying on implicit Releases API tag synthesis.
- Reuse only an existing lightweight tag at the exact release commit and handle concurrent tag creation safely.
- Document the required Production manual-tag fallback and the App Store Connect API rule that all retained start conditions must be sent together.
- Add client and CLI regression coverage proving tag creation precedes prerelease publication.

## Closes following issues:
- Closes: None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - 26.6 (17F113); no app build changes

## Screenshots:

Not applicable; infrastructure-only change.

## Additional notes:

Reproduced during the 5.4.0 release: the GitHub Releases endpoint published the prerelease and synthesized the missing tag, but GitHub emitted no tag-change event and Production Xcode Cloud did not start. The release tag, title, body, build number, and target commit remain unchanged.

`bundle exec rake -f fastlane/Rakefile test`: 291 runs, 1540 assertions, 0 failures, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publishing now creates or verifies the required tag and release before publication.
  * Added recovery support for interrupted releases using validated production tags and matching build records.
  * Production manual releases are restricted to approved production or beta tags.

* **Bug Fixes**
  * Added safeguards against conflicting, annotated, or incorrectly targeted tags and releases.
  * Improved handling of simultaneous tag-creation attempts and incomplete release operations.
  * Improved resume handling for releases interrupted after merging or tagging.

* **Documentation**
  * Updated release instructions with tag verification, recovery, and publication checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->