### PR TITLE
#infra Swift 6 readiness: remove captured-var mutation in concurrent code

### DIFF
--- a/Source/Controllers/SPAppController.swift
+++ b/Source/Controllers/SPAppController.swift
@@ -22,29 +22,41 @@ extension SPAppController {
         tabManager.newWindowForTab()
     }
 
+    /// An open standalone connection window, kept alive until it closes.
+    private struct StandaloneConnectionWindow {
+        /// Keep the controller around so the window isn't deallocated.
+        let controller: SAConnectionWindowController
+
+        /// React to window closing, auto-unsubscribing on dealloc.
+        let closingSubscription: NotificationToken
+    }
+
+    /// Tracks open standalone connection windows so they don't get deallocated.
+    private static var standaloneConnectionWindows: [StandaloneConnectionWindow] = []
+
     /// Opens a standalone connection window (decoupled from document lifecycle).
     /// This is the modernized connection flow — the connection screen exists
     /// independently, and only creates a document tab on successful connect.
-    /// Tracks open standalone connection windows so they don't get deallocated.
-    private static var standaloneConnectionWindows: [SAConnectionWindowController] = []
-
     @IBAction func openStandaloneConnectionWindow(_ sender: Any) {
         let controller = SAConnectionWindowController()
         controller.showWindow(sender)
 
-        // Retain the controller; remove when its window closes.
-        Self.standaloneConnectionWindows.append(controller)
-        var token: NSObjectProtocol?
-        token = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
+        // Retain the controller until its window closes. Dropping the entry also
+        // releases the NotificationToken, which unregisters the observer in its
+        // deinit — so the observer no longer has to remove itself, which is what
+        // required a captured var (and tripped Swift 6 concurrency checking).
+        // Same ownership shape as TabManager's ManagedWindow.
+        let closingSubscription = NotificationCenter.default.observe(
+            name: NSWindow.willCloseNotification,
             object: controller.window,
             queue: .main
         ) { _ in
-            Self.standaloneConnectionWindows.removeAll { $0 === controller }
-            if let token = token {
-                NotificationCenter.default.removeObserver(token)
-            }
+            Self.standaloneConnectionWindows.removeAll { $0.controller === controller }
         }
+
+        Self.standaloneConnectionWindows.append(
+            StandaloneConnectionWindow(controller: controller, closingSubscription: closingSubscription)
+        )
     }
 
     @IBAction func export(_ sender: Any) {

--- a/Source/Other/AWS/AWSSSOClient.swift
+++ b/Source/Other/AWS/AWSSSOClient.swift
@@ -242,16 +242,16 @@ import OSLog
             assertionFailure("AWSSSOClient.resolveCredentials should not be called from the main thread")
         }
 
-        var result: AWSCredentials?
-        var asyncError: Error?
+        let outcome = SAAsyncResultBox<AWSCredentials>()
         let semaphore = DispatchSemaphore(value: 0)
 
         DispatchQueue.global(qos: .userInitiated).async {
             Task {
                 do {
-                    result = try await resolveCredentials(for: profileCredentials)
+                    let credentials = try await resolveCredentials(for: profileCredentials)
+                    outcome.succeed(credentials)
                 } catch {
-                    asyncError = error
+                    outcome.fail(error)
                 }
                 semaphore.signal()
             }
@@ -261,15 +261,14 @@ import OSLog
             throw AWSSSOClientError.requestTimeout
         }
 
-        if let asyncError = asyncError {
+        switch outcome.result {
+        case .success(let credentials):
+            return credentials
+        case .failure(let asyncError):
             throw asyncError
-        }
-
-        guard let result = result else {
+        case nil:
             throw AWSSSOClientError.invalidResponse
         }
-
-        return result
     }
 
     /// Objective-C compatible method that returns nil on error

--- a/Source/Other/AWS/AWSSTSClient.swift
+++ b/Source/Other/AWS/AWSSTSClient.swift
@@ -288,8 +288,7 @@ import OSLog
             assertionFailure("AWSSTSClient.assumeRole should not be called from the main thread")
         }
 
-        var result: AWSCredentials?
-        var asyncError: Error?
+        let outcome = SAAsyncResultBox<AWSCredentials>()
 
         let semaphore = DispatchSemaphore(value: 0)
 
@@ -297,7 +296,7 @@ import OSLog
         DispatchQueue.global(qos: .userInitiated).async {
             Task {
                 do {
-                    result = try await assumeRole(
+                    let assumedCredentials = try await assumeRole(
                         roleArn: roleArn,
                         roleSessionName: roleSessionName,
                         mfaSerialNumber: mfaSerialNumber,
@@ -306,8 +305,9 @@ import OSLog
                         region: region,
                         credentials: credentials
                     )
+                    outcome.succeed(assumedCredentials)
                 } catch {
-                    asyncError = error
+                    outcome.fail(error)
                 }
                 semaphore.signal()
             }
@@ -325,7 +325,10 @@ import OSLog
             return nil
         }
 
-        if let asyncError = asyncError {
+        switch outcome.result {
+        case .success(let assumedCredentials):
+            return assumedCredentials
+        case .failure(let asyncError):
             if let stsError = asyncError as? AWSSTSClientError {
                 error?.pointee = NSError(
                     domain: "AWSSTSClientErrorDomain",
@@ -336,9 +339,11 @@ import OSLog
                 error?.pointee = asyncError as NSError
             }
             return nil
+        case nil:
+            // Neither a result nor an error: the task never completed. Legacy
+            // behavior was to return nil without touching the error pointer.
+            return nil
         }
-
-        return result
     }
 
     /// Convenience method for MFA role assumption.

--- a/Source/Other/Utility/SAAsyncResultBox.swift
+++ b/Source/Other/Utility/SAAsyncResultBox.swift
@@ -1,0 +1,50 @@
+//
+//  SAAsyncResultBox.swift
+//  Sequel Ace
+//
+//  Created as part of the Swift 6 readiness work.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+/// Thread-safe container handing the outcome of an async call back to a thread
+/// that is blocking on a semaphore.
+///
+/// The synchronous-wrapper pattern used by the AWS clients (`DispatchSemaphore`
+/// + `Task`) cannot write its outcome into captured `var`s: mutating them from
+/// the concurrently-executing task is a warning today and an error in the Swift 6
+/// language mode. Writing into a reference type instead takes the mutation out of
+/// the closure.
+///
+/// The lock is not ceremony: the waiter gives up after a timeout, and the task
+/// keeps running — and writing — after that.
+final class SAAsyncResultBox<Success>: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var storedResult: Result<Success, Error>?
+
+    /// The recorded outcome, or nil when nothing has completed yet (the waiter
+    /// timed out, or the task never ran).
+    var result: Result<Success, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedResult
+    }
+
+    /// Records an outcome. One box carries one call, so this is expected to be
+    /// written exactly once; a later write replaces an earlier one.
+    func complete(with result: Result<Success, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        storedResult = result
+    }
+
+    func succeed(_ value: Success) {
+        complete(with: .success(value))
+    }
+
+    func fail(_ error: Error) {
+        complete(with: .failure(error))
+    }
+}

--- a/UnitTests/SAAsyncResultBoxTests.swift
+++ b/UnitTests/SAAsyncResultBoxTests.swift
@@ -1,0 +1,73 @@
+//
+//  SAAsyncResultBoxTests.swift
+//  Unit Tests
+//
+//  Created as part of the Swift 6 readiness work.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SAAsyncResultBoxTests: XCTestCase {
+
+    private enum TestError: Error, Equatable {
+        case boom
+        case other
+    }
+
+    func testAnUncompletedBoxHasNoResult() {
+        let box = SAAsyncResultBox<Int>()
+
+        XCTAssertNil(box.result)
+    }
+
+    func testSuccessIsRecorded() throws {
+        let box = SAAsyncResultBox<String>()
+
+        box.succeed("credentials")
+
+        let result = try XCTUnwrap(box.result)
+        XCTAssertEqual(try result.get(), "credentials")
+    }
+
+    func testFailureIsRecorded() throws {
+        let box = SAAsyncResultBox<String>()
+
+        box.fail(TestError.boom)
+
+        let result = try XCTUnwrap(box.result)
+        switch result {
+        case .success(let value):
+            XCTFail("expected a failure, got \(value)")
+        case .failure(let error):
+            XCTAssertEqual(error as? TestError, .boom)
+        }
+    }
+
+    func testTheLastOutcomeWins() throws {
+        let box = SAAsyncResultBox<String>()
+
+        box.fail(TestError.boom)
+        box.succeed("recovered")
+
+        let result = try XCTUnwrap(box.result)
+        XCTAssertEqual(try result.get(), "recovered")
+    }
+
+    /// The box exists because the waiting thread can time out while the task is
+    /// still writing, so concurrent access must be safe.
+    func testConcurrentCompletionsAreSafe() throws {
+        let box = SAAsyncResultBox<Int>()
+
+        DispatchQueue.concurrentPerform(iterations: 200) { iteration in
+            if iteration.isMultiple(of: 2) {
+                box.succeed(iteration)
+            } else {
+                box.fail(TestError.other)
+            }
+            _ = box.result
+        }
+
+        XCTAssertNotNil(box.result)
+    }
+}

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -484,7 +484,7 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
 1. ~~**Help viewer WKWebView rewrite**~~ — ✅ Done (warnings plan step 6).
    `SAHelpViewerModel` / `SAHelpViewerView` / `SAHelpViewerWindowController`
    replaced SPHelpViewerController + HelpViewer.xib; **legacy WebKit is now gone
-   from the codebase** (26 deprecation warnings retired). Execution notes in
+   from the codebase** (33 deprecation warnings retired). Execution notes in
    `docs/development/warnings-elimination-plan.md`.
 2. **C2b — extend SAConnectionFormModel/View to all connection types**
    (socket, SSH, AWS IAM, Vault + SSL options, colour, time zone). Scope grew
@@ -500,9 +500,12 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
    import/duplicate-detection logic (mostly pure dictionary work, see the
    `candidate*`/`detail*`/`imported*` naming from the shadow-rename pass) into
    tested Swift. Best done while the code is young.
-5. **Warnings remainder** (steps 8-9 + deferred SecKeychain/NSConnection/
-   OpenSSL — see warnings plan). Step 8 (Swift 6 concurrency, 2 sites) is a
-   quick filler any time.
+5. **Warnings remainder** (step 9 + deferred SecKeychain/NSConnection/
+   OpenSSL — see warnings plan). Step 8 (Swift 6 concurrency) is ✅ done: the
+   three blocking-wrapper/observer-token sites now go through
+   `SAAsyncResultBox` and `NotificationToken`, leaving no concurrency
+   warnings. Step 9 (deprecated drag-API delegate methods, ~25 warnings) is
+   the last mechanical batch and wants manual drag-drop verification.
 6. **Phase E (table content / custom query services)** — explicitly gated on
    the PostgreSQL abstraction decision (#2482/#2493): if it lands, extract
    against `id<SPDatabaseConnection>`; starting before that decision risks

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -504,8 +504,9 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
    OpenSSL — see warnings plan). Step 8 (Swift 6 concurrency) is ✅ done: the
    three blocking-wrapper/observer-token sites now go through
    `SAAsyncResultBox` and `NotificationToken`, leaving no concurrency
-   warnings. Step 9 (deprecated drag-API delegate methods, ~25 warnings) is
-   the last mechanical batch and wants manual drag-drop verification.
+   warnings. Step 9 (deprecated drag-API delegate methods, **42** measured on
+   a clean build, not the ~25 originally estimated) is the last mechanical
+   batch and wants manual drag-drop verification per file.
 6. **Phase E (table content / custom query services)** — explicitly gated on
    the PostgreSQL abstraction decision (#2482/#2493): if it lands, extract
    against `id<SPDatabaseConnection>`; starting before that decision risks

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -212,7 +212,7 @@ Execution notes:
   neither a result nor an error is recorded: it still returns nil without
   touching the caller's error pointer.
 
-## Step 9 — "Implementing deprecated method" batch — ~25 warnings
+## Step 9 — "Implementing deprecated method" batch — 42 warnings (measured)
 
 Implementations of deprecated delegate signatures (mostly the pre-10.7
 NSTableView drag API `tableView:writeRowsWithIndexes:toPasteboard:` and
@@ -224,6 +224,9 @@ SPExportController, SPAppController, SPEditorPreferencePane.
 Adopt `NSPasteboardWriting`/`tableView:pasteboardWriterForRow:` per file;
 chunk into 2-3 PRs by area (managers / table views / misc). Each needs manual
 drag-drop verification — slowest batch, do last of the mechanical ones.
+
+⚠️ The original "~25" estimate is low: a clean build after step 8 reports **42**
+of these, so plan for 3 PRs rather than 2.
 
 ## Deferred (own projects, not part of this burn-down)
 
@@ -252,8 +255,17 @@ drag-drop verification — slowest batch, do last of the mechanical ones.
 | 4-5 (archiver + notifications) | ~225 |
 | 6 + 7 (help viewer + AppKit batch) | **173 (measured, clean build)** |
 | 8 (Swift 6) | **165 (measured, clean build)** |
-| 9 (deprecated delegate methods) | ~160* |
+| 9 (deprecated delegate methods) | ~123 (165 − 42 measured) |
 
-\* Remainder is dominated by SPKeychain/NSConnection/linker (deferred) and
-multi-target duplicate counting; the issue-navigator number after step 9
-should land near the duplicates-adjusted floor of the deferred items.
+**How these are counted.** Rows through step 5 are the original estimates, read
+off Xcode's issue navigator (which counts a file compiled into several targets
+several times). Rows from step 6 on are measured: `warning:` lines in a clean
+`xcodebuild` log, deduplicated (`sort -u`) — 165 unique lines / 318 raw. Note
+the unique count includes the compiler's caret-continuation lines, which repeat
+a warning's text under the source excerpt: 16 of the 165 are those, so the
+distinct-diagnostic count is nearer **149**. Compare like with like when
+claiming a delta.
+
+After step 9 the remainder is dominated by the deferred projects, measured on
+the same build: SecKeychain 10, tunnel assistant / NSConnection 4, bundled
+OpenSSL + linker 7. That is the realistic floor without taking one of those on.

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -183,13 +183,34 @@ One-line-ish constant/API swaps, same shape as merged batches #2441/#2443:
   `graphicsPort`, `NSRoundLineCapStyle`) — third-party but vendored; patch the
   three constants in place.
 
-## Step 8 — Swift 6 readiness — ~3 warnings
+## Step 8 — Swift 6 readiness — ✅ Done
 
-- **AWSSSOClient.swift:252** — captured-var mutation in concurrent code
-  (hard error in Swift 6 mode): restructure with a continuation/actor.
-- **SPAppController.swift:38** — `token` mutated after sendable capture:
-  standard NotificationCenter-observer-token dance; use a box or
-  `withExtendedLifetime` pattern.
+5 warnings across 3 sites (the plan listed 2 — see below), all of the
+"mutation of captured var in concurrently-executing code" family that becomes
+a hard error in the Swift 6 language mode. Zero concurrency warnings left;
+clean build 173 → 165 (the extra 3 lines are the compiler's caret-continuation
+output for the same 5 warnings, which the grep counts separately).
+
+Execution notes:
+
+- ⚠️ **The plan missed a site.** `AWSSTSClient.swift:300/310` has the identical
+  blocking-wrapper pattern as AWSSSOClient — same failure mode as step 1, where
+  the truncated issue navigator hid siblings. Fixed too; a step that leaves an
+  identical Swift-6 hard error behind isn't done.
+- Both AWS clients now hand their outcome back through one shared
+  `SAAsyncResultBox<Success>` (`Source/Other/Utility/`, app + Unit Tests
+  targets) instead of writing into captured `var`s. It is a lock-protected
+  `Result` box: the lock is not ceremony, because the waiter abandons the call
+  on timeout while the task keeps running and writing. 5 unit tests, including
+  a concurrent-completion smoke test.
+- `SPAppController.openStandaloneConnectionWindow` needed no box at all: the
+  captured var only existed so the observer could unregister itself. Switching
+  to the repo's existing `NotificationToken` (which unregisters in `deinit`)
+  and storing it next to the controller — the same ownership shape as
+  `TabManager.ManagedWindow` — removes the self-reference entirely.
+- Behavior preserved at all three sites, including the AWSSTSClient path where
+  neither a result nor an error is recorded: it still returns nil without
+  touching the caller's error pointer.
 
 ## Step 9 — "Implementing deprecated method" batch — ~25 warnings
 
@@ -230,7 +251,7 @@ drag-drop verification — slowest batch, do last of the mechanical ones.
 | 3 (nullability) | ~260 |
 | 4-5 (archiver + notifications) | ~225 |
 | 6 + 7 (help viewer + AppKit batch) | **173 (measured, clean build)** |
-| 8 (Swift 6) | ~170 |
+| 8 (Swift 6) | **165 (measured, clean build)** |
 | 9 (deprecated delegate methods) | ~160* |
 
 \* Remainder is dominated by SPKeychain/NSConnection/linker (deferred) and

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
+		10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
 		1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
 		1198F5B31174EDD500670590 /* SPDatabaseCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1198F5B21174EDD500670590 /* SPDatabaseCopy.m */; };
 		11ACD43BE52B0351BBFE518F /* AWSSSOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAD424F195B2E207BF7C604 /* AWSSSOClient.swift */; };
@@ -211,7 +212,6 @@
 		50A9F8B119EAD4B90053E571 /* SPGotoDatabaseController.m in Sources */ = {isa = PBXBuildFile; fileRef = 50A9F8B019EAD4B90053E571 /* SPGotoDatabaseController.m */; };
 		50D3C3521A77135F00B5429C /* SPParserUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = 50D3C3501A77135F00B5429C /* SPParserUtils.c */; };
 		50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D3C35B1A771C4C00B5429C /* SPParserUtilsTest.m */; };
-		794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */; };
 		50D3C35D1A77217800B5429C /* SPParserUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = 50D3C3501A77135F00B5429C /* SPParserUtils.c */; };
 		50E217B318174246009D3580 /* SPColorSelectorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 50E217B218174246009D3580 /* SPColorSelectorView.m */; };
 		50E217B618174280009D3580 /* SPFavoriteColorSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 50E217B518174280009D3580 /* SPFavoriteColorSupport.m */; };
@@ -440,6 +440,7 @@
 		6F0EA9242734ABE200514FF1 /* SABundleRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA9232734ABE200514FF1 /* SABundleRunner.m */; };
 		72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */; };
 		73F70A961E4E547500636550 /* SPJSONFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73F70A951E4E547500636550 /* SPJSONFormatter.m */; };
+		794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */; };
 		7EE575894C57515419B0A30A /* SPMCPPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F0964487758A57DA339AF2 /* SPMCPPreferencePane.swift */; };
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
@@ -466,6 +467,7 @@
 		8831EFCE2240175400D10172 /* button_paginationTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFCC2240175300D10172 /* button_paginationTemplate.pdf */; };
 		8AEAC27B5C5B866575ECDB62 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
 		8AEACED018AABDD8CBB42877 /* TableSortHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACADD4B36D9819ADC93DD /* TableSortHelperTests.swift */; };
+		8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */; };
 		8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
 		961210D2302E7233009A9A2A /* SAGitHubReleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961210D1302E7233009A9A2A /* SAGitHubReleaseTests.swift */; };
 		961210D6302E7269009A9A2A /* GitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A89557825D6DE860060CE72 /* GitHub.swift */; };
@@ -489,7 +491,9 @@
 		9BE765682376A00C82FB93AA /* SPHelpViewerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE764320CE8E86E8F63647B /* SPHelpViewerClient.m */; };
 		9BE765EBBDFD2F121C13D274 /* SPFillView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE768F3989033CEDDC2027E /* SPFillView.m */; };
 		9BE76F2886901784E4FD2321 /* SPFilterTableController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE76A3D5C9830E2F7738770 /* SPFilterTableController.m */; };
+		9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
 		A57A61739BA9FEC6706473D6 /* SPAppController+MCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC51026DDFB4980A84A78F1 /* SPAppController+MCP.swift */; };
+		A946E44AA14C458182205CFF /* CompletionTokens.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC962D651144EACA006170BD /* CompletionTokens.plist */; };
 		AA000001000000000000001B /* SAAboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001A /* SAAboutView.swift */; };
 		B04369CDAE73936C539212F7 /* SPMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4D0AEB506704E1B3B2A8C6 /* SPMCPServer.swift */; };
 		B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7D127BB5BCD94B0E794C5E /* SAHelpViewerWindowController.swift */; };
@@ -533,7 +537,6 @@
 		BC878A71121A836F00AE5066 /* SPColorWellCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BC878A70121A836F00AE5066 /* SPColorWellCell.m */; };
 		BC8C8532100E0A8000D7A129 /* SPTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8C8531100E0A8000D7A129 /* SPTableView.m */; };
 		BC962D661144EACA006170BD /* CompletionTokens.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC962D651144EACA006170BD /* CompletionTokens.plist */; };
-		A946E44AA14C458182205CFF /* CompletionTokens.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC962D651144EACA006170BD /* CompletionTokens.plist */; };
 		BC9F0881100FCF2C00A80D32 /* SPFieldEditorController.m in Sources */ = {isa = PBXBuildFile; fileRef = BC9F0880100FCF2C00A80D32 /* SPFieldEditorController.m */; };
 		BCA6271C1031B9D40047E5D5 /* SPTooltip.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA6271B1031B9D40047E5D5 /* SPTooltip.m */; };
 		BCD0AD490FBBFC340066EA5C /* SPSQLTokenizer.l in Sources */ = {isa = PBXBuildFile; fileRef = BCD0AD480FBBFC340066EA5C /* SPSQLTokenizer.l */; };
@@ -762,6 +765,7 @@
 		11C2109C1180E70800758039 /* SPDatabaseRename.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDatabaseRename.h; sourceTree = "<group>"; };
 		11C2109D1180E70800758039 /* SPDatabaseRename.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseRename.m; sourceTree = "<group>"; };
 		11C210DE1180E9B800758039 /* SPDatabaseRenameTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseRenameTest.m; sourceTree = "<group>"; };
+		138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAAsyncResultBoxTests.swift; sourceTree = "<group>"; };
 		171312CC109D23C700FB465F /* SPTableTextFieldCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTableTextFieldCell.h; sourceTree = "<group>"; };
 		171312CD109D23C700FB465F /* SPTableTextFieldCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableTextFieldCell.m; sourceTree = "<group>"; };
 		171C398D16BD634600209EC6 /* SPDatabaseContentViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDatabaseContentViewDelegate.h; sourceTree = "<group>"; };
@@ -1045,7 +1049,6 @@
 		50D3C3501A77135F00B5429C /* SPParserUtils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SPParserUtils.c; sourceTree = "<group>"; };
 		50D3C3511A77135F00B5429C /* SPParserUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPParserUtils.h; sourceTree = "<group>"; };
 		50D3C35B1A771C4C00B5429C /* SPParserUtilsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPParserUtilsTest.m; sourceTree = "<group>"; };
-		CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAEditorTokensTests.swift; sourceTree = "<group>"; };
 		50E217B118174246009D3580 /* SPColorSelectorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPColorSelectorView.h; sourceTree = "<group>"; };
 		50E217B218174246009D3580 /* SPColorSelectorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPColorSelectorView.m; sourceTree = "<group>"; };
 		50E217B418174280009D3580 /* SPFavoriteColorSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFavoriteColorSupport.h; sourceTree = "<group>"; };
@@ -1343,6 +1346,7 @@
 		AEA35A884E0C42E4A2AF12EE /* SPCustomQuery+Explain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPCustomQuery+Explain.swift"; sourceTree = "<group>"; };
 		AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifier.swift; sourceTree = "<group>"; };
 		AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifierTests.swift; sourceTree = "<group>"; };
+		AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAAsyncResultBox.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -1429,6 +1433,7 @@
 		C9F9270F162D38D70051CB2E /* toolbar-switch-to-table-info@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-info@2x.png"; sourceTree = "<group>"; };
 		C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse.png"; sourceTree = "<group>"; };
 		C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse@2x.png"; sourceTree = "<group>"; };
+		CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAEditorTokensTests.swift; sourceTree = "<group>"; };
 		CB4D0AEB506704E1B3B2A8C6 /* SPMCPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPMCPServer.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
@@ -2571,6 +2576,7 @@
 				1198F5B41174EDDE00670590 /* Database Actions */,
 				17DC886A126B378A00E9AAEC /* Category Additions */,
 				6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */,
+				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -2594,6 +2600,7 @@
 				91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */,
 				51BE43DC30174CC700AF389C /* SANotificationCenter.swift */,
 				51BE68DB3017550E00AF389C /* SAImageRenderer.swift */,
+				AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3429,6 +3436,8 @@
 				0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */,
 				81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */,
 				60111925195F940E7252B376 /* SAHelpViewerModelTests.swift in Sources */,
+				10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */,
+				8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3735,6 +3744,7 @@
 				2456FC7DD02544F7BFE23596 /* SAHelpViewerModel.swift in Sources */,
 				56B8282C3F2B2EAD9499D12F /* SAHelpViewerView.swift in Sources */,
 				B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */,
+				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- **Warnings plan step 8 — Swift 6 readiness.** Removes every "mutation of captured var in concurrently-executing code" warning; these are **hard errors in the Swift 6 language mode**, so this is migration debt, not cosmetics. Zero concurrency warnings remain.
- **`AWSSSOClient` / `AWSSTSClient`** — both wrap an async call for Objective-C callers with `DispatchSemaphore` + `Task` and wrote the outcome into captured `var`s. Both now hand it back through a new shared **`SAAsyncResultBox<Success>`** (`Source/Other/Utility/`, app + Unit Tests targets), a lock-protected `Result` box. The lock is not ceremony: the waiter gives up on timeout while the task keeps running — and writing.
- **`SPAppController.openStandaloneConnectionWindow`** — needed no box. The captured `var` existed only so the observer could unregister *itself*; it now uses the repo's existing **`NotificationToken`** (which unregisters in `deinit`), stored next to the controller in a small `StandaloneConnectionWindow` struct. That is the same ownership shape `TabManager.ManagedWindow` already uses for exactly this problem, so the pattern is now consistent across both call sites.
- **Doc fix:** `modernization-followup-plan.md` said the help viewer rewrite (#2542) retired "26 deprecation warnings"; the measured figure — and what the warnings plan says — is **33**. My error in that PR.
- Warnings plan step 8 marked done with execution notes; roadmap item 5 updated so step 9 is the only mechanical batch left.

### Notes for reviewers
- ⚠️ **The plan's site list was incomplete.** It named `AWSSSOClient.swift:252` and `SPAppController.swift:38` (~3 warnings). A clean build showed **5 warnings across 3 sites** — `AWSSTSClient.swift:300/310` has the identical blocking-wrapper pattern and was not listed. Same failure mode as step 1, where the truncated issue navigator hid siblings. Fixed it too: a "Swift 6 readiness" step that leaves an identical Swift 6 hard error in a sibling file isn't done.
- **Behavior is preserved at all three sites**, including the `AWSSTSClient` edge where neither a result nor an error was recorded (task never completed): it still returns nil without touching the caller's `NSErrorPointer`. That path is now an explicit `case nil` rather than an implicit fall-through, which is how I convinced myself it was unchanged.
- `SAAsyncResultBox` is `@unchecked Sendable` — deliberate, and the reason is the lock: every access to the stored `Result` goes through `NSLock`. It holds no project ObjC types, so it compiles into the Unit Tests target.
- Warning delta measured with clean builds before and after on the same checkout: **173 → 165 unique** (raw 328 → 318). The 8 lines are the 5 distinct warnings plus 3 caret-continuation lines the compiler emits for them, which the grep counts separately.

## Closes following issues:
- Closes: n/a (tracked in `docs/development/warnings-elimination-plan.md` step 8)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 27.0 (macOS 26.5.2, arm64)

Automated: clean build of "Sequel Ace Debug", zero errors and no new warnings; full unit suite **905 tests, 0 failures** (63 skipped), including **5 new `SAAsyncResultBoxTests`** — empty box, success, failure, last-write-wins, and a `concurrentPerform` smoke test for the locking.

⚠️ **Not exercised at runtime:** the two AWS paths need real AWS IAM Identity Center / STS credentials, which I don't have, and the standalone connection window is behind the "New Connection Window" menu item. All three changes are structural (where a value is stored, who removes an observer) with no logic change, and the risky asymmetry — the timeout path — is covered by the box's lock and called out above. If anyone has an AWS SSO or MFA-role profile handy, a connect through it is the check worth doing.

## Screenshots:
n/a — no user-visible change.

## Additional notes:
- pbxproj edited with Xcode closed via the `xcodeproj` toolchain: two file references plus target membership, nothing else.
- Remaining in the burn-down: step 9 (deprecated NSTableView drag-API delegate methods, ~25 warnings, wants manual drag-drop verification per file) and the deferred SecKeychain / NSConnection / bundled-OpenSSL projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of synchronous AWS credential and role operations, including clearer handling of timeouts and incomplete results.
  * Improved cleanup of standalone connection windows and their close-event resources.
* **Tests**
  * Added coverage for successful, failed, empty, and concurrent asynchronous result handling.
* **Documentation**
  * Updated modernization and warning-reduction plans to reflect completed concurrency cleanup and reduced build warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->