### PR TITLE
#fixed Validate SSL files for SSH tunnel connections

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionDetailsValidator.swift
@@ -126,17 +126,17 @@ import Foundation
         //      the shared SSL file fields. The order matches the original code so that
         //      a multi-issue form produces the same first-error UX.
         //
-        //      ⚠️ `.sshTunnel` is absent on purpose, and it is probably an upstream
-        //      bug rather than a decision: the SSH tab does have a "Require SSL"
-        //      checkbox and its own SSL details container
-        //      (`sshConnectionSSLDetailsContainer`, `sslOverSSHKeyFileButton` and
-        //      friends), so an enabled-but-missing key/cert/CA on a tunnel reaches
-        //      connection setup unchecked. The pre-D3 ObjC read
-        //      `(type == SPTCPIPConnection || type == SPSocketConnection) && useSSL`,
-        //      D3 preserved that, and `testSSLChecksDoNotApplyToSSHTunnel` pins it.
-        //      Changing it would also change the shipping AppKit form, so it wants
-        //      its own PR rather than riding along with the SwiftUI work.
-        if (type == .tcpIP || type == .socket || type == .vault) && useSSL {
+        //      `.sshTunnel` was missing here until now, and it was an oversight rather
+        //      than a decision: the SSH tab has its own "Require SSL" checkbox and SSL
+        //      details container (`sshConnectionSSLDetailsContainer`), whose file
+        //      buttons write the very same `sslKeyFileLocation` /
+        //      `sslCertificateFileLocation` / `sslCACertFileLocation` properties this
+        //      validator reads. An enabled-but-missing file on a tunnel therefore
+        //      reached connection setup unchecked and failed at connect time instead.
+        //      The pre-D3 ObjC read `SPTCPIPConnection || SPSocketConnection`, D3
+        //      preserved that, and `.vault` was appended when Vault landed — the SSH
+        //      case simply never got revisited.
+        if (type == .tcpIP || type == .socket || type == .sshTunnel || type == .vault) && useSSL {
             if sslKeyFileLocationEnabled, let path = sslKeyFileLocation,
                !fileExistsExpandingTilde(path) {
                 return SAConnectionValidationFailure(

--- a/UnitTests/SAConnectionDetailsValidatorTests.swift
+++ b/UnitTests/SAConnectionDetailsValidatorTests.swift
@@ -245,17 +245,65 @@ final class SAConnectionDetailsValidatorTests: XCTestCase {
         ))
     }
 
-    func testSSLChecksDoNotApplyToSSHTunnel() {
-        // SSL file checks only run for TCP/IP and socket types per the
-        // original code — SSH tunnel skips them even if useSSL is on.
-        XCTAssertNil(validate(
+    func testSSLChecksApplyToSSHTunnelWhenUseSSLOn() {
+        // The SSH tab offers the same three SSL file rows, writing the same
+        // properties, so a missing file has to be caught here rather than at
+        // connect time. This deliberately diverges from the pre-D3 ObjC, which
+        // checked only TCP/IP and socket — see the note in the validator.
+        XCTAssertEqual(validate(
             type: .sshTunnel,
             host: "db.example.com",
             sshHost: "bastion.example.com",
             useSSL: true,
             sslKeyFileLocationEnabled: true,
             sslKeyFileLocation: missingFilePath
+        )?.kind, .sslKeyFileMissing)
+
+        XCTAssertEqual(validate(
+            type: .sshTunnel,
+            host: "db.example.com",
+            sshHost: "bastion.example.com",
+            useSSL: true,
+            sslCertificateFileLocationEnabled: true,
+            sslCertificateFileLocation: missingFilePath
+        )?.kind, .sslCertificateFileMissing)
+
+        XCTAssertEqual(validate(
+            type: .sshTunnel,
+            host: "db.example.com",
+            sshHost: "bastion.example.com",
+            useSSL: true,
+            sslCACertFileLocationEnabled: true,
+            sslCACertFileLocation: missingFilePath
+        )?.kind, .sslCACertFileMissing)
+    }
+
+    /// The tunnel's own SSL toggle still gates the checks, same as every other
+    /// type — an unticked "Require SSL" leaves stale paths alone.
+    func testSSLChecksSkippedForSSHTunnelWhenUseSSLOff() {
+        XCTAssertNil(validate(
+            type: .sshTunnel,
+            host: "db.example.com",
+            sshHost: "bastion.example.com",
+            useSSL: false,
+            sslKeyFileLocationEnabled: true,
+            sslKeyFileLocation: missingFilePath
         ))
+    }
+
+    /// The SSH key check still comes first: it is an earlier rule, and a tunnel
+    /// with both problems should report the one the user hits first.
+    func testSSHKeyMissingBeatsSSLKeyMissingOnATunnel() {
+        XCTAssertEqual(validate(
+            type: .sshTunnel,
+            host: "db.example.com",
+            sshHost: "bastion.example.com",
+            useSSL: true,
+            sshKeyLocationEnabled: true,
+            sshKeyLocation: missingFilePath,
+            sslKeyFileLocationEnabled: true,
+            sslKeyFileLocation: missingFilePath
+        )?.kind, .sshKeyFileMissing)
     }
 
     func testSSLChecksAppliesToSocketWhenUseSSLOn() {

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -629,24 +629,44 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertNil(SAConnectionFileValidator.rejection(forFileAt: missing, kind: .sslCACert))
     }
 
-    // MARK: - Review round 2: SSL files on an SSH tunnel
+    // MARK: - SSL files on an SSH tunnel
 
-    /// Documents the inherited gap rather than fixing it here: the SSH tab
-    /// offers SSL file rows, but the shared validator has never checked them
-    /// (pre-D3 ObjC read `type == SPTCPIPConnection || type == SPSocketConnection`).
-    /// Fixing it changes the shipping AppKit form too, so it wants its own PR;
-    /// this test will fail loudly there, which is the point.
-    func testSSHTunnelSSLFilesAreNotValidatedYet() {
+    /// The SSH tab offers the same three SSL file rows, writing the same
+    /// properties, so a missing file is caught here rather than at connect time.
+    func testSSHTunnelValidatesItsSSLFiles() {
+        let missing = "/nonexistent/\(UUID().uuidString).pem"
+
+        for (enable, path, expected) in [
+            (\SAConnectionInfo.sslKeyFileLocationEnabled, \SAConnectionInfo.sslKeyFileLocation,
+             SAConnectionValidationFailureKind.sslKeyFileMissing),
+            (\SAConnectionInfo.sslCertificateFileLocationEnabled, \SAConnectionInfo.sslCertificateFileLocation,
+             .sslCertificateFileMissing),
+            (\SAConnectionInfo.sslCACertFileLocationEnabled, \SAConnectionInfo.sslCACertFileLocation,
+             .sslCACertFileMissing),
+        ] {
+            let model = SAConnectionFormModel()
+            model.info.type = .sshTunnel
+            model.info.host = "db.internal"
+            model.info.sshHost = "bastion.example.com"
+            model.useSSL = true
+            model.info[keyPath: enable] = 1
+            model.info[keyPath: path] = missing
+
+            XCTAssertEqual(model.validate()?.kind, expected)
+        }
+    }
+
+    /// The tunnel's own SSL toggle still gates the checks.
+    func testSSHTunnelWithoutSSLIgnoresTheSSLFiles() {
         let model = SAConnectionFormModel()
         model.info.type = .sshTunnel
         model.info.host = "db.internal"
         model.info.sshHost = "bastion.example.com"
-        model.useSSL = true
+        model.useSSL = false
         model.info.sslKeyFileLocationEnabled = 1
         model.info.sslKeyFileLocation = "/nonexistent/\(UUID().uuidString).pem"
 
-        XCTAssertNil(model.validate(),
-                     "known gap inherited from the AppKit form — see SAConnectionDetailsValidator")
+        XCTAssertNil(model.validate())
     }
 
     // MARK: - Review round 2: public keys rejected by the chooser


### PR DESCRIPTION
The SSH tunnel tab offers the same three SSL file rows as every other tab — its own "Require SSL" checkbox and SSL details container (`sshConnectionSSLDetailsContainer`, with `sslOverSSHKeyFileButton` / `sslOverSSHCertificateButton` / `sslOverSSHCACertButton`) — but `SAConnectionDetailsValidator` ran its file-existence checks only for TCP/IP, socket and Vault:

```swift
if (type == .tcpIP || type == .socket || type == .vault) && useSSL {
```

So an enabled-but-missing SSL key, certificate or CA on a tunnel reached connection setup unchecked and surfaced as an opaque connect-time failure instead of an actionable alert.

## Long-standing, not a regression

The pre-D3 Objective-C read:

```objc
if (([self type] == SPTCPIPConnection || [self type] == SPSocketConnection) && [self useSSL])
```

Phase D3 preserved that faithfully and pinned it with `testSSLChecksDoNotApplyToSSHTunnel` ("SSL file checks only run for TCP/IP and socket types per the original code"). `.vault` was appended to the list when Vault landed — which is what makes the SSH case look like something nobody revisited rather than a deliberate decision.

Raised by CodeRabbit on #2569 and deliberately kept out of that PR, because this changes the behaviour of the shipping AppKit form and deserves review on its own rather than riding along with SwiftUI scaffolding.

## No other wiring was needed

Two things make this a genuine one-line fix rather than a partial one, both verified:

- `-initiateConnection:` already passes `sslKeyFileLocation` / `sslCertificateFileLocation` / `sslCACertFileLocation` to the validator **regardless of connection type**, and the SSH tab's file buttons write those very same properties (`SPConnectionController.m:836-856`) rather than SSH-specific ones.
- The controller's per-failure switch keys off `failure.kind`, not the type, so the alert already clears the offending toggle and path for these kinds.

## Behaviour change worth calling out

An existing SSH favourite with SSL enabled and a path that no longer resolves now raises an alert at connect time instead of failing later inside the connection attempt. That alert is **recoverable, not a wall**: the controller clears the offending toggle and path, so the user can correct it or simply connect again without SSL files.

## Testing

`testSSLChecksDoNotApplyToSSHTunnel` → `testSSLChecksApplyToSSHTunnelWhenUseSSLOn`, now covering all three file kinds. Added:

- `testSSLChecksSkippedForSSHTunnelWhenUseSSLOff` — the tunnel's own SSL toggle still gates the checks, so an unticked "Require SSL" leaves stale paths alone
- `testSSHKeyMissingBeatsSSLKeyMissingOnATunnel` — the earlier SSH-key rule still wins when both are broken, so a tunnel with two problems reports the one the user hits first

898 tests pass, 0 fail. Clean build, no new warnings.

## Two things for the reviewer

⚠️ **Manual verification is still outstanding.** The task called for: SSH tunnel tab → tick Require SSL → point the key row at a file → delete the file → Connect, expecting an alert rather than a connect-time failure. I verified the code path analytically (shared properties, unconditional pass-through, type-independent failure handling) and by unit test, but I could not drive the AppKit UI from here, and I did not want to launch the user's database app unprompted. Worth doing before merge.

⚠️ **This conflicts textually with #2569.** That PR added a comment at this exact call site explaining why `.sshTunnel` was absent, and carries `testSSHTunnelSSLFilesAreNotValidatedYet`, which documents the gap and **will fail** once both are on the same branch. Whichever merges second needs that test replaced with the positive assertions — it was written to fail here deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH-tunnel connections now validate required SSL key, client certificate, and CA files when SSL is enabled.
  * Invalid, unreadable, or incorrectly formatted files are rejected with clear, localized messages.
  * Public key files are no longer accepted where private keys are required.
  * Missing SSH key errors take precedence over SSL file errors.
  * SSL file validation remains skipped when tunnel SSL is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->