### PR TITLE
#fixed Fit completion popup to its columns

### DIFF
--- a/Source/Model/SACompletionWindowLayout.swift
+++ b/Source/Model/SACompletionWindowLayout.swift
@@ -1,0 +1,55 @@
+//
+//  SACompletionWindowLayout.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objc final class SACompletionWindowLayout: NSObject {
+
+    /// Returns a scroll-view frame that fits the table content whenever the
+    /// maximum width allows it. If horizontal scrolling is unavoidable, its
+    /// non-overlay scroller is added below the content instead of covering it.
+    @objc(windowSizeForTableContentSize:maximumWidth:scrollerStyle:)
+    static func windowSize(
+        for tableContentSize: NSSize,
+        maximumWidth: CGFloat,
+        scrollerStyle: NSScroller.Style
+    ) -> NSSize {
+        let fittingSize = scrollViewFrameSize(
+            for: tableContentSize,
+            includesHorizontalScroller: false,
+            scrollerStyle: scrollerStyle
+        )
+        let fittingWidth = ceil(fittingSize.width)
+        let availableWidth = max(0, floor(maximumWidth))
+
+        guard fittingWidth > availableWidth else {
+            return NSSize(width: fittingWidth, height: ceil(fittingSize.height))
+        }
+
+        let scrollableSize = scrollViewFrameSize(
+            for: tableContentSize,
+            includesHorizontalScroller: true,
+            scrollerStyle: scrollerStyle
+        )
+        return NSSize(width: availableWidth, height: ceil(scrollableSize.height))
+    }
+
+    private static func scrollViewFrameSize(
+        for contentSize: NSSize,
+        includesHorizontalScroller: Bool,
+        scrollerStyle: NSScroller.Style
+    ) -> NSSize {
+        NSScrollView.frameSize(
+            forContentSize: contentSize,
+            horizontalScrollerClass: includesHorizontalScroller ? NSScroller.self : nil,
+            verticalScrollerClass: NSScroller.self,
+            borderType: .noBorder,
+            controlSize: .small,
+            scrollerStyle: scrollerStyle
+        )
+    }
+}

--- a/Source/Model/SPNarrowDownCompletion.h
+++ b/Source/Model/SPNarrowDownCompletion.h
@@ -69,7 +69,8 @@
 
 	SPTextView *theView;
 
-	NSInteger maxWindowWidth;
+	CGFloat maxWindowWidth;
+	CGFloat tableContentWidth;
 	NSInteger spaceCounter;
 
 	NSMutableCharacterSet *textualInputCharacters;

--- a/Source/Model/SPNarrowDownCompletion.m
+++ b/Source/Model/SPNarrowDownCompletion.m
@@ -287,6 +287,16 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 
 			[[theTableView tableColumnWithIdentifier:@"name"] setWidth:maxWindowWidth];
 		}
+		else {
+			NSScrollView *scrollView = (NSScrollView *)[self contentView];
+			maxWindowWidth = [SACompletionWindowLayout windowSizeForTableContentSize:NSMakeSize(tableContentWidth, 0)
+			                                                           maximumWidth:CGFLOAT_MAX
+			                                                           scrollerStyle:[scrollView scrollerStyle]].width;
+		}
+
+		// setCaretPos: runs before the first filter pass, so size the window now
+		// to keep the expanded popup inside the current screen.
+		[self setContentSize:NSMakeSize(maxWindowWidth, 0)];
 
 		currentDb = selectedDb;
 
@@ -391,6 +401,7 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 
 	[theTableView setDataSource:self];
 	[theTableView setDelegate:self];
+	tableContentWidth = NSWidth([theTableView frame]);
 	[scrollView setDocumentView:theTableView];
 
 	[self setContentView:scrollView];
@@ -729,7 +740,12 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 	NSPoint old = NSMakePoint([self frame].origin.x, [self frame].origin.y + [self frame].size.height);
 
 	NSInteger displayedRows = [newFiltered count] < SPNarrowDownCompletionMaxRows ? [newFiltered count] : SPNarrowDownCompletionMaxRows;
-	CGFloat newHeight = ([theTableView rowHeight] + [theTableView intercellSpacing].height) * ((displayedRows) ? displayedRows : 1);
+	CGFloat rowsHeight = ([theTableView rowHeight] + [theTableView intercellSpacing].height) * ((displayedRows) ? displayedRows : 1);
+	NSScrollView *scrollView = (NSScrollView *)[self contentView];
+	NSSize newWindowSize = [SACompletionWindowLayout windowSizeForTableContentSize:NSMakeSize(tableContentWidth, rowsHeight)
+	                                                                  maximumWidth:maxWindowWidth
+	                                                                  scrollerStyle:[scrollView scrollerStyle]];
+	CGFloat newHeight = newWindowSize.height;
 
 	if(caretPos.y >= 0 && (isAbove || caretPos.y < newHeight)) {
 		isAbove = YES;
@@ -742,7 +758,7 @@ withDBStructureRetriever:(SPDatabaseStructure *)theDatabaseStructure
 
 	// newHeight is currently the new height for theTableView, but we need to resize the whole window
 	// so here we use the difference in height to find the new height for the window
-	[self setFrame:NSMakeRect(old.x, old.y-newHeight, maxWindowWidth, newHeight) display:YES];
+	[self setFrame:NSMakeRect(old.x, old.y-newHeight, newWindowSize.width, newHeight) display:YES];
 	filtered = newFiltered;
 	if(!dictMode) [self checkSpaceForAllowedCharacter];
 	[theTableView reloadData];

--- a/UnitTests/SACompletionWindowLayoutTests.swift
+++ b/UnitTests/SACompletionWindowLayoutTests.swift
@@ -1,0 +1,72 @@
+//
+//  SACompletionWindowLayoutTests.swift
+//  Unit Tests
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+final class SACompletionWindowLayoutTests: XCTestCase {
+
+    private let tableContentSize = NSSize(width: 530, height: 255)
+
+    func testLegacyScrollersFitAllColumnsWithoutReducingRowHeight() {
+        let result = SACompletionWindowLayout.windowSize(
+            for: tableContentSize,
+            maximumWidth: 1_000,
+            scrollerStyle: .legacy
+        )
+
+        let visibleContentSize = contentSize(for: result, includesHorizontalScroller: false, style: .legacy)
+        XCTAssertEqual(visibleContentSize, tableContentSize)
+    }
+
+    func testOverlayScrollersFitAllColumnsWithoutExtraWindowSpace() {
+        let result = SACompletionWindowLayout.windowSize(
+            for: tableContentSize,
+            maximumWidth: 1_000,
+            scrollerStyle: .overlay
+        )
+
+        XCTAssertEqual(result, tableContentSize)
+    }
+
+    func testLegacyHorizontalScrollerIsPlacedBelowRowsWhenWidthIsCapped() {
+        let result = SACompletionWindowLayout.windowSize(
+            for: tableContentSize,
+            maximumWidth: 450,
+            scrollerStyle: .legacy
+        )
+
+        let visibleContentSize = contentSize(for: result, includesHorizontalScroller: true, style: .legacy)
+        XCTAssertEqual(result.width, 450)
+        XCTAssertEqual(visibleContentSize.height, tableContentSize.height)
+    }
+
+    func testOverlayHorizontalScrollerDoesNotIncreaseWindowHeightWhenWidthIsCapped() {
+        let result = SACompletionWindowLayout.windowSize(
+            for: tableContentSize,
+            maximumWidth: 450,
+            scrollerStyle: .overlay
+        )
+
+        XCTAssertEqual(result, NSSize(width: 450, height: tableContentSize.height))
+    }
+
+    private func contentSize(
+        for frameSize: NSSize,
+        includesHorizontalScroller: Bool,
+        style: NSScroller.Style
+    ) -> NSSize {
+        NSScrollView.contentSize(
+            forFrameSize: frameSize,
+            horizontalScrollerClass: includesHorizontalScroller ? NSScroller.self : nil,
+            verticalScrollerClass: NSScroller.self,
+            borderType: .noBorder,
+            controlSize: .small,
+            scrollerStyle: style
+        )
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		1AF0DA8B259F657200961974 /* SPPointerArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF0DA7E259F5D8C00961974 /* SPPointerArrayAdditions.m */; };
 		1AF5A261250AC401009885DF /* SPBracketHighlighter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25E250AC401009885DF /* SPBracketHighlighter.m */; };
 		1AF5A262250AC401009885DF /* SPBrackets.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF5A25F250AC401009885DF /* SPBrackets.m */; };
+		1B1C4038B2DE3B11B53868BB /* SACompletionWindowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */; };
 		1C7055887A73B6C4D4C13D51 /* SPDuplicateImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA7A8F76494CE39908140FA /* SPDuplicateImportViewController.swift */; };
 		1E4E58D8ABEA1E269DC46FD2 /* AWSSSOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAD424F195B2E207BF7C604 /* AWSSSOClient.swift */; };
 		2456FC7DD02544F7BFE23596 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
@@ -520,6 +521,7 @@
 		B58731280F838C9E00087794 /* PreferenceDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = B58731270F838C9E00087794 /* PreferenceDefaults.plist */; };
 		B5E2C5FA0F2353B5007446E0 /* table-property.png in Resources */ = {isa = PBXBuildFile; fileRef = B5E2C5F90F2353B5007446E0 /* table-property.png */; };
 		B5E92F1C0F75B2E800012500 /* SPExportController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E92F1B0F75B2E800012500 /* SPExportController.m */; };
+		B6652B91184395063E5303FC /* SACompletionWindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */; };
 		B6E4019A9F1C4A8AA0B3D101 /* SALocalNetworkPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E4019A9F1C4A8AA0B3D104 /* SALocalNetworkPermissionCheckerTests.swift */; };
 		B6E4019A9F1C4A8AA0B3D102 /* SALocalNetworkPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E4019A9F1C4A8AA0B3D105 /* SALocalNetworkPermissionChecker.swift */; };
 		B6E4019A9F1C4A8AA0B3D103 /* SALocalNetworkPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E4019A9F1C4A8AA0B3D105 /* SALocalNetworkPermissionChecker.swift */; };
@@ -594,6 +596,7 @@
 		CF0000232F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */; };
 		CF0000252F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */; };
 		CF0000262F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */; };
+		D2986F1FE4860F18CAAECCD9 /* SACompletionWindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */; };
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
 		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
 		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
@@ -767,6 +770,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SACompletionWindowLayout.swift; sourceTree = "<group>"; };
 		1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		112730551180788A000737FD /* SPTableCopyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableCopyTest.m; sourceTree = "<group>"; };
 		1141A387117BBFF200126A28 /* SPTableCopy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTableCopy.h; sourceTree = "<group>"; };
@@ -1185,6 +1189,7 @@
 		51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
 		54146A7693E8D862D06856BF /* SAConnectionInfo+ConnectionString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+ConnectionString.swift"; sourceTree = "<group>"; };
 		5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAStaleBookmarkAlertContentTests.swift; sourceTree = "<group>"; };
+		55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SACompletionWindowLayoutTests.swift; sourceTree = "<group>"; };
 		5806B76211A991EC00813A88 /* SPDocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDocumentController.h; sourceTree = "<group>"; };
 		5806B76311A991EC00813A88 /* SPDocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDocumentController.m; sourceTree = "<group>"; };
 		581068B51015411B0068C6E2 /* link-arrow-highlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "link-arrow-highlighted.png"; sourceTree = "<group>"; };
@@ -2226,6 +2231,7 @@
 				5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */,
 				C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */,
 				54146A7693E8D862D06856BF /* SAConnectionInfo+ConnectionString.swift */,
+				0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2604,6 +2610,7 @@
 				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
 				ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */,
 				7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */,
+				55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3479,6 +3486,8 @@
 				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
 				FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */,
 				E51CC2AA59AF37FEF73B06A0 /* SADragPasteboardTests.swift in Sources */,
+				B6652B91184395063E5303FC /* SACompletionWindowLayout.swift in Sources */,
+				1B1C4038B2DE3B11B53868BB /* SACompletionWindowLayoutTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3791,6 +3800,7 @@
 				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
 				16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */,
 				410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */,
+				D2986F1FE4860F18CAAECCD9 /* SACompletionWindowLayout.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- Size multi-column completion popups from the table content using AppKit scroller-aware metrics, keeping the source/path column visible.
- Reserve space below completion rows when a non-overlay horizontal scroller is unavoidable.
- Add regression coverage for fitting and width-capped layouts with both overlay and legacy scrollbars.

## Closes following issues:
- Closes: #2579

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  - 26.6 (17F113)

## Screenshots:
Not attached: the completion popup is a transient borderless window that was not included by the automated screen capture.

## Additional notes:
- Sequel Ace Debug builds successfully.
- Full Unit Tests run: 1,065 passed, 60 skipped, 0 failed.
- Focused layout regression tests: 4 passed, 0 failed.
- Manually verified against MySQL 8.0.46: overlay scrollbars showed the complete 530-point table in a 530-point popup; legacy scrollbars reserved their own space, showed the complete 530-point table, and did not cover rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved completion popup sizing based on table content and available width.
  - Preserved column visibility while correctly accommodating horizontal scrollbars.
  - Improved popup height and frame calculations for different scrollbar styles.

- **Tests**
  - Added coverage for uncapped and width-constrained completion layouts, including legacy and overlay scrollbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->