### PR TITLE
#fixed Handle already-deleted release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,10 +129,13 @@ jobs:
           owner: Sequel-Ace
           repositories: Sequel-Ace
 
-      - name: Check out the frozen main commit
+      - name: Check out immutable dispatch tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.expected_main_sha }}
+          # New-release authorization requires this revision to equal the frozen
+          # approved SHA. Recovery first proves that the frozen SHA is its
+          # ancestor, then keeps the plan and release target pinned below.
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -378,11 +381,7 @@ jobs:
           set -euo pipefail
           bundle exec ruby -Ifastlane/lib -rsequel_ace_release -e '
             client = SequelAceRelease::GitHubClient.new(token: ENV.fetch("SA_GITHUB_TOKEN"))
-            begin
-              client.delete_branch(ENV.fetch("RELEASE_BRANCH"))
-            rescue SequelAceRelease::APIError => error
-              raise unless error.message.include?("HTTP 404")
-            end
+            client.delete_branch(ENV.fetch("RELEASE_BRANCH"), allow_absent: true)
           '
 
       - name: Prepare explicit release files

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -331,6 +331,11 @@ informational):
   version file and `CHANGELOG.md`, reuse it. Unrelated commits may have advanced
   `main`; the recovery approval must be planned against the exact release
   commit, and `mode=resume` is the only mode allowed to start from that ancestor.
+  The recovery job executes the immutable workflow/tooling revision at the
+  authenticated dispatch SHA on protected `main`, so a recovery-only fix can be
+  used without changing the frozen release approval. Planning, build
+  reconciliation, protected-file validation, and the eventual tag target stay
+  pinned to the exact approved release commit.
   When that commit is the generated release-PR merge, the planner uses its
   first parent as the release-notes comparison head, reproducing the original
   change range instead of listing the release-preparation PR itself.

--- a/fastlane/lib/sequel_ace_release/github_client.rb
+++ b/fastlane/lib/sequel_ace_release/github_client.rb
@@ -249,8 +249,17 @@ module SequelAceRelease
       response
     end
 
-    def delete_branch(branch)
-      request!("DELETE", "/repos/#{@repository}/git/refs/heads/#{URI.encode_www_form_component(branch)}", expected: [204])
+    def delete_branch(branch, allow_absent: false)
+      response = @transport.request(
+        "DELETE",
+        "/repos/#{@repository}/git/refs/heads/#{URI.encode_www_form_component(branch)}"
+      )
+      if allow_absent && response.status == 422 && response.body.is_a?(Hash) &&
+         response.body["message"] == "Reference does not exist"
+        return false
+      end
+
+      ensure_response!(response, [204])
       true
     end
 

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -641,6 +641,41 @@ class GitHubClientTest < Minitest::Test
     assert_equal "DELETE", transport.requests.last.fetch(:method)
   end
 
+  def test_delete_branch_can_treat_githubs_exact_missing_reference_response_as_absent
+    branch = "prepare-release/5.4.0-20109-2"
+    transport = FakeTransport.new([
+      http_response(status: 422, body: { "message" => "Reference does not exist" })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    assert_equal false, client.delete_branch(branch, allow_absent: true)
+    request = transport.requests.fetch(0)
+    assert_equal "DELETE", request.fetch(:method)
+    assert_equal "/repos/Sequel-Ace/Sequel-Ace/git/refs/heads/prepare-release%2F5.4.0-20109-2", request.fetch(:path)
+  end
+
+  def test_delete_branch_remains_strict_by_default_for_an_absent_reference
+    branch = "prepare-release/5.4.0-20109-2"
+    transport = FakeTransport.new([
+      http_response(status: 422, body: { "message" => "Reference does not exist" })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    assert_raises(SequelAceRelease::APIError) { client.delete_branch(branch) }
+  end
+
+  def test_delete_branch_does_not_hide_other_unprocessable_responses
+    transport = FakeTransport.new([
+      http_response(status: 422, body: { "message" => "Validation Failed" })
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::APIError) do
+      client.delete_branch("prepare-release/5.4.0-20109-2", allow_absent: true)
+    end
+    assert_includes error.message, "HTTP 422: Validation Failed"
+  end
+
   def test_cleanup_reconciles_an_unpersisted_generated_commit_by_parent_and_content
     base_sha = "a" * 40
     created_sha = "c" * 40

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -75,6 +75,15 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes alpha_step, "failure() || cancelled()"
   end
 
+  def test_tag_only_recovery_treats_an_already_deleted_release_branch_as_absent
+    workflow = File.read(repo_path(".github/workflows/release.yml"))
+    cleanup = workflow.split("- name: Delete a recovered merged release branch", 2).fetch(1)
+                      .split("- name: Prepare explicit release files", 2).first
+
+    assert_includes cleanup, "client.delete_branch(ENV.fetch(\"RELEASE_BRANCH\"), allow_absent: true)"
+    refute_includes cleanup, "HTTP 404"
+  end
+
   def test_mutating_workflows_authorize_the_rerun_initiator
     release = File.read(repo_path(".github/workflows/release.yml"))
     assert_operator release.scan("github.triggering_actor").length, :>=, 2
@@ -408,7 +417,7 @@ class WorkflowRecoveryTest < Minitest::Test
     authorization = workflow.index("- name: Enforce release authorization")
     ancestry = workflow.index("- name: Prove the frozen release SHA is on dispatch main")
     app_token = workflow.index("- name: Mint repository-scoped release App token")
-    checkout = workflow.index("- name: Check out the frozen main commit")
+    checkout = workflow.index("- name: Check out immutable dispatch tooling")
     proof = workflow[ancestry...app_token]
 
     assert_operator authorization, :<, ancestry
@@ -417,6 +426,18 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes workflow[authorization...ancestry], '[[ "${EXPECTED_SHA}" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]'
     assert_includes proof, '/compare/${EXPECTED_SHA}...${DISPATCH_SHA}'
     assert_includes proof, '"${comparison_status}" == "identical" || "${comparison_status}" == "ahead"'
+  end
+
+  def test_exact_resume_executes_trusted_current_tooling_but_keeps_the_release_plan_frozen
+    workflow = File.read(repo_path(".github/workflows/release.yml"))
+    checkout = workflow.split("- name: Check out immutable dispatch tooling", 2).fetch(1)
+                       .split("- name: Exclude transient release evidence from git status", 2).first
+    plan = workflow.split("- name: Decode and validate the approved plan", 2).fetch(1)
+                   .split("- name: Reconcile the authoritative Production Cloud build", 2).first
+
+    assert_includes checkout, 'ref: ${{ github.sha }}'
+    refute_includes checkout, 'ref: ${{ inputs.expected_main_sha }}'
+    assert_includes plan, '--main-ref "${{ inputs.expected_main_sha }}"'
   end
 
   def test_release_workflows_use_commit_and_checksum_pinned_oras


### PR DESCRIPTION
## Changes:
- Treat GitHub’s exact `422 Reference does not exist` response as idempotent only for explicitly opted-in release branch cleanup.
- Execute exact recovery with the immutable authenticated dispatch revision from protected `main`, while keeping the approved plan, protected version files, reconciliation, and tag target pinned to the frozen release commit.
- Keep every other API error fail closed and add focused regression coverage for both recovery edges.

## Closes following issues:
- Closes: none

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (infrastructure-only Ruby/YAML)
- `bundle exec rake -f fastlane/Rakefile test`: 311 runs, 1,608 assertions, 0 failures/errors/skips.

## Screenshots:
- Not applicable.

## Additional notes:
- GitHub returns 422, not 404, when its DELETE-ref endpoint is asked to delete an already-absent branch. That stopped tag-only recovery before prerelease creation.
- The failed recovery checked out the frozen release commit and therefore could not execute a subsequently merged recovery fix. A resume now runs trusted tooling from the exact protected-main dispatch SHA only after proving the frozen release SHA is its ancestor; all approved release data and the tag target stay frozen.
- Default `delete_branch` callers remain strict. The new option recognizes only the exact parsed missing-reference response; permission, policy, malformed, 404, and other 422 responses still fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release recovery now completes successfully when the release branch has already been deleted.
  * Branch cleanup continues safely for absent branches while still reporting other deletion errors.
  * Improved handling of GitHub responses during release recovery.

* **Improvements**
  * Recovery now uses the exact workflow revision while keeping release planning, validation, and tagging tied to the approved release commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->