### PR TITLE
#fixed Authenticate asynchronous release publisher source

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -64,7 +64,7 @@ jobs:
           SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           SOURCE_EVENT: ${{ github.event.workflow_run.event }}
           SOURCE_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          SOURCE_WORKFLOW: ${{ github.event.workflow_run.name }}
+          SOURCE_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
         run: |
           set -euo pipefail
           [[ "${RELEASE_REF}" == "refs/heads/main" ]] || { echo "Artifact publication must run from main." >&2; exit 1; }
@@ -88,7 +88,7 @@ jobs:
                 echo "The source workflow did not succeed; no artifact continuation was attempted." >> "${GITHUB_STEP_SUMMARY}"
                 exit 0
               fi
-              [[ "${SOURCE_WORKFLOW}" == "Release" || "${SOURCE_WORKFLOW}" == "Retry Alpha Beta Artifact" ]] || { echo "Unexpected source workflow." >&2; exit 1; }
+              [[ "${SOURCE_WORKFLOW_PATH}" == ".github/workflows/release.yml" || "${SOURCE_WORKFLOW_PATH}" == ".github/workflows/release_alpha_retry.yml" ]] || { echo "Unexpected source workflow path." >&2; exit 1; }
               [[ "${SOURCE_EVENT}" == "workflow_dispatch" ]] || { echo "Artifact handoffs must originate from an authorized manual workflow." >&2; exit 1; }
               [[ "${SOURCE_HEAD_BRANCH}" == "main" ]] || { echo "Artifact handoff source was not main." >&2; exit 1; }
               [[ "${SOURCE_ACTOR}" == "Jason-Morcos" || "${SOURCE_ACTOR}" == "Kaspik" ]] || { echo "Unauthorized source workflow actor." >&2; exit 1; }
@@ -165,6 +165,7 @@ jobs:
 
           selected_action="none"
           unreadable=0
+          ineligible=0
           while IFS=$'\t' read -r _created_at release_tag; do
             [[ -n "${release_tag}" ]] || continue
             archive_directory="$(mktemp -d "${RUNNER_TEMP}/sequel-ace-publish-archive.XXXXXX")"
@@ -178,6 +179,22 @@ jobs:
               fi
               unreadable=$((unreadable + 1))
               echo "Automated release ${release_tag} has no readable private handoff archive; it was skipped." >> "${GITHUB_STEP_SUMMARY}"
+              continue
+            fi
+
+            locally_eligible="$(bundle exec ruby -Ifastlane/lib -rsequel_ace_release -e '
+              data = SequelAceRelease::Manifest.read(ARGV.fetch(0)).to_h
+              raise SequelAceRelease::ValidationError, "archive tag does not match the candidate" unless data.fetch("tag") == ARGV.fetch(1)
+              puts SequelAceRelease::PublishHandoff::ELIGIBLE_STATES.fetch(data.fetch("channel")).include?(data.fetch("state"))
+            ' "${archive_directory}/manifest.json" "${release_tag}")"
+            if [[ "${locally_eligible}" != "true" ]]; then
+              rm -rf "${archive_directory}" "${state_directory}"
+              if [[ -n "${REQUESTED_TAG}" ]]; then
+                echo "Requested release ${release_tag} is not eligible for artifact publication." >&2
+                exit 1
+              fi
+              ineligible=$((ineligible + 1))
+              echo "Automated release ${release_tag} is in a preserved ineligible state; it was skipped." >> "${GITHUB_STEP_SUMMARY}"
               continue
             fi
 
@@ -276,6 +293,9 @@ jobs:
           fi
           if [[ "${unreadable}" -gt 0 ]]; then
             echo "${unreadable} candidate archive(s) were unreadable and require investigation." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          if [[ "${ineligible}" -gt 0 ]]; then
+            echo "${ineligible} preserved ineligible handoff(s) were skipped." >> "${GITHUB_STEP_SUMMARY}"
           fi
 
   cloud_failure:

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -163,6 +163,13 @@ Cloud-status read and exits; it starts the protected macOS verification job only
 after every required Production and Alpha run is complete and related to the
 expected app build. Authorized manual recovery requires
 `PUBLISH ARTIFACTS <tag>`. Pending checks are successful no-ops, not timeouts.
+The immediate continuation authenticates its source by the immutable workflow
+path from the `workflow_run` payload; GitHub's `workflow_run.name` contains the
+dynamic `run-name` and is not an authorization identity. Scheduled discovery
+locally parses each validated archive and skips terminal or otherwise ineligible
+states before making live API calls, then continues to newer candidates. An
+explicitly requested ineligible tag fails. Every eligible handoff still receives
+strict live validation, and any API or transport failure stops discovery.
 Production is always resolved first; a pending Production run prevents an Alpha
 result from deciding the beta's fate. A completed unsuccessful Cloud run is
 recorded by a separate Ubuntu job, so failure handling never allocates a Mac.

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -398,6 +398,31 @@ class WorkflowRecoveryTest < Minitest::Test
     assert_operator skipped, :<, discovery.index("continue", skipped)
   end
 
+  def test_publisher_skips_locally_ineligible_scheduled_candidates_but_fails_an_explicit_recovery
+    workflow = File.read(repo_path(".github/workflows/release_publish.yml"))
+    discovery = workflow.split("- name: Inspect exact Cloud runs once", 2).fetch(1)
+                        .split("  cloud_failure:", 2).first
+    local_gate = discovery.index('locally_eligible="$(bundle exec ruby -Ifastlane/lib -rsequel_ace_release')
+    requested = discovery.index('if [[ -n "${REQUESTED_TAG}" ]]', local_gate)
+    ineligible = discovery.index("ineligible=$((ineligible + 1))", requested)
+    continuation = discovery.index("continue", ineligible)
+    live_validation = discovery.index("bundle exec ruby fastlane/bin/sa-release validate-publish-handoff", continuation)
+
+    assert local_gate
+    assert requested
+    assert ineligible
+    assert continuation
+    assert live_validation
+    assert_operator local_gate, :<, requested
+    assert_operator requested, :<, ineligible
+    assert_operator ineligible, :<, continuation
+    assert_operator continuation, :<, live_validation
+    assert_includes discovery, "Requested release \${release_tag} is not eligible for artifact publication."
+    assert_includes discovery, "preserved ineligible handoff(s) were skipped."
+    assert_includes discovery, "PublishHandoff::ELIGIBLE_STATES"
+    refute_includes discovery, "if ! bundle exec ruby fastlane/bin/sa-release validate-publish-handoff"
+  end
+
   def test_publisher_shell_uses_environment_indirection_for_external_values
     workflow = File.read(repo_path(".github/workflows/release_publish.yml"))
     download = workflow.split("- name: Download exact Xcode Cloud artifacts", 2).fetch(1)
@@ -639,6 +664,11 @@ class WorkflowRecoveryTest < Minitest::Test
     refute_includes workflow, "ref: main"
     assert_includes workflow, 'SOURCE_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}'
     assert_includes workflow, '[[ "${SOURCE_HEAD_BRANCH}" == "main" ]]'
+    assert_includes workflow, 'SOURCE_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}'
+    assert_includes workflow, '"${SOURCE_WORKFLOW_PATH}" == ".github/workflows/release.yml"'
+    assert_includes workflow, '"${SOURCE_WORKFLOW_PATH}" == ".github/workflows/release_alpha_retry.yml"'
+    refute_includes workflow, "github.event.workflow_run.name"
+    refute_includes workflow, 'SOURCE_WORKFLOW: ${{'
   end
 
   def test_supporting_release_workflows_execute_the_dispatch_revision


### PR DESCRIPTION
## Changes:
- Authenticate `workflow_run` continuations with the exact source workflow path instead of GitHub's dynamic run name.
- Locally skip preserved terminal or otherwise ineligible handoff states during scheduled discovery, while explicit recovery fails and eligible candidates retain strict live API validation.
- Add regression coverage for both the live payload shape and stale-candidate behavior.

## Closes following issues:
- Closes: none

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [ ] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: N/A (infrastructure-only workflow/documentation/tests)
- `bundle exec rake -f fastlane/Rakefile test`: 319 runs, 1,728 assertions, 0 failures/errors/skips.
- Parsed every release workflow with Ruby YAML and ran `git diff --check`.

## Screenshots:
- Not applicable.

## Additional notes:
- Live run 31567768650 reports workflow API path `.github/workflows/release.yml` while its `name` is the dynamic `resume production 5.4.0 by @Jason-Morcos`; publisher run 31567831697 failed only because the old gate compared that dynamic value with `Release`.
- Scheduled run 31567478546 encountered the intentionally preserved RC1 handoff before RC2 and stopped on its now-stale release-file ancestry. Scheduled discovery now reports and skips that candidate; explicit recovery of an invalid tag still aborts.
- The exact RC2 prerelease and private GHCR handoff are durable. No Production or Alpha Xcode Cloud run has been started by this recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for scheduled prerelease candidates.
  * Invalid candidates are skipped safely while processing continues with newer valid candidates.
  * Explicitly requested invalid releases now fail clearly.
  * Release workflow verification now uses immutable workflow identification for more reliable security checks.

* **Documentation**
  * Updated release guidance for workflow authentication and handling stale or invalid prereleases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->