### PR TITLE
#fixed Ignore superseded prereleases in release overlap guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           RELEASE_SHA: ${{ github.sha }}
           EXPECTED_SHA: ${{ inputs.expected_main_sha }}
           RELEASE_MODE: ${{ inputs.mode }}
+          PENDING_ARTIFACT_TAG: ${{ vars.SA_RELEASE_PENDING_ARTIFACT_TAG }}
           PENDING_FINALIZATION_TAG: ${{ vars.SA_RELEASE_PENDING_FINALIZATION_TAG }}
           CHANNEL: ${{ inputs.channel }}
           VERSION: ${{ inputs.version }}
@@ -89,10 +90,12 @@ jobs:
           CONFIRMATION: ${{ inputs.confirmation }}
         run: |
           set -euo pipefail
+          automatic_forward_recovery="false"
           [[ "${RELEASE_ENABLED}" == "true" ]] || { echo "Release publishing is disabled until every feasibility gate passes." >&2; exit 1; }
           if [[ "${RELEASE_ACTOR}" == "github-actions[bot]" && "${RELEASE_TRIGGERING_ACTOR}" == "github-actions[bot]" ]]; then
             [[ "${RELEASE_MODE}" == "resume" ]] || { echo "Automated build recovery must use resume mode." >&2; exit 1; }
             [[ "${RECOVERY_TAG}" =~ ^(production|beta)/[0-9]+\.[0-9]+\.[0-9]+-[1-9][0-9]*$ ]] || { echo "Automated build recovery requires an exact predecessor tag." >&2; exit 1; }
+            automatic_forward_recovery="true"
           else
             [[ "${RELEASE_ACTOR}" == "Jason-Morcos" || "${RELEASE_ACTOR}" == "Kaspik" ]] || { echo "Unauthorized release actor." >&2; exit 1; }
             [[ "${RELEASE_TRIGGERING_ACTOR}" == "Jason-Morcos" || "${RELEASE_TRIGGERING_ACTOR}" == "Kaspik" ]] || { echo "Unauthorized release rerun initiator." >&2; exit 1; }
@@ -100,6 +103,13 @@ jobs:
           fi
           [[ "${RELEASE_REF}" == "refs/heads/main" ]] || { echo "Releases must be dispatched from main." >&2; exit 1; }
           [[ "${RELEASE_MODE}" == "start" || "${RELEASE_MODE}" == "resume" ]] || { echo "Invalid release mode." >&2; exit 1; }
+          [[ -n "${PENDING_ARTIFACT_TAG}" ]] || { echo "SA_RELEASE_PENDING_ARTIFACT_TAG is not configured." >&2; exit 1; }
+          [[ -n "${PENDING_FINALIZATION_TAG}" ]] || { echo "SA_RELEASE_PENDING_FINALIZATION_TAG is not configured." >&2; exit 1; }
+          if [[ "${PENDING_ARTIFACT_TAG}" != "none" &&
+                ( "${automatic_forward_recovery}" != "true" || "${PENDING_ARTIFACT_TAG}" != "${RECOVERY_TAG}" ) ]]; then
+            echo "A release is still awaiting artifact publication: ${PENDING_ARTIFACT_TAG}." >&2
+            exit 1
+          fi
           if [[ -n "${PENDING_FINALIZATION_TAG}" && "${PENDING_FINALIZATION_TAG}" != "none" ]]; then
             echo "A production release is still awaiting finalization: ${PENDING_FINALIZATION_TAG}." >&2
             exit 1
@@ -253,12 +263,23 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
         run: |
           set -euo pipefail
+          source_release_suffix="$(bundle exec ruby -I fastlane/lib -rsequel_ace_release -e '
+            source = SequelAceRelease::VersionFiles.new.current
+            puts "#{source.fetch("version")}-#{source.fetch("build")}"
+          ')"
+          [[ "${source_release_suffix}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[1-9][0-9]*$ ]] || {
+            echo "Current source release identity is malformed." >&2
+            exit 1
+          }
           prereleases_file="$(mktemp "${RUNNER_TEMP}/sequel-ace-existing-prereleases.XXXXXX")"
           gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
             --jq '.[] | select(.prerelease == true and (.tag_name | test("^(production|beta)/[0-9]+\\.[0-9]+\\.[0-9]+-[1-9][0-9]*$"))) | [.tag_name, .author.login, (.author.id | tostring), .created_at] | @tsv' \
             > "${prereleases_file}"
           while IFS=$'\t' read -r release_tag release_author release_author_id release_created_at; do
             [[ -n "${release_tag}" && -n "${release_author}" && -n "${release_author_id}" && -n "${release_created_at}" ]] || continue
+            if [[ "${release_tag}" != "production/${source_release_suffix}" && "${release_tag}" != "beta/${source_release_suffix}" ]]; then
+              continue
+            fi
             if ! bundle exec ruby -I fastlane/lib -rsequel_ace_release -e \
               'author_id = Integer(ARGV.fetch(2), 10) rescue nil; exit(SequelAceRelease::ReleasePublisher.authorized?(tag: ARGV.fetch(0), login: ARGV.fetch(1), id: author_id, created_at: ARGV.fetch(3)) ? 0 : 1)' \
               "${release_tag}" "${release_author}" "${release_author_id}" "${release_created_at}"; then

--- a/fastlane/RELEASING.md
+++ b/fastlane/RELEASING.md
@@ -26,9 +26,21 @@ or creates a GitHub release.
   passes.
 - One `sequel-ace-release` concurrency group prevents overlapping preparation,
   deployment, artifact publication, Alpha recovery, and finalization.
+- Both asynchronous wake-state variables must be configured. An unset or empty
+  `SA_RELEASE_PENDING_ARTIFACT_TAG` or
+  `SA_RELEASE_PENDING_FINALIZATION_TAG` is rejected before checkout and
+  intentionally blocks every release.
 - A non-`none` `SA_RELEASE_PENDING_FINALIZATION_TAG` blocks another release
   start even between workflow runs, so a submitted production release cannot
   be overlapped before its live or terminal checkpoint settles.
+- A non-`none` `SA_RELEASE_PENDING_ARTIFACT_TAG` likewise blocks another release
+  start. The sole exception is an Actions-bot `mode=resume` forward recovery
+  whose authenticated `recovery_tag` exactly equals the armed predecessor; the
+  child replaces that tag only after its own handoff is durably archived. The
+  archive fallback examines only an authorized prerelease whose exact version
+  and build still match every current source version file. This keeps a missing
+  or unreadable current handoff fail-closed without treating preserved,
+  superseded prereleases from before the automation archive as active releases.
 - The GitHub App may bypass the release PR's human-review requirement, but the
   workflow still waits for the exact release commit's `Run Tests`,
   `Release Tool Tests`, and every other observed check to finish acceptably.

--- a/fastlane/test/workflow_recovery_test.rb
+++ b/fastlane/test/workflow_recovery_test.rb
@@ -490,21 +490,78 @@ class WorkflowRecoveryTest < Minitest::Test
 
   def test_new_releases_refuse_an_active_asynchronous_handoff
     workflow = File.read(repo_path(".github/workflows/release.yml"))
+    authorization_start = workflow.index("- name: Enforce release authorization")
+    authorization_end = workflow.index("- name: Prove the frozen release SHA is on dispatch main")
+    checkout = workflow.index("- name: Check out immutable dispatch tooling")
+    authorization = workflow[authorization_start...authorization_end]
     overlap = workflow.index("- name: Refuse overlapping asynchronous release handoffs")
     approval = workflow.index("- name: Recheck release authorization with the tested guard")
     gate = workflow[overlap...approval]
 
+    assert_operator authorization_start, :<, checkout
     assert_operator overlap, :<, approval
     assert_includes gate, "%w[cloud_running artifacts_verified archived submitted finalizing]"
     assert_includes gate, "%w[cloud_running artifacts_verified]"
     assert_includes gate, "ReleaseNaming.new"
     assert_includes gate, "still has an active asynchronous handoff"
+    assert_includes authorization, "SA_RELEASE_PENDING_ARTIFACT_TAG is not configured."
+    assert_includes authorization, "A release is still awaiting artifact publication"
+    assert_includes authorization, 'automatic_forward_recovery="false"'
+    assert_includes authorization, 'automatic_forward_recovery="true"'
+    assert_includes authorization,
+                    '( "${automatic_forward_recovery}" != "true" || "${PENDING_ARTIFACT_TAG}" != "${RECOVERY_TAG}" )'
+    assert_includes authorization, "SA_RELEASE_PENDING_FINALIZATION_TAG is not configured."
+    assert_includes authorization,
+                    '[[ -n "${PENDING_ARTIFACT_TAG}" ]] || { echo "SA_RELEASE_PENDING_ARTIFACT_TAG is not configured." >&2; exit 1; }'
+    assert_includes authorization,
+                    '[[ -n "${PENDING_FINALIZATION_TAG}" ]] || { echo "SA_RELEASE_PENDING_FINALIZATION_TAG is not configured." >&2; exit 1; }'
+    assert_operator authorization.index("SA_RELEASE_PENDING_ARTIFACT_TAG is not configured."), :<,
+                    authorization.index("A release is still awaiting artifact publication")
+    assert_operator authorization.index("SA_RELEASE_PENDING_FINALIZATION_TAG is not configured."), :<,
+                    authorization.index("A production release is still awaiting finalization")
+    pending_artifact_branch = authorization.split(
+      'if [[ "${PENDING_ARTIFACT_TAG}" != "none" &&',
+      2
+    ).fetch(1).split(/^\s+fi$/, 2).first
+    pending_finalization_branch = authorization.split(
+      'if [[ -n "${PENDING_FINALIZATION_TAG}" && "${PENDING_FINALIZATION_TAG}" != "none" ]]',
+      2
+    ).fetch(1).split(/^\s+fi$/, 2).first
+    assert_includes pending_artifact_branch, "exit 1"
+    assert_includes pending_finalization_branch, "exit 1"
+    assert_includes gate, "SequelAceRelease::VersionFiles.new.current"
+    assert_includes gate, 'puts "#{source.fetch("version")}-#{source.fetch("build")}"'
     assert_includes gate, "ReleasePublisher.authorized?"
     assert_includes gate, "release_author"
     assert_includes gate, "release_author_id"
     assert_includes gate, "id: author_id"
     assert_includes gate, "has unreadable private handoff state; refusing to overlap it"
+    assert_includes gate, 'if ! Scripts/archive-release-to-ghcr.sh pull "${archive_ref}" "${work_directory}"'
     refute_includes gate, "if Scripts/archive-release-to-ghcr.sh pull"
+    authorization_check = gate.index("ReleasePublisher.authorized?")
+    archive_pull = gate.index("Scripts/archive-release-to-ghcr.sh pull")
+    assert_operator authorization_check, :<, archive_pull
+    publisher_authorization_branch = gate.split(
+      "if ! bundle exec ruby -I fastlane/lib -rsequel_ace_release -e",
+      2
+    ).fetch(1).split(/^\s+fi$/, 2).first
+    assert_includes publisher_authorization_branch,
+                    'authorized?(tag: ARGV.fetch(0), login: ARGV.fetch(1), id: author_id, created_at: ARGV.fetch(3))'
+    assert_includes publisher_authorization_branch,
+                    '"${release_tag}" "${release_author}" "${release_author_id}" "${release_created_at}"'
+    assert_includes publisher_authorization_branch, "continue"
+    unreadable_archive_branch = gate.split(
+      'if ! Scripts/archive-release-to-ghcr.sh pull "${archive_ref}" "${work_directory}"',
+      2
+    ).fetch(1).split(/^\s+fi$/, 2).first
+    assert_includes unreadable_archive_branch, "exit 1"
+    production_filter = gate.index('release_tag}" != "production/${source_release_suffix}')
+    beta_filter = gate.index('release_tag}" != "beta/${source_release_suffix}')
+    assert_operator production_filter, :<, archive_pull
+    assert_operator beta_filter, :<, archive_pull
+    active_handoff_branch = gate.split('if [[ "${active}" == "true" ]]', 2)
+                                .fetch(1).split(/^\s+fi$/, 2).first
+    assert_includes active_handoff_branch, "exit 1"
   end
 
   def test_publisher_uses_authenticated_xcode_checks_with_a_variable_gated_recovery_poll


### PR DESCRIPTION
## Changes:
- Fail closed when either release wake variable is missing, and block a non-`none` artifact-publication wake before starting another release.
- Limit private-archive overlap checks to an authorized prerelease whose exact version/build still matches the current source files. Preserved historical betas and release candidates without automation-era GHCR manifests therefore remain intact without blocking new releases.
- Keep a current matching prerelease fail-closed when its archive is unreadable, and retain the existing active-manifest state checks.
- Document and regression-test the overlap behavior.

## Closes following issues:
- Closes: none

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Not applicable (release infrastructure only)
- `bundle exec ruby -I fastlane/lib -I fastlane/test fastlane/test/workflow_recovery_test.rb`: 66 runs, 1,443 assertions, 0 failures/errors/skips
- `bundle exec rake -f fastlane/Rakefile test`: 438 runs, 2,839 assertions, 0 failures/errors/skips
- Ruby YAML parse of `.github/workflows/release.yml`
- Live preflight: current source is `5.4.0-20109`; zero GitHub prereleases share that current source identity

## Screenshots:

Not applicable.

## Additional notes:
- [Release run 32396984874](https://github.com/Sequel-Ace/Sequel-Ace/actions/runs/32396984874) stopped before version preparation, PR creation, tagging, or prerelease creation because the old `production/5.3.1-20103` prerelease correctly has no automation-era private archive.
- The approved 5.5.0 beta must be replanned after this workflow change reaches `main`, because the frozen main SHA and generated change list will change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release safety checks to block releases when artifact publication or finalization is pending or improperly configured.
  * Limited automated recovery and overlap detection to authorized prereleases matching the current release version and build.
  * Releases now fail safely when required handoff information is missing, mismatched, or unreadable.
* **Documentation**
  * Clarified required release configuration and recovery safeguards.
* **Tests**
  * Expanded coverage for pending states, exact version matching, tag filtering, authorization, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->