### PR TITLE
#infra Document English localization catalog requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ later.
 - **New UI is SwiftUI** where feasible. Established hosting pattern:
   `@objc final` `NSWindowController` subclass + `NSHostingView` + SwiftUI root
   view — see `SAAboutWindowController`, `SABundleHTMLOutputWindowController`.
+- **Localization:** every new or changed localized UI string — whether added in
+  code, a XIB, or another language catalog — must have a matching key and
+  English value in `Resources/Localization/en.lproj/Localizable.strings` in the
+  same PR. Reuse an existing exact-text key where possible, include a useful
+  translator comment for new entries, and validate the catalog with
+  `plutil -lint`.
 - **SwiftUI view boundaries** (per Apple's performance guidance): splitting a
   `body` into computed properties is *not* factoring for invalidation — every
   section still shares the view's boundary and re-evaluates on any state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ later.
   code, a XIB, or another language catalog — must have a matching key and
   English value in `Resources/Localization/en.lproj/Localizable.strings` in the
   same PR. Reuse an existing exact-text key where possible, include a useful
-  translator comment for new entries, and validate the catalog with
-  `plutil -lint`.
+  translator comment for new entries, and run
+  `plutil -lint Resources/Localization/en.lproj/Localizable.strings`.
 - **SwiftUI view boundaries** (per Apple's performance guidance): splitting a
   `body` into computed properties is *not* factoring for invalidation — every
   section still shares the view's boundary and re-evaluates on any state


### PR DESCRIPTION
## Changes:
- Require every new or changed localized UI string from code, XIBs, or another language catalog to include a matching English entry in `Resources/Localization/en.lproj/Localizable.strings` in the same PR.
- Document exact-key reuse, translator comments, and `plutil -lint` validation.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

Full Unit Tests scheme: 1,061 passed, 60 skipped, 0 failed.

## Screenshots:

N/A — agent-guidance-only change.

## Additional notes:
- Kept separate from the localization fixes on #2591 and #2595.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for managing localized UI strings.
  * Documented requirements for English catalog entries, key reuse, translator comments, and localization file validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->