### PR TITLE
#fixed Authorize exact-target GitHub release mutations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,10 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-actions: read
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Check out immutable dispatch tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -438,6 +442,10 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-actions: read
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Revalidate Production Cloud build immediately before merge or tag
         env:
@@ -537,10 +545,21 @@ jobs:
             --state merged \
             --merge release-target-evidence.json >/dev/null
 
+      - name: Mint exact-target release mutation token
+        id: release_mutation_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Create the tag-backed GitHub prerelease
         id: prerelease
         env:
-          SA_GITHUB_TOKEN: ${{ steps.merge_app_token.outputs.token || steps.app_token.outputs.token }}
+          SA_GITHUB_TOKEN: ${{ steps.release_mutation_token.outputs.token }}
         run: |
           set -euo pipefail
           bundle exec ruby fastlane/bin/sa-release github-create-release \
@@ -592,6 +611,8 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Reconcile a failed release branch
         if: (failure() || cancelled()) && steps.release_context.outputs.branch != ''
@@ -614,22 +635,32 @@ jobs:
             ${reconcile_arguments[@]+"${reconcile_arguments[@]}"} \
             --output branch-cleanup.json
 
+      - name: Mint release mutation token for failure annotation
+        if: (failure() || cancelled()) && steps.release_context.outputs.tag != ''
+        id: failure_release_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Preserve an explanatory failed prerelease
         if: (failure() || cancelled()) && steps.release_context.outputs.tag != ''
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
           GHCR_TOKEN: ${{ github.token }}
           GHCR_USERNAME: ${{ github.actor }}
           ARCHIVE_REFERENCE: ${{ steps.initial_archive.outputs.reference }}
           FAILED_TAG: ${{ steps.release_context.outputs.tag }}
+          RELEASE_COMMIT: ${{ steps.release_target.outputs.sha || steps.release_context.outputs.source_release_commit_sha }}
+          RELEASE_MUTATION_TOKEN: ${{ steps.failure_release_token.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          if ! gh release view "${FAILED_TAG}" --json body --jq .body > failed-release-body.md; then
-            echo "No tag-backed prerelease exists to annotate."
-            exit 0
-          fi
           preserve_release_body=false
           if [[ -f manifest.json && -d release-archive ]]; then
             bundle exec ruby fastlane/bin/sa-release record-failure \
@@ -652,10 +683,29 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
+          if [[ -z "${RELEASE_MUTATION_TOKEN}" ]]; then
+            echo "Failure state was preserved without a GitHub release annotation because the narrow mutation token was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          if [[ ! "${RELEASE_COMMIT}" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]; then
+            echo "Failure state was preserved without a GitHub release annotation because the exact release commit was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          export GH_TOKEN="${RELEASE_MUTATION_TOKEN}"
+          if ! gh release view "${FAILED_TAG}" --json body --jq .body > failed-release-body.md; then
+            echo "No tag-backed prerelease exists to annotate."
+            exit 0
+          fi
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${FAILED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null
           {
             echo
             echo "---"
             echo "Automated release processing stopped. The tag and prerelease are intentionally preserved."
             echo "Workflow evidence: ${RUN_URL}"
           } >> failed-release-body.md
-          gh release edit "${FAILED_TAG}" --prerelease --latest=false --notes-file failed-release-body.md
+          gh release edit "${FAILED_TAG}" --verify-tag --target "${RELEASE_COMMIT}" --prerelease --latest=false --notes-file failed-release-body.md
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${FAILED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null

--- a/.github/workflows/release_alpha_retry.yml
+++ b/.github/workflows/release_alpha_retry.yml
@@ -72,6 +72,7 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-contents: read
 
       - name: Check out release tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -243,22 +244,47 @@ jobs:
             echo "- This runner is complete; Release Artifact Publisher will attach both artifacts only after the retry is notarized and ready."
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Mint release mutation token for failure annotation
+        if: (failure() || cancelled()) && steps.authorization.outputs.authorized == 'true' && steps.release.outputs.validated == 'true'
+        id: failure_release_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Document transient Alpha retry failure without replacing the handoff
         if: (failure() || cancelled()) && steps.authorization.outputs.authorized == 'true' && steps.release.outputs.validated == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
           BETA_TAG: ${{ inputs.beta_tag }}
+          RELEASE_COMMIT: ${{ inputs.expected_commit }}
+          RELEASE_MUTATION_TOKEN: ${{ steps.failure_release_token.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+          if [[ -z "${RELEASE_MUTATION_TOKEN}" ]]; then
+            echo "The durable failed-Alpha handoff was left unchanged; GitHub annotation was skipped because the narrow mutation token was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          export GH_TOKEN="${RELEASE_MUTATION_TOKEN}"
           gh release view "${BETA_TAG}" --json body --jq .body > retry-failed-release-body.md
           if ! grep -Fq "Workflow evidence: ${RUN_URL}" retry-failed-release-body.md; then
+            bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+              --tag "${BETA_TAG}" \
+              --target-sha "${RELEASE_COMMIT}" >/dev/null
             {
               echo
               echo "Alpha-only recovery attempt stopped; the beta tag and existing artifacts were not replaced."
               echo "Workflow evidence: ${RUN_URL}"
             } >> retry-failed-release-body.md
-            gh release edit "${BETA_TAG}" --prerelease --latest=false --notes-file retry-failed-release-body.md
+            gh release edit "${BETA_TAG}" --verify-tag --target "${RELEASE_COMMIT}" --prerelease --latest=false --notes-file retry-failed-release-body.md
+            bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+              --tag "${BETA_TAG}" \
+              --target-sha "${RELEASE_COMMIT}" >/dev/null
           fi
           echo "The exact durable failed-Alpha handoff was left unchanged so a later authorized retry can reuse it." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release_feasibility.yml
+++ b/.github/workflows/release_feasibility.yml
@@ -180,6 +180,8 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create the verified GitHub App commit and disposable PR
         id: github_probe
@@ -233,6 +235,8 @@ jobs:
           private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: Sequel-Ace
           repositories: Sequel-Ace
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Close and delete only the exact feasibility probe
         if: always()

--- a/.github/workflows/release_finalize.yml
+++ b/.github/workflows/release_finalize.yml
@@ -155,11 +155,22 @@ jobs:
             abort("App Store Connect returned the wrong Production app") unless app.fetch("id") == SequelAceRelease::Config::PRODUCTION_APP_ID
           '
 
+      - name: Mint exact-target release mutation token
+        id: release_mutation_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Finalize only exact App Store-live releases
         env:
           FINALIZER_TRIGGER: ${{ needs.discover.outputs.trigger }}
           GH_TOKEN: ${{ github.token }}
-          SA_GITHUB_TOKEN: ${{ github.token }}
+          SA_GITHUB_TOKEN: ${{ steps.release_mutation_token.outputs.token }}
           GHCR_TOKEN: ${{ github.token }}
           GHCR_USERNAME: ${{ github.actor }}
           SA_ASC_KEY_ID: ${{ secrets.SA_ASC_KEY_ID }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -309,6 +309,18 @@ jobs:
           url: https://github.com/oras-project/oras/releases/download/v1.3.3/oras_1.3.3_linux_amd64.tar.gz
           checksum: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59
 
+      - name: Mint release mutation token for Cloud failure annotation
+        id: failure_release_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Authenticate and preserve the failed Cloud handoff
         env:
           ARCHIVE_REFERENCE: ${{ needs.discover.outputs.archive_ref }}
@@ -317,7 +329,8 @@ jobs:
           FAILED_RUN_ID: ${{ needs.discover.outputs.failed_component == 'production' && needs.discover.outputs.production_run_id || needs.discover.outputs.alpha_run_id }}
           GHCR_TOKEN: ${{ github.token }}
           GHCR_USERNAME: ${{ github.actor }}
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ needs.discover.outputs.commit }}
+          RELEASE_MUTATION_TOKEN: ${{ steps.failure_release_token.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SA_GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -343,15 +356,26 @@ jobs:
           RUBY
           cp failure-disposition.json release-archive/
           Scripts/archive-release-to-ghcr.sh push "${ARCHIVE_REFERENCE}" release-archive > failed-archive-evidence.json
+          echo "Exact ${FAILED_COMPONENT} Xcode Cloud run ${FAILED_RUN_ID} completed unsuccessfully; no Mac runner was started." >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -z "${RELEASE_MUTATION_TOKEN}" ]]; then
+            echo "Private failure evidence was preserved; GitHub annotation was skipped because the narrow mutation token was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          export GH_TOKEN="${RELEASE_MUTATION_TOKEN}"
           gh release view "${EXPECTED_TAG}" --json body --jq .body > failed-release-body.md
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${EXPECTED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null
           {
             echo
             echo "---"
             echo "Automated release artifact processing stopped. The tag and prerelease are intentionally preserved."
             echo "Workflow evidence: ${RUN_URL}"
           } >> failed-release-body.md
-          gh release edit "${EXPECTED_TAG}" --prerelease --latest=false --notes-file failed-release-body.md
-          echo "Exact ${FAILED_COMPONENT} Xcode Cloud run ${FAILED_RUN_ID} completed unsuccessfully; no Mac runner was started." >> "${GITHUB_STEP_SUMMARY}"
+          gh release edit "${EXPECTED_TAG}" --verify-tag --target "${RELEASE_COMMIT}" --prerelease --latest=false --notes-file failed-release-body.md
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${EXPECTED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null
 
   publish:
     name: Verify and publish ready release artifacts
@@ -655,23 +679,48 @@ jobs:
           cp app-store-submission.json release-archive/
           Scripts/archive-release-to-ghcr.sh push "${ARCHIVE_REFERENCE}" release-archive > final-archive-evidence.json
 
+      - name: Mint release mutation token for Alpha recovery annotation
+        if: needs.discover.outputs.channel == 'beta' && steps.context.outputs.alpha_recovery == 'true'
+        id: alpha_recovery_release_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Append successful Alpha recovery evidence
         if: needs.discover.outputs.channel == 'beta' && steps.context.outputs.alpha_recovery == 'true'
         continue-on-error: true
         env:
           ALPHA_RUN_ID: ${{ steps.cloud.outputs.alpha_run_id }}
           BETA_TAG: ${{ needs.discover.outputs.tag }}
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ needs.discover.outputs.commit }}
+          RELEASE_MUTATION_TOKEN: ${{ steps.alpha_recovery_release_token.outputs.token }}
         run: |
           set -euo pipefail
+          if [[ -z "${RELEASE_MUTATION_TOKEN}" ]]; then
+            echo "Alpha recovery artifacts are durable; GitHub annotation was skipped because the narrow mutation token was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          export GH_TOKEN="${RELEASE_MUTATION_TOKEN}"
           marker="Alpha artifact recovery succeeded in Xcode Cloud run ${ALPHA_RUN_ID}."
           gh release view "${BETA_TAG}" --json body --jq .body > recovered-release-body.md
           if ! grep -Fq "${marker}" recovered-release-body.md; then
+            bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+              --tag "${BETA_TAG}" \
+              --target-sha "${RELEASE_COMMIT}" >/dev/null
             {
               echo
               echo "${marker} Both beta artifacts are verified and archived."
             } >> recovered-release-body.md
-            gh release edit "${BETA_TAG}" --prerelease --latest=false --notes-file recovered-release-body.md
+            gh release edit "${BETA_TAG}" --verify-tag --target "${RELEASE_COMMIT}" --prerelease --latest=false --notes-file recovered-release-body.md
+            bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+              --tag "${BETA_TAG}" \
+              --target-sha "${RELEASE_COMMIT}" >/dev/null
           fi
 
       - name: Record successful artifact handoff
@@ -804,6 +853,19 @@ jobs:
           Scripts/archive-release-to-ghcr.sh push "${ARCHIVE_REFERENCE}" release-archive > submission-archive-evidence.json
           echo "The exact App Store submission was confirmed and archived; finalization remains eligible." >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Mint release mutation token for terminal failure annotation
+        if: always() && steps.submission.outputs.submitted != 'true' && needs.publish.outputs.terminal_failure == 'artifact_verification'
+        id: failure_release_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SA_RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SA_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: Sequel-Ace
+          repositories: Sequel-Ace
+          permission-contents: write
+          permission-workflows: write
+
       - name: Preserve terminal artifact-verification failure
         if: always() && steps.submission.outputs.submitted != 'true' && needs.publish.outputs.terminal_failure == 'artifact_verification'
         env:
@@ -811,7 +873,8 @@ jobs:
           FAILED_TAG: ${{ needs.discover.outputs.tag }}
           GHCR_TOKEN: ${{ github.token }}
           GHCR_USERNAME: ${{ github.actor }}
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ needs.discover.outputs.commit }}
+          RELEASE_MUTATION_TOKEN: ${{ steps.failure_release_token.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -821,14 +884,25 @@ jobs:
             --output failure-disposition.json
           cp failure-disposition.json release-archive/
           Scripts/archive-release-to-ghcr.sh push "${ARCHIVE_REFERENCE}" release-archive > failed-archive-evidence.json
+          if [[ -z "${RELEASE_MUTATION_TOKEN}" ]]; then
+            echo "Private terminal-failure evidence was preserved; GitHub annotation was skipped because the narrow mutation token was unavailable." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          export GH_TOKEN="${RELEASE_MUTATION_TOKEN}"
           gh release view "${FAILED_TAG}" --json body --jq .body > failed-release-body.md
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${FAILED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null
           {
             echo
             echo "---"
             echo "Automated release artifact processing stopped. The tag and prerelease are intentionally preserved."
             echo "Workflow evidence: ${RUN_URL}"
           } >> failed-release-body.md
-          gh release edit "${FAILED_TAG}" --prerelease --latest=false --notes-file failed-release-body.md
+          gh release edit "${FAILED_TAG}" --verify-tag --target "${RELEASE_COMMIT}" --prerelease --latest=false --notes-file failed-release-body.md
+          bundle exec ruby fastlane/bin/sa-release github-verify-release-tag \
+            --tag "${FAILED_TAG}" \
+            --target-sha "${RELEASE_COMMIT}" >/dev/null
 
       - name: Preserve retryable state after a transient publisher failure
         if: always() && steps.submission.outputs.submitted != 'true' && needs.publish.outputs.terminal_failure != 'artifact_verification'

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -37,8 +37,11 @@ or creates a GitHub release.
 1. Create a dedicated GitHub App owned by the Sequel Ace organization and
    install it only on `Sequel-Ace/Sequel-Ace`.
 2. Grant repository permissions: Contents read/write, Pull requests read/write,
-   Actions read, Checks read, and Metadata read. Do not grant organization-wide
-   access or subscribe it to events.
+   Actions read, Checks read, Metadata read, and Workflows read/write. Do not
+   grant organization-wide access or subscribe it to events. GitHub requires
+   Workflows write when creating or updating a release whose target commit has
+   workflow files that differ from current `main`; workflows request it only in
+   fresh, repository-scoped tokens used for those exact release mutations.
 3. Add the App as the release PR bypass actor. Keep required status checks in
    force. If the repository cannot separately enforce checks for a bypass
    actor, the workflow's exact-head check gate is mandatory and must not be
@@ -96,8 +99,12 @@ network failure because their remote outcome may be ambiguous.
 Long release-PR and feasibility-probe check polling uses the job-scoped
 `GITHUB_TOKEN`. Each workflow mints a fresh release App installation token
 immediately before an App-only mutation and independently refreshes it for
-failure cleanup. This prevents the one-hour App-token lifetime from stranding a
-PR or deterministic release branch during the two-hour check window.
+failure cleanup. Every token explicitly requests only the permissions needed by
+that mutation. In particular, Workflows write is absent from branch, PR, check,
+and cleanup tokens and is present only on the fresh token used to create or
+update an exact-target GitHub release. This prevents both unnecessary privilege
+reuse and the one-hour App-token lifetime from stranding a PR or deterministic
+release branch during the two-hour check window.
 
 Release starts require the frozen SHA to equal the workflow-dispatch `main`
 SHA. Resume runs may use an older frozen SHA only after GitHub's compare API
@@ -131,6 +138,16 @@ Git-reference API before it publishes the prerelease. Do not let the Releases
 API synthesize a missing tag: that path can publish a release without emitting
 the tag-change event Xcode Cloud needs. An existing tag is reusable only when
 it is a lightweight ref that resolves directly to the exact release commit.
+The subsequent Releases API request repeats the complete approved commit as
+`target_commitish`, even when the tag already exists. This atomically binds the
+mutation to the approved target if the tag disappears between validation and
+the request. GitHub requires Contents write plus Workflows write when that
+target's workflow files differ from current `main`; the workflow mints a fresh,
+narrow token for this one mutation. The same narrowly scoped token pattern is
+used for later release-body updates and finalization. See GitHub's
+[Create a release](https://docs.github.com/en/rest/releases/releases#create-a-release)
+and [Update a release](https://docs.github.com/en/rest/releases/releases#update-a-release)
+permission and `target_commitish` rules.
 Prerelease creation is idempotent: an existing release is reused only when its
 tag, title, body, draft flag, and prerelease flag exactly match the approved
 release. The direct-commit tag ref is revalidated immediately before and after
@@ -397,6 +414,10 @@ preserves the old prerelease.
   or launch verification failures are also terminal. Network, runner, download,
   upload, registry, and API failures leave the remote manifest and release body
   unchanged so a later short publisher check can retry the same exact tag.
+- Optional GitHub failure/recovery annotations verify that the remote tag names
+  the exact archived release commit both before and after the edit, require the
+  tag to exist, and send that commit as their target. An absent or moved tag
+  therefore fails closed instead of being recreated from current `main`.
 - The complete Cloud artifacts, dSYMs, zips, checksums, notes, and redacted
   manifest are pushed to the private GHCR OCI archive and pulled back for
   checksum verification using GitHub's
@@ -420,12 +441,16 @@ preserves the old prerelease.
   exact version remains Apple's latest released Production version, the exact
   build remains selected, phased release is `ACTIVE` or `COMPLETE`, and public
   asset checksums match the private manifest. It first records that validation
-  under the active `finalizing` state in the private archive, and only then performs the public GitHub
-  transition; an archive failure therefore leaves the prerelease discoverable
-  for the next scheduled check or an authorized manual retry. Each run continues
-  examining other production prereleases when one archive is missing or
-  malformed. Finalization outputs and logs stay outside the pulled archive; only
-  the validated evidence files and updated regular manifest are copied back.
+  under the active `finalizing` state in the private archive, and only then
+  performs the public GitHub transition; an archive failure therefore leaves the
+  prerelease discoverable for the next scheduled check or an authorized manual
+  retry. The GitHub update repeats both the exact tag and archived release
+  commit, then revalidates the tag ref before accepting the release readback, so
+  a deleted or moved tag cannot redirect the transition to current `main`.
+  Each run continues examining other production prereleases when one archive is
+  missing or malformed. Finalization outputs and logs stay outside the pulled
+  archive; only the validated evidence files and updated regular manifest are
+  copied back.
   After the public transition succeeds, the finalizer records `live` and pushes
   that read-back evidence to the private archive. If that last archive refresh
   fails after GitHub has already transitioned, an authorized manual finalizer

--- a/fastlane/lib/sequel_ace_release/cli.rb
+++ b/fastlane/lib/sequel_ace_release/cli.rb
@@ -41,6 +41,7 @@ module SequelAceRelease
       when "github-wait-checks" then github_wait_checks(argv)
       when "github-merge-pr" then github_merge_pr(argv)
       when "github-validate-release-target" then github_validate_release_target(argv)
+      when "github-verify-release-tag" then github_verify_release_tag(argv)
       when "github-create-release" then github_create_release(argv)
       when "github-upload-asset" then github_upload_asset(argv)
       when "validate-publish-handoff" then validate_publish_handoff(argv)
@@ -476,6 +477,24 @@ module SequelAceRelease
       result = github_client.validate_release_target!(
         target_sha: options[:target_sha],
         protected_paths: release_paths
+      )
+      emit(result, options[:output])
+    end
+
+    def github_verify_release_tag(arguments)
+      options = {}
+      parser = OptionParser.new do |value|
+        value.banner = "Usage: sa-release github-verify-release-tag --tag TAG --target-sha SHA"
+        value.on("--tag TAG") { |item| options[:tag] = item }
+        value.on("--target-sha SHA") { |item| options[:target_sha] = item }
+        value.on("--output FILE") { |item| options[:output] = item }
+      end
+      parser.parse!(arguments)
+      reject_arguments!(arguments)
+      require_options!(options, :tag, :target_sha)
+      result = github_client.validate_release_tag(
+        tag: options[:tag],
+        target_sha: options[:target_sha]
       )
       emit(result, options[:output])
     end
@@ -1020,10 +1039,17 @@ module SequelAceRelease
 
       client.update_release(
         id: release.fetch("id"),
+        tag: data.fetch("tag"),
+        target_sha: archived_commit,
         title: final_title,
         prerelease: false,
         make_latest: true
       )
+      finalized_tag_commit = client.ref_sha("tags/#{data.fetch('tag')}")
+      unless finalized_tag_commit == archived_commit
+        raise ValidationError,
+              "release tag moved during finalization (expected #{archived_commit}, found #{finalized_tag_commit})"
+      end
       release = client.release_by_tag(data.fetch("tag"))
       unless release["id"] == evidence.fetch("release_id") && release["tag_name"] == data.fetch("tag") &&
              release["name"] == final_title && release["draft"] == false && release["prerelease"] == false &&
@@ -1372,6 +1398,7 @@ module SequelAceRelease
           github-merge-pr            Recheck and merge the release PR
           github-validate-release-target
                                      Prove a release commit remains an unchanged main ancestor
+          github-verify-release-tag   Prove a release tag still names the exact release commit
           github-create-release      Create the tag-backed GitHub prerelease
           github-upload-asset        Upload a verified zip to the prerelease
           validate-publish-handoff   Validate an archived prerelease continuation

--- a/fastlane/lib/sequel_ace_release/github_client.rb
+++ b/fastlane/lib/sequel_ace_release/github_client.rb
@@ -407,6 +407,11 @@ module SequelAceRelease
       validate_release_tag_response!(created, expected_ref: expected_ref, target_sha: target_sha, created: true)
     end
 
+    def validate_release_tag(tag:, target_sha:)
+      validate_commit_sha!(target_sha, "release target SHA")
+      validate_exact_release_tag!(tag: tag, target_sha: target_sha)
+    end
+
     def validate_release_target!(target_sha:, protected_paths:)
       validate_commit_sha!(target_sha, "release target SHA")
       current_main = ref_sha
@@ -458,8 +463,11 @@ module SequelAceRelease
       raise ValidationError, "GitHub returned malformed release-target ancestry evidence"
     end
 
-    def update_release(id:, title:, prerelease:, make_latest:)
+    def update_release(id:, tag:, target_sha:, title:, prerelease:, make_latest:)
+      validate_commit_sha!(target_sha, "release target SHA")
       request!("PATCH", "/repos/#{@repository}/releases/#{Integer(id)}", body: {
+        "tag_name" => tag,
+        "target_commitish" => target_sha,
         "name" => title,
         "draft" => false,
         "prerelease" => prerelease,

--- a/fastlane/test/finalization_assets_test.rb
+++ b/fastlane/test/finalization_assets_test.rb
@@ -116,6 +116,8 @@ class FinalizationAssetsTest < Minitest::Test
       assert_equal(
         {
           id: 100,
+          tag: "production/5.3.2-20105",
+          target_sha: "d" * 40,
           title: "5.3.2 (20105)",
           prerelease: false,
           make_latest: true
@@ -123,6 +125,45 @@ class FinalizationAssetsTest < Minitest::Test
         update_options
       )
     end
+  end
+
+  def test_finalization_rechecks_the_tag_after_the_public_transition
+    live_snapshot = metadata_snapshot(state: "READY_FOR_DISTRIBUTION", phased_state: "ACTIVE")
+    app_store = Object.new
+    app_store.define_singleton_method(:metadata_snapshot) { |**_options| live_snapshot }
+    app_store.define_singleton_method(:latest_released_version) { |**_options| live_snapshot.fetch("version") }
+    release_data = release
+    events = []
+    github = Object.new
+    github.define_singleton_method(:ref_sha) do |ref|
+      events << [:ref_sha, ref]
+      events.count { |event| event.first == :ref_sha } == 1 ? "d" * 40 : "e" * 40
+    end
+    github.define_singleton_method(:release_by_tag) { |_tag| release_data }
+    github.define_singleton_method(:latest_release) { { "id" => 99, "tag_name" => "production/5.3.1-20104" } }
+    github.define_singleton_method(:update_release) do |**options|
+      events << [:update_release, options]
+      release_data = release_data.merge(
+        "name" => options.fetch(:title), "draft" => false, "prerelease" => options.fetch(:prerelease)
+      )
+    end
+
+    assert_equal 1, run_finalizer(app_store: app_store, github: github)
+    assert_equal(
+      [
+        [:ref_sha, "tags/production/5.3.2-20105"],
+        [:update_release, {
+          id: 100,
+          tag: "production/5.3.2-20105",
+          target_sha: "d" * 40,
+          title: "5.3.2 (20105)",
+          prerelease: false,
+          make_latest: true
+        }],
+        [:ref_sha, "tags/production/5.3.2-20105"]
+      ],
+      events
+    )
   end
 
   def test_finalization_rejects_a_tag_moved_after_archival

--- a/fastlane/test/github_client_test.rb
+++ b/fastlane/test/github_client_test.rb
@@ -267,6 +267,36 @@ class GitHubClientTest < Minitest::Test
     assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
   end
 
+  def test_validates_an_existing_release_tag_without_creating_it
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, target_sha))
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    result = client.validate_release_tag(tag: tag, target_sha: target_sha)
+
+    assert_equal target_sha, result.dig("object", "sha")
+    assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
+  def test_rejects_an_existing_release_tag_moved_to_another_commit
+    target_sha = "a" * 40
+    tag = "production/5.4.0-20105"
+    transport = FakeTransport.new([
+      http_response(body: release_tag_response(tag, "b" * 40))
+    ])
+    client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
+
+    error = assert_raises(SequelAceRelease::IntegrityError) do
+      client.validate_release_tag(tag: tag, target_sha: target_sha)
+    end
+
+    assert_includes error.message, "exact release commit"
+    assert_equal ["GET"], transport.requests.map { |request| request.fetch(:method) }
+  end
+
   def test_validates_the_winning_tag_when_creation_races_another_request
     target_sha = "a" * 40
     tag = "production/5.4.0-20105"
@@ -992,10 +1022,19 @@ class GitHubClientTest < Minitest::Test
     ])
     client = SequelAceRelease::GitHubClient.new(token: "token", transport: transport)
 
-    client.update_release(id: 100, title: "5.3.2 (20105)", prerelease: false, make_latest: true)
+    client.update_release(
+      id: 100,
+      tag: "production/5.3.2-20105",
+      target_sha: "d" * 40,
+      title: "5.3.2 (20105)",
+      prerelease: false,
+      make_latest: true
+    )
 
     assert_equal(
       {
+        "tag_name" => "production/5.3.2-20105",
+        "target_commitish" => "d" * 40,
         "name" => "5.3.2 (20105)",
         "draft" => false,
         "prerelease" => false,

--- a/fastlane/test/github_release_creation_test.rb
+++ b/fastlane/test/github_release_creation_test.rb
@@ -40,6 +40,17 @@ class GitHubReleaseCreationTest < Minitest::Test
       @events << :publish_release
       { "id" => 100, "tag_name" => tag, "created" => true }
     end
+
+    def validate_release_tag(tag:, target_sha:)
+      raise "wrong tag" unless tag == "production/5.4.0-20105"
+      raise "wrong target" unless target_sha == "a" * 40
+
+      @events << :verify_tag
+      {
+        "ref" => "refs/tags/#{tag}",
+        "object" => { "type" => "commit", "sha" => target_sha }
+      }
+    end
   end
 
   def test_cli_creates_the_exact_tag_before_publishing_the_prerelease
@@ -69,5 +80,23 @@ class GitHubReleaseCreationTest < Minitest::Test
     result = JSON.parse(output.string)
     assert_equal true, result.dig("tag", "created")
     assert_equal 100, result.dig("release", "id")
+  end
+
+  def test_cli_verifies_the_exact_existing_release_tag
+    client = Client.new
+    output = StringIO.new
+    cli = SequelAceRelease::CLI.new(out: output, err: StringIO.new, env: {})
+
+    status = cli.stub(:github_client, client) do
+      cli.run([
+        "github-verify-release-tag",
+        "--tag", "production/5.4.0-20105",
+        "--target-sha", "a" * 40
+      ])
+    end
+
+    assert_equal 0, status
+    assert_equal [:verify_tag], client.events
+    assert_equal "a" * 40, JSON.parse(output.string).dig("object", "sha")
   end
 end

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -24,6 +24,164 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes workflow[cleanup_step..], "steps.cleanup_app_token.outputs.token || github.token"
   end
 
+  def test_only_exact_release_mutations_request_workflows_write
+    branch_permissions = [
+      ["permission-actions", "read"],
+      ["permission-checks", "read"],
+      ["permission-contents", "write"],
+      ["permission-pull-requests", "write"]
+    ]
+    cleanup_permissions = [
+      ["permission-contents", "write"],
+      ["permission-pull-requests", "write"]
+    ]
+    release_mutation_permissions = [
+      ["permission-contents", "write"],
+      ["permission-workflows", "write"]
+    ]
+    expected_permissions = {
+      ".github/workflows/release.yml:Mint repository-scoped release App token" => branch_permissions,
+      ".github/workflows/release.yml:Refresh release App token before merging" => branch_permissions,
+      ".github/workflows/release.yml:Mint exact-target release mutation token" => release_mutation_permissions,
+      ".github/workflows/release.yml:Refresh release App token for failure cleanup" => cleanup_permissions,
+      ".github/workflows/release.yml:Mint release mutation token for failure annotation" => release_mutation_permissions,
+      ".github/workflows/release_alpha_retry.yml:Mint repository-scoped release App token" => [["permission-contents", "read"]],
+      ".github/workflows/release_alpha_retry.yml:Mint release mutation token for failure annotation" => release_mutation_permissions,
+      ".github/workflows/release_feasibility.yml:Mint a fresh release App token for the GitHub probe" => cleanup_permissions,
+      ".github/workflows/release_feasibility.yml:Refresh release App token for probe cleanup" => cleanup_permissions,
+      ".github/workflows/release_finalize.yml:Mint exact-target release mutation token" => release_mutation_permissions,
+      ".github/workflows/release_publish.yml:Mint release mutation token for Cloud failure annotation" => release_mutation_permissions,
+      ".github/workflows/release_publish.yml:Mint release mutation token for Alpha recovery annotation" => release_mutation_permissions,
+      ".github/workflows/release_publish.yml:Mint release mutation token for terminal failure annotation" => release_mutation_permissions
+    }
+    observed_steps = []
+
+    %w[
+      release.yml
+      release_alpha_retry.yml
+      release_feasibility.yml
+      release_finalize.yml
+      release_publish.yml
+    ].each do |filename|
+      path = ".github/workflows/#{filename}"
+      workflow = File.read(repo_path(path))
+      token_steps = workflow.split(/(?=^      - name: )/).select do |step|
+        step.include?("actions/create-github-app-token@")
+      end
+      refute_empty token_steps
+
+      token_steps.each do |step|
+        name = step.match(/^- name: (.+)$/)&.captures&.first ||
+               step.match(/^      - name: (.+)$/)&.captures&.first
+        refute_nil name
+        label = "#{path}:#{name}"
+        observed_steps << label
+        permissions = step.lines.filter_map do |line|
+          match = line.match(/^\s+(permission-[a-z-]+):\s+(\S+)\s*$/)
+          [match[1], match[2]] if match
+        end
+        assert_equal expected_permissions.fetch(label).sort, permissions.sort,
+                     "#{label} must request exactly its allowlisted App permissions"
+      end
+    end
+
+    assert_equal expected_permissions.keys.sort, observed_steps.sort
+  end
+
+  def test_optional_release_annotations_cannot_block_durable_state
+    release = File.read(repo_path(".github/workflows/release.yml"))
+    release_token = release.split("- name: Mint release mutation token for failure annotation", 2).fetch(1)
+                           .split("- name: Preserve an explanatory failed prerelease", 2).first
+    release_failure = release.split("- name: Preserve an explanatory failed prerelease", 2).fetch(1)
+    assert_includes release_token, "continue-on-error: true"
+    assert_includes release_failure, '[[ -z "${RELEASE_MUTATION_TOKEN}" ]]'
+    assert_operator release_failure.index("archive-release-to-ghcr.sh push"), :<,
+                    release_failure.index('[[ -z "${RELEASE_MUTATION_TOKEN}" ]]')
+
+    alpha = File.read(repo_path(".github/workflows/release_alpha_retry.yml"))
+    alpha_token = alpha.split("- name: Mint release mutation token for failure annotation", 2).fetch(1)
+                       .split("- name: Document transient Alpha retry failure", 2).first
+    alpha_failure = alpha.split("- name: Document transient Alpha retry failure", 2).fetch(1)
+    assert_includes alpha_token, "continue-on-error: true"
+    assert_includes alpha_failure, '[[ -z "${RELEASE_MUTATION_TOKEN}" ]]'
+
+    publisher = File.read(repo_path(".github/workflows/release_publish.yml"))
+    cloud_token = publisher.split("- name: Mint release mutation token for Cloud failure annotation", 2).fetch(1)
+                           .split("- name: Authenticate and preserve the failed Cloud handoff", 2).first
+    cloud_failure = publisher.split("- name: Authenticate and preserve the failed Cloud handoff", 2).fetch(1)
+                             .split("  publish:", 2).first
+    assert_includes cloud_token, "continue-on-error: true"
+    assert_operator cloud_failure.index("archive-release-to-ghcr.sh push"), :<,
+                    cloud_failure.index('[[ -z "${RELEASE_MUTATION_TOKEN}" ]]')
+
+    alpha_archive = publisher.index("- name: Refresh the private archive with submission evidence")
+    alpha_token_index = publisher.index("- name: Mint release mutation token for Alpha recovery annotation")
+    alpha_token = publisher[alpha_token_index...publisher.index("- name: Append successful Alpha recovery evidence")]
+    alpha_annotation = publisher.split("- name: Append successful Alpha recovery evidence", 2).fetch(1)
+    assert_operator alpha_archive, :<, alpha_token_index
+    assert_includes alpha_token, "continue-on-error: true"
+    assert_includes alpha_annotation, '[[ -z "${RELEASE_MUTATION_TOKEN}" ]]'
+
+    terminal_token = publisher.split("- name: Mint release mutation token for terminal failure annotation", 2).fetch(1)
+                              .split("- name: Preserve terminal artifact-verification failure", 2).first
+    terminal_failure = publisher.split("- name: Preserve terminal artifact-verification failure", 2).fetch(1)
+                                .split("- name: Preserve retryable state", 2).first
+    assert_includes terminal_token, "continue-on-error: true"
+    assert_operator terminal_failure.index("archive-release-to-ghcr.sh push"), :<,
+                    terminal_failure.index('[[ -z "${RELEASE_MUTATION_TOKEN}" ]]')
+
+    exact_create_token = release.split("- name: Mint exact-target release mutation token", 2).fetch(1)
+                                .split("- name: Create the tag-backed GitHub prerelease", 2).first
+    finalizer = File.read(repo_path(".github/workflows/release_finalize.yml"))
+    exact_finalize_token = finalizer.split("- name: Mint exact-target release mutation token", 2).fetch(1)
+                                    .split("- name: Finalize only exact App Store-live releases", 2).first
+    refute_includes exact_create_token, "continue-on-error: true"
+    refute_includes exact_finalize_token, "continue-on-error: true"
+  end
+
+  def test_optional_release_annotations_cannot_recreate_a_missing_tag_from_main
+    expected_targets = {
+      "release.yml" => {
+        events: [[:verify, "FAILED_TAG"], [:edit, "FAILED_TAG"], [:verify, "FAILED_TAG"]],
+        source: 'RELEASE_COMMIT: ${{ steps.release_target.outputs.sha || steps.release_context.outputs.source_release_commit_sha }}'
+      },
+      "release_alpha_retry.yml" => {
+        events: [[:verify, "BETA_TAG"], [:edit, "BETA_TAG"], [:verify, "BETA_TAG"]],
+        source: 'RELEASE_COMMIT: ${{ inputs.expected_commit }}'
+      },
+      "release_publish.yml" => {
+        events: [
+          [:verify, "EXPECTED_TAG"], [:edit, "EXPECTED_TAG"], [:verify, "EXPECTED_TAG"],
+          [:verify, "BETA_TAG"], [:edit, "BETA_TAG"], [:verify, "BETA_TAG"],
+          [:verify, "FAILED_TAG"], [:edit, "FAILED_TAG"], [:verify, "FAILED_TAG"]
+        ],
+        source: 'RELEASE_COMMIT: ${{ needs.discover.outputs.commit }}'
+      }
+    }
+
+    expected_targets.each do |filename, expected|
+      workflow = File.read(repo_path(".github/workflows/#{filename}"))
+      lines = workflow.lines
+      edits = workflow.lines.grep(/gh release edit/)
+      expected_edits = expected.fetch(:events).count { |event| event.first == :edit }
+
+      assert_equal expected_edits, edits.length
+      assert_equal Array.new(expected_edits, '--verify-tag --target "${RELEASE_COMMIT}"'),
+                   edits.map { |line| line[/--verify-tag --target "\$\{RELEASE_COMMIT\}"/] }
+      assert_equal expected_edits, workflow.scan(expected.fetch(:source)).length
+      mutation_events = lines.each_with_index.filter_map do |line, index|
+        if line.include?("github-verify-release-tag")
+          tag = lines.fetch(index + 1)[/--tag "\$\{([A-Z_]+)\}"/, 1]
+          assert_equal '--target-sha "${RELEASE_COMMIT}" >/dev/null', lines.fetch(index + 2).strip
+          [:verify, tag]
+        elsif line.include?("gh release edit")
+          [:edit, line[/gh release edit "\$\{([A-Z_]+)\}"/, 1]]
+        end
+      end
+      assert_equal expected.fetch(:events), mutation_events
+    end
+  end
+
   def test_cloud_target_is_reconciled_again_after_checks_and_before_merge_or_tag
     workflow = File.read(repo_path(".github/workflows/release.yml"))
     wait_step = workflow.index("- name: Wait for exact-head release PR checks")
@@ -518,13 +676,14 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_includes finalizer_job_env, 'SA_ASC_REQUIRE_ISSUER: "1"'
 
     access = finalizer.split("- name: Verify Production App Store Connect access", 2).fetch(1)
-                      .split("- name: Finalize only exact App Store-live releases", 2).first
+                      .split("- name: Mint exact-target release mutation token", 2).first
     assert_includes access, 'SA_ASC_KEY_ID: ${{ secrets.SA_ASC_KEY_ID }}'
     assert_includes access, 'SA_ASC_PRIVATE_KEY: ${{ secrets.SA_ASC_PRIVATE_KEY }}'
 
     finalize = finalizer.split("- name: Finalize only exact App Store-live releases", 2).fetch(1)
     assert_includes finalize, 'GHCR_TOKEN: ${{ github.token }}'
-    assert_includes finalize, 'SA_GITHUB_TOKEN: ${{ github.token }}'
+    github_token_assignments = finalize.scan(/^\s+SA_GITHUB_TOKEN:\s+(.+)$/).flatten
+    assert_equal ['${{ steps.release_mutation_token.outputs.token }}'], github_token_assignments
     assert_includes finalize, 'SA_ASC_PRIVATE_KEY: ${{ secrets.SA_ASC_PRIVATE_KEY }}'
 
     %w[release_alpha_retry.yml release_feasibility.yml].each do |filename|


### PR DESCRIPTION
## Changes:
- Keep the complete approved release SHA in `target_commitish`, preserving an atomic binding even if the precreated tag disappears between validation and the GitHub release mutation.
- Bind finalization updates to the archived tag and release commit, then revalidate the tag ref before accepting the public transition.
- Verify optional annotation tag-to-commit binding before and after each edit, while requiring the existing tag and exact release target.
- Mint fresh repository-scoped GitHub App tokens with Contents write plus Workflows write only for exact-target release creation, annotations, and finalization.
- Explicitly scope every other release App token to its branch, PR, check, or cleanup permissions so it cannot inherit Workflows write.
- Keep private failure-state archival independent of optional GitHub annotations: an annotation-token mint failure is tolerated, guarded, and cannot skip durable evidence.
- Document GitHub's current Create/Update Release permission contract and add regression coverage for the exact request body, token boundaries, and failure recovery.

## Closes following issues:
- Closes: none

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (infrastructure-only Ruby/workflow/documentation)
- `bundle exec rake -f fastlane/Rakefile test`: 318 runs, 1,701 assertions, 0 failures/errors/skips.
- Parsed every `release*.yml` workflow with Ruby's YAML parser; `git diff --check` passes.

## Screenshots:
- Not applicable.

## Additional notes:
- GitHub documents that Create Release and Update Release require Workflows write when the resolved release target's `.github/workflows` differs from current default `main`; GitHub App installation-token failures may surface as `403 Resource not accessible by integration`.
- The existing dedicated GitHub App now has Workflows read/write approved on its existing selected-repository installation. No second App or credential was introduced.
- The failed recovery stopped before prerelease creation, private GHCR handoff, or Xcode Cloud. Production build 20109 remains unconsumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Release creation and finalization now target and verify the approved commit and tag.
  * Added a command to verify that a release tag points to the expected commit.
  * Release automation uses narrowly scoped access for publishing, recovery, cleanup, and failure reporting.
  * Alpha recovery, feasibility checks, and artifact verification now use dedicated permissions.
* **Bug Fixes**
  * Improved recovery and cleanup behavior when release steps fail.
  * Optional failure annotations no longer block durable release updates when access is unavailable.
  * Finalization now detects unexpected tag or commit changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->