### PR TITLE
#fixed Point libmysqlclient at the bundled plugin directory

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -875,6 +875,16 @@ asm(".desc ___crashreporter_info__, 0x10");
     // Some servers have issues when we try caching_sha2_password first; let's always try mysql_native_password first; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/141
     mysql_options(theConnection, MYSQL_DEFAULT_AUTH, [@"mysql_native_password" UTF8String]);
 
+    // Point libmysqlclient at this framework's PlugIns directory for client-side auth plugins.
+    // Without this the library falls back to the plugin path baked in at compile time - a
+    // directory on the build machine that never exists on user systems - so any server auth
+    // scheme requiring a client plugin (e.g. MariaDB ed25519) failed with a dlopen error
+    // pointing at a meaningless path; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/1036
+    NSString *pluginDirectory = [[NSBundle bundleForClass:[self class]] builtInPlugInsPath];
+    if (pluginDirectory) {
+        mysql_options(theConnection, MYSQL_PLUGIN_DIR, [pluginDirectory fileSystemRepresentation]);
+    }
+
     // Allow using LOAD DATA LOCAL INFILE ...; ref: https://github.com/Sequel-Ace/Sequel-Ace/issues/245
     if(allowDataLocalInfile) {
         mysql_options(theConnection, MYSQL_OPT_LOCAL_INFILE, [@"On" UTF8String]);


### PR DESCRIPTION
## Changes:
- Set `MYSQL_PLUGIN_DIR` on every raw connection to the SPMySQL framework's `PlugIns` directory (`[NSBundle bundleForClass:...].builtInPlugInsPath`).

**Why:** the plugin search path in the bundled `libmysqlclient.24.dylib` is baked in at compile time, and `strings` on the shipped dylib shows what it currently is:

```
/Users/jason/Library/Developer/Xcode/DerivedData/libmysqlclient-goaivsxpqyjxisbrbktddmadayva/Build/Products/arm64/install/lib/plugin
```

— a DerivedData path from the machine that built the dylib. Since `MYSQL_PLUGIN_DIR` was never set anywhere in the app, **no client-side auth plugin can ever load**, and users hitting a server that requires one (MariaDB `ed25519` in #1036) get a dlopen error pointing at a directory that never existed on their system.

## Closes following issues:
- Related to: #1036 (partial — see notes)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.x (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.x (MCP bridge build)

## Screenshots:
n/a

## Additional notes:
This deliberately does **not** claim to close #1036. Full ed25519 support needs the MariaDB `client_ed25519` plugin built for macOS (universal, signed with the app's identity — #1036 shows an unsigned copy is rejected by library validation) and shipped in the framework's `PlugIns` directory, which this PR establishes as the load path. The bundled Oracle MySQL 8.4 client only ships `mysql_native_password` / `caching_sha2_password` / `sha256_password` / `mysql_clear_password`. Adding the plugin build to the dylib build recipe in `Scripts/` would be the follow-up that actually closes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database connection compatibility with servers requiring client-side authentication plugins.
  - Authentication plugins are now located correctly, preventing connection failures caused by missing plugin files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->