### PR TITLE
#infra Host the SwiftUI connection screen in the standalone window (C3)

### DIFF
--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -183,6 +183,26 @@ final class SAConnectionFormModel: ObservableObject {
         objc.info = info
     }
 
+    // MARK: - Loading a favorite
+
+    /// Replaces the edited values with those decoded from a favorite.
+    ///
+    /// Uses the D1 decoder, so the defaulting rules (missing colorIndex → -1,
+    /// unknown type → tcpIP, and the rest) stay in one place. Passwords are
+    /// deliberately not carried: `fromFavoriteDictionary` never decodes them,
+    /// because they live in the keychain rather than the favorites plist.
+    ///
+    /// Assigning `info` wholesale is what re-splits the Vault mount/role halves,
+    /// so a favorite's credentials path lands in both controls.
+    func load(favorite: NSDictionary?) {
+        info = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+    }
+
+    /// Resets to a blank form — the Quick Connect row.
+    func loadQuickConnect() {
+        info = SAConnectionInfo()
+    }
+
     // MARK: - Derived display values
 
     /// The name shown for this connection: the user-entered name when

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -219,12 +219,39 @@ final class SAConnectionFormModel: ObservableObject {
     /// Assigning `info` wholesale is what re-splits the Vault mount/role halves,
     /// so a favorite's credentials path lands in both controls.
     func load(favorite: NSDictionary?) {
-        info = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+        var decoded = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+
+        // D1 deliberately leaves these two out: the AppKit controller reads them
+        // raw so that a *missing* key can drive the field's "443" / "oidc"
+        // placeholder, which a non-optional String cannot express. This path has
+        // no such raw read, so without carrying them a Vault favorite with a
+        // custom endpoint would silently authenticate against the defaults.
+        if let favorite {
+            decoded.vaultPort = Self.string(favorite["vaultPort"]) ?? ""
+            decoded.vaultOIDCMount = Self.string(favorite["vaultOIDCMount"]) ?? ""
+        }
+
+        info = decoded
     }
 
-    /// Resets to a blank form — the Quick Connect row.
+    /// Normalizes a favorite-dictionary value that may be a string or a number.
+    private static func string(_ value: Any?) -> String? {
+        switch value {
+        case let text as String: return text
+        case let number as NSNumber: return number.stringValue
+        default: return nil
+        }
+    }
+
+    /// Resets to the blank form behind the Quick Connect row.
+    ///
+    /// Goes through the nil-favorite decoder rather than `SAConnectionInfo()`:
+    /// the blank form's historical defaults are no colour (-1), compression on,
+    /// and the AWS profile "default", none of which the raw struct defaults
+    /// match. Building it by hand gave Quick Connect an unintended colour and
+    /// silently turned compression off.
     func loadQuickConnect() {
-        info = SAConnectionInfo()
+        load(favorite: nil)
     }
 
     // MARK: - Derived display values

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -195,12 +195,39 @@ final class SAConnectionFormModel: ObservableObject {
     /// Assigning `info` wholesale is what re-splits the Vault mount/role halves,
     /// so a favorite's credentials path lands in both controls.
     func load(favorite: NSDictionary?) {
-        info = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+        var decoded = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+
+        // D1 deliberately leaves these two out: the AppKit controller reads them
+        // raw so that a *missing* key can drive the field's "443" / "oidc"
+        // placeholder, which a non-optional String cannot express. This path has
+        // no such raw read, so without carrying them a Vault favorite with a
+        // custom endpoint would silently authenticate against the defaults.
+        if let favorite {
+            decoded.vaultPort = Self.string(favorite["vaultPort"]) ?? ""
+            decoded.vaultOIDCMount = Self.string(favorite["vaultOIDCMount"]) ?? ""
+        }
+
+        info = decoded
     }
 
-    /// Resets to a blank form — the Quick Connect row.
+    /// Normalizes a favorite-dictionary value that may be a string or a number.
+    private static func string(_ value: Any?) -> String? {
+        switch value {
+        case let text as String: return text
+        case let number as NSNumber: return number.stringValue
+        default: return nil
+        }
+    }
+
+    /// Resets to the blank form behind the Quick Connect row.
+    ///
+    /// Goes through the nil-favorite decoder rather than `SAConnectionInfo()`:
+    /// the blank form's historical defaults are no colour (-1), compression on,
+    /// and the AWS profile "default", none of which the raw struct defaults
+    /// match. Building it by hand gave Quick Connect an unintended colour and
+    /// silently turned compression off.
     func loadQuickConnect() {
-        info = SAConnectionInfo()
+        load(favorite: nil)
     }
 
     // MARK: - Derived display values

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormModel.swift
@@ -207,6 +207,26 @@ final class SAConnectionFormModel: ObservableObject {
         objc.info = info
     }
 
+    // MARK: - Loading a favorite
+
+    /// Replaces the edited values with those decoded from a favorite.
+    ///
+    /// Uses the D1 decoder, so the defaulting rules (missing colorIndex → -1,
+    /// unknown type → tcpIP, and the rest) stay in one place. Passwords are
+    /// deliberately not carried: `fromFavoriteDictionary` never decodes them,
+    /// because they live in the keychain rather than the favorites plist.
+    ///
+    /// Assigning `info` wholesale is what re-splits the Vault mount/role halves,
+    /// so a favorite's credentials path lands in both controls.
+    func load(favorite: NSDictionary?) {
+        info = SAConnectionInfoObjC.info(fromFavoriteDictionary: favorite).info
+    }
+
+    /// Resets to a blank form — the Quick Connect row.
+    func loadQuickConnect() {
+        info = SAConnectionInfo()
+    }
+
     // MARK: - Derived display values
 
     /// The name shown for this connection: the user-entered name when

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -162,8 +162,11 @@ import SwiftUI
         case .quickConnect:
             formModel.loadQuickConnect()
         case .group:
-            // Groups are not connectable and carry no details to show.
-            break
+            // A group is a nil favorite: -updateFavoriteSelection: sets
+            // `node = nil` for one and populates the form from that, so the
+            // previous favorite's details do not linger. Leaving them would let
+            // Connect fire against a favorite that is no longer highlighted.
+            formModel.load(favorite: nil)
         case .favorite:
             formModel.load(favorite: Self.favoriteDictionary(withID: item.favoriteID))
         }
@@ -434,28 +437,35 @@ import SwiftUI
 
         guard let document = windowController?.databaseDocument else { return }
 
-        // 2. Populate the destination document's connection controller before
+        // 2. SSL can be requested and silently not granted: MySQL may lack SSL
+        // support, have it disabled, or have been given too little to negotiate
+        // with. -mySQLConnectionEstablished: warns in that case, and handing off
+        // without the same check leaves the user believing an unencrypted
+        // session is encrypted.
+        warnIfRequestedSSLWasNotEstablished(connection, info: info)
+
+        // 3. Populate the destination document's connection controller before
         // handing the connection over. SPDatabaseDocument reads its title,
         // database, host, user, port, colour and .spf serialization state from
         // that controller, so without this the new tab looks connected but
         // reads blank and saves empty connection details (Codex, #2572).
         info.apply(to: document.connectionController())
 
-        // 3. The document must become the connection's delegate: neither
+        // 4. The document must become the connection's delegate: neither
         // SAConnectionService nor -setConnection: assigns one, and without it the
         // framework falls back to its automatic retry with no query-error
         // logging, no no-connection alert, no keychain password prompt on
         // reconnect and no connection-loss decision UI.
         connection.setDelegate(document)
 
-        // 4. setConnection: transitions the document out of connection mode
+        // 5. setConnection: transitions the document out of connection mode
         // into the database UI (same as the embedded flow's addConnectionToDocument).
         document.setConnection(connection)
 
-        // 5. Mark handoff complete so windowWillClose doesn't cancel the connection
+        // 6. Mark handoff complete so windowWillClose doesn't cancel the connection
         connectionHandedOff = true
 
-        // 6. Close the standalone connection window
+        // 7. Close the standalone connection window
         close()
     }
 
@@ -464,6 +474,30 @@ import SwiftUI
         // so this delegate method is a no-op for that flow.
         // The connectDirectly path shows its own alert below.
         NSLog("Standalone connection failed: %@", error)
+    }
+
+    /// Warns when SSL was asked for but the server did not use it.
+    ///
+    /// Mirrors the check in `-mySQLConnectionEstablished:`, including which
+    /// types it applies to: SSH tunnels are excluded there, since their MySQL
+    /// leg runs inside the tunnel. AWS IAM counts as requesting SSL whether or
+    /// not the toggle is on, because it enables it implicitly.
+    private func warnIfRequestedSSLWasNotEstablished(_ connection: SPMySQLConnection,
+                                                     info: SAConnectionInfoObjC) {
+        let details = info.info
+        let requiresSSL = details.useSSL != 0 || details.type == .awsIAM
+        let checkedTypes: [SAConnectionType] = [.tcpIP, .socket, .awsIAM, .vault]
+
+        guard requiresSSL, checkedTypes.contains(details.type), !connection.isConnectedViaSSL() else {
+            return
+        }
+
+        NSAlert.createWarningAlert(
+            title: NSLocalizedString("SSL connection not established",
+                                         comment: "SSL requested but not used title"),
+            message: NSLocalizedString("You requested that the connection should be established using SSL, but MySQL made the connection without SSL.\n\nThis may be because the server does not support SSL connections, or has SSL disabled; or insufficient details were supplied to establish an SSL connection.\n\nThis connection is not encrypted.",
+                                       comment: "SSL connection requested but not established error detail"),
+            callback: nil)
     }
 
     /// Shows an error alert as a sheet on the standalone window.

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -178,21 +178,147 @@ import SwiftUI
     }
 
     /// Validates and connects using whatever the form currently holds.
+    ///
+    /// AWS IAM and Vault do not authenticate with a typed password: the former
+    /// needs a generated RDS token, the latter a pair of ephemeral credentials
+    /// fetched over OIDC. `SAConnectionService` only configures transport flags,
+    /// so those have to be resolved here — the same work `-_resolvedMySQLPassword`
+    /// and the Vault block in `-initiateConnection:` do for the embedded form.
     private func connectUsingForm() {
         if let failure = formModel.validate() {
             showConnectionError(title: failure.alertTitle, detail: failure.alertMessage)
             return
         }
 
-        let info = SAConnectionInfoObjC(info: formModel.info)
+        resolveCredentials { [weak self] result in
+            guard let self else { return }
 
-        // Passwords come from the form's own fields. Reading a saved favorite's
-        // password out of the keychain is deliberately not wired here — the D1
-        // decoder never carried passwords, and the keychain lookup needs the
-        // account/service naming that still lives in SPConnectionController.
-        connectDirectly(with: info,
-                        password: formModel.info.password,
-                        sshPassword: formModel.info.sshPassword)
+            switch result {
+            case .failure(let failure):
+                self.showConnectionError(title: failure.title, detail: failure.detail)
+
+            case .success(let credentials):
+                var resolved = self.formModel.info
+                resolved.user = credentials.user
+                resolved.password = credentials.password
+
+                self.connectDirectly(with: SAConnectionInfoObjC(info: resolved),
+                                     password: credentials.password,
+                                     sshPassword: resolved.sshPassword)
+            }
+        }
+    }
+
+    /// The username and password to actually connect with.
+    private struct SAResolvedCredentials {
+        let user: String
+        let password: String
+    }
+
+    private struct SACredentialFailure: Error {
+        let title: String
+        let detail: String?
+    }
+
+    /// Resolves type-specific credentials, calling back on the main queue.
+    private func resolveCredentials(_ completion: @escaping (Result<SAResolvedCredentials, SACredentialFailure>) -> Void) {
+        let info = formModel.info
+
+        switch info.type {
+        case .awsIAM:
+            completion(resolveAWSIAMToken(info: info))
+
+        case .vault:
+            resolveVaultCredentials(info: info, completion: completion)
+
+        case .tcpIP, .socket, .sshTunnel:
+            // The typed password is the credential. Reading a saved favorite's
+            // password out of the keychain is still not wired — the D1 decoder
+            // never carried passwords, and the lookup needs the account/service
+            // naming that lives in SPConnectionController.
+            completion(.success(SAResolvedCredentials(user: info.user, password: info.password)))
+        }
+    }
+
+    /// Generates the RDS auth token that stands in for the password. Stays on
+    /// the main queue because the profile flow can raise an MFA sheet.
+    private func resolveAWSIAMToken(info: SAConnectionInfo) -> Result<SAResolvedCredentials, SACredentialFailure> {
+        let port = Int(info.port.trimmingCharacters(in: .whitespaces)) ?? 3306
+        let trimmedProfile = info.awsProfile.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            let token = try AWSIAMAuthManager.generateAuthToken(
+                hostname: info.host,
+                port: port,
+                username: info.user,
+                region: info.awsRegion,
+                // Matches -generateAWSIAMAuthTokenWithError:, which falls back to
+                // "default" rather than passing an empty profile name.
+                profile: trimmedProfile.isEmpty ? "default" : trimmedProfile,
+                accessKey: nil,
+                secretKey: nil,
+                parentWindow: window
+            )
+
+            guard !token.isEmpty else {
+                return .failure(SACredentialFailure(
+                    title: NSLocalizedString("AWS IAM Authentication Failed", comment: "AWS IAM auth failed title"),
+                    detail: NSLocalizedString("Empty authentication token returned", comment: "AWS IAM empty token error")))
+            }
+
+            return .success(SAResolvedCredentials(user: info.user, password: token))
+        } catch {
+            return .failure(SACredentialFailure(
+                title: NSLocalizedString("AWS IAM Authentication Failed", comment: "AWS IAM auth failed title"),
+                detail: error.localizedDescription))
+        }
+    }
+
+    /// Fetches ephemeral Vault credentials off the main queue: the OIDC leg can
+    /// open a browser and take up to two minutes, which must not block the UI.
+    private func resolveVaultCredentials(info: SAConnectionInfo,
+                                         completion: @escaping (Result<SAResolvedCredentials, SACredentialFailure>) -> Void) {
+        let host = info.vaultHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let port = info.vaultPort.isEmpty ? "443" : info.vaultPort
+        let mount = info.vaultOIDCMount.isEmpty ? "oidc" : info.vaultOIDCMount
+        let credPath = info.vaultCredentialsPath
+        let loginIdentifier = VaultOIDCHandler.prepareActiveLogin()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            var username: NSString?
+            var password: NSString?
+            var error: NSError?
+
+            let succeeded = VaultAuthManager.generateCredentials(
+                host: host,
+                port: port,
+                oidcMount: mount,
+                credPath: credPath,
+                loginIdentifier: loginIdentifier,
+                username: &username,
+                password: &password,
+                error: &error
+            )
+            VaultOIDCHandler.clearPreparedActiveLogin(identifier: loginIdentifier)
+
+            DispatchQueue.main.async {
+                guard succeeded,
+                      let username = username as String?, !username.isEmpty,
+                      let password = password as String?, !password.isEmpty else {
+                    // Drop whatever was cached for this endpoint, as the embedded
+                    // flow does, so a retry re-runs the OIDC leg rather than
+                    // reusing a half-formed result.
+                    VaultAuthManager.clearCachedCredentials(host: host, port: port,
+                                                            oidcMount: mount, credPath: credPath)
+                    completion(.failure(SACredentialFailure(
+                        title: NSLocalizedString("Vault Authentication Failed", comment: "Vault auth failed title"),
+                        detail: error?.localizedDescription)))
+                    return
+                }
+
+                completion(.success(SAResolvedCredentials(user: username, password: password)))
+            }
+        }
     }
 
     // MARK: - SAConnectionDelegate
@@ -205,22 +331,28 @@ import SwiftUI
 
         guard let document = windowController?.databaseDocument else { return }
 
-        // 2. Hand off the established connection to the new document.
-        // setConnection: transitions the document out of connection mode
-        // into the database UI (same as the embedded flow's addConnectionToDocument).
-        //
-        // The document must become the connection's delegate first: neither
-        // SAConnectionService nor -setConnection: assigns it, and without it the
+        // 2. Populate the destination document's connection controller before
+        // handing the connection over. SPDatabaseDocument reads its title,
+        // database, host, user, port, colour and .spf serialization state from
+        // that controller, so without this the new tab looks connected but
+        // reads blank and saves empty connection details (Codex, #2572).
+        info.apply(to: document.connectionController())
+
+        // 3. The document must become the connection's delegate: neither
+        // SAConnectionService nor -setConnection: assigns one, and without it the
         // framework falls back to its automatic retry with no query-error
         // logging, no no-connection alert, no keychain password prompt on
-        // reconnect and no connection-loss decision UI (Codex, #2572).
+        // reconnect and no connection-loss decision UI.
         connection.setDelegate(document)
+
+        // 4. setConnection: transitions the document out of connection mode
+        // into the database UI (same as the embedded flow's addConnectionToDocument).
         document.setConnection(connection)
 
-        // 3. Mark handoff complete so windowWillClose doesn't cancel the connection
+        // 5. Mark handoff complete so windowWillClose doesn't cancel the connection
         connectionHandedOff = true
 
-        // 4. Close the standalone connection window
+        // 6. Close the standalone connection window
         close()
     }
 
@@ -282,6 +414,79 @@ import SwiftUI
                 )
             }
         }
+    }
+}
+
+// MARK: - Populating a document's connection controller
+
+extension SAConnectionInfoObjC {
+
+    /// Copies these details onto a document's `SPConnectionController`.
+    ///
+    /// The exact inverse of `-[SPConnectionController _buildConnectionInfo]`,
+    /// field for field and in the same order, so the two can be diffed against
+    /// each other when either gains a field. `SPDatabaseDocument` reads its
+    /// window title, tab label, selected database, favourite colour and `.spf`
+    /// serialization out of the controller, so a document handed a connection
+    /// without this looks connected while reading blank.
+    ///
+    /// `vaultMount` and `vaultCredentialsRole` are not set directly: the
+    /// controller derives them in its `setVaultCredentialsPath:` setter, which
+    /// splits the joined path across both ivars.
+    func apply(to controller: SPConnectionController?) {
+        guard let controller else { return }
+        let info = self.info
+
+        controller.type = info.type.rawValue
+        controller.name = info.name
+        controller.host = info.host
+        controller.user = info.user
+        controller.password = info.password
+        controller.database = info.database
+        controller.socket = info.socket
+        controller.port = info.port
+        controller.colorIndex = info.colorIndex
+        controller.useCompression = info.useCompression
+
+        controller.useSSL = info.useSSL
+        controller.sslKeyFileLocationEnabled = info.sslKeyFileLocationEnabled
+        controller.sslKeyFileLocation = info.sslKeyFileLocation
+        controller.sslCertificateFileLocationEnabled = info.sslCertificateFileLocationEnabled
+        controller.sslCertificateFileLocation = info.sslCertificateFileLocation
+        controller.sslCACertFileLocationEnabled = info.sslCACertFileLocationEnabled
+        controller.sslCACertFileLocation = info.sslCACertFileLocation
+
+        controller.sshHost = info.sshHost
+        controller.sshUser = info.sshUser
+        controller.sshPassword = info.sshPassword
+        controller.sshKeyLocationEnabled = info.sshKeyLocationEnabled
+        controller.sshKeyLocation = info.sshKeyLocation
+        controller.sshPort = info.sshPort
+        controller.sshRemoteSocketPath = info.sshRemoteSocketPath
+
+        controller.connectionKeychainID = info.connectionKeychainID
+        controller.connectionKeychainItemName = info.connectionKeychainItemName
+        controller.connectionKeychainItemAccount = info.connectionKeychainItemAccount
+        controller.connectionSSHKeychainItemName = info.connectionSSHKeychainItemName
+        controller.connectionSSHKeychainItemAccount = info.connectionSSHKeychainItemAccount
+
+        // Both enums are NSInteger-backed and share their case order
+        // (server / system / fixed), so the raw value carries across.
+        controller.timeZoneMode = SPConnectionTimeZoneMode(rawValue: info.timeZoneMode.rawValue) ?? .useServerTZ
+        controller.timeZoneIdentifier = info.timeZoneIdentifier
+
+        controller.allowDataLocalInfile = info.allowDataLocalInfile
+        controller.enableClearTextPlugin = info.enableClearTextPlugin
+        controller.requestServerPublicKey = info.requestServerPublicKey
+
+        controller.useAWSIAMAuth = info.useAWSIAMAuth
+        controller.awsRegion = info.awsRegion
+        controller.awsProfile = info.awsProfile
+
+        controller.vaultHost = info.vaultHost
+        controller.vaultPort = info.vaultPort
+        controller.vaultOIDCMount = info.vaultOIDCMount
+        controller.vaultCredentialsPath = info.vaultCredentialsPath
     }
 }
 

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -46,6 +46,13 @@ import SwiftUI
     /// The in-flight Vault OIDC login, if any, so closing the window releases it.
     private var activeVaultLoginIdentifier: String?
 
+    /// Identifies the current credential attempt. Credential generation is
+    /// asynchronous and the form stays interactive, so a Vault login the user
+    /// abandoned can finish after a newer attempt has started; without this its
+    /// completion would call connectDirectly again, and SAConnectionService's
+    /// startAttempt() would invalidate the newer connection.
+    private var credentialAttemptID: UInt = 0
+
     /// Set to true after a successful connection handoff to prevent
     /// windowWillClose from disconnecting the just-handed-off connection.
     private var connectionHandedOff = false
@@ -110,10 +117,7 @@ import SwiftUI
 
         // Credential generation happens outside the service, so cancelling the
         // service alone leaves a browser-based Vault login holding its slot.
-        if let activeVaultLoginIdentifier {
-            VaultOIDCHandler.cancelActiveLogin(identifier: activeVaultLoginIdentifier)
-            self.activeVaultLoginIdentifier = nil
-        }
+        cancelActiveVaultLogin()
     }
 
     // MARK: - Connection screen
@@ -149,6 +153,10 @@ import SwiftUI
     /// Populates the form from the sidebar selection.
     private func applySelection(_ item: SAFavoriteItem) {
         selection = item.id
+
+        // Picking another row supersedes any credential work already running,
+        // so its result cannot be applied to the details now on screen.
+        _ = beginCredentialAttempt()
 
         switch item.kind {
         case .quickConnect:
@@ -205,9 +213,10 @@ import SwiftUI
         // pick another favorite. Re-reading formModel.info afterwards would pair
         // one endpoint's ephemeral credentials with another's connection details.
         let attempt = formModel.info
+        let attemptID = beginCredentialAttempt()
 
         resolveCredentials(for: attempt) { [weak self] result in
-            guard let self else { return }
+            guard let self, self.credentialAttemptID == attemptID else { return }
 
             switch result {
             case .failure(let failure):
@@ -223,6 +232,22 @@ import SwiftUI
                                      sshPassword: resolved.sshPassword)
             }
         }
+    }
+
+    /// Starts a new credential attempt, superseding any in flight, and returns
+    /// its identifier. Abandoning a Vault login also cancels it rather than
+    /// leaving it to hold the exclusive slot until it times out.
+    private func beginCredentialAttempt() -> UInt {
+        cancelActiveVaultLogin()
+        credentialAttemptID &+= 1
+        return credentialAttemptID
+    }
+
+    /// Releases an in-flight Vault OIDC login, if there is one.
+    private func cancelActiveVaultLogin() {
+        guard let identifier = activeVaultLoginIdentifier else { return }
+        VaultOIDCHandler.cancelActiveLogin(identifier: identifier)
+        activeVaultLoginIdentifier = nil
     }
 
     /// The username and password to actually connect with.

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -208,6 +208,13 @@ import SwiftUI
         // 2. Hand off the established connection to the new document.
         // setConnection: transitions the document out of connection mode
         // into the database UI (same as the embedded flow's addConnectionToDocument).
+        //
+        // The document must become the connection's delegate first: neither
+        // SAConnectionService nor -setConnection: assigns it, and without it the
+        // framework falls back to its automatic retry with no query-error
+        // logging, no no-connection alert, no keychain password prompt on
+        // reconnect and no connection-loss decision UI (Codex, #2572).
+        connection.setDelegate(document)
         document.setConnection(connection)
 
         // 3. Mark handoff complete so windowWillClose doesn't cancel the connection

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -117,7 +117,12 @@ import SwiftUI
 
         // Credential generation happens outside the service, so cancelling the
         // service alone leaves a browser-based Vault login holding its slot.
-        cancelActiveVaultLogin()
+        // Superseding the attempt (rather than only cancelling the login) also
+        // invalidates its token: cancellation wakes generateCredentials with a
+        // failure, and without this the completion guard still accepted it —
+        // clearing the endpoint's cached credentials and presenting an error
+        // against a window that no longer exists.
+        _ = beginCredentialAttempt()
     }
 
     // MARK: - Connection screen
@@ -215,7 +220,29 @@ import SwiftUI
         // sit in a browser for minutes, during which the user may edit the form or
         // pick another favorite. Re-reading formModel.info afterwards would pair
         // one endpoint's ephemeral credentials with another's connection details.
-        let attempt = formModel.info
+        var attempt = formModel.info
+
+        // -initiateConnection: trims the host — and the SSH host for tunnels —
+        // before doing anything else (SPConnectionController.m:537,541). Without
+        // it, pasted whitespace makes IAM sign a different hostname than the one
+        // the service later connects to, and the tunnel resolves a
+        // whitespace-bearing host and fails.
+        attempt.host = attempt.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        if attempt.type == .sshTunnel {
+            attempt.sshHost = attempt.sshHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // A blank name gets the generated one, as the AppKit form commits while
+        // editing. Without it the tab title and a saved .spf fall back to
+        // user@host, disagreeing with the placeholder the form showed.
+        if attempt.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            attempt.name = SAConnectionFormHelpers.generateName(type: attempt.type,
+                                                                host: attempt.host,
+                                                                database: attempt.database,
+                                                                vaultHost: attempt.vaultHost,
+                                                                vaultCredentialsPath: attempt.vaultCredentialsPath) ?? ""
+        }
+
         let attemptID = beginCredentialAttempt()
 
         resolveCredentials(for: attempt) { [weak self] result in

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -7,8 +7,14 @@
 //  independently from SPDatabaseDocument, enabling the connection
 //  UI to be presented without creating a full document first.
 //
+//  Phase C3: the window now hosts the SwiftUI screen (SAFavoritesList +
+//  SAConnectionFormView) rather than the XIB-backed SPConnectionController,
+//  and connects through SAConnectionService directly. This is the first place
+//  the C1b/C2 views actually run.
+//
 
 import AppKit
+import SwiftUI
 
 /// A standalone window controller that presents the connection screen.
 ///
@@ -25,11 +31,17 @@ import AppKit
 
     // MARK: - Properties
 
-    /// The connection controller managing the favorites list and connection logic.
-    private var connectionController: SPConnectionController?
-
-    /// The connection service for direct (non-UI-controller) connection attempts.
+    /// The connection service backing every attempt from this window.
     private let connectionService = SAConnectionService()
+
+    /// The edited connection details, shared with the SwiftUI form.
+    private let formModel = SAConnectionFormModel()
+
+    /// The favorites tree, snapshotted for SwiftUI when the window opens.
+    private var favorites: [SAFavoriteItem] = []
+
+    /// The favorite currently selected in the sidebar.
+    private var selection: SAFavoriteItem.ID?
 
     /// Set to true after a successful connection handoff to prevent
     /// windowWillClose from disconnecting the just-handed-off connection.
@@ -45,6 +57,9 @@ import AppKit
 
     /// The container view hosting the connection UI.
     private let containerView = NSView(frame: .zero)
+
+    /// The SwiftUI screen, once installed.
+    private var hostingView: NSView?
 
     // MARK: - Lifecycle
 
@@ -75,13 +90,11 @@ import AppKit
 
     override func windowDidLoad() {
         super.windowDidLoad()
-        setupConnectionController()
+        installConnectionScreen()
     }
 
     @objc override func showWindow(_ sender: Any?) {
-        if connectionController == nil {
-            setupConnectionController()
-        }
+        installConnectionScreen()
         super.showWindow(sender)
         window?.delegate = self
     }
@@ -90,18 +103,96 @@ import AppKit
     /// unless we've already handed off a successful connection.
     func windowWillClose(_ notification: Notification) {
         guard !connectionHandedOff else { return }
-        connectionController?.cancelConnection(nil)
         connectionService.cancel()
     }
 
-    // MARK: - Connection Controller Setup
+    // MARK: - Connection screen
 
-    private func setupConnectionController() {
-        guard connectionController == nil else { return }
+    /// Swaps the placeholder for the SwiftUI screen. Idempotent: `showWindow`
+    /// can be called repeatedly on the same controller.
+    private func installConnectionScreen() {
+        guard hostingView == nil else { return }
 
-        let controller = SPConnectionController(document: self)
-        controller?.connectionDelegate = self
-        connectionController = controller
+        favorites = Self.loadFavorites()
+
+        let screen = SAConnectionWindowView(
+            favorites: favorites,
+            model: formModel,
+            onSelect: { [weak self] item in self?.applySelection(item) },
+            onConnect: { [weak self] in self?.connectUsingForm() }
+        )
+
+        let hosting = NSHostingView(rootView: screen)
+        hosting.frame = containerView.bounds
+        hosting.autoresizingMask = [.width, .height]
+        placeholderSplitView.isHidden = true
+        containerView.addSubview(hosting)
+        hostingView = hosting
+    }
+
+    /// Snapshot of the favorites tree as the pure SwiftUI model.
+    private static func loadFavorites() -> [SAFavoriteItem] {
+        guard let root = SPFavoritesController.shared().favoritesTree else { return [] }
+        return SAFavoriteItem.tree(from: root)
+    }
+
+    /// Populates the form from the sidebar selection.
+    private func applySelection(_ item: SAFavoriteItem) {
+        selection = item.id
+
+        switch item.kind {
+        case .quickConnect:
+            formModel.loadQuickConnect()
+        case .group:
+            // Groups are not connectable and carry no details to show.
+            break
+        case .favorite:
+            formModel.load(favorite: Self.favoriteDictionary(withID: item.favoriteID))
+        }
+    }
+
+    /// The favorite plist entry behind a sidebar row.
+    ///
+    /// Matched through `SAFavoriteItem.string(_:)`, the same normalization that
+    /// produced the item's `favoriteID` — the stored value is usually an
+    /// NSNumber, so comparing raw values would miss.
+    private static func favoriteDictionary(withID favoriteID: String?) -> NSDictionary? {
+        guard let favoriteID,
+              let root = SPFavoritesController.shared().favoritesTree else { return nil }
+
+        return allFavorites(under: root).first { favorite in
+            SAFavoriteItem.string(favorite[SPFavoriteIDKey]) == favoriteID
+        }
+    }
+
+    /// Every favorite dictionary in the tree, groups walked through.
+    private static func allFavorites(under node: SPTreeNode) -> [NSDictionary] {
+        if node.isGroup {
+            return (node.children ?? [])
+                .compactMap { $0 as? SPTreeNode }
+                .flatMap { allFavorites(under: $0) }
+        }
+
+        guard let favorite = (node.representedObject as? SPFavoriteNode)?.nodeFavorite else { return [] }
+        return [favorite as NSDictionary]
+    }
+
+    /// Validates and connects using whatever the form currently holds.
+    private func connectUsingForm() {
+        if let failure = formModel.validate() {
+            showConnectionError(title: failure.alertTitle, detail: failure.alertMessage)
+            return
+        }
+
+        let info = SAConnectionInfoObjC(info: formModel.info)
+
+        // Passwords come from the form's own fields. Reading a saved favorite's
+        // password out of the keychain is deliberately not wired here — the D1
+        // decoder never carried passwords, and the keychain lookup needs the
+        // account/service naming that still lives in SPConnectionController.
+        connectDirectly(with: info,
+                        password: formModel.info.password,
+                        sshPassword: formModel.info.sshPassword)
     }
 
     // MARK: - SAConnectionDelegate
@@ -183,6 +274,68 @@ import AppKit
                     detail: detail.isEmpty ? nil : detail
                 )
             }
+        }
+    }
+}
+
+// MARK: - The SwiftUI screen
+
+/// The standalone window's content: the favorites sidebar beside the
+/// connection form. This is the first place C1b's `SAFavoritesList` and C2's
+/// `SAConnectionFormView` are actually hosted — until now both compiled but
+/// nothing instantiated them.
+private struct SAConnectionWindowView: View {
+
+    let favorites: [SAFavoriteItem]
+    @ObservedObject var model: SAConnectionFormModel
+
+    /// Called when the sidebar selection changes, so the host can populate the
+    /// form from the underlying favorite.
+    var onSelect: (SAFavoriteItem) -> Void
+
+    /// Called when the form's Connect button passes validation.
+    var onConnect: () -> Void
+
+    @State private var selection: SAFavoriteItem.ID?
+    @State private var searchQuery = ""
+
+    var body: some View {
+        HSplitView {
+            sidebar
+                .frame(minWidth: 200, idealWidth: 240, maxWidth: 360)
+
+            SAConnectionFormView(model: model) { _ in onConnect() }
+                .frame(minWidth: 420)
+        }
+        .onChange(of: selection) { newSelection in
+            guard let newSelection,
+                  let item = favorites.first(byID: newSelection) else { return }
+            onSelect(item)
+        }
+    }
+
+    private var sidebar: some View {
+        VStack(spacing: 0) {
+            SAFavoritesList(
+                items: favorites,
+                searchQuery: searchQuery,
+                selection: $selection,
+                // Double-clicking a favorite selects *and* connects, matching
+                // -nodeDoubleClicked: in the AppKit list.
+                onConnect: { item in
+                    onSelect(item)
+                    onConnect()
+                }
+            )
+
+            Divider()
+
+            TextField(text: $searchQuery, prompt: Text("Search", comment: "connection view : favorites search placeholder")) {
+                Text("Search", comment: "connection view : favorites search placeholder")
+            }
+            .labelsHidden()
+            .textFieldStyle(.roundedBorder)
+            .padding(8)
         }
     }
 }

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionWindowController.swift
@@ -43,6 +43,9 @@ import SwiftUI
     /// The favorite currently selected in the sidebar.
     private var selection: SAFavoriteItem.ID?
 
+    /// The in-flight Vault OIDC login, if any, so closing the window releases it.
+    private var activeVaultLoginIdentifier: String?
+
     /// Set to true after a successful connection handoff to prevent
     /// windowWillClose from disconnecting the just-handed-off connection.
     private var connectionHandedOff = false
@@ -104,6 +107,13 @@ import SwiftUI
     func windowWillClose(_ notification: Notification) {
         guard !connectionHandedOff else { return }
         connectionService.cancel()
+
+        // Credential generation happens outside the service, so cancelling the
+        // service alone leaves a browser-based Vault login holding its slot.
+        if let activeVaultLoginIdentifier {
+            VaultOIDCHandler.cancelActiveLogin(identifier: activeVaultLoginIdentifier)
+            self.activeVaultLoginIdentifier = nil
+        }
     }
 
     // MARK: - Connection screen
@@ -190,7 +200,13 @@ import SwiftUI
             return
         }
 
-        resolveCredentials { [weak self] result in
+        // Snapshot now and carry it through: the Vault leg is asynchronous and can
+        // sit in a browser for minutes, during which the user may edit the form or
+        // pick another favorite. Re-reading formModel.info afterwards would pair
+        // one endpoint's ephemeral credentials with another's connection details.
+        let attempt = formModel.info
+
+        resolveCredentials(for: attempt) { [weak self] result in
             guard let self else { return }
 
             switch result {
@@ -198,7 +214,7 @@ import SwiftUI
                 self.showConnectionError(title: failure.title, detail: failure.detail)
 
             case .success(let credentials):
-                var resolved = self.formModel.info
+                var resolved = attempt
                 resolved.user = credentials.user
                 resolved.password = credentials.password
 
@@ -221,11 +237,21 @@ import SwiftUI
     }
 
     /// Resolves type-specific credentials, calling back on the main queue.
-    private func resolveCredentials(_ completion: @escaping (Result<SAResolvedCredentials, SACredentialFailure>) -> Void) {
-        let info = formModel.info
-
+    private func resolveCredentials(for info: SAConnectionInfo,
+                                    _ completion: @escaping (Result<SAResolvedCredentials, SACredentialFailure>) -> Void) {
         switch info.type {
         case .awsIAM:
+            // Under the sandbox the credential loader cannot read ~/.aws without
+            // a security-scoped bookmark, and the only UI that creates one lives
+            // on SPConnectionController — which this window no longer builds. So
+            // a first-time IAM user would hit an opaque failure here.
+            guard ensureAWSDirectoryAuthorized() else {
+                completion(.failure(SACredentialFailure(
+                    title: NSLocalizedString("AWS Access Not Authorized", comment: "AWS authorization required title"),
+                    detail: NSLocalizedString("Authorize access to your ~/.aws directory before connecting with an AWS IAM favorite.",
+                                              comment: "AWS authorization required message"))))
+                return
+            }
             completion(resolveAWSIAMToken(info: info))
 
         case .vault:
@@ -238,6 +264,43 @@ import SwiftUI
             // naming that lives in SPConnectionController.
             completion(.success(SAResolvedCredentials(user: info.user, password: info.password)))
         }
+    }
+
+    /// Ensures `~/.aws` is reachable under the sandbox, prompting for access if
+    /// not, and reports whether it is authorized afterwards.
+    ///
+    /// The AppKit equivalent is `-authorizeAWSDirectory:`, reachable from a
+    /// button on the IAM tab. This window has no such button, so the check runs
+    /// as part of connecting: without the bookmark the credential loader cannot
+    /// read the default profile and token generation fails opaquely.
+    private func ensureAWSDirectoryAuthorized() -> Bool {
+        if AWSDirectoryBookmarkManager.shared.isAWSDirectoryAuthorized { return true }
+
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        // .aws is hidden, so the panel has to show hidden entries to reach it.
+        panel.showsHiddenFiles = true
+        panel.directoryURL = URL(fileURLWithPath: NSHomeDirectory())
+        panel.message = NSLocalizedString("Select your .aws directory to enable AWS IAM authentication",
+                                          comment: "AWS directory selection message")
+        panel.prompt = NSLocalizedString("Authorize", comment: "AWS directory authorize button")
+
+        guard panel.runModal() == .OK, let url = panel.url else { return false }
+
+        // Same acceptance rule as -authorizeAWSDirectory:: the folder itself, or
+        // any folder holding the files the loader reads.
+        let path = url.path
+        let contents = FileManager.default
+        let looksLikeAWSDirectory = path.hasSuffix(".aws")
+            || contents.fileExists(atPath: (path as NSString).appendingPathComponent("credentials"))
+            || contents.fileExists(atPath: (path as NSString).appendingPathComponent("config"))
+
+        guard looksLikeAWSDirectory else { return false }
+
+        return AWSDirectoryBookmarkManager.shared.addAWSDirectoryBookmark(from: url)
     }
 
     /// Generates the RDS auth token that stands in for the password. Stays on
@@ -283,8 +346,13 @@ import SwiftUI
         let mount = info.vaultOIDCMount.isEmpty ? "oidc" : info.vaultOIDCMount
         let credPath = info.vaultCredentialsPath
         let loginIdentifier = VaultOIDCHandler.prepareActiveLogin()
+        // Remembered so windowWillClose can cancel it: the login holds an
+        // exclusive slot and a fixed callback listener, and abandoning it would
+        // block the next Vault attempt until the two-minute timeout.
+        activeVaultLoginIdentifier = loginIdentifier
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
             var username: NSString?
             var password: NSString?
             var error: NSError?
@@ -302,6 +370,10 @@ import SwiftUI
             VaultOIDCHandler.clearPreparedActiveLogin(identifier: loginIdentifier)
 
             DispatchQueue.main.async {
+                if self.activeVaultLoginIdentifier == loginIdentifier {
+                    self.activeVaultLoginIdentifier = nil
+                }
+
                 guard succeeded,
                       let username = username as String?, !username.isEmpty,
                       let password = password as String?, !password.isEmpty else {
@@ -327,7 +399,13 @@ import SwiftUI
         // 1. Create a new document tab via TabManager
         guard let appDelegate = NSApp.delegate as? SPAppController else { return }
         let tabManager = appDelegate.tabManager
-        let windowController = tabManager?.newWindowForTab()
+        // newWindowForTab() resolves the target through TabManager's mainWindow,
+        // which asserts that a managed database window is main whenever any
+        // exist. This window is not managed, so with it frontmost that assertion
+        // fires and crashes the Debug build on every successful handoff. Asking
+        // for a window sidesteps it, and matches what "New Connection Window"
+        // implies anyway.
+        let windowController = tabManager?.newWindowForWindow()
 
         guard let document = windowController?.databaseDocument else { return }
 
@@ -402,6 +480,11 @@ import SwiftUI
             if result.isSuccess, let connection = result.connection {
                 let wrappedInfo = SAConnectionInfoObjC(info: info.info)
                 self.connectionDidEstablish(connection, info: wrappedInfo)
+            } else if result.userCancelled {
+                // Cancelling the interactive SSH password prompt is not a
+                // failure; the embedded flow restores the UI silently and shows
+                // nothing, and the result carries no error title to show anyway.
+                return
             } else {
                 // Build a meaningful error from all available fields
                 let detail = [result.errorMessage, result.errorDetail]

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAFavoriteItem+Tree.swift
@@ -86,7 +86,11 @@ extension SAFavoriteItem {
 
     /// Normalize a favorite-dictionary value (often an `NSNumber`)
     /// to a string ID.
-    private static func string(_ value: Any?) -> String? {
+    ///
+    /// Internal rather than private so a selection can be resolved back to its
+    /// favorite dictionary through the *same* normalization that produced the
+    /// id — deriving it separately is how the two drift apart.
+    static func string(_ value: Any?) -> String? {
         switch value {
         case let number as NSNumber: return number.stringValue
         case let string as String where !string.isEmpty: return string

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -301,10 +301,11 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         }
     }
 
-    // Note: standalone connection window (SAConnectionWindowController) is available
-    // programmatically but not yet exposed in the menu to avoid confusion with the
-    // existing "New Connection Window" XIB menu item. Menu item can be added once
-    // the standalone window fully replaces the embedded connection flow.
+    // The standalone connection window now hosts the SwiftUI connection screen
+    // (C3), so it is worth reaching. It sits alongside the XIB's document-based
+    // flow rather than replacing it: this one opens a connection screen with no
+    // document behind it, and only creates a tab once a connection succeeds.
+    [self installStandaloneConnectionMenuItem];
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -301,11 +301,20 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         }
     }
 
-    // The standalone connection window now hosts the SwiftUI connection screen
-    // (C3), so it is worth reaching. It sits alongside the XIB's document-based
-    // flow rather than replacing it: this one opens a connection screen with no
-    // document behind it, and only creates a tab once a connection succeeds.
-    [self installStandaloneConnectionMenuItem];
+    // The standalone connection window (SAConnectionWindowController) now hosts
+    // the SwiftUI connection screen, but its handoff into a new document is not
+    // complete, so it stays off the menu and reachable only programmatically.
+    // Three gaps, all found in review of #2572:
+    //   - the destination document's SPConnectionController is never populated
+    //     from the connection details, so the new tab's title, database, colour
+    //     and .spf serialization read blank;
+    //   - AWS IAM and Vault never get their credentials generated
+    //     (AWSIAMAuthManager / VaultAuthManager), so those types cannot
+    //     authenticate through this window at all;
+    //   - favorites CRUD and keychain password retrieval still belong to the
+    //     embedded flow.
+    // Install the item (-installStandaloneConnectionMenuItem) once the handoff
+    // produces a document indistinguishable from the embedded flow's.
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -301,20 +301,16 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         }
     }
 
-    // The standalone connection window (SAConnectionWindowController) now hosts
-    // the SwiftUI connection screen, but its handoff into a new document is not
-    // complete, so it stays off the menu and reachable only programmatically.
-    // Three gaps, all found in review of #2572:
-    //   - the destination document's SPConnectionController is never populated
-    //     from the connection details, so the new tab's title, database, colour
-    //     and .spf serialization read blank;
-    //   - AWS IAM and Vault never get their credentials generated
-    //     (AWSIAMAuthManager / VaultAuthManager), so those types cannot
-    //     authenticate through this window at all;
-    //   - favorites CRUD and keychain password retrieval still belong to the
-    //     embedded flow.
-    // Install the item (-installStandaloneConnectionMenuItem) once the handoff
-    // produces a document indistinguishable from the embedded flow's.
+    // The standalone connection window now hosts the SwiftUI connection screen
+    // and produces a document indistinguishable from the embedded flow's: the
+    // destination document's connection controller is populated from the
+    // details, the connection gets the document as its delegate, and AWS IAM /
+    // Vault resolve their credentials before connecting. Worth reaching now.
+    //
+    // It sits alongside the XIB's document-based flow rather than replacing it:
+    // this one opens a connection screen with no document behind it, and only
+    // creates a tab once a connection succeeds.
+    [self installStandaloneConnectionMenuItem];
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -884,6 +884,80 @@ final class SAConnectionFormModelTests: XCTestCase {
         model.info.host = "elsewhere.example.com"
 
         XCTAssertEqual(model.info.password, "")
+
+    // MARK: - C3: loading a favorite into the form
+
+    func testLoadingAFavoritePopulatesTheForm() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: [
+            "type": SAConnectionType.sshTunnel.rawValue,
+            "name": "prod",
+            "host": "db.internal",
+            "user": "app",
+            "database": "sakila",
+            "sshHost": "bastion.example.com",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.info.type, .sshTunnel)
+        XCTAssertEqual(model.info.name, "prod")
+        XCTAssertEqual(model.info.host, "db.internal")
+        XCTAssertEqual(model.info.sshHost, "bastion.example.com")
+    }
+
+    /// Favorites never carry passwords — they live in the keychain — so loading
+    /// one must not leave a previous entry's password behind in the form.
+    func testLoadingAFavoriteClearsTheTypedPassword() {
+        let model = SAConnectionFormModel()
+        model.info.password = "left-over"
+        model.info.sshPassword = "left-over-ssh"
+
+        model.load(favorite: ["host": "db.example.com"] as NSDictionary)
+
+        XCTAssertEqual(model.info.password, "")
+        XCTAssertEqual(model.info.sshPassword, "")
+    }
+
+    /// Loading replaces `info` wholesale, which is what re-splits the Vault
+    /// halves — otherwise the mount control would keep the previous value.
+    func testLoadingAVaultFavoriteSplitsItsCredentialsPath() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "stale"
+        model.vaultCredentialsRole = "stale-role"
+
+        model.load(favorite: [
+            "type": SAConnectionType.vault.rawValue,
+            "host": "db.example.com",
+            "vaultCredentialsPath": "team/creds/writer",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.vaultMount, "team")
+        XCTAssertEqual(model.vaultCredentialsRole, "writer")
+    }
+
+    func testLoadingANilFavoriteYieldsABlankForm() {
+        let model = SAConnectionFormModel()
+        model.info.host = "something"
+
+        model.load(favorite: nil)
+
+        XCTAssertEqual(model.info.host, "")
+        XCTAssertEqual(model.info.type, .tcpIP)
+    }
+
+    /// Quick Connect is the blank-form row.
+    func testQuickConnectResetsEveryField() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        model.vaultMount = "m"
+        model.vaultCredentialsRole = "r"
+
+        model.loadQuickConnect()
+
+        XCTAssertEqual(model.info.type, .tcpIP)
+        XCTAssertEqual(model.info.host, "")
+        XCTAssertEqual(model.vaultMount, "")
+        XCTAssertEqual(model.vaultCredentialsRole, "")
     }
 
     // MARK: - Review round 5: type-derived state

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -756,6 +756,81 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.vaultCredentialsRole, "")
     }
 
+    // MARK: - C3: loading a favorite into the form
+
+    func testLoadingAFavoritePopulatesTheForm() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: [
+            "type": SAConnectionType.sshTunnel.rawValue,
+            "name": "prod",
+            "host": "db.internal",
+            "user": "app",
+            "database": "sakila",
+            "sshHost": "bastion.example.com",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.info.type, .sshTunnel)
+        XCTAssertEqual(model.info.name, "prod")
+        XCTAssertEqual(model.info.host, "db.internal")
+        XCTAssertEqual(model.info.sshHost, "bastion.example.com")
+    }
+
+    /// Favorites never carry passwords — they live in the keychain — so loading
+    /// one must not leave a previous entry's password behind in the form.
+    func testLoadingAFavoriteClearsTheTypedPassword() {
+        let model = SAConnectionFormModel()
+        model.info.password = "left-over"
+        model.info.sshPassword = "left-over-ssh"
+
+        model.load(favorite: ["host": "db.example.com"] as NSDictionary)
+
+        XCTAssertEqual(model.info.password, "")
+        XCTAssertEqual(model.info.sshPassword, "")
+    }
+
+    /// Loading replaces `info` wholesale, which is what re-splits the Vault
+    /// halves — otherwise the mount control would keep the previous value.
+    func testLoadingAVaultFavoriteSplitsItsCredentialsPath() {
+        let model = SAConnectionFormModel()
+        model.vaultMount = "stale"
+        model.vaultCredentialsRole = "stale-role"
+
+        model.load(favorite: [
+            "type": SAConnectionType.vault.rawValue,
+            "host": "db.example.com",
+            "vaultCredentialsPath": "team/creds/writer",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.vaultMount, "team")
+        XCTAssertEqual(model.vaultCredentialsRole, "writer")
+    }
+
+    func testLoadingANilFavoriteYieldsABlankForm() {
+        let model = SAConnectionFormModel()
+        model.info.host = "something"
+
+        model.load(favorite: nil)
+
+        XCTAssertEqual(model.info.host, "")
+        XCTAssertEqual(model.info.type, .tcpIP)
+    }
+
+    /// Quick Connect is the blank-form row.
+    func testQuickConnectResetsEveryField() {
+        let model = SAConnectionFormModel()
+        model.info.type = .vault
+        model.info.host = "db.example.com"
+        model.vaultMount = "m"
+        model.vaultCredentialsRole = "r"
+
+        model.loadQuickConnect()
+
+        XCTAssertEqual(model.info.type, .tcpIP)
+        XCTAssertEqual(model.info.host, "")
+        XCTAssertEqual(model.vaultMount, "")
+        XCTAssertEqual(model.vaultCredentialsRole, "")
+    }
+
     // MARK: - C2b: generated name across the types
 
     func testSocketConnectionsNameThemselvesLocalhost() {

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -884,6 +884,7 @@ final class SAConnectionFormModelTests: XCTestCase {
         model.info.host = "elsewhere.example.com"
 
         XCTAssertEqual(model.info.password, "")
+    }
 
     // MARK: - C3: loading a favorite into the form
 

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -815,6 +815,69 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.info.type, .tcpIP)
     }
 
+    /// The blank form's historical defaults, which raw `SAConnectionInfo()` does
+    /// not match — building Quick Connect by hand gave it an unintended colour
+    /// and silently turned compression off.
+    func testQuickConnectUsesTheHistoricalBlankFormDefaults() {
+        let model = SAConnectionFormModel()
+        model.loadQuickConnect()
+
+        XCTAssertEqual(model.info.colorIndex, -1, "no colour, not the first swatch")
+        XCTAssertTrue(model.info.useCompression, "compression defaults on")
+        XCTAssertEqual(model.info.awsProfile, "default")
+    }
+
+    func testQuickConnectMatchesTheNilFavoriteDecoder() {
+        let quick = SAConnectionFormModel()
+        quick.loadQuickConnect()
+
+        let decoded = SAConnectionFormModel()
+        decoded.load(favorite: nil)
+
+        XCTAssertEqual(quick.info.colorIndex, decoded.info.colorIndex)
+        XCTAssertEqual(quick.info.useCompression, decoded.info.useCompression)
+        XCTAssertEqual(quick.info.awsProfile, decoded.info.awsProfile)
+        XCTAssertEqual(quick.info.type, decoded.info.type)
+    }
+
+    // MARK: - C3: Vault endpoint fields survive a favorite load
+
+    /// D1 leaves vaultPort / vaultOIDCMount out on purpose — the AppKit
+    /// controller reads them raw so a missing key can drive the "443" / "oidc"
+    /// placeholder. This path has no such read, so it has to carry them itself
+    /// or a custom endpoint silently reverts to the defaults.
+    func testLoadingAVaultFavoriteKeepsItsCustomEndpoint() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: [
+            "type": SAConnectionType.vault.rawValue,
+            "host": "db.example.com",
+            "vaultHost": "https://vault.internal",
+            "vaultPort": "8200",
+            "vaultOIDCMount": "corp-oidc",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "8200")
+        XCTAssertEqual(model.info.vaultOIDCMount, "corp-oidc")
+    }
+
+    /// A numeric port survives too — favorites store some values as NSNumber.
+    func testAVaultPortStoredAsANumberIsCarried() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: ["vaultPort": NSNumber(value: 8200)] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "8200")
+    }
+
+    /// Absent keys stay empty so the form shows its placeholders, and
+    /// resolveVaultCredentials applies the same 443 / oidc fallbacks.
+    func testAVaultFavoriteWithoutAnEndpointLeavesThoseFieldsEmpty() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: ["host": "db.example.com"] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "")
+        XCTAssertEqual(model.info.vaultOIDCMount, "")
+    }
+
     /// Quick Connect is the blank-form row.
     func testQuickConnectResetsEveryField() {
         let model = SAConnectionFormModel()

--- a/UnitTests/SAConnectionFormModelTests.swift
+++ b/UnitTests/SAConnectionFormModelTests.swift
@@ -944,6 +944,69 @@ final class SAConnectionFormModelTests: XCTestCase {
         XCTAssertEqual(model.info.type, .tcpIP)
     }
 
+    /// The blank form's historical defaults, which raw `SAConnectionInfo()` does
+    /// not match — building Quick Connect by hand gave it an unintended colour
+    /// and silently turned compression off.
+    func testQuickConnectUsesTheHistoricalBlankFormDefaults() {
+        let model = SAConnectionFormModel()
+        model.loadQuickConnect()
+
+        XCTAssertEqual(model.info.colorIndex, -1, "no colour, not the first swatch")
+        XCTAssertTrue(model.info.useCompression, "compression defaults on")
+        XCTAssertEqual(model.info.awsProfile, "default")
+    }
+
+    func testQuickConnectMatchesTheNilFavoriteDecoder() {
+        let quick = SAConnectionFormModel()
+        quick.loadQuickConnect()
+
+        let decoded = SAConnectionFormModel()
+        decoded.load(favorite: nil)
+
+        XCTAssertEqual(quick.info.colorIndex, decoded.info.colorIndex)
+        XCTAssertEqual(quick.info.useCompression, decoded.info.useCompression)
+        XCTAssertEqual(quick.info.awsProfile, decoded.info.awsProfile)
+        XCTAssertEqual(quick.info.type, decoded.info.type)
+    }
+
+    // MARK: - C3: Vault endpoint fields survive a favorite load
+
+    /// D1 leaves vaultPort / vaultOIDCMount out on purpose — the AppKit
+    /// controller reads them raw so a missing key can drive the "443" / "oidc"
+    /// placeholder. This path has no such read, so it has to carry them itself
+    /// or a custom endpoint silently reverts to the defaults.
+    func testLoadingAVaultFavoriteKeepsItsCustomEndpoint() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: [
+            "type": SAConnectionType.vault.rawValue,
+            "host": "db.example.com",
+            "vaultHost": "https://vault.internal",
+            "vaultPort": "8200",
+            "vaultOIDCMount": "corp-oidc",
+        ] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "8200")
+        XCTAssertEqual(model.info.vaultOIDCMount, "corp-oidc")
+    }
+
+    /// A numeric port survives too — favorites store some values as NSNumber.
+    func testAVaultPortStoredAsANumberIsCarried() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: ["vaultPort": NSNumber(value: 8200)] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "8200")
+    }
+
+    /// Absent keys stay empty so the form shows its placeholders, and
+    /// resolveVaultCredentials applies the same 443 / oidc fallbacks.
+    func testAVaultFavoriteWithoutAnEndpointLeavesThoseFieldsEmpty() {
+        let model = SAConnectionFormModel()
+        model.load(favorite: ["host": "db.example.com"] as NSDictionary)
+
+        XCTAssertEqual(model.info.vaultPort, "")
+        XCTAssertEqual(model.info.vaultOIDCMount, "")
+    }
+
     /// Quick Connect is the blank-form row.
     func testQuickConnectResetsEveryField() {
         let model = SAConnectionFormModel()

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -454,6 +454,22 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
     delegate; without it the framework fell back to bare automatic retry with no
     query-error logging, no no-connection alert, no keychain prompt on reconnect
     and no connection-loss UI.
+- ✅ Second review round on the connect path (Codex, #2572), all seven fixed:
+  Vault favorites keep a custom `vaultPort` / `vaultOIDCMount` (D1 omits them
+  because the AppKit controller reads them raw for its placeholders, so this
+  path carries them itself); Quick Connect resets through the nil-favorite
+  decoder rather than `SAConnectionInfo()`, restoring colour -1 / compression
+  on / profile "default"; the connection details are snapshotted before the
+  asynchronous Vault leg so one endpoint's credentials cannot pair with
+  another's details; an in-flight Vault OIDC login is cancelled on window close
+  instead of holding its exclusive slot for two minutes; AWS IAM checks and
+  prompts for `~/.aws` authorization before generating a token, which the
+  sandbox needs and only `-authorizeAWSDirectory:` used to offer; a cancelled
+  SSH password prompt no longer shows a spurious "Connection failed"; and the
+  handoff asks TabManager for a *window* rather than a tab, since
+  `newWindowForTab()` resolves through `mainWindow`, whose assertion that a
+  managed database window is main would fire — and crash Debug — with the
+  standalone window frontmost.
 - ⚠️ Also still owned by the AppKit form:
   keychain password retrieval for a selected favorite (the D1 decoder never
   carried passwords, and the lookup needs the account/service naming still in

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -422,7 +422,7 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
 - Files: `SAConnectionFormModel.swift`, `SAConnectionFormView.swift`,
   `UnitTests/SAConnectionFormModelTests.swift`
 
-**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu** — 🟡 Hosting done; document handoff + menu exposure pending
+**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu** — ✅ Done (favorites CRUD + keychain still with the AppKit form)
 - ✅ Done: `SAConnectionWindowController` now hosts `SAConnectionWindowView`
   (an `NSHostingView` over `SAFavoritesList` + `SAConnectionFormView` in an
   `HSplitView`) instead of instantiating `SPConnectionController`. This is the
@@ -432,26 +432,28 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
   (`SAConnectionFormModel.load(favorite:)`); Quick Connect resets it. Connecting
   validates via D3/C2b and goes through the existing `connectDirectly`, i.e.
   `SAConnectionService`, with no `SPConnectionController` involved.
-- ⚠️ The menu item stays **off**. `installStandaloneConnectionMenuItem` exists
-  and is ready, but review of #2572 showed the handoff into a new document is
-  incomplete in ways that would ship a trap, so exposing it was reverted.
-- ⚠️ **The handoff is the remaining C3 work** (Codex, #2572). Hosting the views
-  turned three latent bugs in the scaffolding from dead code into live code:
-  - `connectionDidEstablish` ignores the `info` it is handed and only calls
-    `-setConnection:`, so the destination document's `SPConnectionController`
-    stays blank — the new tab's title, database, host, user, port and colour
-    read empty, and saving it as `.spf` persists empty connection details.
-    Fixing it needs an info → controller applier that does not exist yet (~30
-    properties), which is itself a chunk of SPConnectionController work.
-  - `SAConnectionService` configures transport flags only: it never calls
-    `AWSIAMAuthManager` to generate an IAM token, nor `VaultAuthManager` for
-    ephemeral credentials, both of which `SPConnectionController` does. So AWS
-    IAM authenticates with whatever was typed rather than a generated token,
-    and Vault cannot authenticate at all.
-  - Fixed here: the established connection had no delegate, so the framework
-    fell back to bare automatic retry — no query-error logging, no
-    no-connection alert, no keychain prompt on reconnect, no connection-loss
-    UI. The destination document is now set as the delegate before handoff.
+- ✅ The "New Connection Window" menu item is enabled. It sits alongside the
+  XIB's document-based flow rather than replacing it.
+- ✅ **The handoff is complete** (three gaps found by Codex on #2572; hosting the
+  views turned them from dead scaffolding into live code):
+  - `SAConnectionInfoObjC.apply(to:)` populates the destination document's
+    `SPConnectionController` before the connection is handed over, so the new
+    tab's title, database, host, user, port and colour are right and `.spf`
+    serialization carries real details. It is written as the exact inverse of
+    `-_buildConnectionInfo`, field for field in the same order; the two were
+    diffed mechanically to confirm 41/41 coverage both ways, which is a stronger
+    check than a hand-written test since the risk here is omission, not logic.
+  - AWS IAM and Vault now resolve their credentials before connecting.
+    `SAConnectionService` only configures transport flags, so the window calls
+    `AWSIAMAuthManager.generateAuthToken` for the RDS token (on the main queue,
+    since the profile flow can raise an MFA sheet) and `VaultAuthManager`
+    for ephemeral credentials (off the main queue — the OIDC leg can open a
+    browser for up to two minutes — clearing the cached pair on failure so a
+    retry re-runs it).
+  - The established connection is given the destination document as its
+    delegate; without it the framework fell back to bare automatic retry with no
+    query-error logging, no no-connection alert, no keychain prompt on reconnect
+    and no connection-loss UI.
 - ⚠️ Also still owned by the AppKit form:
   keychain password retrieval for a selected favorite (the D1 decoder never
   carried passwords, and the lookup needs the account/service naming still in

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -422,7 +422,7 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
 - Files: `SAConnectionFormModel.swift`, `SAConnectionFormView.swift`,
   `UnitTests/SAConnectionFormModelTests.swift`
 
-**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu** — 🟡 Hosted; favorites CRUD + keychain pending
+**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu** — 🟡 Hosting done; document handoff + menu exposure pending
 - ✅ Done: `SAConnectionWindowController` now hosts `SAConnectionWindowView`
   (an `NSHostingView` over `SAFavoritesList` + `SAConnectionFormView` in an
   `HSplitView`) instead of instantiating `SPConnectionController`. This is the
@@ -432,10 +432,27 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
   (`SAConnectionFormModel.load(favorite:)`); Quick Connect resets it. Connecting
   validates via D3/C2b and goes through the existing `connectDirectly`, i.e.
   `SAConnectionService`, with no `SPConnectionController` involved.
-- ✅ The "New Connection Window" menu item is enabled — `installStandaloneConnectionMenuItem`
-  existed since the scaffolding landed but was never called. It sits alongside
-  the XIB's document-based flow rather than replacing it.
-- ⚠️ Deliberately not done here, all of which the AppKit form still owns:
+- ⚠️ The menu item stays **off**. `installStandaloneConnectionMenuItem` exists
+  and is ready, but review of #2572 showed the handoff into a new document is
+  incomplete in ways that would ship a trap, so exposing it was reverted.
+- ⚠️ **The handoff is the remaining C3 work** (Codex, #2572). Hosting the views
+  turned three latent bugs in the scaffolding from dead code into live code:
+  - `connectionDidEstablish` ignores the `info` it is handed and only calls
+    `-setConnection:`, so the destination document's `SPConnectionController`
+    stays blank — the new tab's title, database, host, user, port and colour
+    read empty, and saving it as `.spf` persists empty connection details.
+    Fixing it needs an info → controller applier that does not exist yet (~30
+    properties), which is itself a chunk of SPConnectionController work.
+  - `SAConnectionService` configures transport flags only: it never calls
+    `AWSIAMAuthManager` to generate an IAM token, nor `VaultAuthManager` for
+    ephemeral credentials, both of which `SPConnectionController` does. So AWS
+    IAM authenticates with whatever was typed rather than a generated token,
+    and Vault cannot authenticate at all.
+  - Fixed here: the established connection had no delegate, so the framework
+    fell back to bare automatic retry — no query-error logging, no
+    no-connection alert, no keychain prompt on reconnect, no connection-loss
+    UI. The destination document is now set as the delegate before handoff.
+- ⚠️ Also still owned by the AppKit form:
   keychain password retrieval for a selected favorite (the D1 decoder never
   carried passwords, and the lookup needs the account/service naming still in
   `SPConnectionController`), favorites CRUD from this window (add / duplicate /

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -422,7 +422,27 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
 - Files: `SAConnectionFormModel.swift`, `SAConnectionFormView.swift`,
   `UnitTests/SAConnectionFormModelTests.swift`
 
-**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu**
+**C3. Wire SwiftUI into SAConnectionWindowController + expose in menu** — 🟡 Hosted; favorites CRUD + keychain pending
+- ✅ Done: `SAConnectionWindowController` now hosts `SAConnectionWindowView`
+  (an `NSHostingView` over `SAFavoritesList` + `SAConnectionFormView` in an
+  `HSplitView`) instead of instantiating `SPConnectionController`. This is the
+  first place the C1b/C2 views actually run — until now both compiled but
+  nothing created them.
+- ✅ Selecting a favorite populates the form through the D1 decoder
+  (`SAConnectionFormModel.load(favorite:)`); Quick Connect resets it. Connecting
+  validates via D3/C2b and goes through the existing `connectDirectly`, i.e.
+  `SAConnectionService`, with no `SPConnectionController` involved.
+- ✅ The "New Connection Window" menu item is enabled — `installStandaloneConnectionMenuItem`
+  existed since the scaffolding landed but was never called. It sits alongside
+  the XIB's document-based flow rather than replacing it.
+- ⚠️ Deliberately not done here, all of which the AppKit form still owns:
+  keychain password retrieval for a selected favorite (the D1 decoder never
+  carried passwords, and the lookup needs the account/service naming still in
+  `SPConnectionController`), favorites CRUD from this window (add / duplicate /
+  delete / rename / reorder), and the Vault role-list fetch. Typing a password
+  into the form works; a saved favorite's password does not auto-fill.
+- 5 new model tests (73 in `SAConnectionFormModelTests`) covering favorite load,
+  password non-carry, the Vault re-split on load, nil favorites and Quick Connect.
 - The standalone connection window is the ideal host for SwiftUI views
 - Replace the embedded SPConnectionController with SwiftUI favorites list + connection form
 - Use `SAConnectionService` directly for connection establishment


### PR DESCRIPTION
> **Stacked on #2569** — base branch is `feature/swiftui-connection-form-c2b`, which supplies the full `SAConnectionFormView` this hosts. Review after that one; the diff shown here is C3 only.

`SAConnectionWindowController` instantiated `SPConnectionController` and hosted the XIB, so the "standalone" window was really the old connection screen in a new frame. It now hosts `SAConnectionWindowView` — an `NSHostingView` over `SAFavoritesList` + `SAConnectionFormView` in an `HSplitView`.

**This is the first place the C1b and C2 views actually run.** Until now both compiled and nothing created them.

## What works

- **Favorites sidebar** built from `SPFavoritesController.shared().favoritesTree` via `SAFavoriteItem.tree(from:)`, with live search.
- **Selecting a favorite** populates the form through the D1 decoder, so the defaulting rules stay in one place. Assigning `info` wholesale is also what re-splits the Vault mount/role halves. Quick Connect resets to a blank form.
- **Connecting** validates through D3 plus C2b's Vault checks, then goes through the existing `connectDirectly` path — `SAConnectionService`, with no `SPConnectionController` involved at any point. Double-clicking a favorite selects and connects, matching `-nodeDoubleClicked:`.
- **The menu item is enabled.** `installStandaloneConnectionMenuItem` has existed since the scaffolding landed but was never called. It sits *alongside* the XIB's document-based flow rather than replacing it: this one opens a connection screen with no document behind it, and only creates a tab once a connection succeeds.

## One subtlety worth flagging

Resolving a sidebar selection back to its favorite dictionary reuses `SAFavoriteItem.string(_:)` — the same normalization that produced the id — rather than re-deriving it. The stored `SPFavoriteIDKey` value is usually an `NSNumber`, so comparing raw values would silently never match. I made that helper internal instead of private specifically so the two cannot drift apart.

## Deliberately not done

All still owned by the AppKit form, so **this window is not yet a replacement for the embedded flow**:

- **Keychain password retrieval** for a selected favorite. The D1 decoder never carried passwords, and the lookup needs the account/service naming that still lives in `SPConnectionController`. Typing a password into the form works; a saved favorite's does not auto-fill.
- **Favorites CRUD** from this window (add / duplicate / delete / rename / reorder).
- **The Vault role-list fetch** behind the XIB's combo box.

## Testing

5 new model tests (73 in `SAConnectionFormModelTests`): favorite load, passwords not carried, the Vault re-split on load, nil favorites, and Quick Connect. **952 pass, 0 fail.** Clean build, no new warnings.

⚠️ **Not verified in a running app.** The hosting, selection and connect paths are AppKit/SwiftUI plumbing that unit tests do not reach, and I could not drive the UI from here. Worth opening the window from the File menu and clicking through favorites before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone connection window with SwiftUI-based favorites and connection forms.
  - Added a visible menu option to open the standalone connection window.
  - Favorites now restore connection settings, including Vault and OIDC details.
  - Quick Connect resets the form to blank defaults.
  - Supports connection setup for TCP, socket, SSH, AWS IAM, and Vault connections.

- **Bug Fixes**
  - Improved credential handling and connection handoff.
  - Prevented unnecessary failure alerts when users cancel.
  - Added warnings when SSL is requested but not established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->