### PR TITLE
#infra Extend the SwiftUI connection form to every connection type (C2b)

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
@@ -125,6 +125,17 @@ import Foundation
         // 4-6. SSL file checks — run for connection types whose MySQL leg can use
         //      the shared SSL file fields. The order matches the original code so that
         //      a multi-issue form produces the same first-error UX.
+        //
+        //      ⚠️ `.sshTunnel` is absent on purpose, and it is probably an upstream
+        //      bug rather than a decision: the SSH tab does have a "Require SSL"
+        //      checkbox and its own SSL details container
+        //      (`sshConnectionSSLDetailsContainer`, `sslOverSSHKeyFileButton` and
+        //      friends), so an enabled-but-missing key/cert/CA on a tunnel reaches
+        //      connection setup unchecked. The pre-D3 ObjC read
+        //      `(type == SPTCPIPConnection || type == SPSocketConnection) && useSSL`,
+        //      D3 preserved that, and `testSSLChecksDoNotApplyToSSHTunnel` pins it.
+        //      Changing it would also change the shipping AppKit form, so it wants
+        //      its own PR rather than riding along with the SwiftUI work.
         if (type == .tcpIP || type == .socket || type == .vault) && useSSL {
             if sslKeyFileLocationEnabled, let path = sslKeyFileLocation,
                !fileExistsExpandingTilde(path) {
@@ -199,6 +210,18 @@ import Foundation
         case .sshKey, .sslCACert: return nil
         }
     }
+
+    /// File extensions the chooser must refuse outright.
+    ///
+    /// `-panel:shouldEnableURL:` greys out `.pub` files so an SSH *public* key
+    /// cannot be picked as an identity file — OpenSSH cannot use one, and the
+    /// failure would otherwise only appear when the tunnel connects.
+    var rejectedExtensions: Set<String> {
+        switch self {
+        case .sshKey: return ["pub"]
+        case .sslKey, .sslCertificate, .sslCACert: return []
+        }
+    }
 }
 
 /// Why a chosen file was rejected, carrying the same strings the AppKit alert
@@ -269,6 +292,16 @@ struct SAConnectionFileRejection {
     /// An unreadable file is reported with the underlying read error, matching
     /// the original, which surfaced the NSData error before its own check.
     static func rejection(forFileAt url: URL, kind: SAConnectionFileKind) -> SAConnectionFileRejection? {
+        if kind.rejectedExtensions.contains(url.pathExtension.lowercased()) {
+            return SAConnectionFileRejection(
+                alertTitle: String(format: NSLocalizedString("“%@” is a public key.",
+                                                             comment: "connection view : ssh : key file picker : public key error title"),
+                                   url.lastPathComponent),
+                alertMessage: NSLocalizedString("Choose the private key instead — the file without the .pub extension.",
+                                                comment: "connection view : ssh : key file picker : public key error description")
+            )
+        }
+
         guard kind.requiredPEMMarker != nil else { return nil }
 
         let data: Data

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
@@ -26,6 +26,11 @@ import Foundation
     case sslKeyFileMissing
     case sslCertificateFileMissing
     case sslCACertFileMissing
+    // Vault-only preconditions. Raised by SAConnectionFormModel rather than the
+    // validator below, which is shared with the AppKit controller — that runs
+    // its own Vault checks, and duplicating them here would double the alert.
+    case vaultHostMissing
+    case vaultCredentialsPathMissing
 }
 
 /// What the validator returns on failure. Bundles the discriminator
@@ -166,5 +171,117 @@ import Foundation
     /// can also use it to assert that a known path exists/doesn't.
     @objc static func fileExistsExpandingTilde(_ path: String) -> Bool {
         FileManager.default.fileExists(atPath: (path as NSString).expandingTildeInPath)
+    }
+}
+
+// MARK: - Chooser file kinds
+
+/// The four file rows the connection form offers, and what each one requires
+/// of the file the user picks.
+///
+/// Splitting this out of the AppKit chooser is what lets the SwiftUI form apply
+/// the same rules: `-chooseKeyLocation:` branches on which button sent the
+/// action, which a SwiftUI row has no equivalent of.
+@objc enum SAConnectionFileKind: Int {
+    case sshKey
+    case sslKey
+    case sslCertificate
+    case sslCACert
+
+    /// The PEM body marker the file must carry, or nil where the AppKit flow
+    /// accepts any file. Only the SSL key and client certificate are checked —
+    /// SSH keys and CA certificates are deliberately not, matching
+    /// `-chooseKeyLocation:`, which validates just those two.
+    var requiredPEMMarker: String? {
+        switch self {
+        case .sslKey: return "PRIVATE KEY-----"
+        case .sslCertificate: return "CERTIFICATE-----"
+        case .sshKey, .sslCACert: return nil
+        }
+    }
+}
+
+/// Why a chosen file was rejected, carrying the same strings the AppKit alert
+/// shows.
+struct SAConnectionFileRejection {
+    let alertTitle: String
+    let alertMessage: String
+}
+
+/// PEM shape checks for the files the connection form accepts, lifted out of
+/// `-validateKeyFile:error:` / `-validateCertFile:error:` so they can be tested
+/// without a controller. Pure: the caller supplies the file's contents.
+@objc final class SAConnectionFileValidator: NSObject {
+
+    /// Whether `contents` looks like a PEM block for `kind`.
+    ///
+    /// Mirrors the original paragraph walk: a BEGIN line and an END line, each
+    /// carrying the marker. Paragraph enumeration is what handles `\n`, `\r`
+    /// and `\r\n` alike, so the split below uses `.newlines` rather than
+    /// splitting on `\n` only. Kinds with no marker accept anything.
+    static func isValidPEM(contents: String, kind: SAConnectionFileKind) -> Bool {
+        guard let marker = kind.requiredPEMMarker else { return true }
+
+        var foundBegin = false
+        var foundEnd = false
+
+        for line in contents.components(separatedBy: .newlines) {
+            guard line.contains(marker) else { continue }
+            if line.contains("-----BEGIN") { foundBegin = true }
+            if line.contains("-----END") { foundEnd = true }
+        }
+
+        return foundBegin && foundEnd
+    }
+
+    /// The rejection for a file that failed `isValidPEM`, or nil when it passed.
+    /// `fileName` is the display name used in the title, as the original used
+    /// `-lastPathComponent`.
+    static func rejection(contents: String,
+                          kind: SAConnectionFileKind,
+                          fileName: String) -> SAConnectionFileRejection? {
+        guard !isValidPEM(contents: contents, kind: kind) else { return nil }
+
+        switch kind {
+        case .sslKey:
+            return SAConnectionFileRejection(
+                alertTitle: String(format: NSLocalizedString("“%@” is not a valid private key file.",
+                                                             comment: "connection view : ssl : key file picker : wrong format error title"),
+                                   fileName),
+                alertMessage: NSLocalizedString("Make sure the file contains a RSA private key and is using PEM encoding.",
+                                                comment: "connection view : ssl : key file picker : wrong format error description")
+            )
+        case .sslCertificate:
+            return SAConnectionFileRejection(
+                alertTitle: String(format: NSLocalizedString("“%@” is not a valid client certificate file.",
+                                                             comment: "connection view : ssl : client cert file picker : wrong format error title"),
+                                   fileName),
+                alertMessage: NSLocalizedString("Make sure the file contains a X.509 client certificate and is using PEM encoding.",
+                                                comment: "connection view : ssl : client cert picker : wrong format error description")
+            )
+        case .sshKey, .sslCACert:
+            // Unreachable: these kinds have no marker, so isValidPEM passed.
+            return nil
+        }
+    }
+
+    /// Reads `url` and returns its rejection, or nil when it is acceptable.
+    /// An unreadable file is reported with the underlying read error, matching
+    /// the original, which surfaced the NSData error before its own check.
+    static func rejection(forFileAt url: URL, kind: SAConnectionFileKind) -> SAConnectionFileRejection? {
+        guard kind.requiredPEMMarker != nil else { return nil }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url, options: .mappedIfSafe)
+        } catch {
+            return SAConnectionFileRejection(alertTitle: error.localizedDescription,
+                                             alertMessage: (error as NSError).localizedRecoverySuggestion ?? "")
+        }
+
+        // ASCII, as the original decoded it: PEM is ASCII-armoured, and a
+        // non-ASCII byte means this is not a PEM file to begin with.
+        let contents = String(data: data, encoding: .ascii) ?? ""
+        return rejection(contents: contents, kind: kind, fileName: url.lastPathComponent)
     }
 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormHelpers.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormHelpers.swift
@@ -75,4 +75,27 @@ import Foundation
         }
         return "\(base)/\(database)"
     }
+
+    /// As above, but with the Vault rule folded in.
+    ///
+    /// A Vault connection is named after its *Vault* endpoint and role rather
+    /// than the database host — `<vaultHost>/<role>`, falling back to the vault
+    /// host alone, and to the literal "vault" when even that is blank. The rule
+    /// lived inline in `-_generateNameForConnection`; it belongs here so the
+    /// AppKit form and the SwiftUI one cannot drift.
+    @objc static func generateName(
+        type: SAConnectionType,
+        host: String,
+        database: String,
+        vaultHost: String,
+        vaultCredentialsPath: String
+    ) -> String? {
+        guard type == .vault else {
+            return generateName(type: type, host: host, database: database)
+        }
+
+        let role = (vaultCredentialsPath as NSString).lastPathComponent
+        let endpoint = vaultHost.isEmpty ? "vault" : vaultHost
+        return role.isEmpty ? endpoint : "\(endpoint)/\(role)"
+    }
 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -197,8 +197,14 @@ final class SAConnectionFormModel: ObservableObject {
             let hasRemoteSocket = !info.sshRemoteSocketPath
                 .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             return hasHost || hasRemoteSocket
-        case .tcpIP, .awsIAM, .vault:
+        case .tcpIP, .awsIAM:
             return hasHost
+        case .vault:
+            // Vault needs its own endpoint and a credentials path on top of the
+            // database host — `-initiateConnection:` rejects all three.
+            return hasHost
+                && !info.vaultHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !info.vaultCredentialsPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 
@@ -308,7 +314,11 @@ final class SAConnectionFormModel: ObservableObject {
     /// Returns nil when the details are valid; otherwise the first
     /// failure, carrying ready-to-display alert strings.
     func validate() -> SAConnectionValidationFailure? {
-        SAConnectionDetailsValidator.validate(
+        if let vaultFailure = validateVaultDetails() {
+            return vaultFailure
+        }
+
+        return SAConnectionDetailsValidator.validate(
             type: info.type,
             host: info.host,
             sshHost: info.sshHost,
@@ -323,5 +333,50 @@ final class SAConnectionFormModel: ObservableObject {
             sslCACertFileLocationEnabled: info.sslCACertFileLocationEnabled != 0,
             sslCACertFileLocation: info.sslCACertFileLocation
         )
+    }
+
+    /// The three Vault preconditions `-initiateConnection:` enforces before it
+    /// starts authenticating, in its order. They are not in
+    /// `SAConnectionDetailsValidator` because that is shared with the AppKit
+    /// controller, which still runs these itself; duplicating them there would
+    /// double the alert.
+    private func validateVaultDetails() -> SAConnectionValidationFailure? {
+        guard info.type == .vault else { return nil }
+
+        let title = NSLocalizedString("Insufficient connection details",
+                                      comment: "insufficient details message")
+
+        func blank(_ value: String) -> Bool {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        if blank(info.vaultHost) {
+            return SAConnectionValidationFailure(
+                kind: .vaultHostMissing,
+                alertTitle: title,
+                alertMessage: NSLocalizedString("A Vault host is required to connect.",
+                                                comment: "vault host required connect message")
+            )
+        }
+
+        if blank(info.vaultCredentialsPath) {
+            return SAConnectionValidationFailure(
+                kind: .vaultCredentialsPathMissing,
+                alertTitle: title,
+                alertMessage: NSLocalizedString("A Vault credentials path is required to connect. Fill in the mount and role, or paste a full path into the Role field.",
+                                                comment: "vault creds path required connect message")
+            )
+        }
+
+        if blank(info.host) {
+            return SAConnectionValidationFailure(
+                kind: .hostMissing,
+                alertTitle: title,
+                alertMessage: NSLocalizedString("A database host is required to connect.",
+                                                comment: "vault db host required connect message")
+            )
+        }
+
+        return nil
     }
 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -106,6 +106,7 @@ final class SAConnectionFormModel: ObservableObject {
         didSet {
             resplitVaultCredentialsPathIfChangedExternally()
             clearPasswordsIfIdentityWasEdited(from: oldValue)
+            syncTypeDerivedState(from: oldValue)
         }
     }
 
@@ -354,6 +355,37 @@ final class SAConnectionFormModel: ObservableObject {
     /// "Get Public Key" is offered on every tab except AWS IAM.
     var showsRequestServerPublicKeyToggle: Bool {
         !forcesSSL
+    }
+
+    // MARK: - Type changes
+
+    /// Keeps the flags a type switch derives in step with the type.
+    ///
+    /// `-_favoriteTypeDidChange` sets `useAWSIAMAuth` from the type, and
+    /// `-_syncAWSIAMAndSSLInterfaceState` clears the manual SSL flag for IAM,
+    /// which always uses TLS internally. Binding the picker straight to
+    /// `info.type` skipped both, so enabling Require SSL on TCP/IP, visiting
+    /// AWS IAM and coming back left `useSSL` set with the toggle hidden — and
+    /// `useAWSIAMAuth` stale in the bridged info.
+    ///
+    /// Also run on a wholesale replace: the AppKit form re-syncs after a
+    /// favorite is selected too, so a stored favorite whose flags disagree
+    /// with its type is normalized the same way in both forms. Every write is
+    /// guarded by a difference check, so the nested `didSet` a write triggers
+    /// no-ops instead of recursing.
+    private func syncTypeDerivedState(from previous: SAConnectionInfo) {
+        guard info.type != previous.type || isReplacingInfo else { return }
+
+        let isIAM = info.type == .awsIAM
+        if (info.useAWSIAMAuth != 0) != isIAM {
+            info.useAWSIAMAuth = isIAM ? 1 : 0
+        }
+        // IAM connections always use TLS internally; the manual flag is
+        // cleared rather than merely hidden, matching the AppKit sync. It is
+        // not restored on the way back — the AppKit form does not either.
+        if isIAM && info.useSSL != 0 {
+            info.useSSL = 0
+        }
     }
 
     // MARK: - Identity changes

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -125,7 +125,15 @@ final class SAConnectionFormModel: ObservableObject {
         didSet { rejoinVaultCredentialsPath() }
     }
 
-    init(info: SAConnectionInfo = SAConnectionInfo()) {
+    /// The blank form's historical state: no colour (-1), compression on, AWS
+    /// profile "default". Raw `SAConnectionInfo()` matches none of those, so a
+    /// model built from it would show the first colour swatch as chosen and
+    /// silently connect without compression.
+    static var blankFormInfo: SAConnectionInfo {
+        SAConnectionInfoObjC.info(fromFavoriteDictionary: nil).info
+    }
+
+    init(info: SAConnectionInfo = SAConnectionFormModel.blankFormInfo) {
         self.info = info
         // Same one-read rule as the resplit below (didSet observers do not run
         // during init, but the parameter is the honest source either way).
@@ -194,9 +202,18 @@ final class SAConnectionFormModel: ObservableObject {
         if !trimmed.isEmpty {
             return trimmed
         }
-        return SAConnectionFormHelpers.generateName(type: info.type,
-                                                    host: info.host,
-                                                    database: info.database) ?? ""
+        return generatedName ?? ""
+    }
+
+    /// The auto-generated name for the current values, or nil when there is not
+    /// enough to build one. Vault names come from the Vault endpoint and role
+    /// rather than the database host.
+    var generatedName: String? {
+        SAConnectionFormHelpers.generateName(type: info.type,
+                                             host: info.host,
+                                             database: info.database,
+                                             vaultHost: info.vaultHost,
+                                             vaultCredentialsPath: info.vaultCredentialsPath)
     }
 
     /// True when the form has the minimum input to attempt a connection
@@ -322,6 +339,19 @@ final class SAConnectionFormModel: ObservableObject {
     /// "Get Public Key" is offered on every tab except AWS IAM.
     var showsRequestServerPublicKeyToggle: Bool {
         !forcesSSL
+    }
+
+    // MARK: - Identity changes
+
+    /// Drops both stored passwords.
+    ///
+    /// `-controlTextDidEndEditing:` clears the database *and* SSH password
+    /// whenever the standard host, standard user, SSH host or SSH user changes,
+    /// so credentials hydrated for one account are never sent under another
+    /// identity. Called on commit rather than per keystroke, as there.
+    func clearPasswordsAfterIdentityChange() {
+        info.password = ""
+        info.sshPassword = ""
     }
 
     // MARK: - Validation

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -3,7 +3,10 @@
 //  Sequel Ace
 //
 //  Phase C2 of the SwiftUI migration: the observable model behind
-//  SAConnectionFormView. Wraps the value-type SAConnectionInfo so
+//  SAConnectionFormView. C2a covered TCP/IP; C2b extends it to every
+//  connection type (socket, SSH tunnel, AWS IAM, Vault) plus the SSL
+//  file options, colour index and time zone the XIB tabs carry.
+//  Wraps the value-type SAConnectionInfo so
 //  SwiftUI fields can bind straight into it ($model.info.host), and
 //  funnels the pieces extracted in earlier phases:
 //  - SAConnectionDetailsValidator (D3) for pre-connection validation
@@ -18,6 +21,80 @@
 import Foundation
 import Combine
 
+// MARK: - Time Zone Choice
+
+/// The three states the XIB's time-zone popup can be in, collapsed into
+/// one value. `SAConnectionInfo` stores this as a (mode, identifier)
+/// pair where the identifier is only meaningful in `.useFixedTZ`; this
+/// makes the invalid combinations unrepresentable so a SwiftUI picker
+/// can bind to a single selection.
+enum SATimeZoneChoice: Hashable {
+    case server
+    case system
+    case fixed(String)
+
+    /// Reconstructs the choice from the stored pair. A fixed mode with a
+    /// blank identifier degrades to `.server`, matching the AppKit popup,
+    /// which has no menu item that could represent it.
+    init(mode: SAConnectionTimeZoneMode, identifier: String) {
+        switch mode {
+        case .useServerTZ:
+            self = .server
+        case .useSystemTZ:
+            self = .system
+        case .useFixedTZ:
+            self = identifier.isEmpty ? .server : .fixed(identifier)
+        }
+    }
+
+    var mode: SAConnectionTimeZoneMode {
+        switch self {
+        case .server: return .useServerTZ
+        case .system: return .useSystemTZ
+        case .fixed: return .useFixedTZ
+        }
+    }
+
+    /// Blank for the two relative modes — `-didChangeSelectedTimeZone:`
+    /// clears the identifier when leaving the fixed mode, and a stale
+    /// identifier would otherwise be written back to the favorite.
+    var identifier: String {
+        switch self {
+        case .server, .system: return ""
+        case .fixed(let identifier): return identifier
+        }
+    }
+}
+
+/// One row of the time-zone picker, mirroring `-generateTimeZoneMenuItems`:
+/// the two relative entries first, then every known identifier sorted
+/// case-insensitively, with a separator wherever the region prefix changes.
+enum SATimeZoneMenuEntry: Hashable {
+    case choice(SATimeZoneChoice)
+    case separator(afterPrefix: String)
+
+    /// The full menu, in order.
+    static func menu(identifiers: [String] = TimeZone.knownTimeZoneIdentifiers) -> [SATimeZoneMenuEntry] {
+        var entries: [SATimeZoneMenuEntry] = [
+            .choice(.server),
+            .separator(afterPrefix: ""),
+            .choice(.system),
+        ]
+
+        var previousPrefix = ""
+        for identifier in identifiers.sorted(by: { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }) {
+            let prefix = identifier.components(separatedBy: "/").first ?? identifier
+            if prefix != previousPrefix {
+                previousPrefix = prefix
+                entries.append(.separator(afterPrefix: prefix))
+            }
+            entries.append(.choice(.fixed(identifier)))
+        }
+
+        return entries
+    }
+}
+
 final class SAConnectionFormModel: ObservableObject {
 
     /// The connection parameters being edited. SwiftUI binds into this
@@ -25,10 +102,58 @@ final class SAConnectionFormModel: ObservableObject {
     /// a change for the whole model, which is the granularity the form
     /// needs (the effective name and validation state depend on several
     /// fields at once).
-    @Published var info: SAConnectionInfo
+    @Published var info: SAConnectionInfo {
+        didSet {
+            resplitVaultCredentialsPathIfChangedExternally()
+        }
+    }
+
+    // MARK: Vault mount / role
+
+    // `info.vaultCredentialsPath` persists the joined "<mount>/creds/<role>",
+    // but the form edits the two halves separately — same split the AppKit
+    // controller keeps as its `vaultMount` / `vaultCredentialsRole` ivars with
+    // a computed `vaultCredentialsPath` on top. They have to be stored rather
+    // than computed off the path: `credPath(mount:role:)` returns "" while the
+    // role is still blank, so a mount typed first would otherwise vanish.
+
+    @Published var vaultMount: String = "" {
+        didSet { rejoinVaultCredentialsPath() }
+    }
+
+    @Published var vaultCredentialsRole: String = "" {
+        didSet { rejoinVaultCredentialsPath() }
+    }
 
     init(info: SAConnectionInfo = SAConnectionInfo()) {
         self.info = info
+        // Same one-read rule as the resplit below (didSet observers do not run
+        // during init, but the parameter is the honest source either way).
+        let credentialsPath = info.vaultCredentialsPath
+        vaultMount = SAVaultCredentialsPath.mount(fromCredPath: credentialsPath)
+        vaultCredentialsRole = SAVaultCredentialsPath.role(fromCredPath: credentialsPath)
+    }
+
+    private func rejoinVaultCredentialsPath() {
+        info.vaultCredentialsPath = SAVaultCredentialsPath.credPath(mount: vaultMount,
+                                                                    role: vaultCredentialsRole)
+    }
+
+    /// Re-derives the two halves when `info` is replaced wholesale — loading a
+    /// favorite, say. Skipped when the path already equals what the current
+    /// halves join to, which is what stops `rejoinVaultCredentialsPath` and
+    /// this from bouncing off each other.
+    private func resplitVaultCredentialsPathIfChangedExternally() {
+        let joined = SAVaultCredentialsPath.credPath(mount: vaultMount, role: vaultCredentialsRole)
+        guard info.vaultCredentialsPath != joined else { return }
+
+        // Read the incoming path once, up front: assigning either half runs
+        // `rejoinVaultCredentialsPath`, which overwrites
+        // `info.vaultCredentialsPath` with the half-updated pair — so reading
+        // it again for the second half would parse the value we just wrote.
+        let incoming = info.vaultCredentialsPath
+        vaultMount = SAVaultCredentialsPath.mount(fromCredPath: incoming)
+        vaultCredentialsRole = SAVaultCredentialsPath.role(fromCredPath: incoming)
     }
 
     /// Bridge in from the ObjC wrapper (e.g. the controller's current
@@ -75,6 +200,106 @@ final class SAConnectionFormModel: ObservableObject {
         case .tcpIP, .awsIAM, .vault:
             return hasHost
         }
+    }
+
+    // MARK: - Time zone
+
+    /// The time-zone popup's selection, collapsing the stored
+    /// (mode, identifier) pair. Setting it writes both, clearing the
+    /// identifier outside the fixed mode exactly as
+    /// `-didChangeSelectedTimeZone:` does.
+    var timeZoneChoice: SATimeZoneChoice {
+        get { SATimeZoneChoice(mode: info.timeZoneMode, identifier: info.timeZoneIdentifier) }
+        set {
+            info.timeZoneMode = newValue.mode
+            info.timeZoneIdentifier = newValue.identifier
+        }
+    }
+
+    // MARK: - Flag bridges
+
+    // SAConnectionInfo stores these as Int because they cross into ObjC as
+    // 0/1; SwiftUI Toggles need Bool. Non-zero counts as on, which is what
+    // the ObjC `-boolValue` reads the favorite plist with.
+
+    private func flag(_ keyPath: WritableKeyPath<SAConnectionInfo, Int>) -> Bool {
+        info[keyPath: keyPath] != 0
+    }
+
+    private func setFlag(_ keyPath: WritableKeyPath<SAConnectionInfo, Int>, _ isOn: Bool) {
+        info[keyPath: keyPath] = isOn ? 1 : 0
+    }
+
+    var useSSL: Bool {
+        get { flag(\.useSSL) }
+        set { setFlag(\.useSSL, newValue) }
+    }
+
+    var allowDataLocalInfile: Bool {
+        get { flag(\.allowDataLocalInfile) }
+        set { setFlag(\.allowDataLocalInfile, newValue) }
+    }
+
+    var enableClearTextPlugin: Bool {
+        get { flag(\.enableClearTextPlugin) }
+        set { setFlag(\.enableClearTextPlugin, newValue) }
+    }
+
+    var requestServerPublicKey: Bool {
+        get { flag(\.requestServerPublicKey) }
+        set { setFlag(\.requestServerPublicKey, newValue) }
+    }
+
+    var sshKeyLocationEnabled: Bool {
+        get { flag(\.sshKeyLocationEnabled) }
+        set { setFlag(\.sshKeyLocationEnabled, newValue) }
+    }
+
+    var sslKeyFileLocationEnabled: Bool {
+        get { flag(\.sslKeyFileLocationEnabled) }
+        set { setFlag(\.sslKeyFileLocationEnabled, newValue) }
+    }
+
+    var sslCertificateFileLocationEnabled: Bool {
+        get { flag(\.sslCertificateFileLocationEnabled) }
+        set { setFlag(\.sslCertificateFileLocationEnabled, newValue) }
+    }
+
+    var sslCACertFileLocationEnabled: Bool {
+        get { flag(\.sslCACertFileLocationEnabled) }
+        set { setFlag(\.sslCACertFileLocationEnabled, newValue) }
+    }
+
+    // MARK: - Per-type form shape
+
+    /// AWS IAM turns SSL and the cleartext plugin on itself, so its tab
+    /// shows neither toggle — it shows a static explanatory label instead
+    /// (see `awsIAMConnectionFormContainer` in ConnectionView.xib, which
+    /// is also the only tab with no SSL details container).
+    var forcesSSL: Bool {
+        info.type == .awsIAM
+    }
+
+    /// Whether the "Require SSL" toggle is offered at all.
+    var showsSSLToggle: Bool {
+        !forcesSSL
+    }
+
+    /// Whether the three SSL file pickers (key / certificate / CA cert)
+    /// are visible. The XIB reveals that container only while the type's
+    /// SSL toggle is on, and never for AWS IAM.
+    var showsSSLFileOptions: Bool {
+        showsSSLToggle && useSSL
+    }
+
+    /// The cleartext-plugin toggle is likewise absent from the AWS tab.
+    var showsClearTextPluginToggle: Bool {
+        !forcesSSL
+    }
+
+    /// "Get Public Key" is offered on every tab except AWS IAM.
+    var showsRequestServerPublicKeyToggle: Bool {
+        !forcesSSL
     }
 
     // MARK: - Validation

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -105,7 +105,22 @@ final class SAConnectionFormModel: ObservableObject {
     @Published var info: SAConnectionInfo {
         didSet {
             resplitVaultCredentialsPathIfChangedExternally()
+            clearPasswordsIfIdentityWasEdited(from: oldValue)
         }
+    }
+
+    /// Set while `info` is being replaced wholesale rather than typed into, so
+    /// the replacement does not read as a user edit. `-controlTextDidChange:`
+    /// only fires for typing, never for the programmatic `-setStringValue:` a
+    /// favorite load performs.
+    private var isReplacingInfo = false
+
+    /// Replaces every field at once without the change counting as an edit.
+    /// Used by the hosts that load a favorite into the form.
+    func replaceInfo(_ newInfo: SAConnectionInfo) {
+        isReplacingInfo = true
+        info = newInfo
+        isReplacingInfo = false
     }
 
     // MARK: Vault mount / role
@@ -343,13 +358,31 @@ final class SAConnectionFormModel: ObservableObject {
 
     // MARK: - Identity changes
 
-    /// Drops both stored passwords.
+    /// Drops both stored passwords when an identity field is actually edited.
     ///
-    /// `-controlTextDidEndEditing:` clears the database *and* SSH password
-    /// whenever the standard host, standard user, SSH host or SSH user changes,
-    /// so credentials hydrated for one account are never sent under another
-    /// identity. Called on commit rather than per keystroke, as there.
-    func clearPasswordsAfterIdentityChange() {
+    /// `-controlTextDidChange:` clears the database *and* SSH password whenever
+    /// the standard host, standard user, SSH host or SSH user changes, so
+    /// credentials hydrated for one account are never sent under another
+    /// identity. It fires on the *edit* — tabbing through an untouched field
+    /// must not discard a valid password, which is why this compares values
+    /// rather than watching focus.
+    ///
+    /// The same comparison distinguishes an edit from a load: replacing `info`
+    /// through `replaceInfo(_:)` also writes host and user, and clearing then
+    /// would throw away the credentials that load just hydrated.
+    private func clearPasswordsIfIdentityWasEdited(from previous: SAConnectionInfo) {
+        guard !isReplacingInfo else { return }
+
+        let identityEdited = info.host != previous.host
+            || info.user != previous.user
+            || info.sshHost != previous.sshHost
+            || info.sshUser != previous.sshUser
+        guard identityEdited else { return }
+
+        // Nothing to clear — also stops the assignment below re-entering didSet
+        // for no reason.
+        guard !info.password.isEmpty || !info.sshPassword.isEmpty else { return }
+
         info.password = ""
         info.sshPassword = ""
     }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -134,6 +134,22 @@ final class SAConnectionFormModel: ObservableObject {
         vaultCredentialsRole = SAVaultCredentialsPath.role(fromCredPath: credentialsPath)
     }
 
+    /// Splits a full credentials path out of the Role half into Mount + Role.
+    ///
+    /// Mirrors `-controlTextDidEndEditing:`, which does this on commit rather
+    /// than per keystroke so a path being typed is not yanked away mid-edit.
+    /// Without it the two controls disagree with the endpoint actually used:
+    /// `credPath(mount:role:)` honours a pasted full path and ignores the
+    /// mount, so the stale mount stays on screen — and the moment the user
+    /// then types a bare role, it silently comes back.
+    func commitVaultCredentialsRole() {
+        guard SAVaultCredentialsPath.isFullCredPath(vaultCredentialsRole) else { return }
+
+        let pasted = vaultCredentialsRole
+        vaultMount = SAVaultCredentialsPath.mount(fromCredPath: pasted)
+        vaultCredentialsRole = SAVaultCredentialsPath.role(fromCredPath: pasted)
+    }
+
     private func rejoinVaultCredentialsPath() {
         info.vaultCredentialsPath = SAVaultCredentialsPath.credPath(mount: vaultMount,
                                                                     role: vaultCredentialsRole)

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -116,10 +116,15 @@ struct SAConnectionFormView: View {
         }
     }
 
+    /// Built once: the identifier list is fixed for the process lifetime, and
+    /// `body` re-evaluates on every keystroke (any `info` mutation publishes),
+    /// which would otherwise re-sort ~600 identifiers each time.
+    private static let timeZoneMenu = SATimeZoneMenuEntry.menu()
+
     private var timeZoneSection: some View {
         Section {
             Picker(selection: timeZoneBinding) {
-                ForEach(SATimeZoneMenuEntry.menu(), id: \.self) { entry in
+                ForEach(Self.timeZoneMenu, id: \.self) { entry in
                     switch entry {
                     case .choice(.server):
                         Text("Use Server Time Zone", comment: "Leave the server time zone in place when connecting")
@@ -182,16 +187,19 @@ struct SAConnectionFormView: View {
         Section {
             SAOptionalFileRow(
                 title: Text("Key File", comment: "connection view : ssl key file label"),
+                kind: .sslKey,
                 isEnabled: $model.sslKeyFileLocationEnabled,
                 path: $model.info.sslKeyFileLocation
             )
             SAOptionalFileRow(
                 title: Text("Certificate", comment: "connection view : ssl certificate label"),
+                kind: .sslCertificate,
                 isEnabled: $model.sslCertificateFileLocationEnabled,
                 path: $model.info.sslCertificateFileLocation
             )
             SAOptionalFileRow(
                 title: Text("CA Cert", comment: "connection view : ssl ca cert label"),
+                kind: .sslCACert,
                 isEnabled: $model.sslCACertFileLocationEnabled,
                 path: $model.info.sslCACertFileLocation
             )
@@ -264,6 +272,7 @@ struct SAConnectionFormView: View {
                 }
                 SAOptionalFileRow(
                     title: Text("SSH Key", comment: "connection view : ssh key label"),
+                    kind: .sshKey,
                     isEnabled: $model.sshKeyLocationEnabled,
                     path: $model.info.sshKeyLocation
                 )
@@ -418,10 +427,10 @@ private struct SAFavoriteColorPicker: View {
             Text("None", comment: "connection view : no favorite colour")
                 .tag(Self.noColorIndex)
             ForEach(Array(colors.enumerated()), id: \.offset) { index, color in
-                // A label as well as the swatch, so the choice survives
-                // for anyone who cannot distinguish the colours.
+                // A label as well as the swatch, so the choice is distinguishable
+                // without relying on colour perception.
                 Label {
-                    Text(verbatim: colorName(at: index))
+                    Text(colorLabel(at: index))
                 } icon: {
                     Circle().fill(Color(nsColor: color))
                 }
@@ -433,10 +442,13 @@ private struct SAFavoriteColorPicker: View {
         .pickerStyle(.menu)
     }
 
-    /// Names match the asset catalog entries backing the colour list.
-    private func colorName(at index: Int) -> String {
-        let names = ["Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Graphite"]
-        return index < names.count ? names[index] : "\(index)"
+    /// The list is positional and its length is not guaranteed, so the label is
+    /// derived from the index rather than a parallel array of hardcoded names —
+    /// a shorter or reordered list would otherwise mislabel the swatches.
+    private func colorLabel(at index: Int) -> String {
+        String(format: NSLocalizedString("Colour %ld",
+                                         comment: "connection view : favorite colour by position"),
+               index + 1)
     }
 }
 
@@ -448,8 +460,13 @@ private struct SAFavoriteColorPicker: View {
 private struct SAOptionalFileRow: View {
 
     let title: Text
+    /// Decides which PEM check the chosen file must pass — the SwiftUI
+    /// equivalent of `-chooseKeyLocation:` branching on the sending button.
+    let kind: SAConnectionFileKind
     @Binding var isEnabled: Bool
     @Binding var path: String
+
+    @State private var rejection: SAConnectionFileRejection?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -474,6 +491,18 @@ private struct SAOptionalFileRow: View {
                 }
             }
         }
+        .alert(
+            rejection?.alertTitle ?? "",
+            isPresented: Binding(
+                get: { rejection != nil },
+                set: { if !$0 { rejection = nil } }
+            ),
+            presenting: rejection
+        ) { _ in
+            Button { rejection = nil } label: { Text("OK", comment: "OK button") }
+        } message: { rejection in
+            Text(rejection.alertMessage)
+        }
     }
 
     private func chooseFile() {
@@ -484,7 +513,37 @@ private struct SAOptionalFileRow: View {
         // Key and certificate files are routinely kept in ~/.ssh.
         panel.showsHiddenFiles = true
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        // Cancelling clears the row, as -chooseKeyLocation: does: an enabled
+        // checkbox with no path would claim a file the connection cannot use.
+        guard panel.runModal() == .OK, let url = panel.url else {
+            isEnabled = false
+            path = ""
+            return
+        }
+
+        // Reject a file of the wrong shape before storing it, so the failure
+        // surfaces here rather than as an opaque connection error later.
+        if let rejection = SAConnectionFileValidator.rejection(forFileAt: url, kind: kind) {
+            self.rejection = rejection
+            return
+        }
+
+        // Persist a read-only security-scoped bookmark before storing the path.
+        // Without one the sandbox grants access only for this launch: the panel
+        // itself starts access, but a favorite saved with this path would find
+        // the file unreadable after a relaunch. Read-only matters because keys
+        // are routinely mode 400.
+        //
+        // A failed bookmark is not fatal — access still works for this launch —
+        // so the path is stored either way, matching -chooseKeyLocation:.
+        _ = SecureBookmarkManager.sharedInstance.addBookmarkFor(
+            url: url,
+            options: UInt(NSURL.BookmarkCreationOptions.withSecurityScope.rawValue
+                          | NSURL.BookmarkCreationOptions.securityScopeAllowOnlyReadAccess.rawValue),
+            isForStaleBookmark: false,
+            isForKnownHostsFile: false
+        )
+
         path = url.path
     }
 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -40,6 +40,9 @@ struct SAConnectionFormView: View {
     /// an alert (same strings the AppKit flow shows).
     @State private var validationFailure: SAConnectionValidationFailure?
 
+    /// Tracks the Vault Role field so losing focus can commit a pasted path.
+    @FocusState private var roleFieldFocused: Bool
+
     var body: some View {
         Form {
             typeSection
@@ -354,6 +357,14 @@ struct SAConnectionFormView: View {
                 // button are C3 scope, so this is the plain text half for now.
                 TextField(text: $model.vaultCredentialsRole) {
                     Text("Role", comment: "connection view : field label")
+                }
+                // Normalize a pasted full path into Mount + Role once editing
+                // commits, as -controlTextDidEndEditing: does. Focus loss counts
+                // as a commit, so both are wired.
+                .focused($roleFieldFocused)
+                .onSubmit { model.commitVaultCredentialsRole() }
+                .onChange(of: roleFieldFocused) { isFocused in
+                    if !isFocused { model.commitVaultCredentialsRole() }
                 }
             }
         }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -3,23 +3,31 @@
 //  Sequel Ace
 //
 //  Phase C2 of the SwiftUI migration: a SwiftUI form for editing
-//  connection details, starting with the TCP/IP connection type only
-//  (the ConnectionView.xib standard tab). Binds into
-//  SAConnectionFormModel, which wraps the value-type SAConnectionInfo
-//  and reuses the already-extracted validation (D3) and name
-//  generation helpers.
+//  connection details. C2a covered the TCP/IP tab; C2b (here) covers
+//  every type ConnectionView.xib offers — TCP/IP, socket, SSH tunnel,
+//  AWS IAM and Vault — along with the SSL file options, the colour
+//  index and the time-zone popup that the XIB tabs carry.
+//
+//  Binds into SAConnectionFormModel, which wraps the value-type
+//  SAConnectionInfo and reuses the already-extracted validation (D3),
+//  favorite decoding (D1) and name generation helpers. The field sets,
+//  labels and placeholders below mirror the XIB tab by tab; the model
+//  owns which of them a given type shows (forcesSSL and friends).
 //
 //  Like SAFavoritesList (C1b), nothing hosts this view yet — Phase C3
 //  (the standalone connection window) is the intended host, where it
 //  will sit next to the SwiftUI favorites list and drive
-//  SAConnectionService directly. The field set and labels mirror the
-//  XIB's TCP/IP tab; SSL file options and the other connection types are
-//  follow-up scope.
+//  SAConnectionService directly.
+//
+//  App-target only: it touches SPFavoriteColorSupport (ObjC) for the
+//  colour swatches, so it cannot compile into the Unit Tests target.
+//  The branchy parts it renders live on the model, which can.
 //
 
 import SwiftUI
+import AppKit
 
-/// SwiftUI editor for TCP/IP connection details.
+/// SwiftUI editor for connection details, for every connection type.
 struct SAConnectionFormView: View {
 
     @ObservedObject var model: SAConnectionFormModel
@@ -34,52 +42,15 @@ struct SAConnectionFormView: View {
 
     var body: some View {
         Form {
-            Section {
-                TextField(text: $model.info.name, prompt: Text(namePrompt)) {
-                    Text("Name", comment: "connection view : field label")
-                }
+            typeSection
+            identitySection
+            detailsSection
+            timeZoneSection
+            securitySection
+            if model.showsSSLFileOptions {
+                sslFileSection
             }
-
-            Section {
-                TextField(text: $model.info.host) {
-                    Text("Host", comment: "connection view : field label")
-                }
-                TextField(text: $model.info.user) {
-                    Text("Username", comment: "connection view : field label")
-                }
-                SecureField(text: $model.info.password) {
-                    Text("Password", comment: "connection view : field label")
-                }
-            }
-
-            Section {
-                TextField(text: $model.info.database, prompt: Text("optional", comment: "connection view : optional field placeholder")) {
-                    Text("Database", comment: "connection view : field label")
-                }
-                TextField(text: $model.info.port, prompt: Text(verbatim: "3306")) {
-                    Text("Port", comment: "connection view : field label")
-                }
-            }
-
-            Section {
-                Toggle(isOn: requestServerPublicKeyBinding) {
-                    Text("Get Public Key", comment: "connection view : get server public key checkbox")
-                }
-                .help(NSLocalizedString("Request the server RSA public key for caching_sha2_password over non-SSL connections.", comment: "connection view : get server public key help"))
-            }
-
-            Section {
-                HStack {
-                    Spacer()
-                    Button {
-                        submit()
-                    } label: {
-                        Text("Connect", comment: "connection view : connect button")
-                    }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(!model.canAttemptConnection)
-                }
-            }
+            connectSection
         }
         .modifier(SAGroupedFormStyle())
         .alert(
@@ -100,6 +71,303 @@ struct SAConnectionFormView: View {
         }
     }
 
+    // MARK: - Sections
+
+    /// Replaces the XIB's tab bar: picking a type swaps the detail
+    /// fields below rather than a whole tab view.
+    private var typeSection: some View {
+        Section {
+            Picker(selection: $model.info.type) {
+                Text("TCP/IP", comment: "connection type : tcp/ip").tag(SAConnectionType.tcpIP)
+                Text("Socket", comment: "connection type : socket").tag(SAConnectionType.socket)
+                Text("SSH Tunnel", comment: "connection type : ssh tunnel").tag(SAConnectionType.sshTunnel)
+                Text("AWS IAM", comment: "connection type : aws iam").tag(SAConnectionType.awsIAM)
+                Text("Vault", comment: "connection type : vault").tag(SAConnectionType.vault)
+            } label: {
+                Text("Type", comment: "connection view : field label")
+            }
+            .pickerStyle(.menu)
+        }
+    }
+
+    /// Name and colour are common to every tab in the XIB.
+    private var identitySection: some View {
+        Section {
+            TextField(text: $model.info.name, prompt: Text(namePrompt)) {
+                Text("Name", comment: "connection view : field label")
+            }
+            SAFavoriteColorPicker(colorIndex: $model.info.colorIndex)
+        }
+    }
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        switch model.info.type {
+        case .tcpIP:
+            standardFields
+        case .socket:
+            socketFields
+        case .sshTunnel:
+            sshFields
+        case .awsIAM:
+            awsIAMFields
+        case .vault:
+            vaultFields
+        }
+    }
+
+    private var timeZoneSection: some View {
+        Section {
+            Picker(selection: timeZoneBinding) {
+                ForEach(SATimeZoneMenuEntry.menu(), id: \.self) { entry in
+                    switch entry {
+                    case .choice(.server):
+                        Text("Use Server Time Zone", comment: "Leave the server time zone in place when connecting")
+                            .tag(SATimeZoneChoice.server)
+                    case .choice(.system):
+                        Text("Use System Time Zone", comment: "Set the time zone currently used by the user when connecting")
+                            .tag(SATimeZoneChoice.system)
+                    case .choice(.fixed(let identifier)):
+                        Text(verbatim: identifier).tag(SATimeZoneChoice.fixed(identifier))
+                    case .separator:
+                        Divider()
+                    }
+                }
+            } label: {
+                Text("Time Zone", comment: "connection view : field label")
+            }
+            .pickerStyle(.menu)
+        }
+    }
+
+    private var securitySection: some View {
+        Section {
+            Toggle(isOn: $model.allowDataLocalInfile) {
+                Text("Allow LOCAL_DATA_INFILE (insecure)", comment: "connection view : allow local data infile checkbox")
+            }
+
+            if model.showsClearTextPluginToggle {
+                Toggle(isOn: $model.enableClearTextPlugin) {
+                    Text("Enable Cleartext plugin (insecure)", comment: "connection view : enable cleartext plugin checkbox")
+                }
+            }
+
+            if model.showsSSLToggle {
+                Toggle(isOn: $model.useSSL) {
+                    Text("Require SSL", comment: "connection view : require ssl checkbox")
+                }
+            }
+
+            if model.showsRequestServerPublicKeyToggle {
+                Toggle(isOn: $model.requestServerPublicKey) {
+                    Text("Get Public Key", comment: "connection view : get server public key checkbox")
+                }
+                .help(NSLocalizedString("Request the server RSA public key for caching_sha2_password over non-SSL connections.",
+                                        comment: "connection view : get server public key help"))
+            }
+
+            if model.forcesSSL {
+                Text("SSL/TLS and cleartext plugins are enabled automatically for AWS IAM connections.",
+                     comment: "connection view : aws iam security note")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// The XIB's per-tab SSL details container: three optional file
+    /// pickers, each gated by its own checkbox and showing "none set"
+    /// until a path is chosen.
+    private var sslFileSection: some View {
+        Section {
+            SAOptionalFileRow(
+                title: Text("Key File", comment: "connection view : ssl key file label"),
+                isEnabled: $model.sslKeyFileLocationEnabled,
+                path: $model.info.sslKeyFileLocation
+            )
+            SAOptionalFileRow(
+                title: Text("Certificate", comment: "connection view : ssl certificate label"),
+                isEnabled: $model.sslCertificateFileLocationEnabled,
+                path: $model.info.sslCertificateFileLocation
+            )
+            SAOptionalFileRow(
+                title: Text("CA Cert", comment: "connection view : ssl ca cert label"),
+                isEnabled: $model.sslCACertFileLocationEnabled,
+                path: $model.info.sslCACertFileLocation
+            )
+        }
+    }
+
+    private var connectSection: some View {
+        Section {
+            HStack {
+                Spacer()
+                Button {
+                    submit()
+                } label: {
+                    Text("Connect", comment: "connection view : connect button")
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!model.canAttemptConnection)
+            }
+        }
+    }
+
+    // MARK: - Per-type field groups
+
+    private var standardFields: some View {
+        Section {
+            TextField(text: $model.info.host) {
+                Text("Host", comment: "connection view : field label")
+            }
+            TextField(text: $model.info.user) {
+                Text("Username", comment: "connection view : field label")
+            }
+            SecureField(text: $model.info.password) {
+                Text("Password", comment: "connection view : field label")
+            }
+            databaseField
+            portField
+        }
+    }
+
+    private var socketFields: some View {
+        Section {
+            // The socket path is optional: blank means the MySQL default.
+            TextField(text: $model.info.socket, prompt: optionalPrompt) {
+                Text("Socket", comment: "connection view : field label")
+            }
+            TextField(text: $model.info.user) {
+                Text("Username", comment: "connection view : field label")
+            }
+            SecureField(text: $model.info.password) {
+                Text("Password", comment: "connection view : field label")
+            }
+            databaseField
+        }
+    }
+
+    private var sshFields: some View {
+        Group {
+            Section {
+                TextField(text: $model.info.sshHost) {
+                    Text("SSH Host", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.sshUser) {
+                    Text("SSH User", comment: "connection view : field label")
+                }
+                SecureField(text: $model.info.sshPassword) {
+                    Text("SSH Password", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.sshPort, prompt: optionalPrompt) {
+                    Text("SSH Port", comment: "connection view : field label")
+                }
+                SAOptionalFileRow(
+                    title: Text("SSH Key", comment: "connection view : ssh key label"),
+                    isEnabled: $model.sshKeyLocationEnabled,
+                    path: $model.info.sshKeyLocation
+                )
+            }
+
+            Section {
+                TextField(text: $model.info.host) {
+                    Text("MySQL Host", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.user) {
+                    Text("Username", comment: "connection view : field label")
+                }
+                SecureField(text: $model.info.password) {
+                    Text("Password", comment: "connection view : field label")
+                }
+                databaseField
+                portField
+                // Connecting through a socket on the far side of the tunnel
+                // instead of a TCP host — the validator accepts either.
+                TextField(text: $model.info.sshRemoteSocketPath, prompt: optionalPrompt) {
+                    Text("Remote Socket", comment: "connection view : field label")
+                }
+            }
+        }
+    }
+
+    private var awsIAMFields: some View {
+        Group {
+            Section {
+                TextField(text: $model.info.host) {
+                    Text("Host", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.user) {
+                    Text("Username", comment: "connection view : field label")
+                }
+                SecureField(text: $model.info.password) {
+                    Text("Password", comment: "connection view : field label")
+                }
+                databaseField
+                portField
+            }
+
+            Section {
+                TextField(text: $model.info.awsProfile) {
+                    Text("AWS Profile", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.awsRegion) {
+                    Text("Region", comment: "connection view : field label")
+                }
+            }
+        }
+    }
+
+    private var vaultFields: some View {
+        Group {
+            Section {
+                TextField(text: $model.info.host, prompt: Text(verbatim: "e.g. mydb.us-east-1.rds.amazonaws.com")) {
+                    Text("Host", comment: "connection view : field label")
+                }
+                databaseField
+                portField
+            }
+
+            Section {
+                TextField(text: $model.info.vaultHost) {
+                    Text("Vault host", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.vaultPort, prompt: Text(verbatim: "443")) {
+                    Text("Vault port", comment: "connection view : field label")
+                }
+                TextField(text: $model.info.vaultOIDCMount, prompt: Text(verbatim: "oidc")) {
+                    Text("OIDC Mount", comment: "connection view : field label")
+                }
+                TextField(text: $model.vaultMount, prompt: Text(verbatim: "databases_credentials")) {
+                    Text("Vault mount", comment: "connection view : field label")
+                }
+                // The XIB offers this as a combo box backed by a fetched role
+                // list (SAVaultRoleListController); the fetch and its Refresh
+                // button are C3 scope, so this is the plain text half for now.
+                TextField(text: $model.vaultCredentialsRole) {
+                    Text("Role", comment: "connection view : field label")
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared fields
+
+    private var databaseField: some View {
+        TextField(text: $model.info.database, prompt: optionalPrompt) {
+            Text("Database", comment: "connection view : field label")
+        }
+    }
+
+    private var portField: some View {
+        TextField(text: $model.info.port, prompt: Text(verbatim: "3306")) {
+            Text("Port", comment: "connection view : field label")
+        }
+    }
+
+    private var optionalPrompt: Text {
+        Text("optional", comment: "connection view : optional field placeholder")
+    }
+
     /// Placeholder for the name field: the auto-generated name the
     /// connection would get, mirroring the AppKit form's behaviour of
     /// auto-filling "host[/database]" until the user types their own.
@@ -113,10 +381,10 @@ struct SAConnectionFormView: View {
         return NSLocalizedString("Optional Name", comment: "connection view : name field placeholder")
     }
 
-    private var requestServerPublicKeyBinding: Binding<Bool> {
+    private var timeZoneBinding: Binding<SATimeZoneChoice> {
         Binding(
-            get: { model.info.requestServerPublicKey != 0 },
-            set: { model.info.requestServerPublicKey = $0 ? 1 : 0 }
+            get: { model.timeZoneChoice },
+            set: { model.timeZoneChoice = $0 }
         )
     }
 
@@ -126,6 +394,98 @@ struct SAConnectionFormView: View {
             return
         }
         onConnect(model)
+    }
+}
+
+// MARK: - Colour picker
+
+/// The XIB's SPColorSelectorView: one swatch per entry of
+/// SPFavoriteColorSupport's list, plus a "no colour" state. The stored
+/// index is -1 when no colour is set (see SAConnectionInfo+Favorite).
+private struct SAFavoriteColorPicker: View {
+
+    @Binding var colorIndex: Int
+
+    /// -1 is the "none" sentinel the favorites plist uses.
+    private static let noColorIndex = -1
+
+    private var colors: [NSColor] {
+        SPFavoriteColorSupport.sharedInstance().userColorList ?? []
+    }
+
+    var body: some View {
+        Picker(selection: $colorIndex) {
+            Text("None", comment: "connection view : no favorite colour")
+                .tag(Self.noColorIndex)
+            ForEach(Array(colors.enumerated()), id: \.offset) { index, color in
+                // A label as well as the swatch, so the choice survives
+                // for anyone who cannot distinguish the colours.
+                Label {
+                    Text(verbatim: colorName(at: index))
+                } icon: {
+                    Circle().fill(Color(nsColor: color))
+                }
+                .tag(index)
+            }
+        } label: {
+            Text("Colour", comment: "connection view : field label")
+        }
+        .pickerStyle(.menu)
+    }
+
+    /// Names match the asset catalog entries backing the colour list.
+    private func colorName(at index: Int) -> String {
+        let names = ["Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Graphite"]
+        return index < names.count ? names[index] : "\(index)"
+    }
+}
+
+// MARK: - Optional file row
+
+/// A checkbox plus a path chooser, matching the XIB's SSH-key and SSL
+/// file rows: unchecked hides the path, checked shows the chosen file or
+/// "none set" until one is picked.
+private struct SAOptionalFileRow: View {
+
+    let title: Text
+    @Binding var isEnabled: Bool
+    @Binding var path: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: $isEnabled) { title }
+
+            if isEnabled {
+                HStack {
+                    Text(verbatim: path.isEmpty
+                         ? NSLocalizedString("none set", comment: "connection view : no file chosen")
+                         : (path as NSString).abbreviatingWithTildeInPath)
+                        .foregroundColor(path.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Spacer()
+
+                    Button {
+                        chooseFile()
+                    } label: {
+                        Text("Choose…", comment: "connection view : choose file button")
+                    }
+                }
+            }
+        }
+    }
+
+    private func chooseFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        // Key and certificate files are routinely kept in ~/.ssh.
+        panel.showsHiddenFiles = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        path = url.path
     }
 }
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -311,9 +311,17 @@ struct SAConnectionFormView: View {
                 TextField(text: $model.info.user) {
                     Text("Username", comment: "connection view : field label")
                 }
-                SecureField(text: $model.info.password) {
+                // IAM authenticates with a token generated from the profile, so
+                // a typed password can never be used. -_syncAWSIAMAndSSLInterfaceState
+                // disables, clears and relabels the AppKit field; leaving it
+                // editable would invite a value that goes nowhere and would then
+                // sit in the model for the host and any favorite saved from it.
+                SecureField(text: .constant(""),
+                            prompt: Text("Generated from AWS IAM profile",
+                                         comment: "placeholder when AWS IAM auth is enabled")) {
                     Text("Password", comment: "connection view : field label")
                 }
+                .disabled(true)
                 databaseField
                 portField
             }
@@ -482,6 +490,13 @@ private struct SAOptionalFileRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Toggle(isOn: $isEnabled) { title }
+                // Unticking clears the path, as -chooseKeyLocation: does on
+                // cancel. Keeping it would make the old file silently reappear
+                // on re-tick, and would leave a disabled credential path in any
+                // favorite saved or exported afterwards.
+                .onChange(of: isEnabled) { isOn in
+                    if !isOn { path = "" }
+                }
 
             if isEnabled {
                 HStack {

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -43,11 +43,6 @@ struct SAConnectionFormView: View {
     /// Tracks the Vault Role field so losing focus can commit a pasted path.
     @FocusState private var roleFieldFocused: Bool
 
-    /// The four fields whose commit invalidates any stored password.
-    @FocusState private var standardHostFocused: Bool
-    @FocusState private var standardUserFocused: Bool
-    @FocusState private var sshHostFocused: Bool
-    @FocusState private var sshUserFocused: Bool
 
     var body: some View {
         Form {
@@ -234,12 +229,12 @@ struct SAConnectionFormView: View {
 
     private var standardFields: some View {
         Section {
-            identityField(TextField(text: $model.info.host) {
+            TextField(text: $model.info.host) {
                 Text("Host", comment: "connection view : field label")
-            }, focus: $standardHostFocused)
-            identityField(TextField(text: $model.info.user) {
+            }
+            TextField(text: $model.info.user) {
                 Text("Username", comment: "connection view : field label")
-            }, focus: $standardUserFocused)
+            }
             SecureField(text: $model.info.password) {
                 Text("Password", comment: "connection view : field label")
             }
@@ -267,12 +262,12 @@ struct SAConnectionFormView: View {
     private var sshFields: some View {
         Group {
             Section {
-                identityField(TextField(text: $model.info.sshHost) {
+                TextField(text: $model.info.sshHost) {
                     Text("SSH Host", comment: "connection view : field label")
-                }, focus: $sshHostFocused)
-                identityField(TextField(text: $model.info.sshUser) {
+                }
+                TextField(text: $model.info.sshUser) {
                     Text("SSH User", comment: "connection view : field label")
-                }, focus: $sshUserFocused)
+                }
                 SecureField(text: $model.info.sshPassword) {
                     Text("SSH Password", comment: "connection view : field label")
                 }
@@ -288,12 +283,12 @@ struct SAConnectionFormView: View {
             }
 
             Section {
-                identityField(TextField(text: $model.info.host) {
+                TextField(text: $model.info.host) {
                     Text("MySQL Host", comment: "connection view : field label")
-                }, focus: $standardHostFocused)
-                identityField(TextField(text: $model.info.user) {
+                }
+                TextField(text: $model.info.user) {
                     Text("Username", comment: "connection view : field label")
-                }, focus: $standardUserFocused)
+                }
                 SecureField(text: $model.info.password) {
                     Text("Password", comment: "connection view : field label")
                 }
@@ -412,17 +407,6 @@ struct SAConnectionFormView: View {
         return NSLocalizedString("Optional Name", comment: "connection view : name field placeholder")
     }
 
-    /// Clears both passwords once an identity field commits, mirroring
-    /// -controlTextDidEndEditing:. Applied to the standard host and user and the
-    /// SSH host and user — the four fields it watches.
-    private func identityField(_ field: some View, focus: FocusState<Bool>.Binding) -> some View {
-        field
-            .focused(focus)
-            .onSubmit { model.clearPasswordsAfterIdentityChange() }
-            .onChange(of: focus.wrappedValue) { isFocused in
-                if !isFocused { model.clearPasswordsAfterIdentityChange() }
-            }
-    }
 
     private var timeZoneBinding: Binding<SATimeZoneChoice> {
         Binding(

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -43,6 +43,12 @@ struct SAConnectionFormView: View {
     /// Tracks the Vault Role field so losing focus can commit a pasted path.
     @FocusState private var roleFieldFocused: Bool
 
+    /// The four fields whose commit invalidates any stored password.
+    @FocusState private var standardHostFocused: Bool
+    @FocusState private var standardUserFocused: Bool
+    @FocusState private var sshHostFocused: Bool
+    @FocusState private var sshUserFocused: Bool
+
     var body: some View {
         Form {
             typeSection
@@ -228,12 +234,12 @@ struct SAConnectionFormView: View {
 
     private var standardFields: some View {
         Section {
-            TextField(text: $model.info.host) {
+            identityField(TextField(text: $model.info.host) {
                 Text("Host", comment: "connection view : field label")
-            }
-            TextField(text: $model.info.user) {
+            }, focus: $standardHostFocused)
+            identityField(TextField(text: $model.info.user) {
                 Text("Username", comment: "connection view : field label")
-            }
+            }, focus: $standardUserFocused)
             SecureField(text: $model.info.password) {
                 Text("Password", comment: "connection view : field label")
             }
@@ -261,12 +267,12 @@ struct SAConnectionFormView: View {
     private var sshFields: some View {
         Group {
             Section {
-                TextField(text: $model.info.sshHost) {
+                identityField(TextField(text: $model.info.sshHost) {
                     Text("SSH Host", comment: "connection view : field label")
-                }
-                TextField(text: $model.info.sshUser) {
+                }, focus: $sshHostFocused)
+                identityField(TextField(text: $model.info.sshUser) {
                     Text("SSH User", comment: "connection view : field label")
-                }
+                }, focus: $sshUserFocused)
                 SecureField(text: $model.info.sshPassword) {
                     Text("SSH Password", comment: "connection view : field label")
                 }
@@ -282,12 +288,12 @@ struct SAConnectionFormView: View {
             }
 
             Section {
-                TextField(text: $model.info.host) {
+                identityField(TextField(text: $model.info.host) {
                     Text("MySQL Host", comment: "connection view : field label")
-                }
-                TextField(text: $model.info.user) {
+                }, focus: $standardHostFocused)
+                identityField(TextField(text: $model.info.user) {
                     Text("Username", comment: "connection view : field label")
-                }
+                }, focus: $standardUserFocused)
                 SecureField(text: $model.info.password) {
                     Text("Password", comment: "connection view : field label")
                 }
@@ -400,13 +406,22 @@ struct SAConnectionFormView: View {
     /// connection would get, mirroring the AppKit form's behaviour of
     /// auto-filling "host[/database]" until the user types their own.
     private var namePrompt: String {
-        let generated = SAConnectionFormHelpers.generateName(type: model.info.type,
-                                                             host: model.info.host,
-                                                             database: model.info.database)
-        if let generated, !generated.isEmpty {
+        if let generated = model.generatedName, !generated.isEmpty {
             return generated
         }
         return NSLocalizedString("Optional Name", comment: "connection view : name field placeholder")
+    }
+
+    /// Clears both passwords once an identity field commits, mirroring
+    /// -controlTextDidEndEditing:. Applied to the standard host and user and the
+    /// SSH host and user — the four fields it watches.
+    private func identityField(_ field: some View, focus: FocusState<Bool>.Binding) -> some View {
+        field
+            .focused(focus)
+            .onSubmit { model.clearPasswordsAfterIdentityChange() }
+            .onChange(of: focus.wrappedValue) { isFocused in
+                if !isFocused { model.clearPasswordsAfterIdentityChange() }
+            }
     }
 
     private var timeZoneBinding: Binding<SATimeZoneChoice> {

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -3495,15 +3495,13 @@ static NSComparisonResult _compareFavoritesUsingKey(id favorite1, id favorite2, 
  */
 - (NSString *)_generateNameForConnection
 {
-    if ([self type] == SPVaultConnection) {
-        NSString *credPath = [[self vaultCredentialsPath] lastPathComponent];
-        NSString *vHost = [[self vaultHost] length] ? [self vaultHost] : @"vault";
-        return [credPath length] ? [NSString stringWithFormat:@"%@/%@", vHost, credPath] : vHost;
-    }
-
+    // The Vault rule moved into SAConnectionFormHelpers so the SwiftUI form
+    // shares it; behaviour is unchanged.
     return [SAConnectionFormHelpers generateNameWithType:(SAConnectionType)[self type]
                                                     host:[self host] ?: @""
-                                                database:[self database] ?: @""];
+                                                database:[self database] ?: @""
+                                               vaultHost:[self vaultHost] ?: @""
+                                    vaultCredentialsPath:[self vaultCredentialsPath] ?: @""];
 }
 
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -449,6 +449,10 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
                 break;
             case SAConnectionValidationFailureKindHostMissing:
             case SAConnectionValidationFailureKindSshHostMissing:
+            // Raised only by the SwiftUI form's model, never by the validator
+            // this switch handles; listed so the switch stays exhaustive.
+            case SAConnectionValidationFailureKindVaultHostMissing:
+            case SAConnectionValidationFailureKindVaultCredentialsPathMissing:
                 break;
         }
         [NSAlert createWarningAlertWithTitle:failure.alertTitle message:failure.alertMessage callback:nil];

--- a/UnitTests/SAConnectionFormHelpersTests.swift
+++ b/UnitTests/SAConnectionFormHelpersTests.swift
@@ -133,4 +133,48 @@ final class SAConnectionFormHelpersTests: XCTestCase {
             "db.example.com"
         )
     }
+
+    // MARK: - Vault names (review round 4)
+
+    /// The Vault rule moved out of -_generateNameForConnection so both forms
+    /// share it: <vaultHost>/<role>, the endpoint alone without a role, and the
+    /// literal "vault" when the endpoint is blank too.
+    func testVaultNameJoinsTheEndpointAndRole() {
+        XCTAssertEqual(SAConnectionFormHelpers.generateName(
+            type: .vault, host: "db.example.com", database: "sakila",
+            vaultHost: "vault.internal", vaultCredentialsPath: "databases_credentials/creds/readonly"),
+            "vault.internal/readonly")
+    }
+
+    func testVaultNameWithoutARoleIsTheEndpoint() {
+        XCTAssertEqual(SAConnectionFormHelpers.generateName(
+            type: .vault, host: "", database: "",
+            vaultHost: "vault.internal", vaultCredentialsPath: ""),
+            "vault.internal")
+    }
+
+    func testVaultNameWithoutAnEndpointFallsBackToVault() {
+        XCTAssertEqual(SAConnectionFormHelpers.generateName(
+            type: .vault, host: "", database: "", vaultHost: "", vaultCredentialsPath: ""),
+            "vault")
+    }
+
+    /// The database host is deliberately ignored for Vault.
+    func testVaultNameIgnoresTheDatabaseHost() {
+        XCTAssertEqual(SAConnectionFormHelpers.generateName(
+            type: .vault, host: "db.example.com", database: "sakila",
+            vaultHost: "", vaultCredentialsPath: "m/creds/writer"),
+            "vault/writer")
+    }
+
+    /// Every other type falls through to the host[/database] rule unchanged.
+    func testTheVaultAwareOverloadMatchesTheOriginalForOtherTypes() {
+        for type in [SAConnectionType.tcpIP, .socket, .sshTunnel, .awsIAM] {
+            XCTAssertEqual(
+                SAConnectionFormHelpers.generateName(type: type, host: "h", database: "d",
+                                                     vaultHost: "ignored", vaultCredentialsPath: "ignored"),
+                SAConnectionFormHelpers.generateName(type: type, host: "h", database: "d"),
+                "\(type)")
+        }
+    }
 }

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -629,6 +629,113 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertNil(SAConnectionFileValidator.rejection(forFileAt: missing, kind: .sslCACert))
     }
 
+    // MARK: - Review round 2: SSL files on an SSH tunnel
+
+    /// Documents the inherited gap rather than fixing it here: the SSH tab
+    /// offers SSL file rows, but the shared validator has never checked them
+    /// (pre-D3 ObjC read `type == SPTCPIPConnection || type == SPSocketConnection`).
+    /// Fixing it changes the shipping AppKit form too, so it wants its own PR;
+    /// this test will fail loudly there, which is the point.
+    func testSSHTunnelSSLFilesAreNotValidatedYet() {
+        let model = SAConnectionFormModel()
+        model.info.type = .sshTunnel
+        model.info.host = "db.internal"
+        model.info.sshHost = "bastion.example.com"
+        model.useSSL = true
+        model.info.sslKeyFileLocationEnabled = 1
+        model.info.sslKeyFileLocation = "/nonexistent/\(UUID().uuidString).pem"
+
+        XCTAssertNil(model.validate(),
+                     "known gap inherited from the AppKit form — see SAConnectionDetailsValidator")
+    }
+
+    // MARK: - Review round 2: public keys rejected by the chooser
+
+    /// -panel:shouldEnableURL: greys out .pub files so a public key cannot be
+    /// picked as an identity file; OpenSSH cannot use one.
+    func testPublicKeysAreRejectedForTheSSHKeyRow() {
+        let rejection = SAConnectionFileValidator.rejection(
+            forFileAt: URL(fileURLWithPath: "/tmp/id_ed25519.pub"), kind: .sshKey)
+
+        XCTAssertNotNil(rejection)
+        XCTAssertTrue(rejection?.alertTitle.contains("id_ed25519.pub") ?? false)
+    }
+
+    func testPublicKeyRejectionIsCaseInsensitive() {
+        XCTAssertNotNil(SAConnectionFileValidator.rejection(
+            forFileAt: URL(fileURLWithPath: "/tmp/id_rsa.PUB"), kind: .sshKey))
+    }
+
+    /// The rule is specific to the SSH-key row — the SSL rows never offered it.
+    func testOtherRowsDoNotRejectPubFiles() {
+        for kind in [SAConnectionFileKind.sslCACert, .sslKey, .sslCertificate] {
+            let rejection = SAConnectionFileValidator.rejection(
+                forFileAt: URL(fileURLWithPath: "/tmp/thing.pub"), kind: kind)
+            // The SSL kinds still reject it, but for failing to be PEM rather
+            // than for its extension; the CA cert accepts anything.
+            if kind == .sslCACert {
+                XCTAssertNil(rejection, "\(kind)")
+            } else {
+                XCTAssertFalse(rejection?.alertTitle.contains("public key") ?? false, "\(kind)")
+            }
+        }
+    }
+
+    func testAPrivateSSHKeyIsStillAccepted() {
+        XCTAssertNil(SAConnectionFileValidator.rejection(
+            forFileAt: URL(fileURLWithPath: "/tmp/id_ed25519"), kind: .sshKey))
+    }
+
+    // MARK: - Review round 2: committing a pasted Vault path
+
+    /// -controlTextDidEndEditing: splits a full path pasted into Role back into
+    /// Mount + Role, so the controls agree with the endpoint actually used.
+    func testCommittingAPastedPathSplitsItIntoMountAndRole() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "stale_mount"
+        model.vaultCredentialsRole = "team/creds/writer"
+
+        model.commitVaultCredentialsRole()
+
+        XCTAssertEqual(model.vaultMount, "team")
+        XCTAssertEqual(model.vaultCredentialsRole, "writer")
+        XCTAssertEqual(model.info.vaultCredentialsPath, "team/creds/writer")
+    }
+
+    /// The bug the split prevents: without it the stale mount stays on screen
+    /// and silently returns the moment a bare role is typed.
+    func testABareRoleAfterCommittingUsesThePastedMount() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "stale_mount"
+        model.vaultCredentialsRole = "team/creds/writer"
+        model.commitVaultCredentialsRole()
+
+        model.vaultCredentialsRole = "reader"
+
+        XCTAssertEqual(model.info.vaultCredentialsPath, "team/creds/reader")
+    }
+
+    func testCommittingABareRoleChangesNothing() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        model.commitVaultCredentialsRole()
+
+        XCTAssertEqual(model.vaultMount, "databases_credentials")
+        XCTAssertEqual(model.vaultCredentialsRole, "readonly")
+    }
+
+    func testCommittingAnEmptyRoleChangesNothing() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "databases_credentials"
+
+        model.commitVaultCredentialsRole()
+
+        XCTAssertEqual(model.vaultMount, "databases_credentials")
+        XCTAssertEqual(model.vaultCredentialsRole, "")
+    }
+
     // MARK: - C2b: generated name across the types
 
     func testSocketConnectionsNameThemselvesLocalhost() {

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -736,6 +736,90 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.vaultCredentialsRole, "")
     }
 
+    // MARK: - Review round 4: blank-form defaults, Vault names, secret clearing
+
+    /// A brand-new model is the blank form, not raw SAConnectionInfo() — else
+    /// the colour picker shows the first swatch as chosen and compression is off.
+    func testANewModelUsesTheBlankFormDefaults() {
+        let model = SAConnectionFormModel()
+
+        XCTAssertEqual(model.info.colorIndex, -1)
+        XCTAssertTrue(model.info.useCompression)
+        XCTAssertEqual(model.info.awsProfile, "default")
+    }
+
+    /// An explicitly supplied info is still used verbatim.
+    func testAnExplicitInfoIsNotOverriddenByTheBlankDefaults() {
+        var info = SAConnectionInfo()
+        info.colorIndex = 3
+        let model = SAConnectionFormModel(info: info)
+
+        XCTAssertEqual(model.info.colorIndex, 3)
+    }
+
+    /// Vault names come from the Vault endpoint and role, not the database host.
+    func testVaultNamesUseTheVaultEndpointAndRole() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        model.info.vaultHost = "vault.internal"
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        XCTAssertEqual(model.generatedName, "vault.internal/readonly")
+        XCTAssertEqual(model.effectiveName, "vault.internal/readonly")
+    }
+
+    func testAVaultNameFallsBackToTheEndpointThenToVault() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.vaultHost = "vault.internal"
+        XCTAssertEqual(model.generatedName, "vault.internal")
+
+        model.info.vaultHost = ""
+        XCTAssertEqual(model.generatedName, "vault")
+    }
+
+    /// The other types keep the host[/database] rule.
+    func testNonVaultNamesAreUnchanged() {
+        let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
+        model.info.database = "sakila"
+
+        XCTAssertEqual(model.generatedName, "db.example.com/sakila")
+    }
+
+    /// -controlTextDidEndEditing: clears BOTH passwords when an identity field
+    /// changes, so credentials hydrated for one account cannot be sent under
+    /// another.
+    func testAnIdentityChangeClearsBothPasswords() {
+        let model = SAConnectionFormModel()
+        model.info.password = "db-secret"
+        model.info.sshPassword = "ssh-secret"
+
+        model.clearPasswordsAfterIdentityChange()
+
+        XCTAssertEqual(model.info.password, "")
+        XCTAssertEqual(model.info.sshPassword, "")
+    }
+
+    /// Clearing secrets must not disturb the identity being edited.
+    func testClearingPasswordsLeavesTheOtherFieldsAlone() {
+        let model = SAConnectionFormModel()
+        model.info.type = .sshTunnel
+        model.info.host = "db.internal"
+        model.info.user = "app"
+        model.info.sshHost = "bastion.example.com"
+        model.info.sshUser = "jump"
+
+        model.clearPasswordsAfterIdentityChange()
+
+        XCTAssertEqual(model.info.host, "db.internal")
+        XCTAssertEqual(model.info.user, "app")
+        XCTAssertEqual(model.info.sshHost, "bastion.example.com")
+        XCTAssertEqual(model.info.sshUser, "jump")
+    }
+
     // MARK: - C2b: generated name across the types
 
     func testSocketConnectionsNameThemselvesLocalhost() {
@@ -748,8 +832,10 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.effectiveName, "localhost/sakila")
     }
 
+    /// Vault is excluded on purpose: it names itself after its Vault endpoint
+    /// and role, never the database host — see testVaultNamesUseTheVaultEndpointAndRole.
     func testNonSocketTypesGenerateFromTheHost() {
-        for type in [SAConnectionType.tcpIP, .sshTunnel, .awsIAM, .vault] {
+        for type in [SAConnectionType.tcpIP, .sshTunnel, .awsIAM] {
             let model = SAConnectionFormModel()
             model.info.type = type
 

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -866,6 +866,61 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.info.password, "")
     }
 
+    // MARK: - Review round 5: type-derived state
+
+    /// -_favoriteTypeDidChange derives useAWSIAMAuth from the type, and the
+    /// sync clears manual SSL for IAM (which always uses TLS internally).
+    func testSwitchingToAWSIAMDerivesTheFlagAndClearsManualSSL() {
+        let model = SAConnectionFormModel()
+        model.info.type = .tcpIP
+        model.useSSL = true
+
+        model.info.type = .awsIAM
+
+        XCTAssertEqual(model.info.useAWSIAMAuth, 1)
+        XCTAssertEqual(model.info.useSSL, 0, "IAM uses TLS internally; the manual flag is cleared, not hidden")
+    }
+
+    /// Coming back clears the IAM flag; SSL stays off, as in the AppKit form.
+    func testSwitchingBackFromAWSIAMClearsTheIAMFlag() {
+        let model = SAConnectionFormModel()
+        model.info.type = .tcpIP
+        model.useSSL = true
+        model.info.type = .awsIAM
+
+        model.info.type = .tcpIP
+
+        XCTAssertEqual(model.info.useAWSIAMAuth, 0)
+        XCTAssertEqual(model.info.useSSL, 0, "not restored — the AppKit form does not either")
+    }
+
+    func testNonTypeEditsLeaveTheDerivedFlagsAlone() {
+        let model = SAConnectionFormModel()
+        model.info.type = .tcpIP
+        model.useSSL = true
+
+        model.info.host = "db.example.com"
+
+        XCTAssertEqual(model.info.useSSL, 1)
+        XCTAssertEqual(model.info.useAWSIAMAuth, 0)
+    }
+
+    /// A replace re-syncs too, matching the AppKit form's sync after favorite
+    /// selection: a stored favorite whose flags disagree with its type is
+    /// normalized on load.
+    func testReplacingWithInconsistentFlagsNormalizesThem() {
+        let model = SAConnectionFormModel()
+        var inconsistent = SAConnectionInfo()
+        inconsistent.type = .awsIAM
+        inconsistent.useSSL = 1
+        inconsistent.useAWSIAMAuth = 0
+
+        model.replaceInfo(inconsistent)
+
+        XCTAssertEqual(model.info.useAWSIAMAuth, 1)
+        XCTAssertEqual(model.info.useSSL, 0)
+    }
+
     // MARK: - C2b: generated name across the types
 
     func testSocketConnectionsNameThemselvesLocalhost() {

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -124,15 +124,27 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertTrue(model.canAttemptConnection)
     }
 
-    func testCanAttemptConnectionRequiresHostForAWSAndVault() {
-        for type in [SAConnectionType.awsIAM, .vault] {
-            let model = SAConnectionFormModel()
-            model.info.type = type
-            XCTAssertFalse(model.canAttemptConnection, "\(type) without host")
+    func testCanAttemptConnectionRequiresHostForAWS() {
+        let model = SAConnectionFormModel()
+        model.info.type = .awsIAM
+        XCTAssertFalse(model.canAttemptConnection, "without host")
 
-            model.info.host = "db.example.com"
-            XCTAssertTrue(model.canAttemptConnection, "\(type) with host")
-        }
+        model.info.host = "db.example.com"
+        XCTAssertTrue(model.canAttemptConnection, "with host")
+    }
+
+    /// Vault needs a host too, but a host alone is not enough — see
+    /// testVaultConnectGateRequiresHostVaultHostAndCredentials.
+    func testCanAttemptConnectionRequiresHostForVault() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.vaultHost = "https://vault.example.com"
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+        XCTAssertFalse(model.canAttemptConnection, "without host")
+
+        model.info.host = "db.example.com"
+        XCTAssertTrue(model.canAttemptConnection, "with host")
     }
 
     func testCanAttemptConnectionForSSHTunnelAcceptsHostOrRemoteSocket() {
@@ -392,15 +404,13 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertTrue(model.canAttemptConnection)
     }
 
-    func testAWSAndVaultRequireAHost() {
-        for type in [SAConnectionType.awsIAM, .vault] {
-            let model = SAConnectionFormModel()
-            model.info.type = type
-            XCTAssertFalse(model.canAttemptConnection, "\(type)")
+    func testAWSRequiresAHost() {
+        let model = SAConnectionFormModel()
+        model.info.type = .awsIAM
+        XCTAssertFalse(model.canAttemptConnection)
 
-            model.info.host = "db.example.com"
-            XCTAssertTrue(model.canAttemptConnection, "\(type)")
-        }
+        model.info.host = "db.example.com"
+        XCTAssertTrue(model.canAttemptConnection)
     }
 
     // MARK: - C2b: vault mount / role split
@@ -474,6 +484,149 @@ final class SAConnectionFormModelTests: XCTestCase {
         model.vaultCredentialsRole = "team/creds/writer"
 
         XCTAssertEqual(model.info.vaultCredentialsPath, "team/creds/writer")
+    }
+
+    // MARK: - C2b: Vault preconditions (review follow-up)
+
+    // -initiateConnection: refuses to start authenticating without these, so
+    // the form must too rather than handing onConnect an unusable config.
+
+    func testVaultConnectGateRequiresHostVaultHostAndCredentials() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        XCTAssertFalse(model.canAttemptConnection, "vault host still missing")
+
+        model.info.vaultHost = "https://vault.example.com"
+        XCTAssertFalse(model.canAttemptConnection, "credentials path still missing")
+
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+        XCTAssertTrue(model.canAttemptConnection)
+    }
+
+    func testVaultValidationReportsAMissingVaultHostFirst() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+
+        let failure = model.validate()
+        XCTAssertEqual(failure?.kind, .vaultHostMissing)
+        XCTAssertFalse(failure?.alertMessage.isEmpty ?? true)
+    }
+
+    func testVaultValidationReportsAMissingCredentialsPath() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.vaultHost = "https://vault.example.com"
+
+        XCTAssertEqual(model.validate()?.kind, .vaultCredentialsPathMissing)
+    }
+
+    func testVaultValidationReportsAMissingDatabaseHostLast() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.vaultHost = "https://vault.example.com"
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        XCTAssertEqual(model.validate()?.kind, .hostMissing)
+    }
+
+    func testFullyPopulatedVaultDetailsValidate() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        model.info.vaultHost = "https://vault.example.com"
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        XCTAssertNil(model.validate())
+    }
+
+    func testWhitespaceOnlyVaultFieldsCountAsMissing() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        model.info.vaultHost = "   "
+
+        XCTAssertFalse(model.canAttemptConnection)
+        XCTAssertEqual(model.validate()?.kind, .vaultHostMissing)
+    }
+
+    /// The Vault checks must not leak into the other types.
+    func testNonVaultTypesAreUnaffectedByTheVaultChecks() {
+        for type in [SAConnectionType.tcpIP, .socket, .sshTunnel, .awsIAM] {
+            let model = SAConnectionFormModel()
+            model.info.type = type
+            model.info.host = "db.example.com"
+            // The tunnel needs its own host from the D3 validator; supplying it
+            // keeps this test about the Vault checks rather than that rule.
+            if type == .sshTunnel { model.info.sshHost = "bastion.example.com" }
+
+            XCTAssertNil(model.validate(), "\(type)")
+        }
+    }
+
+    // MARK: - C2b: chosen-file validation (review follow-up)
+
+    private static let validKey = "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----"
+    private static let validCert = "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
+
+    func testValidKeyAndCertificateAreAccepted() {
+        XCTAssertTrue(SAConnectionFileValidator.isValidPEM(contents: Self.validKey, kind: .sslKey))
+        XCTAssertTrue(SAConnectionFileValidator.isValidPEM(contents: Self.validCert, kind: .sslCertificate))
+    }
+
+    func testACertificateIsNotAcceptedAsAKey() {
+        XCTAssertFalse(SAConnectionFileValidator.isValidPEM(contents: Self.validCert, kind: .sslKey))
+        XCTAssertFalse(SAConnectionFileValidator.isValidPEM(contents: Self.validKey, kind: .sslCertificate))
+    }
+
+    func testATruncatedPEMBlockIsRejected() {
+        let noEnd = "-----BEGIN RSA PRIVATE KEY-----\nabc\n"
+        XCTAssertFalse(SAConnectionFileValidator.isValidPEM(contents: noEnd, kind: .sslKey))
+    }
+
+    func testGarbageIsRejected() {
+        XCTAssertFalse(SAConnectionFileValidator.isValidPEM(contents: "not a key at all", kind: .sslKey))
+        XCTAssertFalse(SAConnectionFileValidator.isValidPEM(contents: "", kind: .sslKey))
+    }
+
+    /// The original walked paragraphs, which treats \n, \r and \r\n alike.
+    func testLineEndingsAreHandledAlike() {
+        for terminator in ["\n", "\r", "\r\n"] {
+            let key = "-----BEGIN RSA PRIVATE KEY-----\(terminator)abc\(terminator)-----END RSA PRIVATE KEY-----"
+            XCTAssertTrue(SAConnectionFileValidator.isValidPEM(contents: key, kind: .sslKey),
+                          terminator.debugDescription)
+        }
+    }
+
+    /// -chooseKeyLocation: validates only the SSL key and client certificate;
+    /// SSH keys and CA certificates are accepted as-is.
+    func testUncheckedKindsAcceptAnything() {
+        for kind in [SAConnectionFileKind.sshKey, .sslCACert] {
+            XCTAssertTrue(SAConnectionFileValidator.isValidPEM(contents: "anything", kind: kind))
+            XCTAssertNil(SAConnectionFileValidator.rejection(contents: "anything", kind: kind, fileName: "f"))
+        }
+    }
+
+    func testRejectionCarriesTheFileNameAndAdvice() {
+        let rejection = SAConnectionFileValidator.rejection(contents: "junk", kind: .sslKey, fileName: "server.pem")
+
+        XCTAssertTrue(rejection?.alertTitle.contains("server.pem") ?? false)
+        XCTAssertFalse(rejection?.alertMessage.isEmpty ?? true)
+    }
+
+    func testAcceptedFileProducesNoRejection() {
+        XCTAssertNil(SAConnectionFileValidator.rejection(contents: Self.validKey, kind: .sslKey, fileName: "k.pem"))
+    }
+
+    func testAnUnreadableFileIsReportedRatherThanAccepted() {
+        let missing = URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString).pem")
+
+        XCTAssertNotNil(SAConnectionFileValidator.rejection(forFileAt: missing, kind: .sslKey))
+        // An unchecked kind never reads the file at all.
+        XCTAssertNil(SAConnectionFileValidator.rejection(forFileAt: missing, kind: .sslCACert))
     }
 
     // MARK: - C2b: generated name across the types

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -789,35 +789,81 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.generatedName, "db.example.com/sakila")
     }
 
-    /// -controlTextDidEndEditing: clears BOTH passwords when an identity field
-    /// changes, so credentials hydrated for one account cannot be sent under
+    /// -controlTextDidChange: clears BOTH passwords when an identity field is
+    /// edited, so credentials hydrated for one account cannot be sent under
     /// another.
-    func testAnIdentityChangeClearsBothPasswords() {
+    func testEditingAnIdentityFieldClearsBothPasswords() {
+        for edit: (SAConnectionFormModel) -> Void in [
+            { $0.info.host = "other.example.com" },
+            { $0.info.user = "someone-else" },
+            { $0.info.sshHost = "other-bastion" },
+            { $0.info.sshUser = "other-jump" },
+        ] {
+            let model = SAConnectionFormModel()
+            model.info.password = "db-secret"
+            model.info.sshPassword = "ssh-secret"
+
+            edit(model)
+
+            XCTAssertEqual(model.info.password, "")
+            XCTAssertEqual(model.info.sshPassword, "")
+        }
+    }
+
+    /// The bug in the first attempt at this: focus alone is not an edit, so
+    /// touching a field without changing it must keep the passwords.
+    func testAnUnchangedIdentityFieldKeepsThePasswords() {
         let model = SAConnectionFormModel()
+        model.info.host = "db.example.com"
         model.info.password = "db-secret"
         model.info.sshPassword = "ssh-secret"
 
-        model.clearPasswordsAfterIdentityChange()
+        // Re-assigning the same value is what a focus-driven clear would treat
+        // as a change.
+        model.info.host = "db.example.com"
 
-        XCTAssertEqual(model.info.password, "")
-        XCTAssertEqual(model.info.sshPassword, "")
+        XCTAssertEqual(model.info.password, "db-secret")
+        XCTAssertEqual(model.info.sshPassword, "ssh-secret")
     }
 
-    /// Clearing secrets must not disturb the identity being edited.
-    func testClearingPasswordsLeavesTheOtherFieldsAlone() {
+    /// Editing something that is not an identity field leaves them alone.
+    func testEditingANonIdentityFieldKeepsThePasswords() {
         let model = SAConnectionFormModel()
-        model.info.type = .sshTunnel
-        model.info.host = "db.internal"
-        model.info.user = "app"
-        model.info.sshHost = "bastion.example.com"
-        model.info.sshUser = "jump"
+        model.info.password = "db-secret"
 
-        model.clearPasswordsAfterIdentityChange()
+        model.info.database = "sakila"
+        model.info.port = "3307"
 
-        XCTAssertEqual(model.info.host, "db.internal")
-        XCTAssertEqual(model.info.user, "app")
-        XCTAssertEqual(model.info.sshHost, "bastion.example.com")
-        XCTAssertEqual(model.info.sshUser, "jump")
+        XCTAssertEqual(model.info.password, "db-secret")
+    }
+
+    /// Replacing the whole info — what loading a favorite does — writes host and
+    /// user too, and must not discard the credentials it just hydrated.
+    func testReplacingInfoDoesNotCountAsAnEdit() {
+        let model = SAConnectionFormModel()
+
+        var loaded = SAConnectionInfo()
+        loaded.host = "db.example.com"
+        loaded.user = "app"
+        loaded.password = "hydrated"
+        loaded.sshPassword = "hydrated-ssh"
+        model.replaceInfo(loaded)
+
+        XCTAssertEqual(model.info.password, "hydrated")
+        XCTAssertEqual(model.info.sshPassword, "hydrated-ssh")
+    }
+
+    /// Editing after such a load still clears, so the seam does not stick.
+    func testEditingAfterAReplacementStillClears() {
+        let model = SAConnectionFormModel()
+        var loaded = SAConnectionInfo()
+        loaded.host = "db.example.com"
+        loaded.password = "hydrated"
+        model.replaceInfo(loaded)
+
+        model.info.host = "elsewhere.example.com"
+
+        XCTAssertEqual(model.info.password, "")
     }
 
     // MARK: - C2b: generated name across the types

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -200,4 +200,303 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(changes, 2)
         cancellable.cancel()
     }
+
+    // MARK: - C2b: time zone choice
+
+    func testTimeZoneChoiceDefaultsToServer() {
+        XCTAssertEqual(SAConnectionFormModel().timeZoneChoice, .server)
+    }
+
+    func testTimeZoneChoiceRoundTripsThroughTheStoredPair() {
+        let model = SAConnectionFormModel()
+
+        model.timeZoneChoice = .fixed("Europe/Prague")
+        XCTAssertEqual(model.info.timeZoneMode, .useFixedTZ)
+        XCTAssertEqual(model.info.timeZoneIdentifier, "Europe/Prague")
+        XCTAssertEqual(model.timeZoneChoice, .fixed("Europe/Prague"))
+    }
+
+    /// `-didChangeSelectedTimeZone:` clears the identifier when leaving the
+    /// fixed mode; a stale one would otherwise be written to the favorite.
+    func testLeavingFixedModeClearsTheIdentifier() {
+        let model = SAConnectionFormModel()
+        model.timeZoneChoice = .fixed("Europe/Prague")
+
+        model.timeZoneChoice = .system
+        XCTAssertEqual(model.info.timeZoneMode, .useSystemTZ)
+        XCTAssertEqual(model.info.timeZoneIdentifier, "")
+
+        model.timeZoneChoice = .server
+        XCTAssertEqual(model.info.timeZoneMode, .useServerTZ)
+        XCTAssertEqual(model.info.timeZoneIdentifier, "")
+    }
+
+    /// The popup has no item that could show "fixed, but no identifier",
+    /// so that stored combination reads back as the server default.
+    func testFixedModeWithoutAnIdentifierDegradesToServer() {
+        let model = SAConnectionFormModel()
+        model.info.timeZoneMode = .useFixedTZ
+        model.info.timeZoneIdentifier = ""
+
+        XCTAssertEqual(model.timeZoneChoice, .server)
+    }
+
+    // MARK: - C2b: time zone menu
+
+    func testTimeZoneMenuLeadsWithTheTwoRelativeChoices() {
+        let menu = SATimeZoneMenuEntry.menu(identifiers: ["Europe/Prague"])
+
+        XCTAssertEqual(menu.first, .choice(.server))
+        XCTAssertEqual(menu.dropFirst().first, .separator(afterPrefix: ""))
+        XCTAssertEqual(menu.dropFirst(2).first, .choice(.system))
+    }
+
+    func testTimeZoneMenuSeparatesOnEveryPrefixChange() {
+        let menu = SATimeZoneMenuEntry.menu(identifiers: ["Europe/Prague", "Europe/Berlin", "America/New_York", "UTC"])
+        let afterRelative = Array(menu.dropFirst(3))
+
+        XCTAssertEqual(afterRelative, [
+            .separator(afterPrefix: "America"),
+            .choice(.fixed("America/New_York")),
+            .separator(afterPrefix: "Europe"),
+            .choice(.fixed("Europe/Berlin")),
+            .choice(.fixed("Europe/Prague")),
+            .separator(afterPrefix: "UTC"),
+            .choice(.fixed("UTC")),
+        ])
+    }
+
+    func testTimeZoneMenuSortsCaseInsensitively() {
+        let menu = SATimeZoneMenuEntry.menu(identifiers: ["Zulu", "america/x", "America/A"])
+        let identifiers = menu.compactMap { entry -> String? in
+            if case .choice(.fixed(let identifier)) = entry { return identifier }
+            return nil
+        }
+
+        XCTAssertEqual(identifiers, ["America/A", "america/x", "Zulu"])
+    }
+
+    /// The real menu is what ships; make sure it is populated and that every
+    /// entry is unique, since the SwiftUI picker keys its rows by value.
+    func testDefaultTimeZoneMenuIsPopulatedAndUnique() {
+        let menu = SATimeZoneMenuEntry.menu()
+
+        XCTAssertGreaterThan(menu.count, 3)
+        XCTAssertEqual(Set(menu).count, menu.count)
+    }
+
+    // MARK: - C2b: flag bridges
+
+    func testFlagBridgesReadNonZeroAsOn() {
+        let model = SAConnectionFormModel()
+        model.info.useSSL = 1
+        model.info.allowDataLocalInfile = 2  // ObjC -boolValue semantics: any non-zero
+
+        XCTAssertTrue(model.useSSL)
+        XCTAssertTrue(model.allowDataLocalInfile)
+        XCTAssertFalse(model.enableClearTextPlugin)
+    }
+
+    func testFlagBridgesWriteOneAndZero() {
+        let model = SAConnectionFormModel()
+
+        model.useSSL = true
+        model.sshKeyLocationEnabled = true
+        model.sslCACertFileLocationEnabled = true
+        XCTAssertEqual(model.info.useSSL, 1)
+        XCTAssertEqual(model.info.sshKeyLocationEnabled, 1)
+        XCTAssertEqual(model.info.sslCACertFileLocationEnabled, 1)
+
+        model.useSSL = false
+        XCTAssertEqual(model.info.useSSL, 0)
+    }
+
+    func testEveryFlagBridgeTargetsItsOwnField() {
+        let model = SAConnectionFormModel()
+
+        model.useSSL = true
+        model.allowDataLocalInfile = true
+        model.enableClearTextPlugin = true
+        model.requestServerPublicKey = true
+        model.sshKeyLocationEnabled = true
+        model.sslKeyFileLocationEnabled = true
+        model.sslCertificateFileLocationEnabled = true
+        model.sslCACertFileLocationEnabled = true
+
+        XCTAssertEqual(
+            [model.info.useSSL, model.info.allowDataLocalInfile, model.info.enableClearTextPlugin,
+             model.info.requestServerPublicKey, model.info.sshKeyLocationEnabled,
+             model.info.sslKeyFileLocationEnabled, model.info.sslCertificateFileLocationEnabled,
+             model.info.sslCACertFileLocationEnabled],
+            Array(repeating: 1, count: 8)
+        )
+    }
+
+    // MARK: - C2b: per-type form shape
+
+    /// AWS IAM enables SSL and the cleartext plugin itself, so its tab shows
+    /// neither toggle nor an SSL details container — it shows a note instead.
+    func testAWSIAMForcesSSLAndHidesTheSecurityToggles() {
+        let model = SAConnectionFormModel()
+        model.info.type = .awsIAM
+        model.useSSL = true
+
+        XCTAssertTrue(model.forcesSSL)
+        XCTAssertFalse(model.showsSSLToggle)
+        XCTAssertFalse(model.showsClearTextPluginToggle)
+        XCTAssertFalse(model.showsRequestServerPublicKeyToggle)
+        XCTAssertFalse(model.showsSSLFileOptions, "AWS IAM has no SSL details container in the XIB")
+    }
+
+    func testOtherTypesOfferTheSecurityToggles() {
+        for type in [SAConnectionType.tcpIP, .socket, .sshTunnel, .vault] {
+            let model = SAConnectionFormModel()
+            model.info.type = type
+
+            XCTAssertFalse(model.forcesSSL, "\(type)")
+            XCTAssertTrue(model.showsSSLToggle, "\(type)")
+            XCTAssertTrue(model.showsClearTextPluginToggle, "\(type)")
+            XCTAssertTrue(model.showsRequestServerPublicKeyToggle, "\(type)")
+        }
+    }
+
+    /// The XIB reveals the SSL file container only while "Require SSL" is on.
+    func testSSLFileOptionsFollowTheSSLToggle() {
+        let model = SAConnectionFormModel()
+        model.info.type = .tcpIP
+
+        XCTAssertFalse(model.showsSSLFileOptions)
+        model.useSSL = true
+        XCTAssertTrue(model.showsSSLFileOptions)
+    }
+
+    // MARK: - C2b: connect gate across the types
+
+    func testSocketConnectionsNeedNoHost() {
+        let model = SAConnectionFormModel()
+        model.info.type = .socket
+
+        XCTAssertTrue(model.canAttemptConnection)
+    }
+
+    func testSSHTunnelAcceptsEitherAHostOrARemoteSocket() {
+        let model = SAConnectionFormModel()
+        model.info.type = .sshTunnel
+        XCTAssertFalse(model.canAttemptConnection)
+
+        model.info.sshRemoteSocketPath = "/var/run/mysqld/mysqld.sock"
+        XCTAssertTrue(model.canAttemptConnection)
+
+        model.info.sshRemoteSocketPath = ""
+        model.info.host = "db.internal"
+        XCTAssertTrue(model.canAttemptConnection)
+    }
+
+    func testAWSAndVaultRequireAHost() {
+        for type in [SAConnectionType.awsIAM, .vault] {
+            let model = SAConnectionFormModel()
+            model.info.type = type
+            XCTAssertFalse(model.canAttemptConnection, "\(type)")
+
+            model.info.host = "db.example.com"
+            XCTAssertTrue(model.canAttemptConnection, "\(type)")
+        }
+    }
+
+    // MARK: - C2b: vault mount / role split
+
+    func testVaultMountAndRoleJoinIntoTheStoredPath() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        XCTAssertEqual(model.info.vaultCredentialsPath, "databases_credentials/creds/readonly")
+    }
+
+    /// The halves have to be stored, not derived: joining returns "" until a
+    /// role exists, so a mount typed first would be lost on the round trip.
+    func testMountSurvivesBeingTypedBeforeTheRole() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "databases_credentials"
+
+        XCTAssertEqual(model.info.vaultCredentialsPath, "")
+        XCTAssertEqual(model.vaultMount, "databases_credentials")
+
+        model.vaultCredentialsRole = "readonly"
+        XCTAssertEqual(model.info.vaultCredentialsPath, "databases_credentials/creds/readonly")
+    }
+
+    func testInitSplitsAnExistingCredentialsPath() {
+        var info = SAConnectionInfo()
+        info.vaultCredentialsPath = "databases_credentials/creds/readonly"
+
+        let model = SAConnectionFormModel(info: info)
+        XCTAssertEqual(model.vaultMount, "databases_credentials")
+        XCTAssertEqual(model.vaultCredentialsRole, "readonly")
+    }
+
+    /// Loading a favorite replaces `info` wholesale; the two halves must follow.
+    func testReplacingInfoResplitsTheCredentialsPath() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "old"
+        model.vaultCredentialsRole = "role"
+
+        var loaded = SAConnectionInfo()
+        loaded.vaultCredentialsPath = "team/creds/writer"
+        model.info = loaded
+
+        XCTAssertEqual(model.vaultMount, "team")
+        XCTAssertEqual(model.vaultCredentialsRole, "writer")
+        XCTAssertEqual(model.info.vaultCredentialsPath, "team/creds/writer")
+    }
+
+    /// Editing the halves must not be mistaken for an external change and
+    /// bounce back — the guard in the didSet pair is what prevents it.
+    func testEditingHalvesDoesNotResplitThem() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "databases_credentials"
+        model.vaultCredentialsRole = "readonly"
+
+        // Clearing the mount leaves a bare role, which must stay in the role
+        // half rather than being re-parsed into the mount.
+        model.vaultMount = ""
+
+        XCTAssertEqual(model.info.vaultCredentialsPath, "readonly")
+        XCTAssertEqual(model.vaultMount, "")
+        XCTAssertEqual(model.vaultCredentialsRole, "readonly")
+    }
+
+    /// A full path pasted into the Role field is honoured verbatim by
+    /// SAVaultCredentialsPath; the model must not double-prefix it.
+    func testFullPathPastedIntoTheRoleHalfIsHonoured() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "ignored"
+        model.vaultCredentialsRole = "team/creds/writer"
+
+        XCTAssertEqual(model.info.vaultCredentialsPath, "team/creds/writer")
+    }
+
+    // MARK: - C2b: generated name across the types
+
+    func testSocketConnectionsNameThemselvesLocalhost() {
+        let model = SAConnectionFormModel()
+        model.info.type = .socket
+
+        XCTAssertEqual(model.effectiveName, "localhost")
+
+        model.info.database = "sakila"
+        XCTAssertEqual(model.effectiveName, "localhost/sakila")
+    }
+
+    func testNonSocketTypesGenerateFromTheHost() {
+        for type in [SAConnectionType.tcpIP, .sshTunnel, .awsIAM, .vault] {
+            let model = SAConnectionFormModel()
+            model.info.type = type
+
+            XCTAssertEqual(model.effectiveName, "", "\(type) with no host")
+
+            model.info.host = "db.example.com"
+            XCTAssertEqual(model.effectiveName, "db.example.com", "\(type)")
+        }
+    }
 }

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -315,7 +315,7 @@ C1b — pure SwiftUI `List` / `OutlineGroup` — ✅ Done (display/search/select
 - Files: new `SAFavoriteItem.swift`, `SAFavoriteItem+Tree.swift`,
   `SAFavoritesList.swift`, `UnitTests/SAFavoriteItemTests.swift`
 
-**C2. SwiftUI ConnectionFormView** — 🟡 TCP/IP form + model done; other types + SSL + hosting pending
+**C2. SwiftUI ConnectionFormView** — 🟡 All types + SSL/colour/time zone done (C2a+C2b); hosting pending (C3)
 - The 55 IBOutlets in ConnectionView.xib are the eventual target.
 
 C2a — TCP/IP form + observable model — ✅ Done
@@ -392,6 +392,27 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
   round-trip and menu shape, the flag bridges, per-type form shape, the
   connect gate and generated name across all five types, and the Vault
   mount/role split including the resplit-on-load case.
+- Review follow-up (Codex P1/P2, CodeRabbit): three gaps against the AppKit
+  form, all confirmed against `SPConnectionController` before fixing.
+  - The file chooser stored only the path. `-chooseKeyLocation:` also writes a
+    read-only security-scoped bookmark, without which a saved favorite cannot
+    reach its key or certificate after the next launch — the panel grants
+    access for the current launch only. The SwiftUI row now writes the same
+    bookmark, and clears the row on cancel as the AppKit flow does.
+  - It also accepted any existing file. `-chooseKeyLocation:` runs
+    `validateKeyFile:`/`validateCertFile:` on the SSL key and client
+    certificate (and, deliberately, on neither the SSH key nor the CA cert).
+    Those checks moved into `SAConnectionFileValidator` + `SAConnectionFileKind`
+    — pure, so they are tested on strings rather than needing a controller.
+  - Vault could reach `onConnect` with an unusable configuration:
+    `-initiateConnection:` rejects a blank vault host, credentials path or
+    database host, and none of those were checked. They now gate both the
+    Connect button and `validate()`, in the controller's order, via two new
+    `SAConnectionValidationFailureKind` cases.
+  - Also: the time-zone menu is built once rather than re-sorted on every
+    `body` evaluation (which is every keystroke), and the colour swatch labels
+    are derived from position and localized instead of a hardcoded English
+    name list.
 - Not covered here, deliberately: the AWS "Authorize Access to ~/.aws…"
   bookmark flow (needs Security-framework state, same reason D3 left it
   inline), the Vault role *list* fetch behind the XIB's combo box and its

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -348,10 +348,58 @@ C2a — TCP/IP form + observable model — ✅ Done
   objectWillChange publishing on field mutation.
 - Files were added via Xcode MCP `XcodeWrite` (real Xcode IDs); only
   the model's second (Unit Tests) membership was a manual pbxproj edit.
-- Remaining C2 scope: socket/SSH/AWS/Vault type switching, SSL options,
-  color index, time-zone picker, favorites save/auto-name parity.
+- C2b superseded this: see below.
 - Files: `Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift`,
   `SAConnectionFormView.swift`, `UnitTests/SAConnectionFormModelTests.swift`
+
+C2b — all connection types + SSL, colour, time zone — ✅ Done
+- `SAConnectionFormView` now renders every type `ConnectionView.xib`
+  offers. A `Picker` replaces the tab bar; the detail fields switch on
+  `info.type`. Field sets, labels and placeholders were read off the XIB
+  container by container (TCP/IP, socket, SSH, AWS IAM, Vault), so e.g.
+  the socket tab has no Port field and the SSH tab keeps its two groups
+  (tunnel credentials, then MySQL-side details + remote socket).
+- Shared sections added: colour (`SPFavoriteColorSupport`'s 7 swatches
+  plus the -1 "none" sentinel the favorites plist uses), the time-zone
+  picker, the security toggles, and the SSL file rows.
+- `SATimeZoneChoice` (Swift, pure) collapses the stored
+  (`timeZoneMode`, `timeZoneIdentifier`) pair into one selectable value,
+  making the invalid combinations unrepresentable; `SATimeZoneMenuEntry.menu()`
+  reproduces `-generateTimeZoneMenuItems` (two relative entries, then every
+  identifier sorted case-insensitively, separator on each region-prefix
+  change). Setting the choice clears the identifier outside the fixed
+  mode, matching `-didChangeSelectedTimeZone:`.
+- Per-type form shape lives on the model (`forcesSSL`, `showsSSLToggle`,
+  `showsSSLFileOptions`, …) so it is testable: AWS IAM turns SSL and the
+  cleartext plugin on itself, so its tab shows neither toggle nor an SSL
+  container — it shows the explanatory label instead, which is exactly
+  what the XIB does.
+- Bool bridges for the `Int`-typed flags (`useSSL`, `allowDataLocalInfile`,
+  …) so Toggles can bind; non-zero reads as on, matching the ObjC
+  `-boolValue` the favorites plist is read with.
+- ⚠️ **`vaultCredentialsPath` is a computed join, not a field.** The first
+  cut bound a single "Vault mount" text field straight to it; the AppKit
+  controller actually keeps `vaultMount` + `vaultCredentialsRole` ivars and
+  computes the path via `SAVaultCredentialsPath`. The model now mirrors
+  that with two stored halves — they cannot be derived from the path,
+  because `credPath(mount:role:)` returns "" while the role is blank, so a
+  mount typed first would vanish. Writing the tests for it caught a real
+  bug: the resplit assigned `vaultMount` and then re-read
+  `info.vaultCredentialsPath` for the role, but the first assignment had
+  already rewritten that path from the half-updated pair, so loading a
+  favorite kept the previous role.
+- 25 new tests in `SAConnectionFormModelTests` (42 total): time-zone
+  round-trip and menu shape, the flag bridges, per-type form shape, the
+  connect gate and generated name across all five types, and the Vault
+  mount/role split including the resplit-on-load case.
+- Not covered here, deliberately: the AWS "Authorize Access to ~/.aws…"
+  bookmark flow (needs Security-framework state, same reason D3 left it
+  inline), the Vault role *list* fetch behind the XIB's combo box and its
+  Refresh button (`SAVaultRoleListController`) — the Role field is plain
+  text for now — and favorites save parity. All three want a live host,
+  so they belong to C3.
+- Files: `SAConnectionFormModel.swift`, `SAConnectionFormView.swift`,
+  `UnitTests/SAConnectionFormModelTests.swift`
 
 **C3. Wire SwiftUI into SAConnectionWindowController + expose in menu**
 - The standalone connection window is the ideal host for SwiftUI views
@@ -486,10 +534,11 @@ These are the next biggest files after SPDatabaseDocument. Lower priority but ev
    replaced SPHelpViewerController + HelpViewer.xib; **legacy WebKit is now gone
    from the codebase** (33 deprecation warnings retired). Execution notes in
    `docs/development/warnings-elimination-plan.md`.
-2. **C2b — extend SAConnectionFormModel/View to all connection types**
-   (socket, SSH, AWS IAM, Vault + SSL options, colour, time zone). Scope grew
-   since June: Vault and AWS variants now exist and must be covered. Reuse
-   D1/D3 extractions; every new sub-form gets model tests.
+2. ~~**C2b — extend SAConnectionFormModel/View to all connection types**~~ —
+   ✅ Done. All five types render, with SSL options, colour and time zone;
+   42 model tests. The AWS `~/.aws` authorization, the Vault role-list fetch
+   and favorites save parity were deliberately left to C3, which supplies the
+   live host they need.
 3. **C3 — make the standalone window real**: host SAFavoritesList +
    SAConnectionFormView in SAConnectionWindowController via
    SAConnectionViewCoordinator, drive it with SAConnectionService. The


### PR DESCRIPTION
Phase C2b of the SwiftUI migration. C2a shipped the TCP/IP tab only; `SAConnectionFormView` now renders every type `ConnectionView.xib` offers — **TCP/IP, socket, SSH tunnel, AWS IAM and Vault** — with the SSL file options, colour index and time-zone picker those tabs carry. A `Picker` replaces the tab bar and the detail fields switch on `info.type`.

Field sets, labels and placeholders were read off the XIB container by container rather than assumed, which is why the socket tab has no Port field and the SSH tab keeps its two groups (tunnel credentials, then MySQL-side details plus the remote socket).

## Branchy logic lives on the model, so it is tested

| Addition | What it pins |
|---|---|
| `SATimeZoneChoice` | Collapses the stored (`timeZoneMode`, `timeZoneIdentifier`) pair into one selectable value, making the invalid combinations unrepresentable. Setting it clears the identifier outside the fixed mode, matching `-didChangeSelectedTimeZone:`. |
| `SATimeZoneMenuEntry.menu()` | Reproduces `-generateTimeZoneMenuItems`: two relative entries, then every identifier sorted case-insensitively, separator on each region-prefix change. |
| `forcesSSL` / `showsSSLToggle` / `showsSSLFileOptions` / … | AWS IAM enables SSL and the cleartext plugin itself, so its tab shows neither toggle nor an SSL details container — it shows the explanatory label instead, exactly as the XIB does. |
| Bool bridges (`useSSL`, `allowDataLocalInfile`, …) | Toggles bind to the `Int`-typed fields; non-zero reads as on, matching the ObjC `-boolValue` the favorites plist is read with. |

The view keeps only what genuinely needs AppKit (the colour swatches from `SPFavoriteColorSupport`, the `NSOpenPanel` file rows), so it stays app-target-only while the model compiles into the test target.

## A field that isn't a field

`vaultCredentialsPath` turned out to be a **computed join**, not a stored value: the AppKit controller keeps `vaultMount` + `vaultCredentialsRole` ivars and derives the path through `SAVaultCredentialsPath`. The first cut bound a single "Vault mount" text field straight to the path, which would have silently dropped the mount/role distinction.

The model now mirrors the controller with two stored halves. They **cannot** be derived from the path, because `credPath(mount:role:)` returns `""` while the role is still blank — so a mount typed first would vanish.

Writing the tests for that caught a real bug: the resplit assigned `vaultMount` and then re-read `info.vaultCredentialsPath` for the role, but the first assignment had already rewritten that path from the half-updated pair. Loading a favorite kept the *previous* role. Fixed by reading the incoming path once, up front; `testReplacingInfoResplitsTheCredentialsPath` covers it.

## Deliberately not covered

All three need a live host, so they belong to C3:

- the AWS **"Authorize Access to ~/.aws…"** bookmark flow (the same Security-framework reason D3 left it inline)
- the Vault **role-list fetch** behind the XIB's combo box and its Refresh button (`SAVaultRoleListController`) — the Role field is plain text for now
- **favorites save parity**

## Testing

25 new tests (42 in `SAConnectionFormModelTests`) covering the time-zone round-trip and menu shape, the flag bridges, per-type form shape, the connect gate and generated name across all five types, and the Vault mount/role split including the resplit-on-load case. Full suite: **921 pass, 0 fail**. Clean build, no new warnings.

Nothing hosts the view yet — that is still C3, which is the milestone that also stops new connection UI landing in `SPConnectionController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded connection setup for TCP/IP, socket, SSH tunnel, AWS IAM, and Vault connections.
  * Added time-zone selection, SSL options, color selection, file selection, and connection-specific fields.
  * Added Vault mount and role handling, improved connection naming, and AWS IAM token support.

* **Bug Fixes**
  * Improved form synchronization, visibility, validation, and password clearing after identity changes.
  * Added PEM file validation, clearer file-selection errors, and secure file access persistence.
  * Added validation for missing Vault host and credential paths.

* **Documentation**
  * Updated the modernization plan to reflect completed enhancements and remaining work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->