### PR TITLE
#added Replace an existing query favorite

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -1164,6 +1164,9 @@
 /* shutdown server : confirmation dialog : title */
 "Do you really want to shutdown the server?" = "Do you really want to shutdown the server?";
 
+/* Document query favorite scope */
+"Document" = "Document";
+
 /* dtd identifier label (Navigator) */
 "DTD Identifier" = "DTD Identifier";
 
@@ -1232,6 +1235,9 @@
 
 /* Table Info Section : Table Engine */
 "engine: %@" = "engine: %@";
+
+/* Missing query favorite name alert message */
+"Enter a query name or choose a favorite to replace." = "Enter a query name or choose a favorite to replace.";
 
 /* enter connection details label */
 "Enter connection details below, or choose a favorite" = "Enter connection details below, or choose a favorite";
@@ -1429,6 +1435,12 @@
 
 /* export filename favorite name token */
 "Favorite" = "Favorite";
+
+/* Stale query favorite replacement alert title */
+"Favorite Changed" = "Favorite Changed";
+
+/* Query favorite replacement picker accessibility label */
+"Favorite to replace" = "Favorite to replace";
 
 /* favorites label */
 "Favorites" = "Favorites";
@@ -2062,6 +2074,9 @@
 /* optional placeholder string */
 "optional" = "optional";
 
+/* Query favorite replacement picker label */
+"Or replace an existing favorite:" = "Or replace an existing favorite:";
+
 /* Passed parameter couldn't be interpreted. Only string or array (with 2 elements) are allowed. */
 "Passed parameter couldn't be interpreted. Only string or array (with 2 elements) are allowed." = "Passed parameter couldn't be interpreted. Only string or array (with 2 elements) are allowed.";
 
@@ -2122,6 +2137,9 @@
 /* query logging currently disabled label
  query logging disabled label */
 "Query logging is currently disabled" = "Query logging is currently disabled";
+
+/* Query favorite save sheet name label */
+"Query Name:" = "Query Name:";
 
 /* query result print heading */
 "Query Result" = "Query Result";
@@ -2388,11 +2406,17 @@
 /* Save Current Query to Favorites */
 "Save Current Query to Favorites" = "Save Current Query to Favorites";
 
+/* Query favorite save sheet global checkbox */
+"Save globally" = "Save globally";
+
 /* save page as menu item title */
 "Save Page As…" = "Save Page As…";
 
 /* Save Queries… */
 "Save Queries…" = "Save Queries…";
+
+/* Query favorite save sheet title */
+"Save Query Favorite" = "Save Query Favorite";
 
 /* Save Query… */
 "Save Query…" = "Save Query…";
@@ -2850,6 +2874,12 @@
 
 /* export : import settings : file version error description ($1 = is version, $2 = list of supported versions); note: the u00A0 is a non-breaking space, do not add more whitespace. */
 "The selected export settings were stored with version %1$ld, but only settings with the following versions can be imported: %2$@.\n\nEither save the settings in a backwards compatible way or update your version of Sequel Ace." = "The selected export settings were stored with version %1$ld, but only settings with the following versions can be imported: %2$@.\n\nEither save the settings in a backwards compatible way or update your version of Sequel Ace.";
+
+/* Query favorite replacement explanation */
+"The selected favorite keeps its name and location." = "The selected favorite keeps its name and location.";
+
+/* Stale query favorite replacement alert message */
+"The selected favorite was changed or removed in another window. Choose it again before saving." = "The selected favorite was changed or removed in another window. Choose it again before saving.";
 
 /* export : import settings : spf content type error description */
 "The selected file contains data of type “%1$@”, but type “%2$@” is needed. Please choose a different file." = "The selected file contains data of type “%1$@”, but type “%2$@” is needed. Please choose a different file.";

--- a/Source/Controllers/MainViewControllers/SAQueryFavoriteSaveWindowController.swift
+++ b/Source/Controllers/MainViewControllers/SAQueryFavoriteSaveWindowController.swift
@@ -1,0 +1,254 @@
+//
+//  SAQueryFavoriteSaveWindowController.swift
+//  Sequel Ace
+//
+//  SwiftUI replacement for the legacy Query Favorite Sheet in DBView.xib.
+//
+
+
+import SwiftUI
+
+@MainActor
+private final class SAQueryFavoriteSaveViewModel: ObservableObject {
+    @Published var name = ""
+    @Published var saveGlobally: Bool
+    @Published var selectedFavoriteID: String? {
+        didSet {
+            if let selectedFavorite {
+                saveGlobally = selectedFavorite.scope == .global
+            }
+        }
+    }
+    @Published var selections: [SAQueryFavoriteSelection]
+    @Published var errorMessage = ""
+    @Published var isShowingError = false
+
+    init(saveGlobally: Bool, selections: [SAQueryFavoriteSelection]) {
+        self.saveGlobally = saveGlobally
+        self.selections = selections
+    }
+
+    var selectedFavorite: SAQueryFavoriteSelection? {
+        selections.first { $0.id == selectedFavoriteID }
+    }
+
+    var canSave: Bool {
+        selectedFavorite != nil || !name.isEmpty
+    }
+
+    func refreshSelections(_ selections: [SAQueryFavoriteSelection]) {
+        self.selections = selections
+        selectedFavoriteID = nil
+    }
+
+    func showError(_ message: String) {
+        errorMessage = message
+        isShowingError = true
+    }
+}
+
+private struct SAQueryFavoriteSaveView: View {
+    @ObservedObject var model: SAQueryFavoriteSaveViewModel
+    let onSave: () -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var isNameFocused: Bool
+
+    private var isReplacing: Bool {
+        model.selectedFavorite != nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("Query Name:", comment: "Query favorite save sheet name label"))
+                .font(.headline)
+
+            TextField("", text: $model.name)
+                .textFieldStyle(.roundedBorder)
+                .disabled(isReplacing)
+                .focused($isNameFocused)
+
+            Toggle(
+                NSLocalizedString("Save globally", comment: "Query favorite save sheet global checkbox"),
+                isOn: $model.saveGlobally
+            )
+            .disabled(isReplacing)
+
+            Divider()
+
+            Text(NSLocalizedString("Or replace an existing favorite:", comment: "Query favorite replacement picker label"))
+                .font(.headline)
+
+            Picker("", selection: $model.selectedFavoriteID) {
+                Text(NSLocalizedString("None", comment: "No query favorite replacement selection"))
+                    .tag(String?.none)
+
+                ForEach(model.selections) { selection in
+                    Text(selectionTitle(selection))
+                        .tag(Optional(selection.id))
+                }
+            }
+            .labelsHidden()
+            .accessibilityLabel(
+                Text(NSLocalizedString("Favorite to replace", comment: "Query favorite replacement picker accessibility label"))
+            )
+
+            if isReplacing {
+                Text(NSLocalizedString(
+                    "The selected favorite keeps its name and location.",
+                    comment: "Query favorite replacement explanation"
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Spacer()
+
+                Button(NSLocalizedString("Cancel", comment: "Cancel query favorite save"), action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+
+                Button(NSLocalizedString("Save", comment: "Save query favorite"), action: onSave)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!model.canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .onAppear {
+            isNameFocused = true
+        }
+        .alert(
+            NSLocalizedString("Favorite Changed", comment: "Stale query favorite replacement alert title"),
+            isPresented: $model.isShowingError
+        ) {
+            Button(NSLocalizedString("OK", comment: "Dismiss query favorite replacement error"), role: .cancel) {}
+        } message: {
+            Text(model.errorMessage)
+        }
+    }
+
+    private func selectionTitle(_ selection: SAQueryFavoriteSelection) -> String {
+        let scope: String
+        switch selection.scope {
+        case .document:
+            scope = NSLocalizedString("Document", comment: "Document query favorite scope")
+        case .global:
+            scope = NSLocalizedString("Global", comment: "Global query favorite scope")
+        }
+        return "[\(scope)] \(selection.name)"
+    }
+}
+
+@MainActor
+@objc final class SAQueryFavoriteSaveWindowController: NSWindowController {
+    private let query: String
+    private let fileURL: URL
+    private let model: SAQueryFavoriteSaveViewModel
+    private let preferences = UserDefaults.standard
+
+    @objc(initWithQuery:fileURL:defaultSaveGlobally:)
+    init(query: String, fileURL: URL, defaultSaveGlobally: Bool) {
+        self.query = query
+        self.fileURL = fileURL
+
+        let selections = SAQueryFavoriteStore.selections(
+            documentFavorites: Self.documentFavorites(for: fileURL),
+            globalFavorites: Self.globalFavorites()
+        )
+        model = SAQueryFavoriteSaveViewModel(
+            saveGlobally: defaultSaveGlobally,
+            selections: selections
+        )
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 280),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = NSLocalizedString("Save Query Favorite", comment: "Query favorite save sheet title")
+        panel.isReleasedWhenClosed = false
+
+        super.init(window: panel)
+
+        panel.contentView = NSHostingView(
+            rootView: SAQueryFavoriteSaveView(
+                model: model,
+                onSave: { [weak self] in self?.save() },
+                onCancel: { [weak self] in self?.finish(returnCode: .cancel) }
+            )
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    private func save() {
+        let documentFavorites = Self.documentFavorites(for: fileURL)
+        let globalFavorites = Self.globalFavorites()
+
+        do {
+            let mutation = try SAQueryFavoriteStore.save(
+                query: query,
+                name: model.name,
+                saveGlobally: model.saveGlobally,
+                replacing: model.selectedFavorite,
+                documentFavorites: documentFavorites,
+                globalFavorites: globalFavorites
+            )
+
+            switch mutation.scope {
+            case .document:
+                SPQueryController.shared().replaceFavorites(
+                    by: mutation.favorites,
+                    forFileURL: fileURL
+                )
+            case .global:
+                preferences.set(mutation.favorites, forKey: SPQueryFavorites)
+            }
+
+            NotificationCenter.default.post(
+                name: .SPQueryFavoritesHaveBeenUpdated,
+                object: self
+            )
+            finish(returnCode: .OK)
+        } catch SAQueryFavoriteSaveError.selectedFavoriteChanged {
+            model.refreshSelections(SAQueryFavoriteStore.selections(
+                documentFavorites: documentFavorites,
+                globalFavorites: globalFavorites
+            ))
+            model.showError(NSLocalizedString(
+                "The selected favorite was changed or removed in another window. Choose it again before saving.",
+                comment: "Stale query favorite replacement alert message"
+            ))
+        } catch {
+            model.showError(NSLocalizedString(
+                "Enter a query name or choose a favorite to replace.",
+                comment: "Missing query favorite name alert message"
+            ))
+        }
+    }
+
+    private func finish(returnCode: NSApplication.ModalResponse) {
+        guard let window else { return }
+        if let sheetParent = window.sheetParent {
+            sheetParent.endSheet(window, returnCode: returnCode)
+        } else {
+            window.close()
+        }
+    }
+
+    private static func documentFavorites(for fileURL: URL) -> [Any] {
+        guard let favorites = SPQueryController.shared().favorites(forFileURL: fileURL) else {
+            return []
+        }
+        return favorites.map { $0 }
+    }
+
+    private static func globalFavorites() -> [Any] {
+        UserDefaults.standard.array(forKey: SPQueryFavorites) ?? []
+    }
+}

--- a/Source/Controllers/MainViewControllers/SAQueryFavoriteStore.swift
+++ b/Source/Controllers/MainViewControllers/SAQueryFavoriteStore.swift
@@ -1,0 +1,117 @@
+//
+//  SAQueryFavoriteStore.swift
+//  Sequel Ace
+//
+//  Pure favorite-list mutation used by the SwiftUI query-favorite save sheet.
+//  Compiled into BOTH the app and Unit Tests targets.
+//
+
+
+import Foundation
+
+enum SAQueryFavoriteScope: Int {
+    case document
+    case global
+}
+
+/// A snapshot of one favorite shown in the replacement picker.
+///
+/// Query favorites have no persistent identifier. The original position and
+/// full dictionary are therefore retained so a save can revalidate the choice
+/// against the latest list instead of trusting a stale array index.
+struct SAQueryFavoriteSelection: Identifiable {
+    let scope: SAQueryFavoriteScope
+    let originalIndex: Int
+    let favorite: NSDictionary
+    let name: String
+
+    var id: String {
+        "\(scope.rawValue):\(originalIndex)"
+    }
+}
+
+enum SAQueryFavoriteSaveError: Error, Equatable {
+    case nameRequired
+    case selectedFavoriteChanged
+}
+
+struct SAQueryFavoriteMutation {
+    let scope: SAQueryFavoriteScope
+    let favorites: [Any]
+}
+
+enum SAQueryFavoriteStore {
+
+    /// Builds picker choices while retaining each item's real source index.
+    /// Malformed entries remain in storage but are not offered for replacement.
+    static func selections(documentFavorites: [Any], globalFavorites: [Any]) -> [SAQueryFavoriteSelection] {
+        selections(in: documentFavorites, scope: .document)
+            + selections(in: globalFavorites, scope: .global)
+    }
+
+    /// Creates a favorite or replaces the selected favorite's query.
+    ///
+    /// Replacement keeps the existing dictionary intact — including its name,
+    /// tab trigger and any future metadata — and changes only `query`. Before
+    /// writing, the captured favorite is resolved against the current list. If
+    /// concurrent edits make that resolution missing or ambiguous, the save
+    /// fails rather than overwriting a different favorite.
+    static func save(query: String,
+                     name: String,
+                     saveGlobally: Bool,
+                     replacing selection: SAQueryFavoriteSelection?,
+                     documentFavorites: [Any],
+                     globalFavorites: [Any]) throws -> SAQueryFavoriteMutation {
+        guard let selection else {
+            guard !name.isEmpty else { throw SAQueryFavoriteSaveError.nameRequired }
+
+            let scope: SAQueryFavoriteScope = saveGlobally ? .global : .document
+            var favorites = scope == .global ? globalFavorites : documentFavorites
+            favorites.append(["name": name, "query": query] as NSDictionary)
+            return SAQueryFavoriteMutation(scope: scope, favorites: favorites)
+        }
+
+        var favorites = selection.scope == .global ? globalFavorites : documentFavorites
+        guard let index = resolvedIndex(for: selection, in: favorites),
+              let currentFavorite = favorites[index] as? NSDictionary else {
+            throw SAQueryFavoriteSaveError.selectedFavoriteChanged
+        }
+
+        let replacement = NSMutableDictionary(dictionary: currentFavorite)
+        replacement["query"] = query
+        favorites[index] = replacement
+        return SAQueryFavoriteMutation(scope: selection.scope, favorites: favorites)
+    }
+
+    private static func selections(in favorites: [Any],
+                                   scope: SAQueryFavoriteScope) -> [SAQueryFavoriteSelection] {
+        favorites.enumerated().compactMap { index, rawFavorite in
+            guard let favorite = rawFavorite as? NSDictionary,
+                  let name = favorite["name"] as? String else {
+                return nil
+            }
+
+            return SAQueryFavoriteSelection(
+                scope: scope,
+                originalIndex: index,
+                favorite: NSDictionary(dictionary: favorite),
+                name: name
+            )
+        }
+    }
+
+    private static func resolvedIndex(for selection: SAQueryFavoriteSelection,
+                                      in favorites: [Any]) -> Int? {
+        if favorites.indices.contains(selection.originalIndex),
+           let favorite = favorites[selection.originalIndex] as? NSDictionary,
+           favorite.isEqual(selection.favorite) {
+            return selection.originalIndex
+        }
+
+        let matchingIndexes = favorites.indices.filter { index in
+            guard let favorite = favorites[index] as? NSDictionary else { return false }
+            return favorite.isEqual(selection.favorite)
+        }
+        return matchingIndexes.count == 1 ? matchingIndexes[0] : nil
+    }
+}

--- a/Source/Controllers/MainViewControllers/SAQueryFavoriteStore.swift
+++ b/Source/Controllers/MainViewControllers/SAQueryFavoriteStore.swift
@@ -16,14 +16,16 @@ enum SAQueryFavoriteScope: Int {
 
 /// A snapshot of one favorite shown in the replacement picker.
 ///
-/// Query favorites have no persistent identifier. The original position and
-/// full dictionary are therefore retained so a save can revalidate the choice
-/// against the latest list instead of trusting a stale array index.
+/// Query favorites have no persistent identifier. The original position, full
+/// dictionary and source-list snapshot are therefore retained so a save can
+/// revalidate the choice against the latest list instead of trusting a stale
+/// array index.
 struct SAQueryFavoriteSelection: Identifiable {
     let scope: SAQueryFavoriteScope
     let originalIndex: Int
     let favorite: NSDictionary
     let name: String
+    let sourceFavorites: NSArray
 
     var id: String {
         "\(scope.rawValue):\(originalIndex)"
@@ -85,7 +87,13 @@ enum SAQueryFavoriteStore {
 
     private static func selections(in favorites: [Any],
                                    scope: SAQueryFavoriteScope) -> [SAQueryFavoriteSelection] {
-        favorites.enumerated().compactMap { index, rawFavorite in
+        let sourceSnapshotItems: [Any] = favorites.map { rawFavorite -> Any in
+            guard let favorite = rawFavorite as? NSDictionary else { return rawFavorite }
+            return NSDictionary(dictionary: favorite)
+        }
+        let sourceFavorites = NSArray(array: sourceSnapshotItems)
+
+        return favorites.enumerated().compactMap { index, rawFavorite in
             guard let favorite = rawFavorite as? NSDictionary,
                   let name = favorite["name"] as? String else {
                 return nil
@@ -95,18 +103,31 @@ enum SAQueryFavoriteStore {
                 scope: scope,
                 originalIndex: index,
                 favorite: NSDictionary(dictionary: favorite),
-                name: name
+                name: name,
+                sourceFavorites: sourceFavorites
             )
         }
     }
 
     private static func resolvedIndex(for selection: SAQueryFavoriteSelection,
                                       in favorites: [Any]) -> Int? {
-        if favorites.indices.contains(selection.originalIndex),
+        // An unchanged list preserves the identity of even identical entries.
+        // Once the list changes, both the original and current match must be
+        // unique because no persisted favorite identifier exists.
+        if selection.sourceFavorites.isEqual(to: favorites),
+           favorites.indices.contains(selection.originalIndex),
            let favorite = favorites[selection.originalIndex] as? NSDictionary,
            favorite.isEqual(selection.favorite) {
             return selection.originalIndex
         }
+
+        let originalMatchCount = selection.sourceFavorites.reduce(into: 0) { count, rawFavorite in
+            guard let favorite = rawFavorite as? NSDictionary else { return }
+            if favorite.isEqual(selection.favorite) {
+                count += 1
+            }
+        }
+        guard originalMatchCount == 1 else { return nil }
 
         let matchingIndexes = favorites.indices.filter { index in
             guard let favorite = favorites[index] as? NSDictionary else { return false }

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.h
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.h
@@ -64,11 +64,6 @@
 	IBOutlet id queryFavoritesSearchFieldView;
 	IBOutlet NSSearchField *queryFavoritesSearchField;
 
-	IBOutlet NSWindow *queryFavoritesSheet;
-	IBOutlet NSButton *saveQueryFavoriteButton;
-	IBOutlet NSTextField *queryFavoriteNameTextField;
-	IBOutlet NSButton *saveQueryFavoriteGlobal;
-
 	IBOutlet id queryHistoryButton;
 	IBOutlet NSMenuItem *queryHistorySearchMenuItem;
 	IBOutlet id queryHistorySearchFieldView;

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -112,6 +112,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 - (void)queryFavoritesHaveBeenUpdated:(NSNotification *)notification;
 - (void)historyItemsHaveBeenUpdated:(NSNotification *)notification;
 - (void)helpWindowClosedByUser:(NSNotification *)notification;
+- (void)presentQueryFavoriteSaveSheetForQuery:(NSString *)query;
 
 @property (readwrite, strong) NSMutableDictionary<NSNumber*,NSNumber*> *sortCount;
 @property (assign) BOOL recordViewNeedsSelectionRestoreRefresh;
@@ -279,87 +280,50 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 }
 
 /**
- * Insert the choosen favorite query in the query textView or save query to favorites or opens window to edit favorites
+ * Present the SwiftUI save sheet. The completion block intentionally retains
+ * the controller for the sheet's lifetime; the parent releases it afterwards.
+ */
+- (void)presentQueryFavoriteSaveSheetForQuery:(NSString *)query
+{
+    NSWindow *parentWindow = [tableDocumentInstance parentWindowControllerWindow];
+    NSURL *fileURL = [tableDocumentInstance fileURL];
+    if (!parentWindow || !fileURL) return;
+
+    SAQueryFavoriteSaveWindowController *saveController = [[SAQueryFavoriteSaveWindowController alloc]
+        initWithQuery:query
+        fileURL:fileURL
+        defaultSaveGlobally:[tableDocumentInstance isUntitled]];
+    [parentWindow beginSheet:[saveController window] completionHandler:^(__unused NSModalResponse returnCode) {
+        (void)[saveController window];
+    }];
+}
+
+/**
+ * Insert the chosen favorite query in the query text view, save a query to
+ * favorites, or open the favorites manager.
  */
 - (IBAction)chooseQueryFavorite:(id)sender
 {
-    if ([queryFavoritesButton indexOfSelectedItem] == 1) {
-        
-        // This should never evaluate to true as we are now performing menu validation, meaning the 'Save Query to Favorites' menu item will
-        // only be enabled if the query text view has at least one character present.
+    NSInteger selectedItem = [queryFavoritesButton indexOfSelectedItem];
+
+    if (selectedItem == 1 || selectedItem == 2) {
+        // Menu validation normally prevents this path for an empty editor.
         if ([[textView string] isEqualToString:@""]) {
             [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Empty query", @"empty query message") message:NSLocalizedString(@"Cannot save an empty query.", @"empty query informative message") callback:nil];
             return;
         }
-        
-        if ([tableDocumentInstance isUntitled]) {
-            [saveQueryFavoriteGlobal setState:NSControlStateValueOn];
-        }
-        [[tableDocumentInstance parentWindowControllerWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
-            if (returnCode == NSModalResponseOK) {
-                
-                // Add the new query favorite directly the user's preferences here instead of asking the manager to do it
-                // as it may not have been fully initialized yet.
-                NSMutableArray *favorites = [NSMutableArray arrayWithArray:[self->prefs objectForKey:SPQueryFavorites]];
-                
-                // What should be saved
-                NSString *queryToBeAddded;
-                if ([self->textView selectedRange].length) { // First check for a selection
-                    queryToBeAddded = [[self->textView string] substringWithRange:[self->textView selectedRange]];
-                } else if (self->currentQueryRange.length) { // then for a current query
-                    queryToBeAddded = [[self->textView string] substringWithRange:self->currentQueryRange];
-                } else { // otherwise take the entire string
-                    queryToBeAddded = [self->textView string];
-                }
-                
-                if ([self->saveQueryFavoriteGlobal state] == NSControlStateValueOn) {
-                    [favorites addObject:[NSMutableDictionary dictionaryWithObjects: [NSArray arrayWithObjects:[self->queryFavoriteNameTextField stringValue], queryToBeAddded, nil] forKeys:@[@"name", @"query"]]];
-                    
-                    [self->prefs setObject:favorites forKey:SPQueryFavorites];
-                } else {
-                    [[SPQueryController sharedQueryController] addFavorite:[NSMutableDictionary dictionaryWithObjects: [NSArray arrayWithObjects:[self->queryFavoriteNameTextField stringValue], [queryToBeAddded mutableCopy], nil] forKeys:@[@"name", @"query"]] forFileURL:[self->tableDocumentInstance fileURL]];
-                }
-                [self->saveQueryFavoriteGlobal setState:NSControlStateValueOff];
-                [self queryFavoritesHaveBeenUpdated:nil];
-                [self->queryFavoriteNameTextField setStringValue:@""];
+
+        NSString *queryToSave = [textView string];
+        if (selectedItem == 1) {
+            if ([textView selectedRange].length) {
+                queryToSave = [[textView string] substringWithRange:[textView selectedRange]];
+            } else if (currentQueryRange.length) {
+                queryToSave = [[textView string] substringWithRange:currentQueryRange];
             }
-        }];
-        
-    }
-    if ([queryFavoritesButton indexOfSelectedItem] == 2) {
-        
-        // This should never evaluate to true as we are now performing menu validation, meaning the 'Save Query to Favorites' menu item will only be enabled if the query text view has at least one character present.
-        if ([[textView string] isEqualToString:@""]) {
-            [NSAlert createWarningAlertWithTitle:NSLocalizedString(@"Empty query", @"empty query message") message:NSLocalizedString(@"Cannot save an empty query.", @"empty query informative message") callback:nil];
-            return;
         }
-        
-        if ([tableDocumentInstance isUntitled]) {
-            [saveQueryFavoriteGlobal setState:NSControlStateValueOn];
-        }
-        [[tableDocumentInstance parentWindowControllerWindow] beginSheet:queryFavoritesSheet completionHandler:^(NSModalResponse returnCode) {
-            if (returnCode == NSModalResponseOK) {
-                
-                // Add the new query favorite directly the user's preferences here instead of asking the manager to do it
-                // as it may not have been fully initialized yet.
-                NSMutableArray *favorites = [NSMutableArray arrayWithArray:[self->prefs objectForKey:SPQueryFavorites]];
-                
-                // What should be saved
-                NSString *queryToBeAddded = [self->textView string];
-                
-                if ([self->saveQueryFavoriteGlobal state] == NSControlStateValueOn) {
-                    [favorites addObject:[NSMutableDictionary dictionaryWithObjects: [NSArray arrayWithObjects:[self->queryFavoriteNameTextField stringValue], queryToBeAddded, nil] forKeys:@[@"name", @"query"]]];
-                    
-                    [self->prefs setObject:favorites forKey:SPQueryFavorites];
-                } else {
-                    [[SPQueryController sharedQueryController] addFavorite:[NSMutableDictionary dictionaryWithObjects: [NSArray arrayWithObjects:[self->queryFavoriteNameTextField stringValue], [queryToBeAddded mutableCopy], nil] forKeys:@[@"name", @"query"]] forFileURL:[self->tableDocumentInstance fileURL]];
-                }
-                [self->saveQueryFavoriteGlobal setState:NSControlStateValueOff];
-                [self queryFavoritesHaveBeenUpdated:nil];
-                [self->queryFavoriteNameTextField setStringValue:@""];
-            }
-        }];
-    } else if ([queryFavoritesButton indexOfSelectedItem] == 3) {
+
+        [self presentQueryFavoriteSaveSheetForQuery:queryToSave];
+    } else if (selectedItem == 3) {
         
         favoritesManager = [[SPQueryFavoriteManager alloc] initWithDelegate:self];
         
@@ -3169,14 +3133,11 @@ static NSString * const SPDashStyleCommentMarker = @"-- ";
 #pragma mark TextField delegate methods
 
 /**
- * Called whenever the user changes the name of the new query favorite or
- * the user changed the query favorite search string.
+ * Called whenever the user changes a query favorites/history search string.
  */
 - (void)controlTextDidChange:(NSNotification *)notification
 {
-    if ([notification object] == queryFavoriteNameTextField)
-        [saveQueryFavoriteButton setEnabled:[[queryFavoriteNameTextField stringValue] length]];
-    else if ([notification object] == queryFavoritesSearchField){
+    if ([notification object] == queryFavoritesSearchField){
         [self filterQueryFavorites:nil];
     }
     else if ([notification object] == queryHistorySearchField) {

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -933,7 +933,10 @@ static SPQueryController *sharedQueryController = nil;
 - (void)replaceFavoritesByArray:(NSArray *)favoritesArray forFileURL:(NSURL *)fileURL
 {
 	if ([favoritesContainer objectForKey:[fileURL absoluteString]]) {
-		[favoritesContainer setObject:favoritesArray forKey:[fileURL absoluteString]];
+		// The add/remove APIs mutate this stored value in place. Swift arrays
+		// bridge as immutable NSArray instances, so preserve the container's
+		// NSMutableArray contract at this boundary.
+		[favoritesContainer setObject:[favoritesArray mutableCopy] forKey:[fileURL absoluteString]];
 	}
 }
 

--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -3999,78 +3999,6 @@ Gw
             </connections>
             <point key="canvasLocation" x="-991" y="524"/>
         </window>
-        <window title="Query Favorite Sheet" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6405" userLabel="Query Favorite Sheet" customClass="NSPanel">
-            <windowStyleMask key="styleMask" titled="YES" resizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="343" y="488" width="260" height="127"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
-            <value key="minSize" type="size" width="260" height="127"/>
-            <value key="maxSize" type="size" width="600" height="127"/>
-            <view key="contentView" id="6406">
-                <rect key="frame" x="0.0" y="0.0" width="260" height="127"/>
-                <autoresizingMask key="autoresizingMask"/>
-                <subviews>
-                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6409">
-                        <rect key="frame" x="17" y="93" width="225" height="14"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="Query Name:" id="6412">
-                            <font key="font" metaFont="message" size="11"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6408">
-                        <rect key="frame" x="19" y="67" width="220" height="18"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" usesSingleLineMode="YES" id="6413">
-                            <font key="font" metaFont="message" size="11"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                        <connections>
-                            <outlet property="delegate" destination="134" id="6417"/>
-                        </connections>
-                    </textField>
-                    <button tag="1" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6410">
-                        <rect key="frame" x="150" y="13" width="94" height="28"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" borderStyle="border" tag="1" inset="2" id="6411">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="message" size="11"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="closeSheet:" target="134" id="6419"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6407">
-                        <rect key="frame" x="14" y="13" width="99" height="28"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="6414">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="message" size="11"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-Gw
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="closeSheet:" target="134" id="6418"/>
-                        </connections>
-                    </button>
-                    <button toolTip="If set save the favorite globally accessible for each document" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6516">
-                        <rect key="frame" x="18" y="43" width="224" height="18"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="check" title="Save globally" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="6517">
-                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                            <font key="font" metaFont="message" size="11"/>
-                        </buttonCell>
-                    </button>
-                </subviews>
-            </view>
-            <point key="canvasLocation" x="-1127" y="210"/>
-        </window>
         <window title="Secure Text Input Sheet" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6492" userLabel="Secure Text Input Sheet" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
@@ -4349,14 +4277,12 @@ Gw
                 <outlet property="nextHistoryMenuItem" destination="7242" id="7368"/>
                 <outlet property="previousHistoryMenuItem" destination="7243" id="7369"/>
                 <outlet property="queryEditorSplitView" destination="7209" id="8023"/>
-                <outlet property="queryFavoriteNameTextField" destination="6408" id="6416"/>
                 <outlet property="queryFavoritesButton" destination="7218" id="7353"/>
                 <outlet property="queryFavoritesSaveAllMenuItem" destination="7269" id="7363"/>
                 <outlet property="queryFavoritesSaveAsMenuItem" destination="7265" id="7364"/>
                 <outlet property="queryFavoritesSearchField" destination="6432" id="6434"/>
                 <outlet property="queryFavoritesSearchFieldView" destination="6431" id="6435"/>
                 <outlet property="queryFavoritesSearchMenuItem" destination="7268" id="7365"/>
-                <outlet property="queryFavoritesSheet" destination="6405" id="6415"/>
                 <outlet property="queryHistoryButton" destination="7217" id="7354"/>
                 <outlet property="queryHistorySearchField" destination="6448" id="6451"/>
                 <outlet property="queryHistorySearchFieldView" destination="6447" id="6450"/>
@@ -4367,8 +4293,6 @@ Gw
                 <outlet property="runPrimaryActionMenuItem" destination="8323" id="8332"/>
                 <outlet property="runSecondaryActionMenuItem" destination="8324" id="8331"/>
                 <outlet property="saveHistoryMenuItem" destination="7276" id="7373"/>
-                <outlet property="saveQueryFavoriteButton" destination="6410" id="6420"/>
-                <outlet property="saveQueryFavoriteGlobal" destination="6516" id="6518"/>
                 <outlet property="shiftLeftMenuItem" destination="7239" id="7349"/>
                 <outlet property="shiftRightMenuItem" destination="7240" id="7348"/>
                 <outlet property="tableDocumentInstance" destination="-2" id="6256"/>

--- a/Source/Sequel-Ace-Bridging-Header.h
+++ b/Source/Sequel-Ace-Bridging-Header.h
@@ -29,6 +29,7 @@
 
 #import "SPAppController.h"
 #import "SPCustomQuery.h"
+#import "SPQueryController.h"
 #import "SPTextView.h"
 #import "SPSQLParser.h"
 #import "SPStringAdditions.h"

--- a/UnitTests/SAQueryFavoriteStoreTests.swift
+++ b/UnitTests/SAQueryFavoriteStoreTests.swift
@@ -198,6 +198,16 @@ final class SAQueryFavoriteStoreTests: XCTestCase {
         XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["query"] as? String, "SELECT replacement")
     }
 
+    func testReplacementFailsWhenSelectedDuplicateWasRemovedAndAnotherShiftedIntoItsIndex() {
+        let duplicate = favorite("Duplicate")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [duplicate, duplicate],
+            globalFavorites: []
+        )[0]
+
+        assertSelectedFavoriteChanged(selection: selection, current: [duplicate])
+    }
+
     private func assertSelectedFavoriteChanged(selection: SAQueryFavoriteSelection,
                                                current: [Any],
                                                file: StaticString = #filePath,

--- a/UnitTests/SAQueryFavoriteStoreTests.swift
+++ b/UnitTests/SAQueryFavoriteStoreTests.swift
@@ -1,0 +1,226 @@
+//
+//  SAQueryFavoriteStoreTests.swift
+//  Unit Tests
+//
+//  Pins query-favorite replacement identity and metadata preservation.
+//
+
+
+import XCTest
+
+final class SAQueryFavoriteStoreTests: XCTestCase {
+
+    func testSelectionsKeepScopeAndRealSourceIndex() {
+        let malformed = "not a dictionary"
+        let document: [Any] = [malformed, favorite("Document")]
+        let global: [Any] = [favorite("Global")]
+
+        let selections = SAQueryFavoriteStore.selections(
+            documentFavorites: document,
+            globalFavorites: global
+        )
+
+        XCTAssertEqual(selections.count, 2)
+        XCTAssertEqual(selections[0].scope, .document)
+        XCTAssertEqual(selections[0].originalIndex, 1)
+        XCTAssertEqual(selections[0].name, "Document")
+        XCTAssertEqual(selections[1].scope, .global)
+        XCTAssertEqual(selections[1].originalIndex, 0)
+        XCTAssertEqual(selections[1].name, "Global")
+    }
+
+    func testCreatingDocumentFavoriteAppendsWithoutDroppingMalformedEntries() throws {
+        let document: [Any] = ["legacy-entry"]
+
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT 1",
+            name: "One",
+            saveGlobally: false,
+            replacing: nil,
+            documentFavorites: document,
+            globalFavorites: []
+        )
+
+        XCTAssertEqual(mutation.scope, .document)
+        XCTAssertEqual(mutation.favorites.count, 2)
+        XCTAssertEqual(mutation.favorites[0] as? String, "legacy-entry")
+        XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["name"] as? String, "One")
+        XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["query"] as? String, "SELECT 1")
+    }
+
+    func testCreatingGlobalFavoriteUsesGlobalList() throws {
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT 2",
+            name: "Two",
+            saveGlobally: true,
+            replacing: nil,
+            documentFavorites: [favorite("Document")],
+            globalFavorites: [favorite("Existing")]
+        )
+
+        XCTAssertEqual(mutation.scope, .global)
+        XCTAssertEqual(mutation.favorites.count, 2)
+        XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["name"] as? String, "Two")
+    }
+
+    func testCreatingFavoriteRequiresAName() {
+        XCTAssertThrowsError(try SAQueryFavoriteStore.save(
+            query: "SELECT 1",
+            name: "",
+            saveGlobally: false,
+            replacing: nil,
+            documentFavorites: [],
+            globalFavorites: []
+        )) { error in
+            XCTAssertEqual(error as? SAQueryFavoriteSaveError, .nameRequired)
+        }
+    }
+
+    func testReplacementUpdatesOnlyQueryAndIgnoresNewFavoriteInputs() throws {
+        let original = favorite("Production", query: "SELECT old", tabTrigger: "prod")
+        let selections = SAQueryFavoriteStore.selections(
+            documentFavorites: [original],
+            globalFavorites: []
+        )
+
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT new",
+            name: "Ignored Name",
+            saveGlobally: true,
+            replacing: selections[0],
+            documentFavorites: [original],
+            globalFavorites: []
+        )
+
+        XCTAssertEqual(mutation.scope, .document)
+        let replaced = try XCTUnwrap(mutation.favorites[0] as? NSDictionary)
+        XCTAssertEqual(replaced["name"] as? String, "Production")
+        XCTAssertEqual(replaced["query"] as? String, "SELECT new")
+        XCTAssertEqual(replaced["tabtrigger"] as? String, "prod")
+    }
+
+    func testReplacementUsesSelectedGlobalList() throws {
+        let document = favorite("Document")
+        let global = favorite("Global", query: "SELECT old")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [document],
+            globalFavorites: [global]
+        )[1]
+
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT new",
+            name: "",
+            saveGlobally: false,
+            replacing: selection,
+            documentFavorites: [document],
+            globalFavorites: [global]
+        )
+
+        XCTAssertEqual(mutation.scope, .global)
+        XCTAssertEqual(mutation.favorites.count, 1)
+        XCTAssertEqual((mutation.favorites[0] as? NSDictionary)?["name"] as? String, "Global")
+        XCTAssertEqual((mutation.favorites[0] as? NSDictionary)?["query"] as? String, "SELECT new")
+    }
+
+    func testReplacementReResolvesUniqueFavoriteAfterInsertion() throws {
+        let selected = favorite("Selected", query: "SELECT old")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [selected],
+            globalFavorites: []
+        )[0]
+        let inserted = favorite("Inserted")
+
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT new",
+            name: "",
+            saveGlobally: false,
+            replacing: selection,
+            documentFavorites: [inserted, selected],
+            globalFavorites: []
+        )
+
+        XCTAssertEqual((mutation.favorites[0] as? NSDictionary)?["name"] as? String, "Inserted")
+        XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["query"] as? String, "SELECT new")
+    }
+
+    func testReplacementFailsWhenFavoriteWasRemoved() {
+        let selected = favorite("Selected")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [selected],
+            globalFavorites: []
+        )[0]
+
+        assertSelectedFavoriteChanged(selection: selection, current: [])
+    }
+
+    func testReplacementFailsWhenFavoriteWasEdited() {
+        let selected = favorite("Selected", query: "SELECT old")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [selected],
+            globalFavorites: []
+        )[0]
+        let edited = favorite("Selected", query: "SELECT edited elsewhere")
+
+        assertSelectedFavoriteChanged(selection: selection, current: [edited])
+    }
+
+    func testReplacementFailsWhenShiftedIdenticalFavoritesAreAmbiguous() {
+        let selected = favorite("Duplicate")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [selected],
+            globalFavorites: []
+        )[0]
+        let inserted = favorite("Inserted")
+
+        assertSelectedFavoriteChanged(
+            selection: selection,
+            current: [inserted, selected, NSDictionary(dictionary: selected)]
+        )
+    }
+
+    func testReplacementUsesOriginalIndexWhenIdenticalFavoriteRemainsThere() throws {
+        let duplicate = favorite("Duplicate")
+        let selection = SAQueryFavoriteStore.selections(
+            documentFavorites: [duplicate, duplicate],
+            globalFavorites: []
+        )[1]
+
+        let mutation = try SAQueryFavoriteStore.save(
+            query: "SELECT replacement",
+            name: "",
+            saveGlobally: false,
+            replacing: selection,
+            documentFavorites: [duplicate, duplicate],
+            globalFavorites: []
+        )
+
+        XCTAssertEqual((mutation.favorites[0] as? NSDictionary)?["query"] as? String, "SELECT 1")
+        XCTAssertEqual((mutation.favorites[1] as? NSDictionary)?["query"] as? String, "SELECT replacement")
+    }
+
+    private func assertSelectedFavoriteChanged(selection: SAQueryFavoriteSelection,
+                                               current: [Any],
+                                               file: StaticString = #filePath,
+                                               line: UInt = #line) {
+        XCTAssertThrowsError(try SAQueryFavoriteStore.save(
+            query: "SELECT new",
+            name: "",
+            saveGlobally: false,
+            replacing: selection,
+            documentFavorites: current,
+            globalFavorites: []
+        ), file: file, line: line) { error in
+            XCTAssertEqual(error as? SAQueryFavoriteSaveError, .selectedFavoriteChanged, file: file, line: line)
+        }
+    }
+
+    private func favorite(_ name: String,
+                          query: String = "SELECT 1",
+                          tabTrigger: String? = nil) -> NSDictionary {
+        let favorite = NSMutableDictionary(dictionary: ["name": name, "query": query])
+        if let tabTrigger {
+            favorite["tabtrigger"] = tabTrigger
+        }
+        return favorite
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */; };
 		2A7D5700E8EA895137AA6F91 /* SPMCPHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91D4A5EC24F24F7A7BCA7D /* SPMCPHTTP.swift */; };
 		CACA94EDDD5F7ADE62E4CA71 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
+		302DF8917DC7950ACEC08BEB /* SAQueryFavoriteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */; };
 		380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */; };
 		384582C40FB95FF800DDACB6 /* func-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 384582C30FB95FF800DDACB6 /* func-small.png */; };
 		384582C70FB9603600DDACB6 /* proc-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 384582C60FB9603600DDACB6 /* proc-small.png */; };
@@ -456,6 +457,7 @@
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
 		85846AF0695EAD27F908811D /* SADatabaseScopedValueCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */; };
+		8763A84EDF069AC161FD0438 /* SAQueryFavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */; };
 		8831EFA8224011B700D10172 /* button_addTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFA5224011B700D10172 /* button_addTemplate.pdf */; };
 		8831EFAA2240128700D10172 /* button_removeTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFA92240128600D10172 /* button_removeTemplate.pdf */; };
 		8831EFAC2240131500D10172 /* button_editTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFAB2240131400D10172 /* button_editTemplate.pdf */; };
@@ -480,6 +482,7 @@
 		8AEACED018AABDD8CBB42877 /* TableSortHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACADD4B36D9819ADC93DD /* TableSortHelperTests.swift */; };
 		8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */; };
 		8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
+		8E9430236D26BB3D6FFCD99E /* SAQueryFavoriteSaveWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB04CE94BAEDB4110C122697 /* SAQueryFavoriteSaveWindowController.swift */; };
 		961210D2302E7233009A9A2A /* SAGitHubReleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961210D1302E7233009A9A2A /* SAGitHubReleaseTests.swift */; };
 		961210D6302E7269009A9A2A /* GitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A89557825D6DE860060CE72 /* GitHub.swift */; };
 		963DA1C72CACC71000B5A544 /* QuickLookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963DA1C22CACC6F000B5A544 /* QuickLookUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -595,6 +598,7 @@
 		CF0000252F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000242F8C000600C4C14A /* SACellFilterColumnIdentifier.swift */; };
 		CF0000262F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */; };
 		D35577F52728C6CF002B3989 /* SPWindowTabAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */; };
+		D95E363059FDC83627417D74 /* SAQueryFavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */; };
 		DD00DD00DD00DD00DD000001 /* SPFilterRuleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */; };
 		DD00DD00DD00DD00DD000003 /* SPFilterRuleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */; };
 		DD00DD00DD00DD00DD000005 /* SPRuleFilterDropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00DD00DD00DD00DD000006 /* SPRuleFilterDropBox.swift */; };
@@ -1313,6 +1317,7 @@
 		73F70A951E4E547500636550 /* SPJSONFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPJSONFormatter.m; sourceTree = "<group>"; };
 		7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADragPasteboardTests.swift; sourceTree = "<group>"; };
 		7AC51026DDFB4980A84A78F1 /* SPAppController+MCP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SPAppController+MCP.swift"; sourceTree = "<group>"; };
+		812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteStoreTests.swift; sourceTree = "<group>"; };
 		81815809CB9EBE53E9D2AA2A /* SADatabaseScopedValueCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADatabaseScopedValueCacheTests.swift; sourceTree = "<group>"; };
 		8831EFA5224011B700D10172 /* button_addTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_addTemplate.pdf; sourceTree = "<group>"; };
 		8831EFA92240128600D10172 /* button_removeTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_removeTemplate.pdf; sourceTree = "<group>"; };
@@ -1455,6 +1460,7 @@
 		C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse.png"; sourceTree = "<group>"; };
 		C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-browse@2x.png"; sourceTree = "<group>"; };
 		CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAEditorTokensTests.swift; sourceTree = "<group>"; };
+		CB04CE94BAEDB4110C122697 /* SAQueryFavoriteSaveWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteSaveWindowController.swift; sourceTree = "<group>"; };
 		CB4D0AEB506704E1B3B2A8C6 /* SPMCPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPMCPServer.swift; sourceTree = "<group>"; };
 		4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMCPToolDefinitions.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
@@ -1485,6 +1491,7 @@
 		F3A4B8C191E14E7094C9B005 /* AWSIAMAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIAMAuthManager.swift; sourceTree = "<group>"; };
 		F3A4B8C191E14E7094C9B006 /* AWSDirectoryBookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDirectoryBookmarkManager.swift; sourceTree = "<group>"; };
 		F4C0BDAE2E9F4D5E8A1B0201 /* SecureBookmarkManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBookmarkManagerStub.swift; sourceTree = "<group>"; };
+		F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteStore.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E01 /* VaultClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClient.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E02 /* VaultClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClientTests.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E03 /* VaultOIDCHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultOIDCHandler.swift; sourceTree = "<group>"; };
@@ -1774,6 +1781,8 @@
 				5146ADFB2F7A519400C4C14A /* SPDatabaseDocument+ViewMode.swift */,
 				5146E0512F7A640C00C4C14A /* SADatabaseListManager.swift */,
 				5AF0C3000000000000000001 /* SATaskController.swift */,
+				F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */,
+				CB04CE94BAEDB4110C122697 /* SAQueryFavoriteSaveWindowController.swift */,
 			);
 			name = "Main View Controllers";
 			path = MainViewControllers;
@@ -2604,6 +2613,7 @@
 				138583510330B4131DA1C8A9 /* SAAsyncResultBoxTests.swift */,
 				ED6AC28123000BCB7363F94A /* SAKeyboardShortcutTests.swift */,
 				7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */,
+				812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3479,6 +3489,8 @@
 				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
 				FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */,
 				E51CC2AA59AF37FEF73B06A0 /* SADragPasteboardTests.swift in Sources */,
+				8763A84EDF069AC161FD0438 /* SAQueryFavoriteStore.swift in Sources */,
+				302DF8917DC7950ACEC08BEB /* SAQueryFavoriteStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3791,6 +3803,8 @@
 				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
 				16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */,
 				410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */,
+				D95E363059FDC83627417D74 /* SAQueryFavoriteStore.swift in Sources */,
+				8E9430236D26BB3D6FFCD99E /* SAQueryFavoriteSaveWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- Add an "Or replace an existing favorite" picker to both query-favorite save actions.
- Replace the legacy XIB save panel with a SwiftUI sheet and keep Objective-C as a thin presentation bridge.
- Preserve the selected favorite's name, scope, tab trigger, and future metadata while updating only its query.
- Revalidate the captured favorite before saving so concurrent edits cannot overwrite an unrelated entry.
- Preserve the query controller's mutable-array storage contract at the Swift bridge boundary.
- Add focused coverage for document/global creation, document/global replacement, malformed entries, metadata preservation, shifted indexes, deletion, edits, and ambiguous duplicates.

## Closes following issues:
- Closes: #1845

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)
- `Sequel Ace Debug` build passes.
- Focused `SAQueryFavoriteStoreTests`: 12 passed, 0 failed.
- Full `Unit Tests` suite: 1,073 passed, 60 skipped, 0 failed.
- `xmllint` validates `DBView.xib`; `plutil` validates `project.pbxproj`.
- Manually verified against MySQL 8.0.46 over TCP: create a document favorite, select it for replacement, verify name/scope controls are locked, save the new query, and insert the favorite to read the replacement back. The disposable favorite was then removed.

## Screenshots:
Not included; the complete sheet flow was exercised in the manual pass above.

## Additional notes:
- This is a clean, current-`main` replacement for #2567. Thank you to @fefed22 for the original feature contribution and issue implementation.
- The replacement picker includes document and global favorites and labels each scope explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned query favorite save sheet with a SwiftUI interface.
  - Save favorites to the current document or globally.
  - Create new favorites or replace existing ones.
  - Added validation for missing names and outdated favorite selections.
  - Added clear labels and guidance for favorite save and replacement actions.

- **Bug Fixes**
  - Improved favorite list updates to preserve subsequent add and remove operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->