### PR TITLE
#fixed Authenticate release wake-state JWTs as Bearer tokens

### DIFF
--- a/Scripts/release-artifact-wake-state.sh
+++ b/Scripts/release-artifact-wake-state.sh
@@ -68,6 +68,15 @@ api_as_token()
 	GH_TOKEN="${token}" gh api "$@"
 }
 
+api_as_app_jwt()
+{
+	local token="$1"
+	shift
+	# GitHub App JWTs specifically require the Bearer authentication scheme.
+	# GH_TOKEN otherwise makes gh use the ordinary token scheme.
+	GH_TOKEN="${token}" gh api --header "Authorization: Bearer ${token}" "$@"
+}
+
 base64url()
 {
 	openssl base64 -A | tr '+/' '-_' | tr -d '='
@@ -76,7 +85,7 @@ base64url()
 request_installation_token()
 {
 	printf '%s' "${installation_token_request}" |
-		api_as_token "${app_jwt}" --method POST "app/installations/${installation_id}/access_tokens" --input -
+		api_as_app_jwt "${app_jwt}" --method POST "app/installations/${installation_id}/access_tokens" --input -
 }
 
 cleanup()
@@ -120,9 +129,12 @@ mint_exact_repository_token()
 	readonly app_jwt_unsigned="${header}.${payload}"
 	signature="$(printf '%s' "${app_jwt_unsigned}" | openssl dgst -sha256 -sign "${private_key_path}" | base64url)"
 	readonly app_jwt="${app_jwt_unsigned}.${signature}"
+	if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+		printf '::add-mask::%s\n' "${app_jwt}"
+	fi
 
 	local installation_json
-	installation_json="$(retry_command api_as_token "${app_jwt}" "repos/${GITHUB_REPOSITORY}/installation")"
+	installation_json="$(retry_command api_as_app_jwt "${app_jwt}" "repos/${GITHUB_REPOSITORY}/installation")"
 	local parsed_installation_id
 	parsed_installation_id="$(jq -er '.id | select(type == "number" and . > 0)' <<< "${installation_json}")" || {
 		echo "GitHub did not return a valid repository installation ID." >&2

--- a/fastlane/test/release_artifact_wake_state_test.rb
+++ b/fastlane/test/release_artifact_wake_state_test.rb
@@ -125,6 +125,11 @@ class ReleaseArtifactWakeStateTest < Minitest::Test
       api_log = File.read(log)
       assert_includes api_log, "repos/Sequel-Ace/Sequel-Ace/installation"
       assert_includes api_log, "app/installations/123/access_tokens"
+      jwt_api_lines = api_log.lines.grep(/(?:repos\/Sequel-Ace\/Sequel-Ace\/installation|app\/installations\/123\/access_tokens)/)
+      assert_equal 2, jwt_api_lines.length
+      jwt_api_lines.each do |line|
+        assert_includes line, "--header Authorization: Bearer encoded.encoded.encoded"
+      end
       assert_includes api_log, '"repository_ids":[12345]'
       assert_includes api_log, '"actions_variables":"write"'
       assert_includes api_log, "--method DELETE installation/token"

--- a/fastlane/test/release_artifact_wake_state_test.rb
+++ b/fastlane/test/release_artifact_wake_state_test.rb
@@ -225,7 +225,7 @@ class ReleaseArtifactWakeStateTest < Minitest::Test
             "SA_RELEASE_GITHUB_APP_PRIVATE_KEY" => "test-private-key"
           )
         end
-        environment["GITHUB_ACTIONS"] = "true" if github_actions
+        environment["GITHUB_ACTIONS"] = github_actions ? "true" : nil
         environment["SA_RELEASE_WAKE_VARIABLE"] = wake_variable if wake_variable
         arguments = [repo_path("Scripts/release-artifact-wake-state.sh"), operation, tag]
         arguments << predecessor if predecessor

--- a/fastlane/test/release_artifact_wake_state_test.rb
+++ b/fastlane/test/release_artifact_wake_state_test.rb
@@ -117,11 +117,12 @@ class ReleaseArtifactWakeStateTest < Minitest::Test
   end
 
   def test_workflow_credentials_mint_and_revoke_an_exact_repository_variables_token
-    with_fake_github("none", provided_token: false) do |run, state, log|
-      _stdout, stderr, status = run.call("arm", PRODUCTION_TAG)
+    with_fake_github("none", provided_token: false, github_actions: true) do |run, state, log|
+      stdout, stderr, status = run.call("arm", PRODUCTION_TAG)
 
       assert_predicate status, :success?, stderr
       assert_equal PRODUCTION_TAG, File.read(state).strip
+      assert_includes stdout, "::add-mask::encoded.encoded.encoded"
       api_log = File.read(log)
       assert_includes api_log, "repos/Sequel-Ace/Sequel-Ace/installation"
       assert_includes api_log, "app/installations/123/access_tokens"
@@ -157,6 +158,7 @@ class ReleaseArtifactWakeStateTest < Minitest::Test
     initial_value,
     provided_token: true,
     installation_response: '{"id":123}',
+    github_actions: false,
     wake_variable: nil
   )
     Dir.mktmpdir("sequel-ace-wake-state-test") do |directory|
@@ -223,6 +225,7 @@ class ReleaseArtifactWakeStateTest < Minitest::Test
             "SA_RELEASE_GITHUB_APP_PRIVATE_KEY" => "test-private-key"
           )
         end
+        environment["GITHUB_ACTIONS"] = "true" if github_actions
         environment["SA_RELEASE_WAKE_VARIABLE"] = wake_variable if wake_variable
         arguments = [repo_path("Scripts/release-artifact-wake-state.sh"), operation, tag]
         arguments << predecessor if predecessor


### PR DESCRIPTION
## Changes:

- Authenticate the wake-state adapter's GitHub App JWT requests with the required `Bearer` scheme instead of GitHub CLI's ordinary token scheme.
- Mask the generated short-lived App JWT before it is used in GitHub Actions.
- Add regression coverage requiring Bearer authentication for both App-JWT API requests.

## Closes following issues:

- Closes: N/A

## Tested:

- Processors:
  - [x] Apple Silicon
- macOS Versions:
  - [x] 26.x
- Xcode Version: N/A (release infrastructure only)
- `bash -n Scripts/release-artifact-wake-state.sh`
- `bundle exec ruby -Ifastlane/lib -Ifastlane/test fastlane/test/release_artifact_wake_state_test.rb` — 12 runs, 67 assertions
- `bundle exec rake -f fastlane/Rakefile test` — 439 runs, 2,884 assertions

## Screenshots:

- No UI changes.

## Additional notes:

- This fixes the post-archive wake-state failure in release run 32403002160. The existing `beta/5.5.0-20110` tag, prerelease, and private handoff remain intact and are not modified by this PR.
- GitHub's App-JWT documentation requires `Authorization: Bearer`; the GitHub CLI's normal token path does not satisfy that JWT-specific requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub App authentication for release artifact workflows.
  * Ensured required Bearer authorization is used when creating installation tokens and locating repository installations.
  * Enhanced protection of generated App credentials in workflow logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->