### PR TITLE
#infra Cut test-scheme clean-build warnings from 104 to 78 occurrences

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
@@ -43,8 +43,9 @@
  * Pass in the third parameter to receive the length of the converted string (INCLUDING
  * the terminating \0 character), or pass in NULL if you do not want this information.
  */
-#warning This method doesn't make sense. It's only addition over [str dataUsingEncoding:allowLossyConversion:] is the terminating NUL byte. \
-         But the "string" can already contain NUL bytes, so it's not a valid c string anyway.
+// TODO (#2604): this method doesn't make sense — its only addition over
+// [str dataUsingEncoding:allowLossyConversion:] is the terminating NUL byte,
+// but the "string" can already contain NUL bytes, so it's not a valid c string anyway.
 + (const char *)_cStringForString:(NSString *)aString usingEncoding:(NSStringEncoding)anEncoding returningLengthAs:(NSUInteger *)cStringLengthPointer
 {
 	// Don't try and convert nil strings

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -127,7 +127,8 @@ databaseContextIsRequired:(BOOL)databaseContextIsRequired;
 	// any nul characters contained in the string.
 	NSData *escapedData;
 	if (includeQuotes) {
-#warning This code assumes that the encoding cData is in is still ASCII-compatible which may not be the case (e.g. for UTF16, EBCDIC)
+		// TODO (#2604): this code assumes that the encoding cData is in is still ASCII-compatible,
+		// which may not be the case (e.g. for UTF16, EBCDIC)
 		// Add quotes if requested
 		escBuffer[0] = '\'';
 		escBuffer[escapedLength+1] = '\'';

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -313,7 +313,7 @@ static id NSNullPointer;
     
     return (str == nil) ? @"" : str;
 }
-#warning duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
+// TODO (#2604): duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
 - (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy
 {
 	if(!bytes || !length) return @""; //to match -[NSString initWithBytes:length:encoding:]

--- a/Source/Controllers/DataExport/Exporters/SPExporter.h
+++ b/Source/Controllers/DataExport/Exporters/SPExporter.h
@@ -153,9 +153,10 @@
  * Write a string to the current output file using UTF-8 encoding
  * @param input The string to write
  */
-#warning This method mainly exists to shorten some old code which sometimes uses [self exportOutputEncoding] and sometimes NSUTF8StringEncoding. \
-	     In general there should be no need to have more than one encoding in a file. \
-         Someone needs to check if that was an oversight or intentional.
+// TODO (#2609): this method mainly exists to shorten some old code which sometimes uses
+// [self exportOutputEncoding] and sometimes NSUTF8StringEncoding. In general there should
+// be no need to have more than one encoding in a file; someone needs to check whether
+// that was an oversight or intentional.
 - (void)writeUTF8String:(NSString *)input;
 
 @end

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -342,7 +342,9 @@
             if (sqlOutputIncludeStructure && createTableSyntax && tableType == SPTableTypeTable) {
 
                 if ([createTableSyntax isKindOfClass:[NSData class]]) {
-#warning This doesn't make sense. If the NSData really contains a string it would be in utf8, utf8mb4 or a mysql pre-4.1 legacy charset, but not in the export output charset. This whole if() is likely a side effect of the BINARY flag confusion (#2700)
+                    // TODO (#2609): this doesn't make sense — if the NSData really contains a string it would be
+                    // in utf8, utf8mb4 or a mysql pre-4.1 legacy charset, but not in the export output charset.
+                    // This whole if() is likely a side effect of the BINARY flag confusion (upstream sequelpro#2700).
                     createTableSyntax = [[NSString alloc] initWithData:createTableSyntax encoding:[self exportOutputEncoding]];
                 }
 

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -46,7 +46,7 @@ typedef enum {
 
 @interface SPDataImport : NSObject <NSOpenSavePanelDelegate>
 {
-#warning Outlets belong to multiple xib files!
+	// TODO (#2606): outlets belong to multiple xib files, so each xib load overwrites part of this set
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -931,7 +931,7 @@
 			BOOL atPartialLineEnding = NO;
 			NSInteger segmentEndPosition = dataBufferPosition;
 
-#warning This EOL detection logic will break for multibyte encodings (like UTF16)!
+			// TODO (#2605): this EOL detection logic will break for multibyte encodings (like UTF16)
 			if (csvLineTerminatorLength && dataBufferPosition < dataBufferLength) {
 				NSInteger remainingBytes = dataBufferLength - dataBufferPosition;
 				NSInteger bytesToCompare = MIN(remainingBytes, csvLineTerminatorLength);
@@ -1167,7 +1167,7 @@
 
 						rowsImported++;
 						csvRowsThisQuery++;
-#warning Updating the UI for every single row is likely a performance killer (even without synchronization).
+						// TODO (#2606): updating the UI for every single row is likely a performance killer (even without synchronization)
 						SPMainQSync(^{
 							if (fileIsCompressed) {
 								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
@@ -1205,7 +1205,7 @@
 								[[SPQueryController sharedQueryController] showErrorInConsole:mySQLConnection.lastErrorMessage connection:mySQLConnection.host database:databaseName];
 							}
 						}
-#warning duplicate code (see above)
+						// TODO (#2606): duplicate progress-update code (see above)
 						rowsImported++;
 						SPMainQSync(^{
 							if (fileIsCompressed) {
@@ -1219,7 +1219,7 @@
 					}
 				} else {
 					rowsImported += csvRowsThisQuery;
-#warning duplicate code (see above)
+					// TODO (#2606): duplicate progress-update code (see above)
 					SPMainQSync(^{
 						if (fileIsCompressed) {
 							[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];

--- a/Source/Controllers/DataImport/SPFieldMapperController.m
+++ b/Source/Controllers/DataImport/SPFieldMapperController.m
@@ -1998,7 +1998,12 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 	column = [fieldMapperTableView editedColumn];
 
 	// TODO: jcs - using rowViewAtRow:createIfNeeded means changing the entire table to be view based rather than cell based. leaveing for now - 2020-10-22
+	// Containment, not migration: this table is still cell-based, so the
+	// deprecated cell API is the only correct one until the view-based rewrite.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 	BOOL isCellComplex = ([[fieldMapperTableView preparedCellAtColumn:column row:row] isKindOfClass:[NSComboBoxCell class]]) ? YES : NO;
+#pragma clang diagnostic pop
 
 	// Trap tab key
 	// -- for handling of blob fields and to check if it's editable look at [[self delegate] control:textShouldBeginEditing:]

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -3872,7 +3872,7 @@ static NSString * const SPDashStyleCommentMarker = @"-- ";
  */
 - (id)_resultDataItemAtRow:(NSInteger)row columnIndex:(NSUInteger)column preserveNULLs:(BOOL)preserveNULLs asPreview:(BOOL)asPreview;
 {
-#warning duplicate code with SPTableContent.m tableView:objectValueForTableColumn:…
+    // TODO (#2607): duplicate code with SPTableContent.m tableView:objectValueForTableColumn:…
     id value = nil;
     
     // While the table is being loaded, additional validation is required - data

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1994,7 +1994,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		NSString *columnEncoding = [rowData safeObjectForKey:@"encodingName"];
 		NSString *columnCollation = [rowData safeObjectForKey:@"collationName"]; // loadTable: has already inferred it, if not set explicit
 
-#warning Building the collation menu here is a big performance hog. This should be done in menuNeedsUpdate: below!
+		// TODO (#2608): building the collation menu here is a big performance hog; it should happen in menuNeedsUpdate: below
 		NSPopUpButtonCell *collationCell = [tableColumn dataCell];
 		[collationCell removeAllItems];
 		[collationCell addItemWithTitle:@"dummy"];

--- a/Source/Other/CategoryAdditions/SPWindowAdditions.m
+++ b/Source/Other/CategoryAdditions/SPWindowAdditions.m
@@ -76,7 +76,7 @@
 
 	if (frontDoc && [frontDoc isKindOfClass:[SPDatabaseDocument class]] && [frontDoc valueForKeyPath:@"spHistoryControllerInstance"] && ![frontDoc isWorking])
 	{
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		if ([event deltaX] == -1.0f) {
 			[[frontDoc valueForKeyPath:@"spHistoryControllerInstance"] valueForKey:@"goForwardInHistory"];
 		}

--- a/Source/Other/Parsing/SPEditorTokens.l
+++ b/Source/Other/Parsing/SPEditorTokens.l
@@ -43,6 +43,10 @@
  */
  
 #import "SPEditorTokens.h"
+
+// File-scope on purpose: the unreachable code lives in flex's generated
+// boilerplate below this prologue, which cannot carry its own pragma.
+#pragma clang diagnostic ignored "-Wunreachable-code"
 #include "SPParserUtils.h"
 
 size_t yyuoffset, yyuleng;

--- a/Source/Other/Parsing/SPSQLTokenizer.l
+++ b/Source/Other/Parsing/SPSQLTokenizer.l
@@ -33,6 +33,10 @@
 #import "SPSQLTokenizer.h"
 #include "SPParserUtils.h"
 
+// File-scope on purpose: the unreachable code lives in flex's generated
+// boilerplate below this prologue, which cannot carry its own pragma.
+#pragma clang diagnostic ignored "-Wunreachable-code"
+
 size_t yyuoffset, yyuleng;
 
 //keep track of the current utf-8 character (not byte) offset and token length

--- a/Source/ThirdParty/RegexKitLite/RegexKitLite.m
+++ b/Source/ThirdParty/RegexKitLite/RegexKitLite.m
@@ -1119,7 +1119,7 @@ exitNow:
 
 static void rkl_handleDelayedAssert(id self, SEL _cmd, id exception) {
 	if(RKL_EXPECTED(exception != NULL, 1L)) {
-		if([exception isKindOfClass:[NSException class]]) { [[NSException exceptionWithName:[exception name] reason:rkl_stringFromClassAndMethod(self, _cmd, [exception reason]) userInfo:[exception userInfo]] raise]; }
+		if([exception isKindOfClass:[NSException class]]) { [[NSException exceptionWithName:[(NSException *)exception name] reason:rkl_stringFromClassAndMethod(self, _cmd, [(NSException *)exception reason]) userInfo:[(NSException *)exception userInfo]] raise]; }
 		else {
 			id functionString = [exception objectForKey:@"function"], fileString = [exception objectForKey:@"file"], descriptionString = [exception objectForKey:@"description"], lineNumber = [exception objectForKey:@"line"];
 			RKLCHardAbortAssert((functionString != NULL) && (fileString != NULL) && (descriptionString != NULL) && (lineNumber != NULL));

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -49,7 +49,7 @@
 		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
 			delegateForUse = delegate;
 		}
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		else if ( [delegate valueForKey:@"tableContentInstance"]
 					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
 			delegateForUse = [delegate valueForKey:@"tableContentInstance"];
@@ -115,7 +115,7 @@
 		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
 			delegateForUse = delegate;
 		}
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		else if ( [delegate valueForKey:@"tableContentInstance"]
 					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
 			delegateForUse = [delegate valueForKey:@"tableContentInstance"];

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -167,7 +167,12 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
  */
 - (BOOL)isCellComplex {
 	// TODO: using rowViewAtRow:createIfNeeded means changing the entire table to be view based rather than cell based. leaveing for now - 2020-10-22
+	// Containment, not migration: this table is still cell-based, so the
+	// deprecated cell API is the only correct one until the view-based rewrite.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 	return (![[self preparedCellAtColumn:[self editedColumn] row:[self editedRow]] isKindOfClass:[SPTextAndLinkCell class]]);
+#pragma clang diagnostic pop
 }
 
 #pragma mark -

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -408,6 +408,41 @@ view-based-tableview migration, not a cast), generated lexer unreachable-code
 (2), RegexKitLite (1, vendored), `selectionHighlightStyle = .sourceList` and
 the three intentional `legacyUnarchive`/`legacyArchivedData` markers.
 
+## Step 11 — Third-party / generated-code containment — ✅ Done
+
+Same basis as step 10 ("Unit Tests" scheme, clean `build-for-testing`, fresh
+derived data): **104 → 78 raw occurrences, 60 → 34 unique lines** — exactly the
+−26 predicted, zero new warnings. What remains is now *only* the deferred
+migrations and the intentional markers (see below).
+
+- **Firebase `-Wquoted-include-in-framework-header` (21)** — the prebuilt
+  FirebaseAnalytics xcframework's own headers, unfixable from here. Silenced
+  with per-file `-Wno-quoted-include-in-framework-header` on the only two TUs
+  that `@import` Firebase modules (SPAppController.m,
+  ReportExceptionApplication.m), set via the Xcode MCP. Deliberately *not* the
+  target-wide `CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO`, so the
+  check still guards our own framework headers. Verified the per-file flags do
+  reach the module builds on Xcode 26.
+- **`preparedCellAtColumn:row:` (2)** — containment, not migration: both
+  tables (SPCopyTable, SPFieldMapperController's field mapper) are still
+  cell-based, so the deprecated cell API is the only correct one until the
+  view-based rewrite their existing 2020 TODOs already call for. Pragma-wrapped
+  with a comment saying exactly that.
+- **Generated lexer `-Wunreachable-code` (2)** — the unreachable code is
+  flex's boilerplate in the generated `.yy.c`, so each `.l` prologue now
+  carries a file-scope `#pragma clang diagnostic ignored` (a scoped push/pop
+  can't reach generated code).
+- **RegexKitLite `-Wobjc-multiple-method-names` (1)** — vendored third-party,
+  patched in place per the step 7 precedent: the ambiguous `id` receiver is
+  inside an `isKindOfClass:[NSException class]` branch, so it now casts to
+  `NSException *` (also de-ambiguating `reason`/`userInfo` on the same line).
+
+The remaining 34 unique lines are the floor this plan predicted: SecKeychain
+(10) + NSConnection (6) deferred migrations, the intentional `#warning`
+markers (14), and the intentional Swift deprecation markers (4:
+`selectionHighlightStyle = .sourceList`, `legacyUnarchive`,
+`legacyArchivedData` ×2).
+
 ## Deferred (own projects, not part of this burn-down)
 
 - **SPKeychain SecKeychain* API (~15)** — migrate to `SecItem*` with in-place

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -443,6 +443,33 @@ markers (14), and the intentional Swift deprecation markers (4:
 `selectionHighlightStyle = .sourceList`, `legacyUnarchive`,
 `legacyArchivedData` ×2).
 
+## Step 12 — `#warning` markers → GitHub issues — ✅ Done
+
+Same basis as steps 10-11: **78 → 52 raw occurrences, 34 → 20 unique lines**.
+Every `#warning` in the codebase (15 sites — the build showed 14 because the
+`Querying & Preparation.m` one had the same normalized text as a sibling) is
+now a `// TODO (#issue):` comment pointing at a tracked Sequel-Ace issue:
+
+| Issue | Markers |
+|---|---|
+| #2603 cross-class ivar access via KVC | SPWindowAdditions:79, SPImageView:52/118 |
+| #2604 SPMySQLFramework encoding/dup conversion | Conversion.m:46, Querying & Preparation.m:130, SPMySQLResult.m:316 |
+| #2605 CSV EOL detection vs multibyte encodings | SPDataImport.m:934 |
+| #2606 SPDataImport cleanup (per-row UI, dup code, xib outlets) | SPDataImport.m:1170/1208/1222, SPDataImport.h:49 |
+| #2607 dedupe result-cell lookup with SPTableContent | SPCustomQuery.m:3875 |
+| #2608 collation menu rebuilt per cell-display | SPTableStructure.m:1997 |
+| #2609 exporter encoding audit (writeUTF8String / NSData decode) | SPExporter.h:156, SPSQLExporter.m:345 |
+
+The old markers' `#2978`/`#2700` references were **upstream sequel-pro issue
+numbers**, not Sequel-Ace ones (they resolve to unrelated PRs here); the new
+issues cite `sequelpro/sequelpro#2978` / `#2700` explicitly for history.
+
+Remaining after this step: **20 unique lines**, all of them the two deferred
+migrations — SecKeychain (10) and NSConnection (6) — plus the 4 intentional
+Swift deprecation markers (`selectionHighlightStyle = .sourceList`,
+`legacyUnarchive`, `legacyArchivedData` ×2). Zero is now gated purely on the
+deferred projects below.
+
 ## Deferred (own projects, not part of this burn-down)
 
 - **SPKeychain SecKeychain* API (~15)** — migrate to `SecItem*` with in-place
@@ -462,10 +489,11 @@ markers (14), and the intentional Swift deprecation markers (4:
   message now reads "building for macOS-13.5", but the committed dylibs were
   not rebuilt. `build-libmysqlclient.sh` *was* updated to 13.5, so whenever the
   rebuild happens it will produce a consistent binary.
-- **Intentional markers, keep**: SAArchiving `legacyUnarchive` (by design),
-  `#warning` TODOs (collation-menu perf hog SPTableStructure:1994, duplicate
-  code SPDataImport:1167 / SPCustomQuery:3761, private-ivar note
-  SPImageView:50 (#2978)) — convert to GitHub issues if we want a clean zero.
+- **Intentional markers, keep**: SAArchiving `legacyUnarchive` /
+  `legacyArchivedData` (by design — the deprecation attribute *is* the
+  guard-rail) and `selectionHighlightStyle = .sourceList` (replacement changes
+  row metrics; wants a visual pass). The `#warning` TODOs were converted to
+  tracked issues in step 12.
 
 ## Expected trajectory
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03B3C091388E27E56C58B846 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
 		0F2381A80270EFDE50D73890 /* SAParserUtilsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
@@ -71,7 +72,7 @@
 		17E0937E114AE154007FC1B4 /* SPTableInfoPrintTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = 17E0937D114AE154007FC1B4 /* SPTableInfoPrintTemplate.html */; };
 		17E641460EF01EB5001BC333 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641440EF01EB5001BC333 /* main.m */; };
 		17E641560EF01EF6001BC333 /* SPCustomQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641490EF01EF6001BC333 /* SPCustomQuery.m */; };
-		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; };
+		17E641570EF01EF6001BC333 /* SPAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414B0EF01EF6001BC333 /* SPAppController.m */; settings = {COMPILER_FLAGS = "-Wno-quoted-include-in-framework-header"; }; };
 		17E641590EF01EF6001BC333 /* SPTableContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6414F0EF01EF6001BC333 /* SPTableContent.m */; };
 		17E6415A0EF01EF6001BC333 /* SPDatabaseDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641510EF01EF6001BC333 /* SPDatabaseDocument.m */; };
 		17E6415B0EF01EF6001BC333 /* SPDataImport.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641530EF01EF6001BC333 /* SPDataImport.m */; };
@@ -119,7 +120,7 @@
 		1A5A83532545DA8B00EDC196 /* SPObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 584D878A15140FEB00F24774 /* SPObjectAdditions.m */; };
 		1A6377D4259B414400B1E96D /* SecureBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A96E4B42588F34C0055F5F5 /* SecureBookmark.swift */; };
 		1A6D28FE25DD8018007509F1 /* ProgressWindowController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A6D28FD25DD8018007509F1 /* ProgressWindowController.storyboard */; };
-		1A70BC6625EF4243004BB992 /* ReportExceptionApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A0751DF25EAF37700FFDF6B /* ReportExceptionApplication.m */; };
+		1A70BC6625EF4243004BB992 /* ReportExceptionApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A0751DF25EAF37700FFDF6B /* ReportExceptionApplication.m */; settings = {COMPILER_FLAGS = "-Wno-quoted-include-in-framework-header"; }; };
 		1A70BC6B25EF439F004BB992 /* FileManagerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A70BC6A25EF439F004BB992 /* FileManagerExtension.swift */; };
 		1A70BC9225EF7EE9004BB992 /* FileManagerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A70BC6A25EF439F004BB992 /* FileManagerExtension.swift */; };
 		1A85CB8D2493BC4A00B57B93 /* SPSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A85CB8C2493BC4A00B57B93 /* SPSyncTests.m */; };
@@ -182,7 +183,6 @@
 		29FA88231114619E00D1AF3D /* SPTableTriggers.m in Sources */ = {isa = PBXBuildFile; fileRef = 29FA88221114619E00D1AF3D /* SPTableTriggers.m */; };
 		2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */; };
 		2A7D5700E8EA895137AA6F91 /* SPMCPHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91D4A5EC24F24F7A7BCA7D /* SPMCPHTTP.swift */; };
-		CACA94EDDD5F7ADE62E4CA71 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
 		302DF8917DC7950ACEC08BEB /* SAQueryFavoriteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */; };
 		380F4EF50FC0B68F00B0BFD7 /* SPStringAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 380F4EF40FC0B68F00B0BFD7 /* SPStringAdditionsTests.m */; };
 		384582C40FB95FF800DDACB6 /* func-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 384582C30FB95FF800DDACB6 /* func-small.png */; };
@@ -342,7 +342,6 @@
 		51D9527625AE2B5300574BEB /* FMDB in Frameworks */ = {isa = PBXBuildFile; productRef = 51D9527525AE2B5300574BEB /* FMDB */; };
 		51DCBEF0257134190098E303 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
 		51DD6920303C2F6B004792F0 /* SAFavoriteDuplicateMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD691F303C2F6B004792F0 /* SAFavoriteDuplicateMatcher.swift */; };
-		B01E10DB2BF1A67138C32D0C /* SAFavoriteDuplicateMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD691F303C2F6B004792F0 /* SAFavoriteDuplicateMatcher.swift */; };
 		51DD6925303C2F99004792F0 /* SAFavoriteDuplicateMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD6924303C2F99004792F0 /* SAFavoriteDuplicateMatcherTests.swift */; };
 		51EA02532FDFF02C00DF6A7B /* SAArchivingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EA02522FDFF02C00DF6A7B /* SAArchivingTests.swift */; };
 		51EAE7252FDFEFA300DF6A7B /* SAArchiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EAE7242FDFEFA300DF6A7B /* SAArchiving.swift */; };
@@ -514,8 +513,8 @@
 		A57A61739BA9FEC6706473D6 /* SPAppController+MCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC51026DDFB4980A84A78F1 /* SPAppController+MCP.swift */; };
 		A946E44AA14C458182205CFF /* CompletionTokens.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC962D651144EACA006170BD /* CompletionTokens.plist */; };
 		AA000001000000000000001B /* SAAboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000001A /* SAAboutView.swift */; };
+		B01E10DB2BF1A67138C32D0C /* SAFavoriteDuplicateMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD691F303C2F6B004792F0 /* SAFavoriteDuplicateMatcher.swift */; };
 		B04369CDAE73936C539212F7 /* SPMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4D0AEB506704E1B3B2A8C6 /* SPMCPServer.swift */; };
-		03B3C091388E27E56C58B846 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
 		B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7D127BB5BCD94B0E794C5E /* SAHelpViewerWindowController.swift */; };
 		B51D6B9E114C310C0074704E /* toolbar-switch-to-table-triggers.png in Resources */ = {isa = PBXBuildFile; fileRef = B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */; };
 		B52460D70F8EF92300171639 /* SPArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52460D40F8EF92300171639 /* SPArrayAdditions.m */; };
@@ -582,6 +581,7 @@
 		C9F92710162D38D70051CB2E /* toolbar-switch-to-table-info@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F9270F162D38D70051CB2E /* toolbar-switch-to-table-info@2x.png */; };
 		C9F92712162D39E60051CB2E /* toolbar-switch-to-browse.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */; };
 		C9F92714162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */; };
+		CACA94EDDD5F7ADE62E4CA71 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
@@ -1046,6 +1046,7 @@
 		4D90B79C101E0CF200D116A1 /* SPUserMO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUserMO.h; sourceTree = "<group>"; };
 		4D90B79D101E0CF200D116A1 /* SPUserMO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUserMO.m; sourceTree = "<group>"; };
 		4FB06F6EE917719170B0804B /* AWSLoginCredentialsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AWSLoginCredentialsProvider.swift; sourceTree = "<group>"; };
+		4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMCPToolDefinitions.swift; sourceTree = "<group>"; };
 		500C1F901BFB5F9F0095DC7F /* SPPrivilegesMO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPPrivilegesMO.h; sourceTree = "<group>"; };
 		500C1F911BFB5F9F0095DC7F /* SPPrivilegesMO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPPrivilegesMO.m; sourceTree = "<group>"; };
 		500DA4B51BEFF877000773FE /* SPComboBoxCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPComboBoxCell.h; sourceTree = "<group>"; };
@@ -1472,7 +1473,6 @@
 		CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAEditorTokensTests.swift; sourceTree = "<group>"; };
 		CB04CE94BAEDB4110C122697 /* SAQueryFavoriteSaveWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteSaveWindowController.swift; sourceTree = "<group>"; };
 		CB4D0AEB506704E1B3B2A8C6 /* SPMCPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPMCPServer.swift; sourceTree = "<group>"; };
-		4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAMCPToolDefinitions.swift; sourceTree = "<group>"; };
 		CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorTests.swift; sourceTree = "<group>"; };
 		CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperator.swift; sourceTree = "<group>"; };
 		CF0000072F8C000600C4C14A /* SACellFilterOperatorRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterOperatorRoundTripTests.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## Changes:
- Third-party / generated-code containment batch, on the same measurement basis as #2598 ("Unit Tests" scheme, clean `xcodebuild build-for-testing`, fresh derived data): **104 → 78 raw occurrences, 60 → 34 unique lines** — exactly the predicted −26, with **zero new warnings** and no behavior change. What remains is now *only* the deferred SecKeychain (10) / NSConnection (6) migrations, the intentional `#warning` markers (14), and the intentional Swift deprecation markers (4).
- **Firebase `-Wquoted-include-in-framework-header` (21, the biggest chunk):** these come from the prebuilt FirebaseAnalytics xcframework's own headers, which we can't fix. Silenced with per-file `-Wno-quoted-include-in-framework-header` on the only two TUs that `@import` Firebase modules (`SPAppController.m`, `ReportExceptionApplication.m`), set via the Xcode MCP. Deliberately **not** the target-wide `CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO`, so the check still guards our own framework headers (SPMySQL). Verified empirically that the per-file flags reach the clang module builds on Xcode 26.
- **`preparedCellAtColumn:row:` (2):** containment, not migration — both tables (SPCopyTable's `isCellComplex`, SPFieldMapperController's tab-trap) are still cell-based, so the deprecated cell API is the only correct one until the view-based rewrite their existing 2020 TODOs already call for. Pragma-wrapped with a comment saying exactly that.
- **Generated lexer `-Wunreachable-code` (2):** the unreachable code is flex's boilerplate in the generated `.yy.c` files, so each `.l` prologue now carries a file-scope `#pragma clang diagnostic ignored "-Wunreachable-code"` — a scoped push/pop can't wrap code we don't author.
- **RegexKitLite `-Wobjc-multiple-method-names` (1):** vendored third-party, patched in place per the YRKSpinningProgressIndicator precedent from the earlier AppKit batch. The ambiguous `id` receiver sits inside an `isKindOfClass:[NSException class]` branch, so it now casts to `NSException *` (also de-ambiguating `reason`/`userInfo` on the same line).
- Recorded as Step 11 in `docs/development/warnings-elimination-plan.md`.

## Closes following issues:
- None

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.5

## Screenshots:
N/A — no UI change.

## Additional notes:
- Fully behavior-preserving: every change is a suppression, a cast proven by an existing `isKindOfClass:` check, or a comment.
- Full suite green: **1142 tests, 0 failures** (63 environment-skipped).
- Warning-set diff verified with `comm` over normalized sorted logs: exactly the four targeted families disappeared, nothing appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling delayed exception details.
  * Preserved existing table-cell behavior while improving compatibility with current development tools.

* **Documentation**
  * Updated the development warnings plan to reflect completed cleanup work and remaining known items.

* **Maintenance**
  * Improved project registration and build configuration consistency.
  * Reduced compiler warnings across application, generated, and third-party code.
  * Replaced compile-time warnings with tracked follow-up notes without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->