### PR TITLE
#infra Ship the Xcode MCP server and document the windowless workflow

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "xcode": {
+      "type": "stdio",
+      "command": "xcrun",
+      "args": ["mcpbridge"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,11 @@ object being decomposed), `SPTableContent.m` (~5k), `SPExportController.m`
   Beta" is a build configuration of the same target, not a separate target.
 - Dependencies come via SPM (Firebase, Alamofire, SnapKit, OCMock, FMDB, …);
   first resolve needs network access.
-- Run the "Unit Tests" target's tests for any change. The full suite is ~700+
+- Run the "Unit Tests" target's tests for any change. The full suite is 900+
   tests and should be fully green.
+- Agents: prefer the Xcode MCP (`BuildProject`, `GetTestList`, `RunSomeTests`,
+  `RunAllTests`, `GetBuildLog`) over shelling out to `xcodebuild` — see
+  [Xcode automation (MCP)](#xcode-automation-mcp) below.
 
 ### Unit Tests target — sharp edges
 
@@ -96,21 +99,48 @@ object being decomposed), `SPTableContent.m` (~5k), `SPExportController.m`
   bridge code in a separate app-target-only file (e.g. `SAFavoriteItem.swift`
   vs `SAFavoriteItem+Tree.swift`).
 
+## Xcode automation (MCP)
+
+- The repo ships an `xcode` MCP server in `.mcp.json`. It runs `xcrun
+  mcpbridge`, which is bundled with Xcode 26+ — no install step, and because it
+  is committed it works from any clone path. Approve it once per checkout when
+  the client prompts. On an older Xcode the server simply fails to start; fall
+  back to `xcodebuild` and the notes below.
+- It is **windowless**. `XcodeOpenWorkspace` does not launch the Xcode UI — a
+  background `XcodeService` does the work and nothing appears on screen. Do not
+  tell the user "I opened Xcode".
+- **Open the project first, every session.** Call `XcodeOpenWorkspace` with the
+  absolute path to `sequel-ace.xcodeproj` and pass the returned
+  `workspaceIdentifier` to the other tools. That identifier is minted per open
+  and is not stable across opens; handing a path to a workspace that is not
+  open fails with "Unknown workspace identifier".
+- Beyond file management it covers builds and tests (`BuildProject`,
+  `GetBuildLog`, `GetTestList`, `RunSomeTests`, `RunAllTests`) and reads the
+  project tree with `XcodeLS` / `XcodeGrep`, which reflect *project*
+  organization and target membership rather than the filesystem — which is what
+  you want when verifying a file was registered.
+
 ## Xcode project file (pbxproj) rules
 
 - The project uses **classic groups**, not filesystem-synchronized folders.
   Files must be registered in `project.pbxproj` with target membership.
-- **Never hand-edit `project.pbxproj` while Xcode has the project open** —
-  Xcode clobbers on-disk edits with its in-memory model, and conversely a
-  behind-Xcode's-back change (branch switch, merge) leaves Xcode's in-memory
+- **Add and remove files with `XcodeWrite` / `XcodeRM`** — they register real
+  IDs and target membership. A Swift file exercised by tests needs to land in
+  **both** "Sequel Ace" and "Unit Tests"; confirm with `XcodeLS` plus a test run
+  that shows the new tests, not by reading the pbxproj diff.
+- **Never hand-edit `project.pbxproj` while the Xcode UI has the project
+  open** — Xcode clobbers on-disk edits with its in-memory model, and
+  conversely a behind-Xcode's-back change (branch switch, merge) leaves its
   model stale: builds then silently compile the *old* file set while reporting
-  success. If the pbxproj changed outside Xcode, close and reopen the project
-  (or verify the build log actually compiled your files) before trusting any
-  build.
-- Agents with Xcode automation (MCP `XcodeWrite`/`XcodeRM`): use it to
-  add/remove files — it updates Xcode's live model with real IDs. Otherwise,
-  ask the user to add the file in Xcode rather than editing the pbxproj by
-  hand.
+  success. The MCP bridge does **not** share this hazard — it tracks the
+  pbxproj on disk, so a `git checkout` under a workspace opened by the bridge is
+  picked up with no close/reopen. Either way, after any out-of-band pbxproj
+  change, verify the build actually compiled your files before trusting it.
+- Without the MCP and without Xcode, the `xcodeproj` Ruby gem (already present
+  transitively via fastlane) writes a valid additions-only diff. Verify with
+  `plutil -lint` and a build that compiles the new files. Note it drops a couple
+  of cosmetic `/* comment */` annotations on the main group; restore them to
+  keep the diff additions-only.
 - Prefer resolving pbxproj merge conflicts by replaying the add/remove
   operations on a fresh branch instead of hand-merging conflict hunks.
 


### PR DESCRIPTION
## Changes

The `xcode` MCP server (`xcrun mcpbridge`, bundled with Xcode 26+) was only ever configured per-machine **and per-project-path**. A second checkout of this repo on the same machine silently got no Xcode automation, and agents fell back to hand-rolled pbxproj edits — which is exactly what happened while preparing #2565.

- **`.mcp.json`** (new) registers the server in the repo, so it is available from any clone path with no per-machine setup. Clients prompt for approval once per checkout.
- **`AGENTS.md`** — the Xcode automation guidance predated the bridge and told agents to "ask the user to add the file in Xcode". Refreshed:
  - New **Xcode automation (MCP)** section: it is **windowless** (`XcodeOpenWorkspace` drives a background `XcodeService`; the Xcode UI never launches), and the session contract is open-workspace-first, then pass the returned `workspaceIdentifier` — which is minted per open, not stable across opens.
  - pbxproj rules now lead with `XcodeWrite` / `XcodeRM`, and record the `xcodeproj` Ruby gem as the no-MCP fallback.
  - The stale-in-memory-model warning is scoped to the Xcode **UI**. The bridge does not share that hazard.
  - Build/test notes point at `BuildProject` / `GetTestList` / `RunSomeTests`, and the suite size is corrected (900+, not 700+).

## Verified

Claims in the doc were checked against the running bridge rather than assumed:

| Claim | How it was checked |
| --- | --- |
| Windowless | `XcodeOpenWorkspace` succeeded with `Xcode.app` absent from the process list; only `XcodeService` and `mcpbridge` were running |
| Must open first | `XcodeLS` with an absolute path to an unopened project fails with "Unknown workspace identifier" |
| Identifier not stable | Close + reopen minted a different identifier |
| Bridge is not stale-prone | Reverted `project.pbxproj` to an older commit under an open workspace — `XcodeLS` dropped the file immediately; restoring brought it back. A branch switch was likewise picked up with no close/reopen |
| Test tools work | `RunSomeTests` on `SAAsyncResultBoxTests`: 5 passed |

Docs and config only — no product code touched.

## Additional notes

On an Xcode older than 26 the server simply fails to start; that is a soft failure and the doc says to fall back to `xcodebuild`. `.mcp.json` is not covered by the `.claude/` gitignore entry, so it is tracked normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to reflect the current test suite size.
  * Added guidance for using Xcode MCP tools, including workspace lifecycle, builds, tests, and project inspection.
  * Documented recommended workflows for project-file updates and validation.
* **Chores**
  * Added configuration for connecting to the Xcode MCP server through standard input/output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->