### PR TITLE
#infra Adopt the formal AppKit validation/editing protocols (step 9a)

### DIFF
--- a/Source/Controllers/BundleSupport/SPBundleEditorController.m
+++ b/Source/Controllers/BundleSupport/SPBundleEditorController.m
@@ -73,7 +73,9 @@
 
 @end
 
-@interface SPBundleEditorController ()
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPBundleEditorController () <NSMenuItemValidation, NSControlTextEditingDelegate>
 
 - (void)_updateBundleDataView;
 - (void)_updateBundleMetaSummary;

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -90,8 +90,9 @@ static inline NSNumber *IsOn(id obj);
  */
 static inline void SetOnOff(NSNumber *ref,id obj);
 
-@interface SPExportController () <SPCSVExporterProtocol, SPSQLExporterProtocol, SPXMLExporterProtocol, SPDotExporterProtocol, SPPDFExporterProtocol, SPHTMLExporterProtocol>
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPExportController () <SPCSVExporterProtocol, SPSQLExporterProtocol, SPXMLExporterProtocol, SPDotExporterProtocol, SPPDFExporterProtocol, SPHTMLExporterProtocol, NSMenuItemValidation, NSControlTextEditingDelegate>
 @property (readwrite, copy) NSString *exportDatabaseName;
 
 - (void)_switchTab;

--- a/Source/Controllers/DataImport/SPFieldMapperController.m
+++ b/Source/Controllers/DataImport/SPFieldMapperController.m
@@ -53,7 +53,9 @@ static NSString *SPTableViewSqlColumnID         = @"sql";
 static NSUInteger SPSourceColumnTypeText        = 0;
 static NSUInteger SPSourceColumnTypeInteger     = 1;
 
-@interface SPFieldMapperController ()
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPFieldMapperController () <NSMenuItemValidation, NSControlTextEditingDelegate>
 - (void)_setupFieldMappingPopUpMenus;
 @end
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -78,8 +78,9 @@ static NSString *SPConnectionViewNibName   = @"ConnectionView";
 const static NSInteger SPUseServerTimeZoneTag = -1;
 const static NSInteger SPUseSystemTimeZoneTag = -2;
 
-@interface SPConnectionController () <SAVaultRoleListControllerDelegate>
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPConnectionController () <SAVaultRoleListControllerDelegate, NSMenuItemValidation, NSControlTextEditingDelegate>
 // Privately redeclare as read/write to get the synthesized setter
 @property (readwrite, assign) BOOL isEditingConnection;
 @property (readwrite, assign) BOOL allowSplitViewResizing;

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -98,8 +98,9 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 - (void)_updateProgress;
 @end
 
-@interface SPCustomQuery ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPCustomQuery () <NSMenuItemValidation, NSFontChanging>
 - (id)_resultDataItemAtRow:(NSInteger)row columnIndex:(NSUInteger)column preserveNULLs:(BOOL)preserveNULLs asPreview:(BOOL)asPreview;
 - (void)_updateColumnHeadersForCurrentPreference;
 + (NSAttributedString *)columnHeaderAttributedStringForColumnDefinition:(NSDictionary *)columnDefinition showColumnTypes:(BOOL)showColumnTypes;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -94,8 +94,9 @@ static NSString *SPNewDatabaseCopyContent = @"SPNewDatabaseCopyContent";
 
 static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
-@interface SPDatabaseDocument () <SADatabaseSelectionDelegate>
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPDatabaseDocument () <SADatabaseSelectionDelegate, NSToolbarItemValidation>
 // Privately redeclare as read/write to get the synthesized setter
 @property (readwrite, assign) BOOL allowSplitViewResizing;
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -100,8 +100,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 @end
 
-@interface SPTableContent () <SATableHeaderViewDelegate>
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTableContent () <SATableHeaderViewDelegate, NSMenuItemValidation>
 - (BOOL)cancelRowEditing;
 - (void)documentWillClose:(NSNotification *)notification;
 

--- a/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
+++ b/Source/Controllers/MainViewControllers/TableRelations/SPTableRelations.m
@@ -48,8 +48,9 @@ static NSString *SPRelationFKColumnsKey  = @"fk_columns";
 static NSString *SPRelationOnUpdateKey   = @"on_update";
 static NSString *SPRelationOnDeleteKey   = @"on_delete";
 
-@interface SPTableRelations ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTableRelations () <NSMenuItemValidation>
 - (void)_refreshRelationDataForcingCacheRefresh:(BOOL)clearAllCaches;
 - (void)_updateAvailableTableColumns;
 - (BOOL)_serverRequiresStandardForeignKeyReferences;

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -109,7 +109,9 @@ struct _cmpMap {
  */
 static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntries);
 
-@interface SPTableStructure () {
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTableStructure () <NSMenuItemValidation> {
 	TableSortHelper *fieldsSortHelper;
 }
 

--- a/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
+++ b/Source/Controllers/MainViewControllers/TableTriggers/SPTableTriggers.m
@@ -62,8 +62,9 @@ typedef NS_ENUM(NSInteger, SPTriggerEventTag) {
 static SPTriggerActionTimeTag TagForActionTime(NSString *mysql);
 static SPTriggerEventTag TagForEvent(NSString *mysql);
 
-@interface SPTableTriggers ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTableTriggers () <NSMenuItemValidation, NSControlTextEditingDelegate>
 - (void)_editTriggerAtIndex:(NSInteger)index;
 - (void)_toggleConfirmAddTriggerButtonEnabled;
 - (void)_refreshTriggerDataForcingCacheRefresh:(BOOL)clearAllCaches;

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.m
@@ -46,8 +46,9 @@ static NSString *SPCustomColorSchemeNameLC  = @"user-defined";
 
 #define SP_EXPORT_COLOR_SCHEME_NAME_STRING NSLocalizedString(@"MyTheme", @"Preferences : Themes : Initial filename for 'Export'")
 
-@interface SPEditorPreferencePane ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPEditorPreferencePane () <NSControlTextEditingDelegate, NSFontChanging>
 - (BOOL)_checkForUnsavedTheme;
 - (NSArray *)_getAvailableThemes;
 - (void)_saveColorThemeAtPath:(NSString *)path;

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -62,7 +62,9 @@
 
 static const double SPDelayBeforeCheckingForNewReleases = 10;
 
-@interface SPAppController ()
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPAppController () <NSMenuItemValidation>
 @property (strong) IBOutlet NSMenu *mainMenu;
 
 - (void)_copyDefaultThemes;

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.m
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.m
@@ -47,6 +47,11 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 #define SP_NAME_REQUIRED_PLACEHOLDER_STRING      NSLocalizedString(@"[name required]", @"displayed when new content filter has empty Name field (ContentFilterManager)")
 #define SP_FILE_PARSER_ERROR_TITLE_STRING        NSLocalizedString(@"Error while reading data file", @"error while reading data file")
 
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPContentFilterManager () <NSMenuItemValidation, NSControlTextEditingDelegate>
+@end
+
 @implementation SPContentFilterManager
 
 /**

--- a/Source/Controllers/SubviewControllers/SPIndexesController.m
+++ b/Source/Controllers/SubviewControllers/SPIndexesController.m
@@ -55,8 +55,9 @@ static const NSString *SPNewIndexKeyBlockSize   = @"IndexKeyBlockSize";
  */
 static void *IndexesControllerKVOContext = &IndexesControllerKVOContext;
 
-@interface SPIndexesController ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPIndexesController () <NSMenuItemValidation>
 - (BOOL)_isFullTextIndexSelected;
 - (void)_addAdditionalIndexTypes;
 - (void)_reloadIndexedColumnsTableData;

--- a/Source/Controllers/SubviewControllers/SPProcessListController.m
+++ b/Source/Controllers/SubviewControllers/SPProcessListController.m
@@ -47,8 +47,9 @@ static NSString *SPTableViewProgressColumnIdentifier = @"Progress";
 static NSString * const SPKillModeKey = @"SPKillMode";
 static NSString * const SPKillIdKey   = @"SPKillId";
 
-@interface SPProcessListController ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPProcessListController () <NSMenuItemValidation, NSControlTextEditingDelegate>
 - (void)_processListRefreshed;
 - (void)_startAutoRefreshTimer;
 - (void)_killAutoRefreshTimer;

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -54,8 +54,9 @@ static NSString *SPCompletionTokensSnippetsKey  = @"function_argument_snippets";
 
 static NSUInteger SPMessageTruncateCharacterLength = 256;
 
-@interface SPQueryController ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPQueryController () <NSMenuItemValidation, NSControlTextEditingDelegate>
 - (void)_updateFilterState;
 - (void)_allowFilterClearOrSave:(NSNumber *)enabled;
 - (BOOL)_messageMatchesCurrentFilters:(NSString *)message;

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -46,7 +46,9 @@
 #define SP_MULTIPLE_SELECTION_PLACEHOLDER_STRING NSLocalizedString(@"[multiple selection]", @"[multiple selection]")
 #define SP_NO_SELECTION_PLACEHOLDER_STRING       NSLocalizedString(@"[no selection]", @"[no selection]")
 
-@interface SPQueryFavoriteManager ()
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPQueryFavoriteManager () <NSMenuItemValidation, NSControlTextEditingDelegate>
 
 - (void)_initWithNoSelection;
 

--- a/Source/Controllers/SubviewControllers/SPServerVariablesController.m
+++ b/Source/Controllers/SubviewControllers/SPServerVariablesController.m
@@ -37,8 +37,9 @@
 
 #import "sequel-ace-Swift.h"
 
-@interface SPServerVariablesController ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPServerVariablesController () <NSMenuItemValidation, NSControlTextEditingDelegate>
 - (void)_getDatabaseServerVariables;
 - (void)_updateServerVariablesFilterForFilterString:(NSString *)filterString;
 - (void)_copyServerVariablesToPasteboardIncludingName:(BOOL)name andValue:(BOOL)value;

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -63,8 +63,9 @@ static NSString *SPNewTableType         = @"SPNewTableType";
 static NSString *SPNewTableCharacterSet = @"SPNewTableCharacterSet";
 static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 
-@interface SPTablesList () <NSSplitViewDelegate, NSTableViewDataSource>
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTablesList () <NSSplitViewDelegate, NSTableViewDataSource, NSMenuItemValidation>
 - (void)_removeTable:(BOOL)force;
 - (void)_truncateTable;
 - (void)_addTable;

--- a/Source/Controllers/SubviewControllers/SPUserManager.m
+++ b/Source/Controllers/SubviewControllers/SPUserManager.m
@@ -48,8 +48,9 @@ static NSString *SPGlobalPrivilegesTabIdentifier = @"Global Privileges";
 static NSString *SPResourcesTabIdentifier = @"Resources";
 static NSString *SPSchemaPrivilegesTabIdentifier = @"Schema Privileges";
 
-@interface SPUserManager ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPUserManager () <NSMenuItemValidation>
 - (void)_initializeTree:(NSArray *)items;
 - (void)_initializeUsers;
 - (void)_selectParentFromSelection;

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -78,8 +78,9 @@
 
 #pragma mark -
 
-@interface SPTextView ()
-
+// Formal conformance for methods AppKit moved off the informal NSObject
+// categories; implementing them without it is deprecated. No behavior change.
+@interface SPTextView () <NSFontChanging>
 NSInteger _alphabeticSort(id string1, id string2, void *reverse);
 - (void)_setTextSelectionColor:(NSColor *)newSelectionColor;
 - (void)_setTextSelectionColor:(NSColor *)newSelectionColor onBackgroundColor:(NSColor *)aBackgroundColor;

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -504,9 +504,12 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
    OpenSSL — see warnings plan). Step 8 (Swift 6 concurrency) is ✅ done: the
    three blocking-wrapper/observer-token sites now go through
    `SAAsyncResultBox` and `NotificationToken`, leaving no concurrency
-   warnings. Step 9 (deprecated drag-API delegate methods, **42** measured on
-   a clean build, not the ~25 originally estimated) is the last mechanical
-   batch and wants manual drag-drop verification per file.
+   warnings. Step 9 turned out to be mostly informal-protocol conformance
+   rather than the drag-API rewrites the plan assumed: 36 of its 42 warnings
+   were fixed by declaring `NSMenuItemValidation` /
+   `NSControlTextEditingDelegate` / `NSFontChanging` /
+   `NSToolbarItemValidation` (step 9a, done). Only 6 real delegate methods
+   remain (step 9b), and those do want manual verification.
 6. **Phase E (table content / custom query services)** — explicitly gated on
    the PostgreSQL abstraction decision (#2482/#2493): if it lands, extract
    against `id<SPDatabaseConnection>`; starting before that decision risks

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -212,21 +212,45 @@ Execution notes:
   neither a result nor an error is recorded: it still returns nil without
   touching the caller's error pointer.
 
-## Step 9 — "Implementing deprecated method" batch — 42 warnings (measured)
+## Step 9a — Informal-protocol conformance — ✅ Done (36 of the 42)
 
-Implementations of deprecated delegate signatures (mostly the pre-10.7
-NSTableView drag API `tableView:writeRowsWithIndexes:toPasteboard:` and
-friends) across SPFieldMapperController, SPQueryFavoriteManager,
-SPContentFilterManager, SPProcessListController, SPQueryController,
-SPServerVariablesController, SPBundleEditorController, SPNavigatorController,
-SPConnectionController, SPCustomQuery, SPTableTriggers, SPTableRelations,
-SPExportController, SPAppController, SPEditorPreferencePane.
-Adopt `NSPasteboardWriting`/`tableView:pasteboardWriterForRow:` per file;
-chunk into 2-3 PRs by area (managers / table views / misc). Each needs manual
-drag-drop verification — slowest batch, do last of the mechanical ones.
+⚠️ **The plan mis-described this batch.** It assumed "mostly the pre-10.7
+NSTableView drag API … each needs manual drag-drop verification — slowest batch".
+Reading the actual method behind each of the 42 warnings says otherwise:
 
-⚠️ The original "~25" estimate is low: a clean build after step 8 reports **42**
-of these, so plan for 3 PRs rather than 2.
+| Method | Count | Formal protocol |
+|---|---|---|
+| `validateMenuItem:` | 18 | `NSMenuItemValidation` |
+| `controlTextDidChange:` / `…EndEditing:` | 14 | `NSControlTextEditingDelegate` |
+| `validModesForFontPanel:` | 3 | `NSFontChanging` |
+| `validateToolbarItem:` | 1 | `NSToolbarItemValidation` |
+| `tableView:` / `outlineView:` / `splitView:` | 6 | see step 9b |
+
+36 of them are AppKit informal `NSObject` category methods that became members
+of formal protocols (`API_DEPRECATED("This is now … of the X protocol")`), so
+the fix is one conformance declaration per class — method bodies untouched, no
+behavior change, nothing to drag-test. Landed as a single sweep over 21 files,
+following the conformance style already used by `SPFilterTableController` and
+`SPGotoDatabaseController`.
+
+## Step 9b — Genuinely deprecated delegate methods — 6 warnings
+
+The remainder, which do need real changes and manual verification:
+
+- `tableView:writeRowsWithIndexes:toPasteboard:` (4) — SPCustomQuery:2629,
+  SPTableContent:4482, SPTableStructure:2239, SPNetworkPreferencePane:764.
+  Adopt `tableView:pasteboardWriterForRow:`; note the drop side
+  (`validateDrop:` / `acceptDrop:`) is *not* deprecated and stays as is, but it
+  reads the pasteboard the write side produces — change both together per file.
+- `outlineView:writeItems:toPasteboard:` (1) — SPNavigatorController:1080.
+  Same migration, `outlineView:pasteboardWriterForItem:`.
+- `splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:` (1) —
+  SPSplitView:478. Unrelated to dragging; check what replaced it before
+  touching, it may just need the delegate protocol adopted.
+
+So the drag-API assumption was right for 5 of 42, not "most". These do touch
+behavior: verify drag-and-drop (table reordering, navigator drags to the query
+editor) and divider double-click collapse by hand, one PR per area.
 
 ## Deferred (own projects, not part of this burn-down)
 
@@ -255,7 +279,8 @@ of these, so plan for 3 PRs rather than 2.
 | 4-5 (archiver + notifications) | ~225 |
 | 6 + 7 (help viewer + AppKit batch) | **173 (measured, clean build)** |
 | 8 (Swift 6) | **165 (measured, clean build)** |
-| 9 (deprecated delegate methods) | ~123 (165 − 42 measured) |
+| 9a (informal-protocol conformance) | **129 (measured, clean build)** |
+| 9b (6 real delegate methods) | ~123 |
 
 **How these are counted.** Rows through step 5 are the original estimates, read
 off Xcode's issue navigator (which counts a file compiled into several targets


### PR DESCRIPTION
## Changes:
- **Warnings plan step 9, conformance half (9a).** Clears **36 of its 42** "implementing deprecated method" warnings across 21 files: **165 → 129** on a clean build, none introduced.
- Declares the formal AppKit protocols whose methods used to live on informal `NSObject` categories:

  | Deprecated informal method | Count | Now declared |
  |---|---|---|
  | `validateMenuItem:` | 18 | `NSMenuItemValidation` |
  | `controlTextDidChange:` / `controlTextDidEndEditing:` | 14 | `NSControlTextEditingDelegate` |
  | `validModesForFontPanel:` | 3 | `NSFontChanging` |
  | `validateToolbarItem:` | 1 | `NSToolbarItemValidation` |

- Every hunk is the same shape — a two-line comment plus protocols added to the class extension. **No method body is touched.** AppKit already dispatched these through `-respondsToSelector:`, so declaring conformance changes nothing at runtime; the SDK deprecations say so explicitly (`API_DEPRECATED("This is now … of the NSMenuItemValidation protocol.")`).
- Follows the conformance style already in the codebase — `SPFilterTableController` (class extension) and `SPGotoDatabaseController` (header) declare `NSControlTextEditingDelegate` the same way.

### The plan was wrong about this batch — worth knowing before step 9b
The plan described step 9 as "mostly the pre-10.7 NSTableView drag API `tableView:writeRowsWithIndexes:toPasteboard:` and friends … **each needs manual drag-drop verification — slowest batch**". I extracted the actual method behind all 42 warnings before starting, and that assumption held for **5 of 42**, not most. Hence this split:

- **9a (this PR)** — 36 conformance declarations. Zero behaviour change, verified by the compiler, nothing to drag-test.
- **9b (follow-up)** — the 6 that genuinely changed, now recorded in the plan with signatures and call sites: `tableView:writeRowsWithIndexes:toPasteboard:` in SPCustomQuery:2629, SPTableContent:4482, SPTableStructure:2239, SPNetworkPreferencePane:764; `outlineView:writeItems:toPasteboard:` in SPNavigatorController:1080; `splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:` in SPSplitView:478. Those do want hands-on drag-and-drop verification.

One thing I'd flag for 9b: the drop side (`validateDrop:` / `acceptDrop:`) is *not* deprecated, but it reads the pasteboard the write side produces — so both sides have to move together per file.

## Closes following issues:
- Closes: n/a (tracked in `docs/development/warnings-elimination-plan.md` step 9a)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 27.0 (macOS 26.5.2, arm64)

Automated: clean builds before and after on the same checkout — **165 → 129** unique warnings (raw 318 → 282), the 36 removed are exactly the targeted ones, and a line-number-insensitive diff of the two warning sets shows **zero new warnings**. Full unit suite **905 tests, 0 failures** (63 skipped).

Risk note, so it isn't overstated in either direction: this is a compile-time-only change and the compiler is the check that matters — a wrong conformance would fail the build, not misbehave at runtime. Worth a passing glance at menu enable/disable state (the `validateMenuItem:` classes) if you're in the app anyway, but I wouldn't hold the PR for it.

## Screenshots:
n/a — no user-visible change.

## Additional notes:
- Applied with a script over the 21 class extensions rather than by hand, then reviewed hunk by hunk; the one irregular case (`SPTableStructure`, whose extension carries an ivar block) is handled — `@interface SPTableStructure () <NSMenuItemValidation> {`.
- After this, the burn-down is at 129: step 9b (6), then the deferred projects — SecKeychain 10, tunnel assistant 4, bundled OpenSSL + linker 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formal compatibility with macOS menu, text-editing, font, toolbar, and table protocols across the application.
  * No user-visible behavior changes were introduced.

* **Documentation**
  * Updated warning-remediation plans to record completed protocol-conformance work.
  * Identified six remaining delegate methods for future behavioral migration and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->