### PR TITLE
#added Add a preference to hide the filter drop zone

### DIFF
--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -201,6 +201,8 @@
 	<false/>
 	<key>ResetAutoIncrementAfterDeletionOfAllRows</key>
 	<true/>
+	<key>RuleFilterShowDropZone</key>
+	<true/>
 	<key>SelectLastFavoriteUsed</key>
 	<true/>
 	<key>ShowNoAffectedRowsError</key>

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -301,6 +301,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
     [self->prefs addObserver:self forKeyPath:SPDisplayTableViewColumnTypes options:NSKeyValueObservingOptionNew context:TableContentKVOContext];
     [self->prefs addObserver:self forKeyPath:SPGlobalFontSettings options:NSKeyValueObservingOptionNew context:TableContentKVOContext];
     [self->prefs addObserver:self forKeyPath:SPDisplayBinaryDataAsHex options:NSKeyValueObservingOptionNew context:TableContentKVOContext];
+    [self->prefs addObserver:self forKeyPath:[SARuleFilterDropZoneLayoutPolicy defaultsKey] options:NSKeyValueObservingOptionNew context:TableContentKVOContext];
 
     // Add observer to change view sizes with filter rule editor
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -3743,22 +3744,17 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	CGFloat availableHeight = contentAreaRect.size.height;
 	NSRect ruleEditorRect = [[[ruleFilterController view] enclosingScrollView] frame];
 
-	// Space reserved at the bottom of the filter container for the
-	// "Drop a value here, or click to add a filter" zone. The drop box sits
-	// below the rule editor's scroll view, shrinking the scroll view
-	// upward so both fit without overlapping the Apply / Add Filter
-	// buttons pinned to the right.
-	CGFloat dropBoxReserved = showFilterRuleEditor ? [ruleFilterController dropBoxReservedHeight] : 0;
-	// When the rule editor has no rules, collapse its scroll view so
-	// the filter container shrinks to just the drop box – leaving a
-	// tall empty band above the drop box would look abandoned.
-	BOOL ruleEditorHasRows = showFilterRuleEditor && ![ruleFilterController isEmpty];
-	CGFloat ruleEditorTopMargin = ruleEditorHasRows ? 1 : 0;
+	SARuleFilterDropZoneLayoutMetrics *layout = [SARuleFilterDropZoneLayoutPolicy metricsWithEditorVisible:showFilterRuleEditor
+	                                                                                       editorHasRows:![ruleFilterController isEmpty]
+	                                                                                      requestedHeight:requestedHeight
+	                                                                                       dropZoneHeight:[ruleFilterController dropBoxReservedHeight]
+	                                                                                         userDefaults:prefs];
+	CGFloat dropBoxReserved = [layout dropZoneReservedHeight];
 	ruleEditorRect.origin.x = 1;
-	ruleEditorRect.origin.y = dropBoxReserved + ruleEditorTopMargin;
+	ruleEditorRect.origin.y = [layout ruleEditorOriginY];
 
 	//adjust for the UI elements below the rule editor, but only if the view should not be hidden
-	CGFloat containerRequestedHeight = showFilterRuleEditor ? (dropBoxReserved + (ruleEditorHasRows ? MAX(requestedHeight, 29) + ruleEditorTopMargin : 0)) : 0;
+	CGFloat containerRequestedHeight = [layout containerRequestedHeight];
 
 	//the rule editor can ask for about one-third of the available space before we have it use it's scrollbar
 	CGFloat topContainerGivenHeight = MAX(MIN(containerRequestedHeight,(availableHeight / 3)), 1);
@@ -3815,7 +3811,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
         [[[ruleFilterController view] enclosingScrollView] setFrame:ruleEditorRect];
         if (dropBox) [dropBox setFrame:dropBoxRect];
 	}
-	[dropBox setHidden:!showFilterRuleEditor];
+	[dropBox setHidden:![layout dropZoneVisible]];
 
 	//disable rubberband scrolling as long as there is nothing to scroll
     NSScrollView *filterControllerScroller = [[ruleFilterController view] enclosingScrollView];
@@ -4058,6 +4054,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
                                           [tableDataInstance getConstraints], @"constraints",
                                           nil];
             [[self onMainThread] setTableDetails:tableDetails];
+		}
+		else if ([keyPath isEqualToString:[SARuleFilterDropZoneLayoutPolicy defaultsKey]] && showFilterRuleEditor) {
+			[self updateFilterRuleEditorSize:[[ruleFilterController onMainThread] preferredHeight] animate:YES];
 		}
 	}
 	else {
@@ -5294,6 +5293,7 @@ static NSString* dbHostPrefKey(SPTableContent* tc) {
 		[prefs removeObserver:self forKeyPath:SPDisplayBinaryDataAsHex];
 		[prefs removeObserver:self forKeyPath:SPDisplayTableViewVerticalGridlines];
 		[prefs removeObserver:self forKeyPath:SPDisplayTableViewColumnTypes];
+		[prefs removeObserver:self forKeyPath:[SARuleFilterDropZoneLayoutPolicy defaultsKey]];
 	}
 
 	// Cancel previous performSelector: requests on ourselves and the table view

--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1036,9 +1036,9 @@
                                                                         </scroller>
                                                                     </scrollView>
                                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4676">
-                                                                        <rect key="frame" x="579" y="-1" width="111" height="32"/>
+                                                                        <rect key="frame" x="579" y="2" width="101" height="27"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                                                        <buttonCell key="cell" type="push" title="Apply Filter(s)" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4677">
+                                                                        <buttonCell key="cell" type="push" title="Apply Filter(s)" bezelStyle="rounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4677">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                             <font key="font" metaFont="system" size="11"/>
                                                                         </buttonCell>
@@ -1048,9 +1048,9 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xVl-jD-jgc">
-                                                                        <rect key="frame" x="579" y="-1" width="111" height="32"/>
+                                                                        <rect key="frame" x="579" y="2" width="101" height="27"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                                                        <buttonCell key="cell" type="push" title="Add Filter" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MCE-yX-CGu">
+                                                                        <buttonCell key="cell" type="push" title="Add Filter" bezelStyle="rounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MCE-yX-CGu">
                                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                             <font key="font" metaFont="system" size="11"/>
                                                                         </buttonCell>

--- a/Source/Interfaces/Preferences.xib
+++ b/Source/Interfaces/Preferences.xib
@@ -940,7 +940,7 @@ Gw
             <point key="canvasLocation" x="-19" y="1116"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="512" userLabel="Tables">
-            <rect key="frame" x="0.0" y="0.0" width="549" height="359"/>
+            <rect key="frame" x="0.0" y="0.0" width="549" height="390"/>
             <userGuides>
                 <userLayoutGuide location="195" affinity="minX"/>
             </userGuides>
@@ -971,13 +971,13 @@ Gw
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="552">
-                    <rect key="frame" x="180" y="248" width="349" height="5"/>
+                    <rect key="frame" x="180" y="279" width="349" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="XQn-Hf-WgQ"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="535">
-                    <rect key="frame" x="180" y="219" width="349" height="22"/>
+                    <rect key="frame" x="180" y="250" width="349" height="22"/>
                     <buttonCell key="cell" type="check" title="Don't load blob and text fields until needed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="538">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -988,6 +988,19 @@ Gw
                     </constraints>
                     <connections>
                         <binding destination="117" name="value" keyPath="values.LoadBlobsAsNeeded" id="614"/>
+                    </connections>
+                </button>
+                <button toolTip="Show or hide the &quot;Drop a value here...&quot; area below table filters" translatesAutoresizingMaskIntoConstraints="NO" id="C1x-7W-DzP">
+                    <rect key="frame" x="180" y="219" width="349" height="22"/>
+                    <buttonCell key="cell" type="check" title="Show filter drop zone" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="rFZ-4S-9oQ">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="22" id="J92-oZ-Apd"/>
+                    </constraints>
+                    <connections>
+                        <binding destination="117" name="value" keyPath="values.RuleFilterShowDropZone" id="p4g-D3-Km8"/>
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="532">
@@ -1052,7 +1065,7 @@ Gw
                     </connections>
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="518">
-                    <rect key="frame" x="180" y="291" width="349" height="22"/>
+                    <rect key="frame" x="180" y="322" width="349" height="22"/>
                     <buttonCell key="cell" type="check" title="Editing a row" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="524">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1079,7 +1092,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="516">
-                    <rect key="frame" x="180" y="322" width="349" height="22"/>
+                    <rect key="frame" x="180" y="353" width="349" height="22"/>
                     <buttonCell key="cell" type="check" title="Adding a row" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="526">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1106,7 +1119,7 @@ Gw
                     </connections>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="514">
-                    <rect key="frame" x="18" y="323" width="154" height="20"/>
+                    <rect key="frame" x="18" y="354" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="atp-2o-EmZ"/>
                         <constraint firstAttribute="width" constant="150" id="uia-kW-GYj"/>
@@ -1118,7 +1131,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="513">
-                    <rect key="frame" x="180" y="260" width="349" height="22"/>
+                    <rect key="frame" x="180" y="291" width="349" height="22"/>
                     <buttonCell key="cell" type="check" title="Removing a row" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="529">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1241,7 +1254,7 @@ Gw
                 <constraint firstItem="535" firstAttribute="trailing" secondItem="518" secondAttribute="trailing" id="Prb-2M-s2K"/>
                 <constraint firstItem="515" firstAttribute="trailing" secondItem="535" secondAttribute="trailing" id="Q4L-Wc-m65"/>
                 <constraint firstItem="517" firstAttribute="top" secondItem="553" secondAttribute="bottom" constant="9" id="QMo-la-sjs"/>
-                <constraint firstItem="950" firstAttribute="top" secondItem="535" secondAttribute="bottom" constant="9" id="SLx-mS-ImY"/>
+                <constraint firstItem="950" firstAttribute="top" secondItem="C1x-7W-DzP" secondAttribute="bottom" constant="9" id="SLx-mS-ImY"/>
                 <constraint firstItem="516" firstAttribute="top" secondItem="512" secondAttribute="top" constant="15" id="T2u-oA-dCw"/>
                 <constraint firstItem="1467" firstAttribute="top" secondItem="532" secondAttribute="bottom" constant="9" id="Te7-4g-Xzx"/>
                 <constraint firstItem="515" firstAttribute="centerY" secondItem="517" secondAttribute="centerY" id="Vat-H9-p6s"/>
@@ -1256,6 +1269,9 @@ Gw
                 <constraint firstItem="535" firstAttribute="trailing" secondItem="552" secondAttribute="trailing" id="gEf-Yt-4oK"/>
                 <constraint firstItem="517" firstAttribute="leading" secondItem="516" secondAttribute="leading" id="gbh-Ii-Zzd"/>
                 <constraint firstItem="535" firstAttribute="top" secondItem="552" secondAttribute="bottom" constant="9" id="id8-2Z-Cwy"/>
+                <constraint firstItem="C1x-7W-DzP" firstAttribute="leading" secondItem="535" secondAttribute="leading" id="FtA-M9-Yt1"/>
+                <constraint firstItem="C1x-7W-DzP" firstAttribute="top" secondItem="535" secondAttribute="bottom" constant="9" id="V8s-E2-Hn6"/>
+                <constraint firstItem="C1x-7W-DzP" firstAttribute="trailing" secondItem="535" secondAttribute="trailing" id="L5v-Q4-Jc7"/>
                 <constraint firstItem="suA-e3-Xus" firstAttribute="trailing" secondItem="1470" secondAttribute="trailing" id="k0P-6r-dl3"/>
                 <constraint firstItem="518" firstAttribute="leading" secondItem="516" secondAttribute="leading" id="kgA-Tk-nbF"/>
                 <constraint firstItem="950" firstAttribute="leading" secondItem="516" secondAttribute="leading" id="lri-W5-gQr"/>

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -54,6 +54,88 @@ import Cocoa
     }
 }
 
+/// Immutable layout values consumed by the legacy table-content controller.
+/// Keeping the policy in Swift makes the Objective-C call site a thin view
+/// trampoline and gives the preference combinations direct unit coverage.
+@objc public final class SARuleFilterDropZoneLayoutMetrics: NSObject {
+    @objc public let dropZoneVisible: Bool
+    @objc public let dropZoneReservedHeight: CGFloat
+    @objc public let ruleEditorOriginY: CGFloat
+    @objc public let containerRequestedHeight: CGFloat
+
+    fileprivate init(
+        dropZoneVisible: Bool,
+        dropZoneReservedHeight: CGFloat,
+        ruleEditorOriginY: CGFloat,
+        containerRequestedHeight: CGFloat
+    ) {
+        self.dropZoneVisible = dropZoneVisible
+        self.dropZoneReservedHeight = dropZoneReservedHeight
+        self.ruleEditorOriginY = ruleEditorOriginY
+        self.containerRequestedHeight = containerRequestedHeight
+    }
+}
+
+/// Controls whether the optional filter drop zone participates in layout.
+/// Missing preferences deliberately preserve the existing visible behavior for
+/// users upgrading from versions that predate the setting.
+@objc public final class SARuleFilterDropZoneLayoutPolicy: NSObject {
+    private static let preferenceKey = "RuleFilterShowDropZone"
+
+    @objc(defaultsKey)
+    public static var defaultsKey: String {
+        return preferenceKey
+    }
+
+    @objc(metricsWithEditorVisible:editorHasRows:requestedHeight:dropZoneHeight:userDefaults:)
+    public static func metrics(
+        editorVisible: Bool,
+        editorHasRows: Bool,
+        requestedHeight: CGFloat,
+        dropZoneHeight: CGFloat,
+        userDefaults: UserDefaults
+    ) -> SARuleFilterDropZoneLayoutMetrics {
+        let showDropZone = userDefaults.object(forKey: preferenceKey).map { _ in
+            userDefaults.bool(forKey: preferenceKey)
+        } ?? true
+
+        return metrics(
+            editorVisible: editorVisible,
+            editorHasRows: editorHasRows,
+            requestedHeight: requestedHeight,
+            dropZoneHeight: dropZoneHeight,
+            showDropZonePreference: showDropZone
+        )
+    }
+
+    static func metrics(
+        editorVisible: Bool,
+        editorHasRows: Bool,
+        requestedHeight: CGFloat,
+        dropZoneHeight: CGFloat,
+        showDropZonePreference: Bool
+    ) -> SARuleFilterDropZoneLayoutMetrics {
+        let effectiveEditorHasRows = editorVisible && editorHasRows
+        let dropZoneVisible = editorVisible && showDropZonePreference
+        let reservedDropZoneHeight = dropZoneVisible ? max(dropZoneHeight, 0) : 0
+        let ruleEditorTopMargin: CGFloat = effectiveEditorHasRows ? 1 : 0
+
+        // With no rows, the drop zone is normally the only visible affordance.
+        // If the user hides it, retain the original 29-point editor/button row
+        // so the filter UI never becomes an enabled-but-inaccessible zero-height
+        // strip.
+        let shouldReserveRuleEditor = effectiveEditorHasRows || (editorVisible && !dropZoneVisible)
+        let ruleEditorHeight = shouldReserveRuleEditor ? max(requestedHeight, 29) + ruleEditorTopMargin : 0
+
+        return SARuleFilterDropZoneLayoutMetrics(
+            dropZoneVisible: dropZoneVisible,
+            dropZoneReservedHeight: reservedDropZoneHeight,
+            ruleEditorOriginY: reservedDropZoneHeight + ruleEditorTopMargin,
+            containerRequestedHeight: editorVisible ? reservedDropZoneHeight + ruleEditorHeight : 0
+        )
+    }
+}
+
 /// `NSRuleEditor` subclass that extends the content-tab filter with
 /// drag-and-drop support for the
 /// `SPCellValuePasteboard.pasteboardRowTypeRaw` payload. Dropping a

--- a/UnitTests/SACellFilterMergeTests.swift
+++ b/UnitTests/SACellFilterMergeTests.swift
@@ -244,3 +244,99 @@ final class SARuleFilterVisibilityPolicyTests: XCTestCase {
         ))
     }
 }
+
+final class SARuleFilterDropZoneLayoutPolicyTests: XCTestCase {
+
+    func testVisibleDropZonePreservesExistingPopulatedEditorLayout() {
+        let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+            editorVisible: true,
+            editorHasRows: true,
+            requestedHeight: 72,
+            dropZoneHeight: 40,
+            showDropZonePreference: true
+        )
+
+        XCTAssertTrue(metrics.dropZoneVisible)
+        XCTAssertEqual(metrics.dropZoneReservedHeight, 40)
+        XCTAssertEqual(metrics.ruleEditorOriginY, 41)
+        XCTAssertEqual(metrics.containerRequestedHeight, 113)
+    }
+
+    func testHiddenDropZoneRestoresCompactPopulatedEditorLayout() {
+        let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+            editorVisible: true,
+            editorHasRows: true,
+            requestedHeight: 72,
+            dropZoneHeight: 40,
+            showDropZonePreference: false
+        )
+
+        XCTAssertFalse(metrics.dropZoneVisible)
+        XCTAssertEqual(metrics.dropZoneReservedHeight, 0)
+        XCTAssertEqual(metrics.ruleEditorOriginY, 1)
+        XCTAssertEqual(metrics.containerRequestedHeight, 73)
+    }
+
+    func testVisibleDropZoneOwnsEmptyEditorHeight() {
+        let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+            editorVisible: true,
+            editorHasRows: false,
+            requestedHeight: 0,
+            dropZoneHeight: 40,
+            showDropZonePreference: true
+        )
+
+        XCTAssertTrue(metrics.dropZoneVisible)
+        XCTAssertEqual(metrics.ruleEditorOriginY, 40)
+        XCTAssertEqual(metrics.containerRequestedHeight, 40)
+    }
+
+    func testEmptyEditorRetainsAddFilterRowWhenDropZoneIsHidden() {
+        let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+            editorVisible: true,
+            editorHasRows: false,
+            requestedHeight: 0,
+            dropZoneHeight: 40,
+            showDropZonePreference: false
+        )
+
+        XCTAssertFalse(metrics.dropZoneVisible)
+        XCTAssertEqual(metrics.ruleEditorOriginY, 0)
+        XCTAssertEqual(metrics.containerRequestedHeight, 29)
+    }
+
+    func testHiddenEditorCollapsesRegardlessOfDropZonePreference() {
+        for showDropZone in [false, true] {
+            let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+                editorVisible: false,
+                editorHasRows: true,
+                requestedHeight: 72,
+                dropZoneHeight: 40,
+                showDropZonePreference: showDropZone
+            )
+
+            XCTAssertFalse(metrics.dropZoneVisible)
+            XCTAssertEqual(metrics.dropZoneReservedHeight, 0)
+            XCTAssertEqual(metrics.ruleEditorOriginY, 0)
+            XCTAssertEqual(metrics.containerRequestedHeight, 0)
+        }
+    }
+
+    func testMissingPreferenceDefaultsToVisibleForUpgradingUsers() {
+        let suiteName = "SARuleFilterDropZoneLayoutPolicyTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let metrics = SARuleFilterDropZoneLayoutPolicy.metrics(
+            editorVisible: true,
+            editorHasRows: true,
+            requestedHeight: 29,
+            dropZoneHeight: 40,
+            userDefaults: defaults
+        )
+
+        XCTAssertEqual(SARuleFilterDropZoneLayoutPolicy.defaultsKey, "RuleFilterShowDropZone")
+        XCTAssertTrue(metrics.dropZoneVisible)
+    }
+}

--- a/UnitTests/SPTableContentColumnFilterTests.swift
+++ b/UnitTests/SPTableContentColumnFilterTests.swift
@@ -62,6 +62,17 @@ final class SPTableContentColumnFilterTests: XCTestCase {
         XCTAssertEqual(value, false)
     }
 
+    /// Existing users should retain the drop zone unless they explicitly hide it.
+    func testFilterDropZoneShownByDefault() {
+        guard let defaults = preferenceDefaultsDictionary() else {
+            XCTFail("Could not find PreferenceDefaults.plist in any loaded bundle")
+            return
+        }
+
+        let value = defaults[SARuleFilterDropZoneLayoutPolicy.defaultsKey] as? Bool
+        XCTAssertEqual(value, true)
+    }
+
     // MARK: - Helper Functions (mirrors SPTableContent logic)
 
     /// Parse comma-separated filter string into array of lowercase trimmed terms


### PR DESCRIPTION
## Changes:
- Adds a Tables preference to show or hide the filter drop zone.
- Keeps the existing drop zone enabled by default, including for upgrades where the preference key is absent.
- Applies preference changes immediately while a table filter is open and reclaims the full 40-point band when hidden.
- Keeps an empty filter editor usable by reserving its compact Add Filter row when the drop zone is disabled.
- Gives the Add Filter and Apply Filter buttons consistent small-control sizing with explicit bottom and right padding.
- Moves the layout policy into testable Swift and leaves the legacy Objective-C controller as a thin bridge.
- Adds regression coverage for visible, hidden, populated, empty, and collapsed filter layouts plus the shipped default.

## Closes following issues:
- Closes: #2501

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 12.x (Monterey)
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)
- `xcodebuild test -scheme "Unit Tests"`: 1,008 tests, 60 existing skips, 0 failures.
- `xcodebuild build -scheme "Sequel Ace Debug"`: succeeded.
- `plutil`, `xmllint`, and `ibtool --warnings --errors`: passed for the changed preference and database-view resources.
- Manual UI pass on the exact debug build:
  - Confirmed **Show filter drop zone** is visible in **Settings → Tables**, immediately below **Don't load blob and text fields until needed**.
  - Cycled the preference toolbar and visually checked the resized Tables pane for alignment, margins, clipping, and control accessibility.
  - Toggled the new preference repeatedly, confirmed immediate animated updates, verified persistence across relaunch, and restored the original enabled state after testing.
  - Exercised a disposable local MySQL 8.0.46 schema with populated one-rule and two-rule filter editors in both layouts.
  - Checked normal and zoomed window sizes, filter show/hide transitions, and Structure to Content tab round trips.
  - Confirmed compact mode removes the complete drop-zone band while retaining the editor, Apply Filter controls, result header, and result grid alignment.
  - Checked enabled and disabled Add Filter plus Apply Filter(s) in expanded and compact layouts, including their bottom and right padding.

## Screenshots:
All screenshots were captured from the exact PR head using a disposable local MySQL schema containing only synthetic data.

### Settings → Tables

<img width="656" height="478" alt="Settings Tables pane showing Show filter drop zone" src="https://github.com/user-attachments/assets/19a62de9-123e-4d50-939f-26d7dd6c7cd4" />

### Drop zone shown (default)

<img width="767" height="848" alt="Table Content filter with the drop zone shown and padded Apply Filter button" src="https://github.com/user-attachments/assets/10ccbb88-3bb3-449a-871b-d3096cd93f98" />

### Drop zone hidden (compact)

<img width="767" height="848" alt="Table Content filter with the drop zone hidden and padded Apply Filter button" src="https://github.com/user-attachments/assets/30a71556-7a4c-4d30-acb0-c08f3e955667" />

## Additional notes:
- The default remains unchanged: users only get the compact layout after explicitly disabling **Show filter drop zone** in Tables preferences.
- The disposable local test schema was removed after the UI pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preference to show or hide the filter drop zone.
  * The drop zone is visible by default for existing and new installations.
  * Filter layout updates smoothly when the preference changes.

* **Style**
  * Reduced the size of filter action buttons for a more compact interface.

* **Bug Fixes**
  * Improved filter editor sizing and positioning when the drop zone is hidden or has no rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
