### PR TITLE
#fixed Bound utf8strlen reads to lexer token bytes

### DIFF
--- a/Source/Other/Parsing/SPEditorTokens.l
+++ b/Source/Other/Parsing/SPEditorTokens.l
@@ -48,7 +48,7 @@
 size_t yyuoffset, yyuleng;
 
 //keep track of the current utf-8 character (not byte) offset and token length
-#define YY_USER_ACTION { yyuoffset += yyuleng; yyuleng = utf8strlen(yytext); }
+#define YY_USER_ACTION { yyuoffset += yyuleng; yyuleng = utf8strlen(yytext, (size_t)yyleng); }
 %}
 %option noyywrap
 %option nounput

--- a/Source/Other/Parsing/SPParserUtils.c
+++ b/Source/Other/Parsing/SPParserUtils.c
@@ -29,90 +29,48 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #include "SPParserUtils.h"
-#include <stdint.h>
+#include <string.h>
 
 #define SIZET (sizeof(size_t))
-#define SIZET1 (SIZET - 1)
-#define SBYTE (SIZET1 * 8)
+#define SBYTE ((SIZET - 1) * 8)
 
 #define ONEMASK ((size_t)(-1) / 0xFF)
 #define ONEMASK8 (ONEMASK * 0x80)
 #define FMASK ((size_t)(-1)*(ONEMASK*0xf)-1)
 
 // adapted from http://www.daemonology.net/blog/2008-06-05-faster-utf8-strlen.html
-size_t utf8strlen(const char * _s)
+size_t utf8strlen(const char *bytes, size_t byteLength)
 {
-	
-	/* Due to [NSString length] behaviour for chars > 0xFFFF {length = 2}
-	 "correct" the variable 'count' by subtraction the number
-	 of occurrences of the start byte 0xF0 (4-byte UTF-8 char).
-	 Here we assume that only up to 4-byte UTF-8 chars
-	 are allowed [latest UTF-8 specification].
-	 
-	 Marked in the source code by "CORRECT".
-	 */
-	
-	const char * s;
-	long count = 0;
-	size_t u = 0;
-	size_t u1 = 0;
-	unsigned char b;
-	
-	
-	/* Handle any initial misaligned bytes. */
-	for (s = _s; (uintptr_t)(s) & SIZET1; s++) {
-		b = *s;
-		
-		/* Exit if we hit a zero byte. */
-		if (b == '\0')
-			goto done;
-		
-		/* Is this byte NOT the first byte of a character? */
-		count += (b >> 7) & ((~b) >> 6);
-		
-		/* CORRECT */
-		count -= (b & 0xf0) == 0xf0;
-	}
-	
-	/* Handle complete blocks. */
-	for (; ; s += SIZET) {
-		/* Prefetch 256 bytes ahead. */
-		__builtin_prefetch(&s[256], 0, 0);
+	/* NSString counts characters outside the BMP as two UTF-16 code units.
+	 * Here we assume that only up to 4-byte UTF-8 characters are allowed
+	 * [latest UTF-8 specification]. */
+	size_t continuationByteCount = 0;
+	size_t fourByteLeadCount = 0;
+	size_t offset = 0;
 
-		/* Grab 4 or 8 bytes of UTF-8 data. */
-		u = *(size_t *)(s); // FIXME: AddressSanitizer: heap-buffer-overflow - GitHub issue: #792
-		
-		/* Exit the loop if there are any zero bytes. */
-		if ((u - ONEMASK) & (~u) & ONEMASK8)
-			break;
-		
-		/* CORRECT */
-		u1 = u & FMASK;
-		u1 = (u1 >> 7) & (u1 >> 6) & (u1 >> 5) & (u1 >> 4);
-		if (u1) count -= (u1 * ONEMASK) >> SBYTE;
-		
-		/* Count bytes which are NOT the first byte of a character. */
-		u = ((u & ONEMASK8) >> 7) & ((~u) >> 6);
-		
-		count += (u * ONEMASK) >> SBYTE;
+	/* Process only complete words inside the caller-provided byte span. memcpy()
+	 * keeps unaligned loads defined without sacrificing the SWAR bulk path. */
+	for (; byteLength - offset >= SIZET; offset += SIZET) {
+		size_t word;
+		memcpy(&word, bytes + offset, sizeof(word));
 
+		size_t fourByteLeadBytes = word & FMASK;
+		fourByteLeadBytes = (fourByteLeadBytes >> 7)
+			& (fourByteLeadBytes >> 6)
+			& (fourByteLeadBytes >> 5)
+			& (fourByteLeadBytes >> 4);
+		fourByteLeadCount += (fourByteLeadBytes * ONEMASK) >> SBYTE;
+
+		size_t continuationBytes = ((word & ONEMASK8) >> 7) & ((~word) >> 6);
+		continuationByteCount += (continuationBytes * ONEMASK) >> SBYTE;
 	}
-	
-	/* Take care of any left-over bytes. */
-	for (; ; s++) {
-		b = *s;
-		
-		/* Exit if we hit a zero byte. */
-		if (b == '\0')
-			break;
-		
-		/* Is this byte NOT the first byte of a character? */
-		count += (b >> 7) & ((~b) >> 6);
-		
-		/* CORRECT */
-		count -= (b & 0xf0) == 0xf0;
+
+	/* Take care of the remaining bytes without reading beyond byteLength. */
+	for (; offset < byteLength; offset++) {
+		unsigned char byte = (unsigned char)bytes[offset];
+		continuationByteCount += (byte & 0xc0) == 0x80;
+		fourByteLeadCount += (byte & 0xf0) == 0xf0;
 	}
-	
-done:
-	return ((s - _s) - count);
+
+	return byteLength - continuationByteCount + fourByteLeadCount;
 }

--- a/Source/Other/Parsing/SPParserUtils.h
+++ b/Source/Other/Parsing/SPParserUtils.h
@@ -34,8 +34,9 @@
 #include <stdio.h>
 
 /**
- * Return number of characters (NOT bytes) in a given UTF-8 encoded C string.
+ * Return the number of UTF-16 code units (matching NSString.length) in a
+ * UTF-8 byte span. The input does not need to be NUL-terminated.
  */
-size_t utf8strlen(const char * _s);
+size_t utf8strlen(const char *bytes, size_t byteLength);
 
 #endif /* defined(__SPParserUtils__) */

--- a/Source/Other/Parsing/SPSQLTokenizer.l
+++ b/Source/Other/Parsing/SPSQLTokenizer.l
@@ -36,7 +36,7 @@
 size_t yyuoffset, yyuleng;
 
 //keep track of the current utf-8 character (not byte) offset and token length
-#define YY_USER_ACTION { yyuoffset += yyuleng; yyuleng = utf8strlen(yytext); }
+#define YY_USER_ACTION { yyuoffset += yyuleng; yyuleng = utf8strlen(yytext, (size_t)yyleng); }
 //ignore the output of unmatched characters
 #define ECHO {}
 %}

--- a/UnitTests/SAParserUtilsTestSupport.swift
+++ b/UnitTests/SAParserUtilsTestSupport.swift
@@ -1,0 +1,78 @@
+//
+//  SAParserUtilsTestSupport.swift
+//  Sequel Ace
+//
+
+import Foundation
+import XCTest
+
+/// Owns the regression fixtures in Swift while exposing only the C-call block
+/// needed by the legacy Objective-C test target. `public` makes this test-only
+/// helper visible in the target's generated Swift header.
+@objc public final class SAParserUtilsTestSupport: NSObject {
+
+    @objc(runTestsWithCounter:)
+    public static func runTests(counter: @escaping (UnsafePointer<CChar>, UInt) -> UInt) {
+        testShortExactBuffers(counter: counter)
+        testLongLexerToken(counter: counter)
+    }
+
+    private static func testShortExactBuffers(counter: (UnsafePointer<CChar>, UInt) -> UInt) {
+        let cases = [
+            "", "a", "ab", "abc", "abcd", "selec", "abcdef", "abcdefg", "abcdefgh", "abcdefghi",
+            "ä", "こ", "🍏", "🍏🍋"
+        ]
+
+        for string in cases {
+            let data = Data(string.utf8)
+            let byteLength = data.count
+            let allocation = UnsafeMutableRawPointer.allocate(
+                byteCount: byteLength + 1,
+                alignment: MemoryLayout<UInt>.alignment
+            )
+            defer { allocation.deallocate() }
+
+            // Start one byte into the allocation so the input is unaligned and
+            // ends exactly at the allocation boundary, with no NUL terminator.
+            // Under ASan, any overread enters the redzone.
+            let input = allocation.advanced(by: 1)
+            if byteLength > 0 {
+                data.withUnsafeBytes { source in
+                    input.copyMemory(from: source.baseAddress!, byteCount: byteLength)
+                }
+            }
+
+            let bytes = input.assumingMemoryBound(to: CChar.self)
+            XCTAssertEqual(
+                counter(UnsafePointer(bytes), UInt(byteLength)),
+                UInt(string.utf16.count),
+                "character count for \(string) (\(byteLength) bytes)"
+            )
+        }
+    }
+
+    private static func testLongLexerToken(counter: (UnsafePointer<CChar>, UInt) -> UInt) {
+        // The 10-byte pattern shifts relative to the 8-byte word boundary on
+        // every repetition, exercising the bulk path and its tail handling.
+        let pattern: [UInt8] = [
+            0x61,                           // one UTF-8 byte, one UTF-16 code unit
+            0xc3, 0xa4,                     // two UTF-8 bytes, one UTF-16 code unit
+            0xe3, 0x81, 0x93,               // three UTF-8 bytes, one UTF-16 code unit
+            0xf0, 0x9f, 0x8d, 0x8f          // four UTF-8 bytes, two UTF-16 code units
+        ]
+        let repetitions = 100_000
+        let byteLength = pattern.count * repetitions
+        let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: byteLength)
+        defer { bytes.deallocate() }
+
+        for repetition in 0..<repetitions {
+            let offset = repetition * pattern.count
+            for (index, byte) in pattern.enumerated() {
+                bytes[offset + index] = byte
+            }
+        }
+
+        let input = UnsafeRawPointer(bytes).assumingMemoryBound(to: CChar.self)
+        XCTAssertEqual(counter(input, UInt(byteLength)), UInt(5 * repetitions))
+    }
+}

--- a/UnitTests/SPParserUtilsTest.m
+++ b/UnitTests/SPParserUtilsTest.m
@@ -34,10 +34,14 @@
 #import <XCTest/XCTest.h>
 
 #include "SPParserUtils.h"
+#include <stdlib.h>
+#include <string.h>
 
 @interface SPParserUtilsTest : XCTestCase
 
 - (void)testUtf8strlen;
+- (void)testUtf8strlenShortBuffers;
+- (void)testUtf8strlenLongLexerToken;
 
 @end
 
@@ -49,7 +53,7 @@
 	
 	const char *empty = "";
 	NSString *emptyString = [NSString stringWithCString:empty encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(empty),[emptyString length], @"empty string");
+	XCTAssertEqual(utf8strlen(empty, strlen(empty)),[emptyString length], @"empty string");
 	
 	// This is just a little safeguard.
 	// If any of those conditions fail, all of the following assumptions are moot.
@@ -60,28 +64,84 @@
 	
 	const char *singleByteSeq = "Hello World!";
 	NSString *singleByteString = [NSString stringWithCString:singleByteSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(singleByteSeq), [singleByteString length], @"ASCII UTF-8 subset");
+	XCTAssertEqual(utf8strlen(singleByteSeq, strlen(singleByteSeq)), [singleByteString length], @"ASCII UTF-8 subset");
 	
 	const char *twoByteSeq = "H\xC3\xA4ll\xC3\xB6 W\xC3\x9Crld\xC3\x9F!"; // Hällö WÜrldß!
 	NSString *twoByteString = [NSString stringWithCString:twoByteSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(twoByteSeq), [twoByteString length], @"String containing two-byte utf8 characters");
+	XCTAssertEqual(utf8strlen(twoByteSeq, strlen(twoByteSeq)), [twoByteString length], @"String containing two-byte utf8 characters");
 	
 	const char *threeByteSeq = "\xE3\x81\x93.\xE3\x82\x93.\xE3\x81\xAB.\xE3\x81\xA1.\xE3\x81\xAF"; // こ.ん.に.ち.は
 	NSString *threeByteString = [NSString stringWithCString:threeByteSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(threeByteSeq), [threeByteString length], @"String containing three-byte utf8 characters");
+	XCTAssertEqual(utf8strlen(threeByteSeq, strlen(threeByteSeq)), [threeByteString length], @"String containing three-byte utf8 characters");
 	
 	const char *fourByteSeq = "\xF0\x9F\x8D\x8F\xF0\x9F\x8D\x8B\xF0\x9F\x8D\x92"; //🍏🍋🍒
 	NSString *fourByteString = [NSString stringWithCString:fourByteSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(fourByteSeq), [fourByteString length], @"String containing only 4-byte utf8 characters (outside BMP)");
+	XCTAssertEqual(utf8strlen(fourByteSeq, strlen(fourByteSeq)), [fourByteString length], @"String containing only 4-byte utf8 characters (outside BMP)");
 
 	const char *mixedSeq = "\xE3\x81\x82\xE3\x82\x81\xE3\x80\x90\xE9\xA3\xB4\xE3\x80\x91\xF0\x9F\x8D\xAD \xE2\x89\x88 S\xC3\xBC\xC3\x9Figkeit"; // あめ【飴】🍭 ≈ Süßigkeit
 	NSString *mixedString = [NSString stringWithCString:mixedSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(mixedSeq), [mixedString length], @"utf8 characters with all 4 lengths mixed together.");
+	XCTAssertEqual(utf8strlen(mixedSeq, strlen(mixedSeq)), [mixedString length], @"utf8 characters with all 4 lengths mixed together.");
 	
 	//composed vs. decomposed chars
 	const char *decompSeq = "\xC3\xA4 - a\xCC\x88"; // ä - ä
 	NSString *decompString = [NSString stringWithCString:decompSeq encoding:NSUTF8StringEncoding];
-	XCTAssertEqual(utf8strlen(decompSeq), [decompString length], @"\"LATIN SMALL LETTER A WITH DIAERESIS\" vs. \"LATIN SMALL LETTER A\" + \"COMBINING DIAERESIS\"");
+	XCTAssertEqual(utf8strlen(decompSeq, strlen(decompSeq)), [decompString length], @"\"LATIN SMALL LETTER A WITH DIAERESIS\" vs. \"LATIN SMALL LETTER A\" + \"COMBINING DIAERESIS\"");
+}
+
+- (void)testUtf8strlenShortBuffers {
+	NSArray<NSString *> *cases = @[
+		@"", @"a", @"ab", @"abc", @"abcd", @"selec", @"abcdef", @"abcdefg", @"abcdefgh", @"abcdefghi",
+		@"ä", @"こ", @"\U0001F34F", @"\U0001F34F\U0001F34B"
+	];
+
+	for (NSString *string in cases) {
+		NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+		size_t byteLength = [data length];
+		char *allocation = malloc(byteLength + 1);
+		if (!allocation) {
+			XCTFail(@"Could not allocate test buffer");
+			return;
+		}
+
+		/* Start one byte into the allocation so the input is unaligned and ends
+		 * exactly at the allocation boundary, with no NUL terminator. Under ASan,
+		 * any read beyond the explicit byte span enters the redzone. */
+		char *bytes = allocation + 1;
+		if (byteLength > 0) {
+			memcpy(bytes, [data bytes], byteLength);
+		}
+
+		size_t actual = utf8strlen(bytes, byteLength);
+		free(allocation);
+
+		XCTAssertEqual(actual, [string length], @"character count for %@ (%zu bytes)", string, byteLength);
+	}
+}
+
+- (void)testUtf8strlenLongLexerToken {
+	/* A mixed 10-byte pattern deliberately shifts relative to the 8-byte word
+	 * boundary on every repetition, exercising both the SWAR bulk path and its
+	 * tail handling across a representative one-megabyte lexer token. */
+	const unsigned char pattern[] = {
+		'a',                         // one UTF-8 byte, one UTF-16 code unit
+		0xc3, 0xa4,                  // two UTF-8 bytes, one UTF-16 code unit
+		0xe3, 0x81, 0x93,            // three UTF-8 bytes, one UTF-16 code unit
+		0xf0, 0x9f, 0x8d, 0x8f      // four UTF-8 bytes, two UTF-16 code units
+	};
+	const size_t repetitions = 100000;
+	const size_t byteLength = sizeof(pattern) * repetitions;
+	unsigned char *bytes = malloc(byteLength);
+	if (!bytes) {
+		XCTFail(@"Could not allocate long lexer-token buffer");
+		return;
+	}
+
+	for (size_t offset = 0; offset < byteLength; offset += sizeof(pattern)) {
+		memcpy(bytes + offset, pattern, sizeof(pattern));
+	}
+
+	XCTAssertEqual(utf8strlen((const char *)bytes, byteLength), (size_t)(5 * repetitions));
+	free(bytes);
 }
 
 @end

--- a/UnitTests/SPParserUtilsTest.m
+++ b/UnitTests/SPParserUtilsTest.m
@@ -32,16 +32,15 @@
 
 #import <Cocoa/Cocoa.h>
 #import <XCTest/XCTest.h>
+#import "sequel-ace-Swift.h"
 
 #include "SPParserUtils.h"
-#include <stdlib.h>
 #include <string.h>
 
 @interface SPParserUtilsTest : XCTestCase
 
 - (void)testUtf8strlen;
-- (void)testUtf8strlenShortBuffers;
-- (void)testUtf8strlenLongLexerToken;
+- (void)testUtf8strlenBounds;
 
 @end
 
@@ -88,60 +87,10 @@
 	XCTAssertEqual(utf8strlen(decompSeq, strlen(decompSeq)), [decompString length], @"\"LATIN SMALL LETTER A WITH DIAERESIS\" vs. \"LATIN SMALL LETTER A\" + \"COMBINING DIAERESIS\"");
 }
 
-- (void)testUtf8strlenShortBuffers {
-	NSArray<NSString *> *cases = @[
-		@"", @"a", @"ab", @"abc", @"abcd", @"selec", @"abcdef", @"abcdefg", @"abcdefgh", @"abcdefghi",
-		@"ä", @"こ", @"\U0001F34F", @"\U0001F34F\U0001F34B"
-	];
-
-	for (NSString *string in cases) {
-		NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
-		size_t byteLength = [data length];
-		char *allocation = malloc(byteLength + 1);
-		if (!allocation) {
-			XCTFail(@"Could not allocate test buffer");
-			return;
-		}
-
-		/* Start one byte into the allocation so the input is unaligned and ends
-		 * exactly at the allocation boundary, with no NUL terminator. Under ASan,
-		 * any read beyond the explicit byte span enters the redzone. */
-		char *bytes = allocation + 1;
-		if (byteLength > 0) {
-			memcpy(bytes, [data bytes], byteLength);
-		}
-
-		size_t actual = utf8strlen(bytes, byteLength);
-		free(allocation);
-
-		XCTAssertEqual(actual, [string length], @"character count for %@ (%zu bytes)", string, byteLength);
-	}
-}
-
-- (void)testUtf8strlenLongLexerToken {
-	/* A mixed 10-byte pattern deliberately shifts relative to the 8-byte word
-	 * boundary on every repetition, exercising both the SWAR bulk path and its
-	 * tail handling across a representative one-megabyte lexer token. */
-	const unsigned char pattern[] = {
-		'a',                         // one UTF-8 byte, one UTF-16 code unit
-		0xc3, 0xa4,                  // two UTF-8 bytes, one UTF-16 code unit
-		0xe3, 0x81, 0x93,            // three UTF-8 bytes, one UTF-16 code unit
-		0xf0, 0x9f, 0x8d, 0x8f      // four UTF-8 bytes, two UTF-16 code units
-	};
-	const size_t repetitions = 100000;
-	const size_t byteLength = sizeof(pattern) * repetitions;
-	unsigned char *bytes = malloc(byteLength);
-	if (!bytes) {
-		XCTFail(@"Could not allocate long lexer-token buffer");
-		return;
-	}
-
-	for (size_t offset = 0; offset < byteLength; offset += sizeof(pattern)) {
-		memcpy(bytes + offset, pattern, sizeof(pattern));
-	}
-
-	XCTAssertEqual(utf8strlen((const char *)bytes, byteLength), (size_t)(5 * repetitions));
-	free(bytes);
+- (void)testUtf8strlenBounds {
+	[SAParserUtilsTestSupport runTestsWithCounter:^NSUInteger(const char *bytes, NSUInteger byteLength) {
+		return utf8strlen(bytes, byteLength);
+	}];
 }
 
 @end

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
+		0F2381A80270EFDE50D73890 /* SAParserUtilsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
 		10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
 		1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
@@ -1305,6 +1306,7 @@
 		6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAHelpViewerModelTests.swift; sourceTree = "<group>"; };
 		65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFilePreferencePane.m; sourceTree = "<group>"; };
 		65F52CCC24AE21F200FED3CB /* SPFilePreferencePane.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPFilePreferencePane.h; sourceTree = "<group>"; };
+		6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAParserUtilsTestSupport.swift; sourceTree = "<group>"; };
 		6BEA4EA5654FB073302AAD7F /* SAHelpViewerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAHelpViewerView.swift; sourceTree = "<group>"; };
 		6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBundleManagerAdditions.swift; sourceTree = "<group>"; };
 		6F0EA9222734ABE200514FF1 /* SABundleRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SABundleRunner.h; sourceTree = "<group>"; };
@@ -2604,6 +2606,7 @@
 				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
 				ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */,
 				7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */,
+				6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3479,6 +3482,7 @@
 				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
 				FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */,
 				E51CC2AA59AF37FEF73B06A0 /* SADragPasteboardTests.swift in Sources */,
+				0F2381A80270EFDE50D73890 /* SAParserUtilsTestSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- Pass flex's already-known byte length into `utf8strlen()` so it never has to inspect storage beyond the current lexer token.
- Retain the SWAR bulk path for complete in-bounds words, using `memcpy()` for defined unaligned loads, and count only the bounded tail byte-by-byte.
- Cover unaligned, exact-size, non-NUL-terminated UTF-8 buffers from 0–9 bytes plus short multibyte cases and a mixed one-megabyte lexer token.

## Closes following issues:
- Closes: #792

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - Xcode 26.6 (17F113) on macOS 26.6.2 (25G83)

## Screenshots:
- n/a — C lexer utility and tests only; no UI changes.

## Additional notes:
- This is a clean successor to #2522, rebuilt on current `main` and retaining Yuri Chukhlib's contribution via the signed commit's co-author trailer.
- Root-cause RED: compiling `main` with AddressSanitizer and calling `utf8strlen()` on the issue's six-byte heap allocation (`"selec\0"`) reports an 8-byte heap-buffer-overflow at the SWAR load and exits 134.
- GREEN: the two focused `SPParserUtilsTest` cases pass both normally and with AddressSanitizer enabled. `SAEditorTokensTests` also passes, and the generated editor/tokenizer C sources were verified to call the bounded signature.
- Full `Unit Tests` result: 1,062 passed, 60 skipped, 0 failed. The local `xcpretty` shim points to an unavailable gem, so this used the CI wrapper's underlying `xcodebuild` invocation directly.
- Additional parity check: 10,008 valid UTF-8 spans and 25,700 arbitrary nonzero byte spans matched the established counting semantics under strict C compilation.
- A 16 MiB / 40-iteration Apple Silicon microbenchmark measured about 3.20 ms per call for this bounded SWAR implementation, 3.28 ms for `main`, and 12.35 ms for #2522's bytewise loop (about 3.9× faster than the bytewise replacement). This is local diagnostic evidence, not a timing assertion in the test suite.
- The production utility remains C because both callers are flex-generated C hot paths. The new fixtures and assertions live in `SAParserUtilsTestSupport.swift`; `SPParserUtilsTest.m` retains only the minimal block needed to call the C symbol without adding a Unit Tests bridging header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 token length handling for bounded input, including buffers that are not NUL-terminated.
  * Prevented out-of-bounds reads when processing lexer tokens.
  * Preserved correct UTF-16 length calculations for Unicode characters.

* **Tests**
  * Added coverage for short, unaligned buffers and large mixed-UTF-8 tokens.
  * Expanded regression testing for multibyte characters and exact-length input processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->