### PR TITLE
#fixed Make "+"/"-" in the content filter respond immediately

### DIFF
--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1068,20 +1068,32 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 
 - (void)ruleEditorRowsDidChange:(NSNotification *)notification 
 {
-	//TODO find a better way to trigger resize
-	// We can't do this here, because it will cause rows to jump around when removing them (the add case works fine, though)
-	[self performSelector:@selector(_resize) withObject:nil afterDelay:0.2];
-	//[self _resize];
+	// The rule editor is very liberal in the use of this notification: one click on "+"/"-" can post it
+	// several times, and not every post means the number of rows actually changed.
+	NSInteger newRowCount = [filterRuleEditor numberOfRows];
+
+	if(newRowCount != previousRowCount) {
+		// Coalesce: drop any resize still pending from an earlier notification of the same gesture,
+		// otherwise every one of them would animate the container again after the fixed delay.
+		[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(_resize) object:nil];
+		if(newRowCount > previousRowCount) {
+			// Growing: resize right away so the container makes room while the rule editor is still
+			// animating the new row in. Running both at the same time is what makes "+" feel immediate.
+			[self _resize];
+		}
+		else {
+			// Shrinking: the rule editor is still animating the removed row out; resizing the container
+			// underneath it makes the remaining rows jump, so wait for that animation to finish first.
+			[self performSelector:@selector(_resize) withObject:nil afterDelay:0.2];
+		}
+	}
 	[self _updateButtonStates];
 
 	// if a row has been added, we need to update the checkboxes to match again
 	[self _recalculateCheckboxStatesFromRow:-1];
 
 	// if the user removed the last row in the editor by pressing "-" (and only then) we immediately want to trigger a filter reset.
-	// There are two problems with that:
-	// - The rule editor is very liberal in the use of this notification. Receiving it does not mean the number of rows actually did change
-	// - There is no direct way to know whether the action was triggered by the user, so we can only try to exclude all other causes of changes
-	NSInteger newRowCount = [filterRuleEditor numberOfRows];
+	// There is no direct way to know whether the action was triggered by the user, so we can only try to exclude all other causes of changes
 	if(!isDoingChangeCausedOutsideOfRuleEditor && previousRowCount > 0 && newRowCount == 0) {
 		[self _invokeFilterTargetActionWithObject:nil];
 	}

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1069,23 +1069,20 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 - (void)ruleEditorRowsDidChange:(NSNotification *)notification 
 {
 	// The rule editor is very liberal in the use of this notification: one click on "+"/"-" can post it
-	// several times, and not every post means the number of rows actually changed.
+	// several times, and not every post means the number of rows actually changed. SARuleFilterResizePolicy
+	// decides what to do; this method only carries it out (see the policy for the reasoning).
 	NSInteger newRowCount = [filterRuleEditor numberOfRows];
-
-	if(newRowCount != previousRowCount) {
-		// Coalesce: drop any resize still pending from an earlier notification of the same gesture,
-		// otherwise every one of them would animate the container again after the fixed delay.
-		[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(_resize) object:nil];
-		if(newRowCount > previousRowCount) {
-			// Growing: resize right away so the container makes room while the rule editor is still
-			// animating the new row in. Running both at the same time is what makes "+" feel immediate.
+	switch([SARuleFilterResizePolicy actionForRowCount:newRowCount previousRowCount:previousRowCount]) {
+		case SARuleFilterResizeActionNone:
+			break;
+		case SARuleFilterResizeActionImmediate:
+			[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(_resize) object:nil];
 			[self _resize];
-		}
-		else {
-			// Shrinking: the rule editor is still animating the removed row out; resizing the container
-			// underneath it makes the remaining rows jump, so wait for that animation to finish first.
-			[self performSelector:@selector(_resize) withObject:nil afterDelay:0.2];
-		}
+			break;
+		case SARuleFilterResizeActionDeferred:
+			[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(_resize) object:nil];
+			[self performSelector:@selector(_resize) withObject:nil afterDelay:[SARuleFilterResizePolicy deferredResizeDelay]];
+			break;
 	}
 	[self _updateButtonStates];
 

--- a/Source/Controllers/SubviewControllers/SPRuleFilterController.m
+++ b/Source/Controllers/SubviewControllers/SPRuleFilterController.m
@@ -1066,6 +1066,10 @@ static void _addIfNotNil(NSMutableArray *array, id toAdd);
 }
 
 
+/**
+ * NSRuleEditorRowsDidChangeNotification handler: keeps the container height, the button states and the
+ * checkbox states in sync with the rows, and resets the filter when the user removed the last row.
+ */
 - (void)ruleEditorRowsDidChange:(NSNotification *)notification 
 {
 	// The rule editor is very liberal in the use of this notification: one click on "+"/"-" can post it

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -54,6 +54,47 @@ import Cocoa
     }
 }
 
+/// What `-[SPRuleFilterController ruleEditorRowsDidChange:]` should do about
+/// the container size after the rule editor reported a rows change.
+@objc public enum SARuleFilterResizeAction: Int {
+    /// The row count did not change – nothing to resize.
+    case none
+    /// Resize right away.
+    case immediate
+    /// Resize after `SARuleFilterResizePolicy.deferredResizeDelay`.
+    case deferred
+}
+
+/// Decides when the filter container follows a rows change in the rule editor.
+///
+/// `NSRuleEditor` posts its rows-did-change notification several times per
+/// click on "+" / "−", and not every post means the number of rows changed.
+/// Scheduling a delayed resize for each of them (the pre-2026 behaviour)
+/// stacked delay and container animations on top of the rule editor's own row
+/// animation, which made the buttons feel like they hang. The policy turns a
+/// (row count, previous row count) pair into a single action:
+///
+/// * unchanged count → nothing;
+/// * growing → resize immediately, so the container makes room while the
+///   rule editor animates the new row in (both animations run concurrently);
+/// * shrinking → wait for the rule editor's removal animation first, because
+///   resizing the container underneath it makes the remaining rows jump.
+///
+/// The caller is expected to cancel any pending deferred resize before acting
+/// on the returned action, so one gesture ends in one resize.
+@objc public final class SARuleFilterResizePolicy: NSObject {
+    /// Delay for `.deferred`, matching the rule editor's row-removal animation.
+    @objc public static let deferredResizeDelay: TimeInterval = 0.2
+
+    @objc(actionForRowCount:previousRowCount:)
+    public static func action(rowCount: Int, previousRowCount: Int) -> SARuleFilterResizeAction {
+        if rowCount == previousRowCount {
+            return .none
+        }
+        return rowCount > previousRowCount ? .immediate : .deferred
+    }
+}
+
 /// Immutable layout values consumed by the legacy table-content controller.
 /// Keeping the policy in Swift makes the Objective-C call site a thin view
 /// trampoline and gives the preference combinations direct unit coverage.

--- a/Source/Views/Controls/SPFilterRuleEditor.swift
+++ b/Source/Views/Controls/SPFilterRuleEditor.swift
@@ -86,6 +86,13 @@ import Cocoa
     /// Delay for `.deferred`, matching the rule editor's row-removal animation.
     @objc public static let deferredResizeDelay: TimeInterval = 0.2
 
+    /// Picks the resize action for a rows-did-change notification.
+    ///
+    /// - Parameters:
+    ///   - rowCount: The rule editor's row count after the change.
+    ///   - previousRowCount: The row count the controller last acted on.
+    /// - Returns: `.none` when the count is unchanged, `.immediate` when rows
+    ///   were added, `.deferred` when rows were removed.
     @objc(actionForRowCount:previousRowCount:)
     public static func action(rowCount: Int, previousRowCount: Int) -> SARuleFilterResizeAction {
         if rowCount == previousRowCount {

--- a/UnitTests/SPTableContentColumnFilterTests.swift
+++ b/UnitTests/SPTableContentColumnFilterTests.swift
@@ -120,6 +120,28 @@ final class SPTableContentColumnFilterTests: XCTestCase {
     }
 }
 
+final class SARuleFilterResizePolicyTests: XCTestCase {
+
+    /// Verifies an unchanged row count schedules no resize at all.
+    func testUnchangedRowCountDoesNothing() {
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 3, previousRowCount: 3), .none)
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 0, previousRowCount: 0), .none)
+    }
+
+    /// Verifies growing resizes immediately so the container makes room while the row animates in.
+    func testGrowingResizesImmediately() {
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 1, previousRowCount: 0), .immediate)
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 5, previousRowCount: 2), .immediate)
+    }
+
+    /// Verifies shrinking waits for the rule editor's removal animation.
+    func testShrinkingDefersResize() {
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 2, previousRowCount: 3), .deferred)
+        XCTAssertEqual(SARuleFilterResizePolicy.action(rowCount: 0, previousRowCount: 1), .deferred)
+        XCTAssertGreaterThan(SARuleFilterResizePolicy.deferredResizeDelay, 0)
+    }
+}
+
 final class PinnedTableMigrationPlannerTests: XCTestCase {
 
     func testPinnedTableMigrationTokenGeneration() {


### PR DESCRIPTION
## Changes:
- Clicking "+" or "−" in the content filter's rule editor felt like a short hang. Cause: `-[SPRuleFilterController ruleEditorRowsDidChange:]` scheduled `_resize` with a fixed 0.2 s `performSelector:afterDelay:` on **every** rows-did-change notification – and `NSRuleEditor` posts that notification several times per click – without cancelling the ones already pending. Each `_resize` then posted `SPRuleFilterHeightChangedNotification`, which `SPTableContent` answers with another animated container resize. Net effect: delay + stacked animations after the rule editor's own row animation.
- The resize is now coalesced per gesture (`cancelPreviousPerformRequests…`) and only scheduled when the row count actually changed. Growing resizes immediately, so the container makes room while the rule editor animates the new row in (the two animations now run concurrently instead of back-to-back). Shrinking keeps the 0.2 s delay, because resizing the container while the removed row is still animating out makes the remaining rows jump – that is the case the original `TODO` comment was about.
- The decision lives in `SARuleFilterResizePolicy` (Swift, next to the other rule-filter policies in `SPFilterRuleEditor.swift`, member of both targets, unit-tested for the none / immediate / deferred cases); `-[SPRuleFilterController ruleEditorRowsDidChange:]` is a trampoline that only carries out the returned action. No format or API changes.

## Closes following issues:
- Closes: —

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

## Screenshots:
_(timing change, nothing visual to show)_

## Additional notes:
- Found while working on #2600 (AND/OR switch for the content filter); kept separate because it is an independent fix.
- The policy is unit-tested (`SARuleFilterResizePolicyTests`); the actual animation timing is not (NSRuleEditor internals). Full "Unit Tests" scheme on the final state: 1145 tests, 63 environment-skipped, 0 failures. Verified manually with the Debug build against a live server: "+" now responds immediately, "−" no longer makes the remaining rows jump.
