### PR TITLE
#infra Adopt Apple's SwiftUI invalidation guidance (view boundaries, closure bindings)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,33 @@ Deployment target is macOS 12+.
 - **New UI is SwiftUI** where feasible. Established hosting pattern:
   `@objc final` `NSWindowController` subclass + `NSHostingView` + SwiftUI root
   view — see `SAAboutWindowController`, `SABundleHTMLOutputWindowController`.
+- **SwiftUI view boundaries** (per Apple's performance guidance): splitting a
+  `body` into computed properties is *not* factoring for invalidation — every
+  section still shares the view's boundary and re-evaluates on any state
+  change. Give an expensive section its own `View` struct. Two caveats before
+  assuming a split helps here:
+  - A child holding `@ObservedObject`, a `Binding`, or a closure re-evaluates
+    anyway (the object publishes to it; non-equatable fields defeat SwiftUI's
+    memberwise comparison). Gate such a child with an explicit `Equatable`
+    conformance comparing only its meaningful inputs, plus `.equatable()` at
+    the call site — see `SATimeZonePicker` in `SAConnectionFormView.swift`.
+  - The connection form's single `@Published var info` makes every keystroke
+    publish model-wide; that granularity is fixed by `@Observable`
+    (macOS 14+), not by splitting views — blocked on the 12.0 target.
+- **No closure-built `Binding(get:set:)` as a child-view input** (same Apple
+  guidance): the closure pair is recreated every body evaluation and SwiftUI
+  cannot compare it, so the child re-evaluates even when nothing changed.
+  Bind through a stable key path instead — `$model.<property>` works on
+  `@ObservedObject`/`@State` even for *computed* read-write properties, so a
+  write that needs routing (validation, side effects) gets a computed accessor
+  on the model rather than a `set:` closure — see
+  `SARecordViewModel.validatedEditDraft`. (`@Bindable` + subscript is the
+  macOS 14+ form of the same idea.) Presentation flags for `.alert` get their
+  own `@State` Bool next to the presented optional rather than a Bool binding
+  derived from it. One sanctioned exception: a binding built *inside* an
+  `.equatable()`-gated child from its own snapshot, which never crosses the
+  boundary as an input — see `SATimeZonePicker.selection` and its comment for
+  why holding a live Binding there instead would break the gate.
 - **ObjC interop:** mark classes `@objc final class X: NSObject`. When a Swift
   method's internal argument label would be dropped in the generated selector,
   spell the selector explicitly — e.g. `func font(from data: Data?)` bridges to

--- a/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SAConnectionFormView.swift
@@ -37,8 +37,14 @@ struct SAConnectionFormView: View {
     var onConnect: (SAConnectionFormModel) -> Void = { _ in }
 
     /// The first validation failure of the latest submit, surfaced as
-    /// an alert (same strings the AppKit flow shows).
+    /// an alert (same strings the AppKit flow shows). Presentation is a
+    /// separate Bool so the alert binds `$isPresentingValidationFailure` — a
+    /// key path SwiftUI can compare — rather than a closure-built Binding
+    /// derived from the optional, which cannot be compared and forces
+    /// re-evaluation. The optional intentionally survives dismissal; it is
+    /// only read while presented and the next submit overwrites it.
     @State private var validationFailure: SAConnectionValidationFailure?
+    @State private var isPresentingValidationFailure = false
 
     /// Tracks the Vault Role field so losing focus can commit a pasted path.
     @FocusState private var roleFieldFocused: Bool
@@ -59,14 +65,11 @@ struct SAConnectionFormView: View {
         .modifier(SAGroupedFormStyle())
         .alert(
             validationFailure?.alertTitle ?? "",
-            isPresented: Binding(
-                get: { validationFailure != nil },
-                set: { if !$0 { validationFailure = nil } }
-            ),
+            isPresented: $isPresentingValidationFailure,
             presenting: validationFailure
         ) { _ in
             Button {
-                validationFailure = nil
+                // Dismissal is driven by the isPresented binding; nothing to do.
             } label: {
                 Text("OK", comment: "OK button")
             }
@@ -120,32 +123,19 @@ struct SAConnectionFormView: View {
         }
     }
 
-    /// Built once: the identifier list is fixed for the process lifetime, and
-    /// `body` re-evaluates on every keystroke (any `info` mutation publishes),
-    /// which would otherwise re-sort ~600 identifiers each time.
-    private static let timeZoneMenu = SATimeZoneMenuEntry.menu()
-
     private var timeZoneSection: some View {
         Section {
-            Picker(selection: timeZoneBinding) {
-                ForEach(Self.timeZoneMenu, id: \.self) { entry in
-                    switch entry {
-                    case .choice(.server):
-                        Text("Use Server Time Zone", comment: "Leave the server time zone in place when connecting")
-                            .tag(SATimeZoneChoice.server)
-                    case .choice(.system):
-                        Text("Use System Time Zone", comment: "Set the time zone currently used by the user when connecting")
-                            .tag(SATimeZoneChoice.system)
-                    case .choice(.fixed(let identifier)):
-                        Text(verbatim: identifier).tag(SATimeZoneChoice.fixed(identifier))
-                    case .separator:
-                        Divider()
-                    }
-                }
-            } label: {
-                Text("Time Zone", comment: "connection view : field label")
+            // .equatable() + the explicit Equatable conformance is what lets
+            // SwiftUI skip the picker: its ~600-row menu would otherwise be
+            // rebuilt on every body evaluation, i.e. on every keystroke in any
+            // field, since any `info` mutation publishes. A plain child struct
+            // would not be enough — the callback closure defeats SwiftUI's
+            // memberwise comparison, so re-evaluation must be gated on the one
+            // value that matters, the selection.
+            SATimeZonePicker(choice: model.timeZoneChoice) { newChoice in
+                model.timeZoneChoice = newChoice
             }
-            .pickerStyle(.menu)
+            .equatable()
         }
     }
 
@@ -408,19 +398,72 @@ struct SAConnectionFormView: View {
     }
 
 
-    private var timeZoneBinding: Binding<SATimeZoneChoice> {
-        Binding(
-            get: { model.timeZoneChoice },
-            set: { model.timeZoneChoice = $0 }
-        )
-    }
-
     private func submit() {
         if let failure = model.validate() {
             validationFailure = failure
+            isPresentingValidationFailure = true
             return
         }
         onConnect(model)
+    }
+}
+
+// MARK: - Time-zone picker
+
+/// The time-zone menu as its own invalidation boundary.
+///
+/// Splitting a body into computed properties looks like factoring, but every
+/// section still shares the parent view's invalidation boundary, so each
+/// keystroke re-evaluated this ~600-entry menu along with everything else.
+/// A separate struct gets its own boundary — but only pays off with the
+/// explicit `Equatable` conformance and `.equatable()` at the call site,
+/// because the `onSelect` closure defeats SwiftUI's memberwise comparison
+/// and would otherwise force re-evaluation anyway. The comparison keys on
+/// the selection alone, which is the only input that changes.
+private struct SATimeZonePicker: View, Equatable {
+
+    let choice: SATimeZoneChoice
+    let onSelect: (SATimeZoneChoice) -> Void
+
+    static func == (a: Self, b: Self) -> Bool {
+        a.choice == b.choice
+    }
+
+    /// Built once: the identifier list is fixed for the process lifetime.
+    private static let menu = SATimeZoneMenuEntry.menu()
+
+    var body: some View {
+        Picker(selection: selection) {
+            ForEach(Self.menu, id: \.self) { entry in
+                switch entry {
+                case .choice(.server):
+                    Text("Use Server Time Zone", comment: "Leave the server time zone in place when connecting")
+                        .tag(SATimeZoneChoice.server)
+                case .choice(.system):
+                    Text("Use System Time Zone", comment: "Set the time zone currently used by the user when connecting")
+                        .tag(SATimeZoneChoice.system)
+                case .choice(.fixed(let identifier)):
+                    Text(verbatim: identifier).tag(SATimeZoneChoice.fixed(identifier))
+                case .separator:
+                    Divider()
+                }
+            }
+        } label: {
+            Text("Time Zone", comment: "connection view : field label")
+        }
+        .pickerStyle(.menu)
+    }
+
+    /// A closure-built Binding is normally the pattern to avoid — SwiftUI
+    /// cannot compare it, forcing re-evaluation — but here it never crosses a
+    /// view boundary as an input: it is built inside this body, which the
+    /// `.equatable()` gate only runs when `choice` actually changed. The
+    /// alternative (holding a live keypath Binding and comparing its
+    /// `wrappedValue` in `==`) is subtly broken: the old and new view values
+    /// would both read the same live model and always compare equal, so the
+    /// picker would never refresh.
+    private var selection: Binding<SATimeZoneChoice> {
+        Binding(get: { choice }, set: { onSelect($0) })
     }
 }
 
@@ -484,7 +527,9 @@ private struct SAOptionalFileRow: View {
     @Binding var isEnabled: Bool
     @Binding var path: String
 
+    /// Same split as the form's validation alert: the Bool binds by key path.
     @State private var rejection: SAConnectionFileRejection?
+    @State private var isPresentingRejection = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -518,13 +563,10 @@ private struct SAOptionalFileRow: View {
         }
         .alert(
             rejection?.alertTitle ?? "",
-            isPresented: Binding(
-                get: { rejection != nil },
-                set: { if !$0 { rejection = nil } }
-            ),
+            isPresented: $isPresentingRejection,
             presenting: rejection
         ) { _ in
-            Button { rejection = nil } label: { Text("OK", comment: "OK button") }
+            Button {} label: { Text("OK", comment: "OK button") }
         } message: { rejection in
             Text(rejection.alertMessage)
         }
@@ -550,6 +592,7 @@ private struct SAOptionalFileRow: View {
         // surfaces here rather than as an opaque connection error later.
         if let rejection = SAConnectionFileValidator.rejection(forFileAt: url, kind: kind) {
             self.rejection = rejection
+            isPresentingRejection = true
             return
         }
 

--- a/Source/Views/SARecordView.swift
+++ b/Source/Views/SARecordView.swift
@@ -133,6 +133,18 @@ final class SARecordViewModel: ObservableObject {
         cancelEdit()
     }
 
+    /// Keypath-bindable draft that routes writes through validation.
+    ///
+    /// SwiftUI cannot compare closure-built `Binding(get:set:)` pairs, so a
+    /// text field fed one is re-evaluated on every body pass. Binding
+    /// `$model.validatedEditDraft` instead derives the binding through a
+    /// stable key path SwiftUI can compare — the macOS 12 equivalent of the
+    /// `@Bindable` + subscript pattern (`@Bindable` needs macOS 14).
+    var validatedEditDraft: String {
+        get { editDraft }
+        set { updateEditDraft(newValue) }
+    }
+
     func updateEditDraft(_ value: String) {
         guard let fieldID = editingFieldID else {
             return
@@ -211,10 +223,7 @@ private struct SARecordView: View {
             }
             TableColumn("Value") { field in
                 if model.editingFieldID == field.id {
-                    TextField("Value", text: Binding(
-                        get: { model.editDraft },
-                        set: model.updateEditDraft
-                    ))
+                    TextField("Value", text: $model.validatedEditDraft)
                         .textFieldStyle(.plain)
                         .onSubmit(model.commitEdit)
                         .focused($focusedFieldID, equals: field.id)

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -484,6 +484,32 @@ C2b — all connection types + SSL, colour, time zone — ✅ Done
 - Re-enable the "New Connection Window" menu item (currently deferred to avoid duplicate with XIB item)
 - Eventually the XIB menu item (`newWindow:`) gets replaced by the standalone window flow
 
+**C2/C3 follow-up — SwiftUI invalidation boundaries** — 🟡 Time-zone picker done
+- Apple's guidance: computed-property sections share their view's invalidation
+  boundary, so `SAConnectionFormView`'s sections all re-evaluate on every
+  keystroke (any `info` mutation publishes). The one expensive section — the
+  ~600-entry time-zone menu — is now `SATimeZonePicker`, a separate `View`
+  struct with an explicit `Equatable` conformance keyed on the selection and
+  `.equatable()` at the call site. The conformance is load-bearing: the
+  `onSelect` closure defeats SwiftUI's memberwise comparison, so a plain child
+  struct would have re-evaluated anyway.
+- Splitting the remaining sections is deliberately not done: each holds
+  `Binding`s into the shared model, so extra structs would add boundaries that
+  never skip. The real granularity fix is `@Observable`'s per-property
+  tracking — **macOS 14+, blocked on the 12.0 deployment target**. Revisit when
+  the target moves; until then treat `SATimeZonePicker` as the pattern for any
+  genuinely expensive section (guidance recorded in AGENTS.md).
+- Companion rule, same source: no closure-built `Binding(get:set:)` as a
+  child-view input — SwiftUI cannot compare the closures, so the child
+  re-evaluates regardless. The three shipped instances were converted:
+  `SARecordView`'s edit field now binds `$model.validatedEditDraft`, a computed
+  accessor routing writes through validation (the macOS 12 stand-in for
+  `@Bindable` + subscript), and both connection-form alerts present via a
+  dedicated `@State` Bool instead of a Bool binding derived from the optional.
+  `SATimeZonePicker.selection` stays closure-built on purpose — built inside
+  the `.equatable()` gate from a snapshot, it never crosses a boundary; its
+  comment explains why a live keypath Binding there would break the gate.
+
 ### Phase D: SPConnectionController further cleanup
 
 **D1. Replace `updateFavoriteSelection:` with structured data flow** — ✅ Done


### PR DESCRIPTION
Follow-up applying two rules from Apple's SwiftUI performance guidance where the shipped code did the "avoid", plus AGENTS.md / plan-doc entries so future SwiftUI work follows them by default.

## 1. Splitting large views

Computed-property sections share their view's invalidation boundary, so every `SAConnectionFormView` section re-evaluated on each keystroke (any `info` mutation publishes).

The one *expensive* section — the ~600-entry time-zone menu — is now **`SATimeZonePicker`**, a separate `View` struct with an explicit `Equatable` conformance keyed on the selection and `.equatable()` at the call site. The conformance is load-bearing: the `onSelect` closure defeats SwiftUI's memberwise comparison, so a plain child struct would have re-evaluated anyway. Result: the menu is rebuilt only when the selection changes, not per keystroke.

Deliberately **not** split: the remaining sections. They hold `Binding`s into the shared model, so extra structs would add boundaries that never skip. The real granularity fix is `@Observable`'s per-property tracking — macOS 14+, blocked on the 12.0 target, and noted in the plan doc as the thing to revisit when the target moves.

## 2. Closure-built `Binding(get:set:)`

SwiftUI cannot compare the closure pair, so a child fed one re-evaluates every body pass. Three shipped instances converted:

| Site | Now |
|---|---|
| `SARecordView` edit field | `$model.validatedEditDraft` — a computed accessor routing writes through the existing validation. `$model.<property>` on `ObservedObject` derives a comparable keypath binding even for computed properties, making this the macOS 12 stand-in for `@Bindable` + subscript. |
| Form validation alert | dedicated `@State` Bool bound by keypath; the optional only feeds `presenting:` |
| File-row rejection alert | same split |

**One sanctioned exception, documented in code:** `SATimeZonePicker.selection` stays closure-built. It is constructed *inside* the `.equatable()` gate from a snapshot, so it never crosses a view boundary as an input — and the tempting alternative (holding a live keypath `Binding` and comparing `wrappedValue` in `==`) is subtly broken: old and new view values would both read the same live model, always compare equal, and the picker would never refresh.

## Docs

- **AGENTS.md**: two new bullets under the SwiftUI conventions — view boundaries (with the `Equatable`/`.equatable()` caveat and the `@Observable` note) and the closure-binding rule, each pointing at the in-repo exemplar.
- **modernization-followup-plan.md**: the C2/C3 follow-up entry records what was done, what was deliberately skipped, and why.

## Testing

No behaviour change intended. **1021 tests pass, 0 fail**, clean build. The one visual to sanity-check by hand: pick a time zone in the standalone connection window and confirm the menu checkmark updates (the exact failure mode the exemption comment warns about, exercised nowhere by unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and file-rejection alert presentation for clearer, more reliable feedback.
  * Reduced unnecessary view updates in the time-zone picker and editable record fields.
  * Preserved validation behavior while improving text-field responsiveness.

* **Documentation**
  * Added SwiftUI performance guidance and modernization follow-up details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->