### PR TITLE
#fixed Restrict the favorites search shortcut to plain ⌘F

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -5251,15 +5251,8 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
         // Match ⌘F only, not merely "Command is among the modifiers". This monitor runs
         // ahead of the main menu's key equivalent dispatch, so accepting any superset of
         // ⌘ would swallow ⌃⌘F (Enter Full Screen), ⌥⌘F (Filter Content) and ⌃⌥⌘F (Filter
-        // Tables) before those menu items ever see them. Caps Lock / Fn / numeric pad are
-        // not part of the comparison as they don't distinguish a shortcut.
-        NSEventModifierFlags chordFlags = [event modifierFlags] & (NSEventModifierFlagCommand |
-                                                                  NSEventModifierFlagControl |
-                                                                  NSEventModifierFlagOption |
-                                                                  NSEventModifierFlagShift);
-        BOOL isCmdF = (chordFlags == NSEventModifierFlagCommand)
-                   && ([[event charactersIgnoringModifiers] caseInsensitiveCompare:@"f"] == NSOrderedSame);
-        if (!isCmdF) return event;
+        // Tables) before those menu items ever see them.
+        if (![SAKeyboardShortcut.commandF matchesEvent:event]) return event;
 
         NSWindow *window = [connView window];
         if (!window || [NSApp keyWindow] != window) return event;

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -5248,8 +5248,17 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
         NSView *connView = strongSelf->connectionView;
         if (!field || !connView) return event;
 
-        BOOL cmdPressed = ([event modifierFlags] & NSEventModifierFlagCommand) != 0;
-        BOOL isCmdF = cmdPressed && [[event charactersIgnoringModifiers] isEqualToString:@"f"];
+        // Match ⌘F only, not merely "Command is among the modifiers". This monitor runs
+        // ahead of the main menu's key equivalent dispatch, so accepting any superset of
+        // ⌘ would swallow ⌃⌘F (Enter Full Screen), ⌥⌘F (Filter Content) and ⌃⌥⌘F (Filter
+        // Tables) before those menu items ever see them. Caps Lock / Fn / numeric pad are
+        // not part of the comparison as they don't distinguish a shortcut.
+        NSEventModifierFlags chordFlags = [event modifierFlags] & (NSEventModifierFlagCommand |
+                                                                  NSEventModifierFlagControl |
+                                                                  NSEventModifierFlagOption |
+                                                                  NSEventModifierFlagShift);
+        BOOL isCmdF = (chordFlags == NSEventModifierFlagCommand)
+                   && ([[event charactersIgnoringModifiers] caseInsensitiveCompare:@"f"] == NSOrderedSame);
         if (!isCmdF) return event;
 
         NSWindow *window = [connView window];

--- a/Source/Other/Utility/SAKeyboardShortcut.swift
+++ b/Source/Other/Utility/SAKeyboardShortcut.swift
@@ -1,0 +1,56 @@
+//
+//  SAKeyboardShortcut.swift
+//  Sequel Ace
+//
+//  Created as part of the modernization effort.
+//  Exact keyboard chord matching for hand-rolled key event handling.
+//
+
+import AppKit
+
+/// An exact keyboard chord — a character plus the precise set of modifiers that must be held.
+///
+/// Code that inspects key events by hand (local `NSEvent` monitors, `keyDown:` overrides) runs
+/// ahead of the main menu's key equivalent dispatch, so a matcher that merely asks "is ⌘ among
+/// the modifiers" also swallows ⌃⌘, ⌥⌘ and ⇧⌘ variants of the same character before the menu
+/// items bound to them ever see the event. This type compares the whole chord instead.
+@objc final class SAKeyboardShortcut: NSObject {
+
+    /// The modifiers that distinguish one shortcut from another.
+    ///
+    /// Caps Lock, Fn and the numeric pad flag are deliberately excluded: they ride along on
+    /// ordinary key presses without changing which shortcut the user meant.
+    static let significantModifiers: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+
+    /// The unmodified character, compared case-insensitively.
+    let character: String
+
+    /// The exact set of significant modifiers that must be held — no more, no less.
+    let modifiers: NSEvent.ModifierFlags
+
+    init(character: String, modifiers: NSEvent.ModifierFlags) {
+        self.character = character
+        self.modifiers = modifiers.intersection(Self.significantModifiers)
+        super.init()
+    }
+
+    /// ⌘F, with no other modifier held.
+    @objc static let commandF = SAKeyboardShortcut(character: "f", modifiers: .command)
+
+    /// Whether `event` is exactly this chord.
+    @objc(matchesEvent:)
+    func matches(_ event: NSEvent) -> Bool {
+        matches(modifierFlags: event.modifierFlags, charactersIgnoringModifiers: event.charactersIgnoringModifiers)
+    }
+
+    /// Whether the given key event components are exactly this chord.
+    ///
+    /// A `nil` or empty `charactersIgnoringModifiers` never matches: some key events carry no
+    /// character at all, and treating those as a match would consume unrelated events.
+    @objc(matchesModifierFlags:charactersIgnoringModifiers:)
+    func matches(modifierFlags: NSEvent.ModifierFlags, charactersIgnoringModifiers: String?) -> Bool {
+        guard let characters = charactersIgnoringModifiers, !characters.isEmpty else { return false }
+        guard modifierFlags.intersection(Self.significantModifiers) == modifiers else { return false }
+        return characters.compare(character, options: .caseInsensitive) == .orderedSame
+    }
+}

--- a/UnitTests/SAKeyboardShortcutTests.swift
+++ b/UnitTests/SAKeyboardShortcutTests.swift
@@ -1,0 +1,101 @@
+//
+//  SAKeyboardShortcutTests.swift
+//  Unit Tests
+//
+//  Created as part of the modernization effort.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+final class SAKeyboardShortcutTests: XCTestCase {
+
+    private let commandF = SAKeyboardShortcut.commandF
+
+    private func matches(_ modifiers: NSEvent.ModifierFlags, _ characters: String?) -> Bool {
+        commandF.matches(modifierFlags: modifiers, charactersIgnoringModifiers: characters)
+    }
+
+    // MARK: - The chord it is meant to match
+
+    func testPlainCommandFMatches() {
+        XCTAssertTrue(matches(.command, "f"))
+    }
+
+    func testCapsLockedCharacterMatches() {
+        // charactersIgnoringModifiers honours Caps Lock, so the character arrives uppercased
+        // even though no shift-like modifier is reported.
+        XCTAssertTrue(matches([.command, .capsLock], "F"))
+    }
+
+    // MARK: - Modifier supersets belong to other shortcuts
+
+    func testControlCommandFDoesNotMatch() {
+        // ⌃⌘F is View → Enter Full Screen.
+        XCTAssertFalse(matches([.command, .control], "f"))
+    }
+
+    func testOptionCommandFDoesNotMatch() {
+        // ⌥⌘F is View → Filter Content.
+        XCTAssertFalse(matches([.command, .option], "f"))
+    }
+
+    func testControlOptionCommandFDoesNotMatch() {
+        // ⌃⌥⌘F is View → Filter Tables.
+        XCTAssertFalse(matches([.command, .control, .option], "f"))
+    }
+
+    func testShiftCommandFDoesNotMatch() {
+        XCTAssertFalse(matches([.command, .shift], "F"))
+    }
+
+    // MARK: - Insignificant modifiers are ignored
+
+    func testFunctionAndNumericPadFlagsAreIgnored() {
+        XCTAssertTrue(matches([.command, .function, .numericPad], "f"))
+    }
+
+    // MARK: - Other events pass through
+
+    func testMissingCommandDoesNotMatch() {
+        XCTAssertFalse(matches([], "f"))
+        XCTAssertFalse(matches(.control, "f"))
+    }
+
+    func testDifferentCharacterDoesNotMatch() {
+        XCTAssertFalse(matches(.command, "g"))
+    }
+
+    func testNilCharactersDoNotMatch() {
+        XCTAssertFalse(matches(.command, nil))
+    }
+
+    func testEmptyCharactersDoNotMatch() {
+        XCTAssertFalse(matches(.command, ""))
+    }
+
+    // MARK: - Initialisation
+
+    func testInsignificantModifiersAreStrippedFromTheChord() {
+        let shortcut = SAKeyboardShortcut(character: "f", modifiers: [.command, .capsLock])
+
+        XCTAssertEqual(shortcut.modifiers, .command)
+        XCTAssertTrue(shortcut.matches(modifierFlags: .command, charactersIgnoringModifiers: "f"))
+    }
+
+    func testMatchingAnNSEvent() throws {
+        let event = try XCTUnwrap(NSEvent.keyEvent(with: .keyDown,
+                                                  location: .zero,
+                                                  modifierFlags: .command,
+                                                  timestamp: 0,
+                                                  windowNumber: 0,
+                                                  context: nil,
+                                                  characters: "\u{06}",
+                                                  charactersIgnoringModifiers: "f",
+                                                  isARepeat: false,
+                                                  keyCode: 3))
+
+        XCTAssertTrue(commandF.matches(event))
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		11ACD43BE52B0351BBFE518F /* AWSSSOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAD424F195B2E207BF7C604 /* AWSSSOClient.swift */; };
 		11B55BFE1189E3B2009EF465 /* SPDatabaseAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 11B55BFD1189E3B2009EF465 /* SPDatabaseAction.m */; };
 		11C211301180EC9A00758039 /* SPDatabaseRename.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C2109D1180E70800758039 /* SPDatabaseRename.m */; };
+		16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */; };
 		171312CE109D23C700FB465F /* SPTableTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 171312CD109D23C700FB465F /* SPTableTextFieldCell.m */; };
 		1717FA401558313A0065C036 /* RegexKitLite.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DC8AB0F909194002A3258 /* RegexKitLite.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		1717FA43155831600065C036 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 296DC8BE0F9091DF002A3258 /* libicucore.dylib */; };
@@ -90,6 +91,7 @@
 		17F5B39C1049B96A00FC794F /* SPSQLExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F5B39B1049B96A00FC794F /* SPSQLExporter.m */; };
 		17F90E481210B42700274C98 /* SPExportFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F90E471210B42700274C98 /* SPExportFile.m */; };
 		17FDB04C1280778B00DBBBC2 /* SPFontPreviewTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 17FDB04B1280778B00DBBBC2 /* SPFontPreviewTextField.m */; };
+		190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */; };
 		1A071B8D254D983700246912 /* SPNSMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A071B8C254D983700246912 /* SPNSMutableDictionaryAdditions.m */; };
 		1A0FA3EE258B758B00486D52 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
 		1A11E50425A327F1001CB721 /* SPPanelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A11E50325A327F1001CB721 /* SPPanelOptions.m */; };
@@ -175,6 +177,7 @@
 		296DC8BC0F909194002A3258 /* MGTemplateStandardFilters.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DC8B40F909194002A3258 /* MGTemplateStandardFilters.m */; };
 		296DC8BF0F9091DF002A3258 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 296DC8BE0F9091DF002A3258 /* libicucore.dylib */; };
 		29FA88231114619E00D1AF3D /* SPTableTriggers.m in Sources */ = {isa = PBXBuildFile; fileRef = 29FA88221114619E00D1AF3D /* SPTableTriggers.m */; };
+		2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */; };
 		2A7D5700E8EA895137AA6F91 /* SPMCPHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91D4A5EC24F24F7A7BCA7D /* SPMCPHTTP.swift */; };
 		380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */; };
 		384582C40FB95FF800DDACB6 /* func-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 384582C30FB95FF800DDACB6 /* func-small.png */; };
@@ -1282,6 +1285,7 @@
 		5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+Favorite.swift"; sourceTree = "<group>"; };
 		5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfoFavoriteTests.swift; sourceTree = "<group>"; };
 		5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPMCPFavorite.swift; sourceTree = "<group>"; };
+		644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAKeyboardShortcut.swift; sourceTree = "<group>"; };
 		6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAHelpViewerModelTests.swift; sourceTree = "<group>"; };
 		65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFilePreferencePane.m; sourceTree = "<group>"; };
 		65F52CCC24AE21F200FED3CB /* SPFilePreferencePane.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPFilePreferencePane.h; sourceTree = "<group>"; };
@@ -1452,6 +1456,7 @@
 		DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleEditor.swift; sourceTree = "<group>"; };
 		DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPRuleFilterDropBox.swift; sourceTree = "<group>"; };
 		E19FEB555305B2E43ECCAA39 /* SPMCPServerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPMCPServerTests.swift; sourceTree = "<group>"; };
+		ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAKeyboardShortcutTests.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCredentialsTests.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RDSIAMAuthenticationTests.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9A103 /* AWSDirectoryBookmarkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDirectoryBookmarkManagerTests.swift; sourceTree = "<group>"; };
@@ -2577,6 +2582,7 @@
 				17DC886A126B378A00E9AAEC /* Category Additions */,
 				6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */,
 				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
+				ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -2601,6 +2607,7 @@
 				51BE43DC30174CC700AF389C /* SANotificationCenter.swift */,
 				51BE68DB3017550E00AF389C /* SAImageRenderer.swift */,
 				AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */,
+				644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3438,6 +3445,8 @@
 				60111925195F940E7252B376 /* SAHelpViewerModelTests.swift in Sources */,
 				10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */,
 				8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */,
+				2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */,
+				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3745,6 +3754,7 @@
 				56B8282C3F2B2EAD9499D12F /* SAHelpViewerView.swift in Sources */,
 				B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */,
 				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
+				16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Fixes #2563.

## Problem

⌃⌘F ("Enter Full Screen") stopped working in 5.3.0. The `View → Enter Full Screen` menu item and the green traffic-light button still worked — only the key combination failed.

The cause is the local key-down monitor added in #2393 (favorites search field), which focuses the search field on ⌘F:

```objc
BOOL cmdPressed = ([event modifierFlags] & NSEventModifierFlagCommand) != 0;
BOOL isCmdF = cmdPressed && [[event charactersIgnoringModifiers] isEqualToString:@"f"];
```

It only asked whether Command was *among* the modifiers, never whether it was the *only* one, so every ⌘F superset matched and got consumed (`return nil`). Local `NSEvent` monitors run ahead of `-[NSApplication sendEvent:]`, so this beats the main menu's key equivalent dispatch and the menu item never sees the event. Clicking the menu item or the green button bypasses key equivalent handling entirely, which is why those kept working.

Three shortcuts were swallowed while the connection view was frontmost (at launch, on a new tab/window, or after disconnecting — once connected the connection view is removed from the hierarchy and the monitor's guards bail out):

| Shortcut | Menu item |
| --- | --- |
| ⌃⌘F | View → Enter Full Screen |
| ⌥⌘F | View → Filter Content |
| ⌃⌥⌘F | View → Filter Tables |

## Changes

- **New `SAKeyboardShortcut`** (`Source/Other/Utility/SAKeyboardShortcut.swift`) — an exact keyboard chord: a character plus the precise set of ⌘/⌃/⌥/⇧ that must be held. Caps Lock, Fn and the numeric pad flag are excluded from the comparison since they ride along without changing which shortcut the user meant, and the character is compared case-insensitively so ⌘F also works with Caps Lock on (the old `isEqualToString:@"f"` silently missed that, as `charactersIgnoringModifiers` does honour Caps Lock). A nil or empty character never matches.
- **`SPConnectionController.m`** keeps only a thin call, per the language policy in AGENTS.md:
  ```objc
  if (![SAKeyboardShortcut.commandF matchesEvent:event]) return event;
  ```
- **`SAKeyboardShortcutTests`** — 13 tests covering the matched chord, each regressing superset, the insignificant modifiers, and the nil/empty character guard.

## Tested

- Xcode 26.1, macOS 26.6.1, Apple silicon.
- `Unit Tests`: 918 executed, 63 skipped, 0 failures (905 before, +13 new).
- Manual: on the connection screen, ⌘F still focuses the favorites search field; ⌃⌘F now enters full screen.

## Additional notes

The new Swift file is registered in both the "Sequel Ace" and "Unit Tests" targets. The pbxproj change was made with the `xcodeproj` gem (Xcode closed) rather than by hand, and is additions-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the favorites search keyboard shortcut to respond only to the exact Command-F combination.
  * Other key combinations now continue to work normally with menu handling.
  * Shortcut recognition is now consistent regardless of the letter’s capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->