### PR TITLE
#infra Migrate the internal drag reorders off the deprecated write API (step 9b, part 1)

### DIFF
--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -2236,22 +2236,27 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 /**
  * Begin a drag and drop operation from the table - copy a single dragged row to the drag pasteboard.
  */
-- (BOOL)tableView:(NSTableView *)aTableView writeRowsWithIndexes:(NSIndexSet *)rows toPasteboard:(NSPasteboard*)pboard
+- (id <NSPasteboardWriting>)tableView:(NSTableView *)aTableView pasteboardWriterForRow:(NSInteger)row
 {
 	// Make sure that the drag operation is started from the right table view
-	if (aTableView != tableSourceView) return NO;
+	if (aTableView != tableSourceView) return nil;
 
 	// Check whether a save of the current field row is required.
-	if (![self saveRowOnDeselect]) return NO;
+	if (![self saveRowOnDeselect]) return nil;
 
-	if ([rows count] == 1) {
-		[pboard declareTypes:@[SPDefaultPasteboardDragType] owner:nil];
-		[pboard setString:[NSString stringWithFormat:@"%lu",[rows firstIndex]] forType:SPDefaultPasteboardDragType];
+	// Reordering only handles a single field, and -acceptDrop: below reads one
+	// index off the pasteboard. The previous implementation refused the whole
+	// drag when several rows were selected; returning nil for every row of a
+	// multi-row selection keeps that.
+	if ([aTableView isRowSelected:row] && [aTableView numberOfSelectedRows] > 1) return nil;
 
-		return YES;
-	}
+	// Same payload as before the migration off
+	// -tableView:writeRowsWithIndexes:toPasteboard:, so -validateDrop:/-acceptDrop:
+	// keep reading the row index with -stringForType:.
+	NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
+	[item setString:[NSString stringWithFormat:@"%ld", (long)row] forType:SPDefaultPasteboardDragType];
 
-	return NO;
+	return item;
 }
 
 /**

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1398,7 +1398,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	[indexesController setConnection:mySQLConnection];
 	
 	// Set up tableView
-	[tableSourceView registerForDraggedTypes:@[SPDefaultPasteboardDragType]];
+	[tableSourceView registerForDraggedTypes:@[SADragPasteboard.tableRowType]];
 }
 
 /**
@@ -2245,18 +2245,13 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	if (![self saveRowOnDeselect]) return nil;
 
 	// Reordering only handles a single field, and -acceptDrop: below reads one
-	// index off the pasteboard. The previous implementation refused the whole
-	// drag when several rows were selected; returning nil for every row of a
-	// multi-row selection keeps that.
-	if ([aTableView isRowSelected:row] && [aTableView numberOfSelectedRows] > 1) return nil;
+	// index off the pasteboard, so multi-row drags stay refused as before.
+	if ([SADragPasteboard refusesMultiRowDragForRow:row selectedRows:[aTableView selectedRowIndexes]]) return nil;
 
 	// Same payload as before the migration off
 	// -tableView:writeRowsWithIndexes:toPasteboard:, so -validateDrop:/-acceptDrop:
 	// keep reading the row index with -stringForType:.
-	NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
-	[item setString:[NSString stringWithFormat:@"%ld", (long)row] forType:SPDefaultPasteboardDragType];
-
-	return item;
+	return [SADragPasteboard itemWithRow:row forType:SADragPasteboard.tableRowType];
 }
 
 /**
@@ -2273,11 +2268,11 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	NSInteger originalRow;
 
 	// Ensure the drop is of the correct type
-	if (operation == NSTableViewDropAbove && row != -1 && [pboardTypes containsObject:SPDefaultPasteboardDragType]) {
+	if (operation == NSTableViewDropAbove && row != -1 && [pboardTypes containsObject:SADragPasteboard.tableRowType]) {
 
 		// Ensure the drag originated within this table
 		if ([info draggingSource] == tableView) {
-			originalRow = [[[info draggingPasteboard] stringForType:SPDefaultPasteboardDragType] integerValue];
+			originalRow = [[[info draggingPasteboard] stringForType:SADragPasteboard.tableRowType] integerValue];
 
 			if (row != originalRow && row != (originalRow+1)) {
 				return NSDragOperationMove;
@@ -2297,7 +2292,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 	if (tableView != tableSourceView) return NO;
 
 	// Extract the original row position from the pasteboard and retrieve the details
-	NSInteger originalRowIndex = [[[info draggingPasteboard] stringForType:SPDefaultPasteboardDragType] integerValue];
+	NSInteger originalRowIndex = [[[info draggingPasteboard] stringForType:SADragPasteboard.tableRowType] integerValue];
 	NSDictionary *originalRow = [[NSDictionary alloc] initWithDictionary:[[self activeFieldsSource] objectAtIndex:originalRowIndex]];
 
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"SMySQLQueryWillBePerformed" object:tableDocumentInstance];

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -727,10 +727,15 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	if(row < 0) return NO; //why is that even a signed int when all "indexes" are unsigned!?
 	
 	NSPasteboard *pboard = [info draggingPasteboard];
-	NSArray *draggedItems = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSString class], nil]
-	                                                             fromData:[pboard dataForType:SPSSLCipherPboardTypeName]
-	                                                                error:nil];
-	
+
+	// One pasteboard item per dragged row, in row order (see
+	// -tableView:pasteboardWriterForRow: above).
+	NSMutableArray<NSString *> *draggedItems = [NSMutableArray array];
+	for (NSPasteboardItem *item in [pboard pasteboardItems]) {
+		NSString *cipher = [item stringForType:SPSSLCipherPboardTypeName];
+		if (cipher) [draggedItems addObject:cipher];
+	}
+
 	NSUInteger nextInsert = row;
 	for (NSString *item in draggedItems) {
 		NSUInteger oldPos = [sslCiphers indexOfObject:item];
@@ -761,22 +766,23 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 	return (operation == NSTableViewDropOn)? NSDragOperationNone : NSDragOperationMove;
 }
 
-- (BOOL)tableView:(NSTableView *)aTableView writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
+- (id <NSPasteboardWriting>)tableView:(NSTableView *)aTableView pasteboardWriterForRow:(NSInteger)row
 {
+	NSUInteger markerIndex = [sslCiphers indexOfObject:SPSSLCipherListMarkerItem];
+
 	//the marker cannot be actively reordered
-	if ([rowIndexes containsIndex:[sslCiphers indexOfObject:SPSSLCipherListMarkerItem]])
-		return NO;
-	
-	//put the names of the items on the pasteboard. easier to work with than indexes...
-	NSMutableArray *items = [NSMutableArray arrayWithCapacity:[rowIndexes count]];
-	[rowIndexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-		[items addObject:[sslCiphers objectAtIndex:idx]];
-	}];
-	
-	NSData *arch = [NSKeyedArchiver archivedDataWithRootObject:items requiringSecureCoding:YES error:nil];
-	[pboard declareTypes:@[SPSSLCipherPboardTypeName] owner:self];
-	[pboard setData:arch forType:SPSSLCipherPboardTypeName];
-	return YES;
+	if ((NSUInteger)row == markerIndex) return nil;
+
+	//...and neither can a selection containing it: the previous implementation
+	//refused the whole drag in that case, so refuse every row of such a drag
+	if ([aTableView isRowSelected:row] && [[aTableView selectedRowIndexes] containsIndex:markerIndex]) return nil;
+
+	//put the name of the item on the pasteboard. easier to work with than indexes...
+	//one item per row now, rather than one archived array for the whole drag
+	NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
+	[item setString:[sslCiphers objectAtIndex:row] forType:SPSSLCipherPboardTypeName];
+
+	return item;
 }
 
 @end

--- a/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
+++ b/Source/Controllers/Preferences/Panes/SPNetworkPreferencePane.m
@@ -37,7 +37,6 @@
 #import "sequel-ace-Swift.h"
 
 static NSString *SPSSLCipherListMarkerItem = @"--";
-static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 
 @interface SPMySQLConnection (CipherPreferenceMerging)
 + (NSArray<NSString *> *)defaultSSLCipherList;
@@ -127,8 +126,8 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
     [self updateSSHConfigPopUp:knownHostsChooser];
 
 	[self loadSSLCiphers];
-	if(![[sslCipherView registeredDraggedTypes] containsObject:SPSSLCipherPboardTypeName])
-		[sslCipherView registerForDraggedTypes:@[SPSSLCipherPboardTypeName]];
+	if(![[sslCipherView registeredDraggedTypes] containsObject:SADragPasteboard.sslCipherType])
+		[sslCipherView registerForDraggedTypes:@[SADragPasteboard.sslCipherType]];
 }
 
 
@@ -726,15 +725,10 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 {
 	if(row < 0) return NO; //why is that even a signed int when all "indexes" are unsigned!?
 	
-	NSPasteboard *pboard = [info draggingPasteboard];
-
 	// One pasteboard item per dragged row, in row order (see
 	// -tableView:pasteboardWriterForRow: above).
-	NSMutableArray<NSString *> *draggedItems = [NSMutableArray array];
-	for (NSPasteboardItem *item in [pboard pasteboardItems]) {
-		NSString *cipher = [item stringForType:SPSSLCipherPboardTypeName];
-		if (cipher) [draggedItems addObject:cipher];
-	}
+	NSArray<NSString *> *draggedItems = [SADragPasteboard stringsFromPasteboard:[info draggingPasteboard]
+	                                                                   forType:SADragPasteboard.sslCipherType];
 
 	NSUInteger nextInsert = row;
 	for (NSString *item in draggedItems) {
@@ -768,21 +762,15 @@ static NSString *SPSSLCipherPboardTypeName = @"SSLCipherPboardType";
 
 - (id <NSPasteboardWriting>)tableView:(NSTableView *)aTableView pasteboardWriterForRow:(NSInteger)row
 {
-	NSUInteger markerIndex = [sslCiphers indexOfObject:SPSSLCipherListMarkerItem];
-
-	//the marker cannot be actively reordered
-	if ((NSUInteger)row == markerIndex) return nil;
-
-	//...and neither can a selection containing it: the previous implementation
-	//refused the whole drag in that case, so refuse every row of such a drag
-	if ([aTableView isRowSelected:row] && [[aTableView selectedRowIndexes] containsIndex:markerIndex]) return nil;
+	//the marker cannot be actively reordered, and neither can a selection
+	//containing it (the previous implementation refused the whole drag)
+	if ([SADragPasteboard refusesDragForRow:row
+	                           selectedRows:[aTableView selectedRowIndexes]
+	                            excludedRow:[sslCiphers indexOfObject:SPSSLCipherListMarkerItem]]) return nil;
 
 	//put the name of the item on the pasteboard. easier to work with than indexes...
 	//one item per row now, rather than one archived array for the whole drag
-	NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
-	[item setString:[sslCiphers objectAtIndex:row] forType:SPSSLCipherPboardTypeName];
-
-	return item;
+	return [SADragPasteboard itemWithString:[sslCiphers objectAtIndex:row] forType:SADragPasteboard.sslCipherType];
 }
 
 @end

--- a/Source/Other/Utility/SADragPasteboard.swift
+++ b/Source/Other/Utility/SADragPasteboard.swift
@@ -1,0 +1,95 @@
+//
+//  SADragPasteboard.swift
+//  Sequel Ace
+//
+//  Created as part of the deprecated drag-API migration.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+/// Pasteboard plumbing and refusal rules for the table views migrated off the
+/// deprecated `-tableView:writeRowsWithIndexes:toPasteboard:`.
+///
+/// Its replacement, `-tableView:pasteboardWriterForRow:`, is asked about one row
+/// at a time and cannot see the whole drag, so the "refuse this entire drag"
+/// decisions the old API expressed by returning NO have to be reconstructed from
+/// the row plus the selection. That reconstruction is the part worth testing, so
+/// it lives here rather than in the delegate methods.
+@objc final class SADragPasteboard: NSObject {
+
+    // MARK: - Types
+
+    // ⚠️ These must stay UTI-conformant (reverse-DNS). `NSPasteboardItem` and
+    // `NSPasteboardWriting` both refuse a type that isn't a valid UTI — AppKit
+    // logs "'X' is not a valid UTI string. Cannot set data for an invalid UTI."
+    // and the item ends up carrying nothing, while `writeObjects:` still returns
+    // YES. The deprecated `-declareTypes:`/`-setString:forType:` path accepted
+    // the app's legacy names ("SequelProPasteboard", "SSLCipherPboardType"),
+    // which is why these drags needed new type names when they were migrated.
+
+    /// Row index of a table row being reordered within its own table.
+    @objc static let tableRowType = "com.sequel-ace.pasteboard.table-row"
+
+    /// Name of an SSL cipher being reordered in the network preference pane.
+    @objc static let sslCipherType = "com.sequel-ace.pasteboard.ssl-cipher"
+
+    // MARK: - Writing
+
+    /// A pasteboard item carrying `string` under `type`.
+    @objc(itemWithString:forType:)
+    static func item(string: String, forType type: String) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        let stored = item.setString(string, forType: NSPasteboard.PasteboardType(type))
+
+        // Rather than let a non-UTI type produce an empty item and a drag that
+        // silently carries nothing.
+        assert(stored, "'\(type)' was rejected by NSPasteboardItem; pasteboard types must be valid UTIs")
+
+        return item
+    }
+
+    /// A pasteboard item carrying `row` as its decimal string under `type`.
+    @objc(itemWithRow:forType:)
+    static func item(row: Int, forType type: String) -> NSPasteboardItem {
+        item(string: String(row), forType: type)
+    }
+
+    // MARK: - Reading
+
+    /// The strings stored under `type` by each item on `pasteboard`, in item
+    /// order — which is row order, since the writer is asked per row.
+    ///
+    /// Replaces reading one archived collection written for the whole drag.
+    @objc(stringsFromPasteboard:forType:)
+    static func strings(from pasteboard: NSPasteboard, forType type: String) -> [String] {
+        let pasteboardType = NSPasteboard.PasteboardType(type)
+        return (pasteboard.pasteboardItems ?? []).compactMap { $0.string(forType: pasteboardType) }
+    }
+
+    // MARK: - Refusal rules
+
+    /// True when a drag beginning at `row` must be refused because it would carry
+    /// more than one row.
+    ///
+    /// For drop handlers that reorder exactly one row: the old delegate method
+    /// refused such a drag outright, and allowing it would silently move only the
+    /// first row. A row that isn't selected is dragged on its own, so it is fine.
+    @objc(refusesMultiRowDragForRow:selectedRows:)
+    static func refusesMultiRowDrag(row: Int, selectedRows: IndexSet) -> Bool {
+        selectedRows.contains(row) && selectedRows.count > 1
+    }
+
+    /// True when a drag beginning at `row` must be refused because it would carry
+    /// `excludedRow` — a row that cannot be reordered, such as the SSL cipher
+    /// list's "use system defaults" marker.
+    ///
+    /// Refuses both the excluded row itself and every row of a selection holding
+    /// it, matching the old whole-drag refusal. `NSNotFound` means "no such row".
+    @objc(refusesDragForRow:selectedRows:excludedRow:)
+    static func refusesDrag(row: Int, selectedRows: IndexSet, excludedRow: Int) -> Bool {
+        guard excludedRow != NSNotFound else { return false }
+        if row == excludedRow { return true }
+        return selectedRows.contains(row) && selectedRows.contains(excludedRow)
+    }
+}

--- a/Source/Views/SPSplitView.m
+++ b/Source/Views/SPSplitView.m
@@ -468,33 +468,12 @@
 	return NO;
 }
 
-/**
- * Handle requests as to whether a subview should be collapsed as a result of
- * a double-click on a divider.  If a subview is collapsible, by default this
- * will return NO, but an animated collapse/expand will be triggered instead to
- * perform the same action with animation.
- * The delegate can override this if necessary.
- */
-- (BOOL)splitView:(NSSplitView *)splitView shouldCollapseSubview:(NSView *)subview forDoubleClickOnDividerAtIndex:(NSInteger)dividerIndex
-{
-	if ([delegate respondsToSelector:@selector(splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:)]) {
-		return [delegate splitView:splitView shouldCollapseSubview:subview forDoubleClickOnDividerAtIndex:dividerIndex];
-	}
-
-	// If there's no collapsible subview, don't allow collapse
-	if (collapsibleSubviewIndex == NSNotFound) {
-		return NO;
-	}
-
-	// Ensure the divider is adjacent to the collapsible view
-	if ((NSUInteger)dividerIndex != collapsibleSubviewIndex && (NSUInteger)dividerIndex != (collapsibleSubviewIndex - 1)) {
-		return NO;
-	}
-
-	// Trigger an animated collapse and prevent the original collapse
-	[self setCollapsibleSubviewCollapsed:YES animate:YES];
-	return NO;
-}
+// -splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex: used to live
+// here, animating the collapse instead of letting AppKit do it. It was removed
+// because AppKit stopped calling it: "NSSplitView no longer supports collapsing
+// sections via double-click. This delegate method is never called." (deprecated
+// in 10.15, and this app targets macOS 12). Collapsing is still available
+// through -toggleCollapse: and -setCollapsibleSubviewCollapsed:animate:.
 
 /**
  * While the collapsible subview is collapsed, hide the adjacent divider.

--- a/UnitTests/SADragPasteboardTests.swift
+++ b/UnitTests/SADragPasteboardTests.swift
@@ -1,0 +1,134 @@
+//
+//  SADragPasteboardTests.swift
+//  Unit Tests
+//
+//  Created as part of the deprecated drag-API migration.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+final class SADragPasteboardTests: XCTestCase {
+
+    // Must be UTI-conformant, like the shipped types — see the pinning test below.
+    private let type = "com.sequel-ace.tests.drag"
+
+    // MARK: - Writing and reading
+
+    func testItemCarriesTheStringUnderTheGivenType() {
+        let item = SADragPasteboard.item(string: "DHE-RSA-AES256-SHA", forType: type)
+
+        XCTAssertEqual(item.string(forType: NSPasteboard.PasteboardType(type)), "DHE-RSA-AES256-SHA")
+    }
+
+    func testItemForRowCarriesTheRowIndexAsAString() {
+        XCTAssertEqual(
+            SADragPasteboard.item(row: 7, forType: type).string(forType: NSPasteboard.PasteboardType(type)),
+            "7"
+        )
+    }
+
+    /// The drop side reads the items back in row order, replacing the single
+    /// archived collection the deprecated write API produced.
+    func testStringsAreReadBackInItemOrder() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("SADragPasteboardTests.order"))
+        pasteboard.clearContents()
+        pasteboard.writeObjects([
+            SADragPasteboard.item(string: "first", forType: type),
+            SADragPasteboard.item(string: "second", forType: type),
+            SADragPasteboard.item(string: "third", forType: type),
+        ])
+
+        XCTAssertEqual(SADragPasteboard.strings(from: pasteboard, forType: type), ["first", "second", "third"])
+    }
+
+    func testItemsWithoutTheTypeAreSkipped() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("SADragPasteboardTests.mixed"))
+        pasteboard.clearContents()
+
+        let other = NSPasteboardItem()
+        other.setString("ignored", forType: .string)
+        pasteboard.writeObjects([SADragPasteboard.item(string: "kept", forType: type), other])
+
+        XCTAssertEqual(SADragPasteboard.strings(from: pasteboard, forType: type), ["kept"])
+    }
+
+    func testAnEmptyPasteboardYieldsNoStrings() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("SADragPasteboardTests.empty"))
+        pasteboard.clearContents()
+
+        XCTAssertEqual(SADragPasteboard.strings(from: pasteboard, forType: type), [])
+    }
+
+    // MARK: - Multi-row refusal (SPTableStructure field reorder)
+
+    func testDraggingAnUnselectedRowIsAllowedEvenWithAMultiRowSelection() {
+        // AppKit drags just that row, so there is nothing to refuse.
+        XCTAssertFalse(SADragPasteboard.refusesMultiRowDrag(row: 9, selectedRows: IndexSet([2, 3])))
+    }
+
+    func testDraggingOneOfSeveralSelectedRowsIsRefused() {
+        let selection = IndexSet([2, 3])
+
+        XCTAssertTrue(SADragPasteboard.refusesMultiRowDrag(row: 2, selectedRows: selection))
+        XCTAssertTrue(SADragPasteboard.refusesMultiRowDrag(row: 3, selectedRows: selection))
+    }
+
+    func testDraggingTheOnlySelectedRowIsAllowed() {
+        XCTAssertFalse(SADragPasteboard.refusesMultiRowDrag(row: 2, selectedRows: IndexSet([2])))
+        XCTAssertFalse(SADragPasteboard.refusesMultiRowDrag(row: 2, selectedRows: IndexSet()))
+    }
+
+    // MARK: - Excluded-row refusal (SSL cipher list marker)
+
+    func testTheExcludedRowItselfIsRefused() {
+        XCTAssertTrue(SADragPasteboard.refusesDrag(row: 4, selectedRows: IndexSet([4]), excludedRow: 4))
+        // …even when it isn't selected.
+        XCTAssertTrue(SADragPasteboard.refusesDrag(row: 4, selectedRows: IndexSet(), excludedRow: 4))
+    }
+
+    func testASelectionContainingTheExcludedRowIsRefusedEntirely() {
+        let selection = IndexSet([1, 4, 6])
+
+        XCTAssertTrue(SADragPasteboard.refusesDrag(row: 1, selectedRows: selection, excludedRow: 4))
+        XCTAssertTrue(SADragPasteboard.refusesDrag(row: 6, selectedRows: selection, excludedRow: 4))
+    }
+
+    func testASelectionWithoutTheExcludedRowIsAllowed() {
+        let selection = IndexSet([1, 6])
+
+        XCTAssertFalse(SADragPasteboard.refusesDrag(row: 1, selectedRows: selection, excludedRow: 4))
+        XCTAssertFalse(SADragPasteboard.refusesDrag(row: 6, selectedRows: selection, excludedRow: 4))
+    }
+
+    func testDraggingAnUnselectedRowIgnoresTheExcludedRowInTheSelection() {
+        // Only the dragged row travels, so a selected marker elsewhere is irrelevant.
+        XCTAssertFalse(SADragPasteboard.refusesDrag(row: 9, selectedRows: IndexSet([4]), excludedRow: 4))
+    }
+
+    /// `indexOfObject:` returns NSNotFound when the list has no marker at all.
+    func testAMissingExcludedRowRefusesNothing() {
+        XCTAssertFalse(SADragPasteboard.refusesDrag(row: 3, selectedRows: IndexSet([3]), excludedRow: NSNotFound))
+    }
+
+    // MARK: - Type names
+
+    /// The shipped types must be valid UTIs. NSPasteboardItem refuses anything
+    /// else — it logs "not a valid UTI string", stores nothing, and the drag then
+    /// carries an empty item while every API involved still reports success. The
+    /// legacy names these drags used before the migration ("SequelProPasteboard",
+    /// "SSLCipherPboardType") failed exactly that way.
+    func testShippedPasteboardTypesAreAcceptedByNSPasteboardItem() {
+        for type in [SADragPasteboard.tableRowType, SADragPasteboard.sslCipherType] {
+            let item = SADragPasteboard.item(string: "payload", forType: type)
+
+            XCTAssertEqual(item.types, [NSPasteboard.PasteboardType(type)], type)
+            XCTAssertEqual(item.string(forType: NSPasteboard.PasteboardType(type)), "payload", type)
+        }
+    }
+
+    func testShippedPasteboardTypesAreDistinct() {
+        XCTAssertNotEqual(SADragPasteboard.tableRowType, SADragPasteboard.sslCipherType)
+    }
+}

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -233,24 +233,43 @@ behavior change, nothing to drag-test. Landed as a single sweep over 21 files,
 following the conformance style already used by `SPFilterTableController` and
 `SPGotoDatabaseController`.
 
-## Step 9b — Genuinely deprecated delegate methods — 6 warnings
+## Step 9b — Genuinely deprecated delegate methods — 3 of 6 done
 
-The remainder, which do need real changes and manual verification:
+Split by who consumes the dragged payload, because that decides the risk.
 
-- `tableView:writeRowsWithIndexes:toPasteboard:` (4) — SPCustomQuery:2629,
-  SPTableContent:4482, SPTableStructure:2239, SPNetworkPreferencePane:764.
-  Adopt `tableView:pasteboardWriterForRow:`; note the drop side
-  (`validateDrop:` / `acceptDrop:`) is *not* deprecated and stays as is, but it
-  reads the pasteboard the write side produces — change both together per file.
-- `outlineView:writeItems:toPasteboard:` (1) — SPNavigatorController:1080.
-  Same migration, `outlineView:pasteboardWriterForItem:`.
-- `splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:` (1) —
-  SPSplitView:478. Unrelated to dragging; check what replaced it before
-  touching, it may just need the delegate protocol adopted.
+**Done — payload stays inside the app (both ends ours), plus one dead method:**
 
-So the drag-API assumption was right for 5 of 42, not "most". These do touch
-behavior: verify drag-and-drop (table reordering, navigator drags to the query
-editor) and divider double-click collapse by hand, one PR per area.
+- `splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:` —
+  SPSplitView. **Not a migration: deleted.** The SDK says "NSSplitView no
+  longer supports collapsing sections via double-click. This delegate method is
+  never called." (deprecated 10.15, app targets 12), so the animated-collapse
+  branch it guarded had been unreachable for years. Collapsing still works via
+  `-toggleCollapse:` / `-setCollapsibleSubviewCollapsed:animate:`.
+- `tableView:pasteboardWriterForRow:` — SPTableStructure (field reorder) and
+  SPNetworkPreferencePane (SSL cipher reorder). Both write and read their own
+  pasteboard, so both ends moved together. SPTableStructure keeps the exact
+  payload (row index string under `SPDefaultPasteboardDragType`);
+  SPNetworkPreferencePane moved from one archived array to one item per row,
+  and its `-acceptDrop:` now reads the items.
+
+**Remaining (3) — the payload leaves the view, so it must keep its current
+shape on the pasteboard:**
+
+- `tableView:writeRowsWithIndexes:toPasteboard:` — SPCustomQuery:2629,
+  SPTableContent:4482. These write *one* combined blob for the whole selection
+  (tab-delimited text, SQL INSERTs when a modifier is held, plus a single-cell
+  type in SPTableContent) which is dropped into other apps and into the rule
+  filter. Per-row writers would put N items on the pasteboard, and a receiver
+  reading `-stringForType:` gets only the first — so write the combined payload
+  in `tableView:draggingSession:willBeginAtPoint:forRowIndexes:` and return a
+  lightweight item per row.
+- `outlineView:writeItems:toPasteboard:` — SPNavigatorController:1080, same
+  shape (three types incl. a string dropped into the query editor);
+  `outlineView:draggingSession:willBeginAtPoint:forItems:`.
+
+Verify by hand: drag rows from the query result and content views into TextEdit
+(with and without ⌘/⇧/⌥), a cell onto a rule-filter field, and a navigator item
+into the query editor.
 
 ## Deferred (own projects, not part of this burn-down)
 
@@ -280,7 +299,8 @@ editor) and divider double-click collapse by hand, one PR per area.
 | 6 + 7 (help viewer + AppKit batch) | **173 (measured, clean build)** |
 | 8 (Swift 6) | **165 (measured, clean build)** |
 | 9a (informal-protocol conformance) | **129 (measured, clean build)** |
-| 9b (6 real delegate methods) | ~123 |
+| 9b part 1 (internal reorders + dead split-view method) | **125 (measured, clean build)** |
+| 9b part 2 (3 drag-out payloads) | ~122 |
 
 **How these are counted.** Rows through step 5 are the original estimates, read
 off Xcode's issue navigator (which counts a file compiled into several targets

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -247,10 +247,24 @@ Split by who consumes the dragged payload, because that decides the risk.
   `-toggleCollapse:` / `-setCollapsibleSubviewCollapsed:animate:`.
 - `tableView:pasteboardWriterForRow:` — SPTableStructure (field reorder) and
   SPNetworkPreferencePane (SSL cipher reorder). Both write and read their own
-  pasteboard, so both ends moved together. SPTableStructure keeps the exact
-  payload (row index string under `SPDefaultPasteboardDragType`);
-  SPNetworkPreferencePane moved from one archived array to one item per row,
-  and its `-acceptDrop:` now reads the items.
+  pasteboard, so both ends moved together, via the new Swift `SADragPasteboard`
+  (items, item-order reads, and the refusal rules the per-row API can no longer
+  express on its own — 15 unit tests).
+
+⚠️ **The modern API requires UTI-conformant pasteboard type names, and this is
+silent.** `NSPasteboardItem.setString:forType:` and `NSPasteboardWriting`'s
+`writableTypesForPasteboard:` both reject anything that is not a valid UTI:
+AppKit logs *"'SequelProPasteboard' is not a valid UTI string. Cannot set data
+for an invalid UTI."*, the item carries nothing, and `writeObjects:` still
+returns YES. The deprecated `-declareTypes:`/`-setString:forType:` path accepted
+the app's legacy names, so a like-for-like migration compiles, runs, and drags
+nothing. Caught here only because the extraction came with unit tests.
+
+The two migrated sites therefore use new types owned by `SADragPasteboard`
+(`com.sequel-ace.pasteboard.table-row`, `…ssl-cipher`), with both ends updated
+together. `SPDefaultPasteboardDragType` ("SequelProPasteboard") now has no live
+readers — its remaining references are inside SPCustomQuery's commented-out
+drop handlers.
 
 **Remaining (3) — the payload leaves the view, so it must keep its current
 shape on the pasteboard:**
@@ -265,7 +279,10 @@ shape on the pasteboard:**
   lightweight item per row.
 - `outlineView:writeItems:toPasteboard:` — SPNavigatorController:1080, same
   shape (three types incl. a string dropped into the query editor);
-  `outlineView:draggingSession:willBeginAtPoint:forItems:`.
+  `outlineView:draggingSession:willBeginAtPoint:forItems:`. Note its types
+  (`SPNavigatorPasteboardDragType`, `SPNavigatorTableDataPasteboardDragType`)
+  are legacy names too, so they hit the UTI rule above and must be renamed with
+  their readers — SPTextView reads them.
 
 Verify by hand: drag rows from the query result and content views into TextEdit
 (with and without ⌘/⇧/⌥), a cell onto a rule-filter field, and a navigator item

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */; };
+		FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */; };
+		E51CC2AA59AF37FEF73B06A0 /* SADragPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */; };
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
 		10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
@@ -759,6 +762,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADragPasteboard.swift; sourceTree = "<group>"; };
+		7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADragPasteboardTests.swift; sourceTree = "<group>"; };
 		1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		112730551180788A000737FD /* SPTableCopyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableCopyTest.m; sourceTree = "<group>"; };
 		1141A387117BBFF200126A28 /* SPTableCopy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTableCopy.h; sourceTree = "<group>"; };
@@ -2589,6 +2594,7 @@
 				6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */,
 				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
 				ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */,
+				7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -2614,6 +2620,7 @@
 				51BE68DB3017550E00AF389C /* SAImageRenderer.swift */,
 				AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */,
 				644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */,
+				5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3456,6 +3463,8 @@
 				8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */,
 				2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */,
 				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
+				FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */,
+				E51CC2AA59AF37FEF73B06A0 /* SADragPasteboardTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3765,6 +3774,7 @@
 				B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */,
 				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
 				16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */,
+				410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- **Warnings plan step 9b, part 1.** Takes 4 of the 6 remaining "implementing deprecated method" warnings: **129 → 125** on a clean build, none introduced.
- **`SPSplitView` — deleted, not migrated.** `splitView:shouldCollapseSubview:forDoubleClickOnDividerAtIndex:` carries an unusually specific deprecation: *"NSSplitView no longer supports collapsing sections via double-click. **This delegate method is never called.**"* (deprecated 10.15; we target macOS 12). So the animated-collapse branch it guarded, and its forwarding to an external delegate, have been unreachable for years — nothing else in the codebase implements or calls it. Removing it also clears the matching `-Wdeprecated-declarations` warning, which is why this PR clears 4 warnings from 3 files. Collapsing still works through `-toggleCollapse:` / `-setCollapsibleSubviewCollapsed:animate:`.
- **`SPTableStructure` and `SPNetworkPreferencePane` — adopt `tableView:pasteboardWriterForRow:`.** Both write *and* read their own pasteboard, so both ends moved together:
  - `SPTableStructure` (field reorder) keeps the **exact** payload — the row index as a string under `SPDefaultPasteboardDragType` — so `validateDrop:`/`acceptDrop:` are untouched.
  - `SPNetworkPreferencePane` (SSL cipher reorder) moves from one archived `NSArray` to one item per row, and `acceptDrop:` now reads the items in row order.
- **Both refusals preserved deliberately**, since the new API is per-row and the old one saw the whole drag:
  - `SPTableStructure` declined multi-row drags (its accept side reorders exactly one field, so a multi-row drag would have silently moved only the first). Now every row of a multi-row selection returns nil, which refuses the drag the same way.
  - The SSL cipher list declined any drag containing the "use system defaults" marker. Now the marker row returns nil, and so does every row of a selection containing it.

### Why this is 4 of 6 rather than all 6
The split is by **who reads the payload**, because that decides the risk. The three remaining sites — `SPCustomQuery`, `SPTableContent`, `SPNavigatorController` — put *one combined blob* on the pasteboard for the whole selection (tab-delimited text, SQL `INSERT`s when a modifier is held, a single-cell type for the rule filter, a navigator item for the query editor). Per-row writers would put N items there, and any receiver reading `-stringForType:` — including other apps — gets only the first, so a 3-row drag into TextEdit would paste one row. Those need the combined payload written in `draggingSession:willBeginAtPoint:forRowIndexes:` instead, which is a different mechanism worth verifying on its own. Part 2 covers them; the plan now records the reasoning and the gestures to test.

### Review follow-up (798d38798) — the migration was silently broken
Both bots flagged the new Objective-C as against AGENTS.md, so the behaviour moved into a new Swift `SADragPasteboard` (app + Unit Tests targets) with the delegate methods left as trampolines. **The tests that extraction earned failed on the first run, for a real reason:**

`NSPasteboardItem` refuses type names that are not valid UTIs — `'SequelProPasteboard' is not a valid UTI string. Cannot set data for an invalid UTI.` — `setString:forType:` returns NO, the item carries nothing, and nothing else reports a problem (`NSPasteboardWriting` refuses them the same way while `writeObjects:` still returns YES). The deprecated `-declareTypes:`/`-setString:forType:` path accepted this app's legacy names, so **the like-for-like migration compiled, ran, and would have dragged empty items** — both reorders silently broken, in the one PR where I said I couldn't verify drag behaviour.

Fixed by moving both sites to UTI types owned by the helper (`com.sequel-ace.pasteboard.table-row`, `…ssl-cipher`) with their readers updated together, plus an assertion in `itemWithString:forType:` so a rejected type can't fail quietly again. 15 unit tests cover the items, item-order reads, both refusal rules, and pin the shipped type names. The plan now records the UTI rule for part 2, whose navigator types are legacy names with an external reader in SPTextView.

**This does not remove the need for the manual checks below** — it removes a defect that would have made them fail.

## Closes following issues:
- Closes: n/a (tracked in `docs/development/warnings-elimination-plan.md` step 9b)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 27.0 (macOS 26.5.2, arm64)

Automated: clean builds before and after — **129 → 125** unique warnings (raw 282 → 278), the 4 removed are exactly the targeted ones, line-insensitive diff shows **zero new**. Full unit suite **920 tests, 0 failures** (63 skipped).

⚠️ **Unlike the last two PRs, this one changes behaviour and I cannot verify it — I have no way to perform a drag.** This is the part of step 9 that genuinely needs hands-on checking, so please do these four before merging:

- [ ] **Table structure**: drag a field row up/down to reorder it — the reorder still applies (it runs an `ALTER TABLE`, so it needs a connection).
- [ ] **Table structure, multi-row**: select two fields and try to drag — should refuse, as before.
- [ ] **Preferences ▸ Network ▸ SSL ciphers**: drag one cipher, and a multi-cipher selection, to reorder; order persists after closing prefs.
- [ ] **SSL ciphers, marker**: try dragging the "use system defaults" marker row, and a selection containing it — both should refuse.
- [ ] **Split view sanity**: double-click a divider (e.g. the table list / content splitter). Expected: nothing happens, on this build *and* on current main — the behaviour was already gone; this PR only deletes the dead code.

## Screenshots:
n/a — no visual change.

## Additional notes:
- ~~New Objective-C in existing `.m` files…~~ Withdrawn: I argued the glue had "no logic worth testing", both reviewers disagreed, and they were right — the extraction is in Swift as `SADragPasteboard`, and the tests it made possible caught a bug that would have shipped.
- After part 2, the burn-down reaches its floor: ~122, of which ~44 belong to no plan step (a hygiene re-sweep of code that landed after steps 1–2), ~53 are third-party or intentional `#warning` markers, and 17 are the deferred SecKeychain / NSConnection projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved table-row drag-and-drop for more reliable single-row transfers.
  - Improved SSL cipher drag-and-drop, including multi-cipher moves that preserve order.
  - Preserved existing drop validation and editing workflows.

- **Behavior Changes**
  - Double-clicking a split-view divider no longer automatically collapses the pane; panes remain collapsible through explicit controls.

- **Documentation**
  - Updated development documentation to reflect completed warning-reduction work and remaining drag-and-drop improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
