### PR TITLE
#infra Convert every #warning marker to a tracked issue, cutting warnings 78 to 52

### DIFF
--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
@@ -43,8 +43,9 @@
  * Pass in the third parameter to receive the length of the converted string (INCLUDING
  * the terminating \0 character), or pass in NULL if you do not want this information.
  */
-#warning This method doesn't make sense. It's only addition over [str dataUsingEncoding:allowLossyConversion:] is the terminating NUL byte. \
-         But the "string" can already contain NUL bytes, so it's not a valid c string anyway.
+// TODO (#2604): this method doesn't make sense — its only addition over
+// [str dataUsingEncoding:allowLossyConversion:] is the terminating NUL byte,
+// but the "string" can already contain NUL bytes, so it's not a valid c string anyway.
 + (const char *)_cStringForString:(NSString *)aString usingEncoding:(NSStringEncoding)anEncoding returningLengthAs:(NSUInteger *)cStringLengthPointer
 {
 	// Don't try and convert nil strings

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -127,7 +127,8 @@ databaseContextIsRequired:(BOOL)databaseContextIsRequired;
 	// any nul characters contained in the string.
 	NSData *escapedData;
 	if (includeQuotes) {
-#warning This code assumes that the encoding cData is in is still ASCII-compatible which may not be the case (e.g. for UTF16, EBCDIC)
+		// TODO (#2604): this code assumes that the encoding cData is in is still ASCII-compatible,
+		// which may not be the case (e.g. for UTF16, EBCDIC)
 		// Add quotes if requested
 		escBuffer[0] = '\'';
 		escBuffer[escapedLength+1] = '\'';

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -313,7 +313,7 @@ static id NSNullPointer;
     
     return (str == nil) ? @"" : str;
 }
-#warning duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
+// TODO (#2604): duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
 - (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy
 {
 	if(!bytes || !length) return @""; //to match -[NSString initWithBytes:length:encoding:]

--- a/Source/Controllers/DataExport/Exporters/SPExporter.h
+++ b/Source/Controllers/DataExport/Exporters/SPExporter.h
@@ -153,9 +153,10 @@
  * Write a string to the current output file using UTF-8 encoding
  * @param input The string to write
  */
-#warning This method mainly exists to shorten some old code which sometimes uses [self exportOutputEncoding] and sometimes NSUTF8StringEncoding. \
-	     In general there should be no need to have more than one encoding in a file. \
-         Someone needs to check if that was an oversight or intentional.
+// TODO (#2609): this method mainly exists to shorten some old code which sometimes uses
+// [self exportOutputEncoding] and sometimes NSUTF8StringEncoding. In general there should
+// be no need to have more than one encoding in a file; someone needs to check whether
+// that was an oversight or intentional.
 - (void)writeUTF8String:(NSString *)input;
 
 @end

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -342,7 +342,9 @@
             if (sqlOutputIncludeStructure && createTableSyntax && tableType == SPTableTypeTable) {
 
                 if ([createTableSyntax isKindOfClass:[NSData class]]) {
-#warning This doesn't make sense. If the NSData really contains a string it would be in utf8, utf8mb4 or a mysql pre-4.1 legacy charset, but not in the export output charset. This whole if() is likely a side effect of the BINARY flag confusion (#2700)
+                    // TODO (#2609): this doesn't make sense — if the NSData really contains a string it would be
+                    // in utf8, utf8mb4 or a mysql pre-4.1 legacy charset, but not in the export output charset.
+                    // This whole if() is likely a side effect of the BINARY flag confusion (upstream sequelpro#2700).
                     createTableSyntax = [[NSString alloc] initWithData:createTableSyntax encoding:[self exportOutputEncoding]];
                 }
 

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -46,7 +46,7 @@ typedef enum {
 
 @interface SPDataImport : NSObject <NSOpenSavePanelDelegate>
 {
-#warning Outlets belong to multiple xib files!
+	// TODO (#2606): outlets belong to multiple xib files, so each xib load overwrites part of this set
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -931,7 +931,7 @@
 			BOOL atPartialLineEnding = NO;
 			NSInteger segmentEndPosition = dataBufferPosition;
 
-#warning This EOL detection logic will break for multibyte encodings (like UTF16)!
+			// TODO (#2605): this EOL detection logic will break for multibyte encodings (like UTF16)
 			if (csvLineTerminatorLength && dataBufferPosition < dataBufferLength) {
 				NSInteger remainingBytes = dataBufferLength - dataBufferPosition;
 				NSInteger bytesToCompare = MIN(remainingBytes, csvLineTerminatorLength);
@@ -1167,7 +1167,7 @@
 
 						rowsImported++;
 						csvRowsThisQuery++;
-#warning Updating the UI for every single row is likely a performance killer (even without synchronization).
+						// TODO (#2606): updating the UI for every single row is likely a performance killer (even without synchronization)
 						SPMainQSync(^{
 							if (fileIsCompressed) {
 								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
@@ -1205,7 +1205,7 @@
 								[[SPQueryController sharedQueryController] showErrorInConsole:mySQLConnection.lastErrorMessage connection:mySQLConnection.host database:databaseName];
 							}
 						}
-#warning duplicate code (see above)
+						// TODO (#2606): duplicate progress-update code (see above)
 						rowsImported++;
 						SPMainQSync(^{
 							if (fileIsCompressed) {
@@ -1219,7 +1219,7 @@
 					}
 				} else {
 					rowsImported += csvRowsThisQuery;
-#warning duplicate code (see above)
+					// TODO (#2606): duplicate progress-update code (see above)
 					SPMainQSync(^{
 						if (fileIsCompressed) {
 							[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -3872,7 +3872,7 @@ static NSString * const SPDashStyleCommentMarker = @"-- ";
  */
 - (id)_resultDataItemAtRow:(NSInteger)row columnIndex:(NSUInteger)column preserveNULLs:(BOOL)preserveNULLs asPreview:(BOOL)asPreview;
 {
-#warning duplicate code with SPTableContent.m tableView:objectValueForTableColumn:…
+    // TODO (#2607): duplicate code with SPTableContent.m tableView:objectValueForTableColumn:…
     id value = nil;
     
     // While the table is being loaded, additional validation is required - data

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -1994,7 +1994,7 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 		NSString *columnEncoding = [rowData safeObjectForKey:@"encodingName"];
 		NSString *columnCollation = [rowData safeObjectForKey:@"collationName"]; // loadTable: has already inferred it, if not set explicit
 
-#warning Building the collation menu here is a big performance hog. This should be done in menuNeedsUpdate: below!
+		// TODO (#2608): building the collation menu here is a big performance hog; it should happen in menuNeedsUpdate: below
 		NSPopUpButtonCell *collationCell = [tableColumn dataCell];
 		[collationCell removeAllItems];
 		[collationCell addItemWithTitle:@"dummy"];

--- a/Source/Other/CategoryAdditions/SPWindowAdditions.m
+++ b/Source/Other/CategoryAdditions/SPWindowAdditions.m
@@ -76,7 +76,7 @@
 
 	if (frontDoc && [frontDoc isKindOfClass:[SPDatabaseDocument class]] && [frontDoc valueForKeyPath:@"spHistoryControllerInstance"] && ![frontDoc isWorking])
 	{
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		if ([event deltaX] == -1.0f) {
 			[[frontDoc valueForKeyPath:@"spHistoryControllerInstance"] valueForKey:@"goForwardInHistory"];
 		}

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -49,7 +49,7 @@
 		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
 			delegateForUse = delegate;
 		}
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		else if ( [delegate valueForKey:@"tableContentInstance"]
 					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
 			delegateForUse = [delegate valueForKey:@"tableContentInstance"];
@@ -115,7 +115,7 @@
 		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
 			delegateForUse = delegate;
 		}
-#warning Private ivar accessed from outside (#2978)
+		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
 		else if ( [delegate valueForKey:@"tableContentInstance"]
 					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
 			delegateForUse = [delegate valueForKey:@"tableContentInstance"];

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -443,6 +443,33 @@ markers (14), and the intentional Swift deprecation markers (4:
 `selectionHighlightStyle = .sourceList`, `legacyUnarchive`,
 `legacyArchivedData` ×2).
 
+## Step 12 — `#warning` markers → GitHub issues — ✅ Done
+
+Same basis as steps 10-11: **78 → 52 raw occurrences, 34 → 20 unique lines**.
+Every `#warning` in the codebase (15 sites — the build showed 14 because the
+`Querying & Preparation.m` one had the same normalized text as a sibling) is
+now a `// TODO (#issue):` comment pointing at a tracked Sequel-Ace issue:
+
+| Issue | Markers |
+|---|---|
+| #2603 cross-class ivar access via KVC | SPWindowAdditions:79, SPImageView:52/118 |
+| #2604 SPMySQLFramework encoding/dup conversion | Conversion.m:46, Querying & Preparation.m:130, SPMySQLResult.m:316 |
+| #2605 CSV EOL detection vs multibyte encodings | SPDataImport.m:934 |
+| #2606 SPDataImport cleanup (per-row UI, dup code, xib outlets) | SPDataImport.m:1170/1208/1222, SPDataImport.h:49 |
+| #2607 dedupe result-cell lookup with SPTableContent | SPCustomQuery.m:3875 |
+| #2608 collation menu rebuilt per cell-display | SPTableStructure.m:1997 |
+| #2609 exporter encoding audit (writeUTF8String / NSData decode) | SPExporter.h:156, SPSQLExporter.m:345 |
+
+The old markers' `#2978`/`#2700` references were **upstream sequel-pro issue
+numbers**, not Sequel-Ace ones (they resolve to unrelated PRs here); the new
+issues cite `sequelpro/sequelpro#2978` / `#2700` explicitly for history.
+
+Remaining after this step: **20 unique lines**, all of them the two deferred
+migrations — SecKeychain (10) and NSConnection (6) — plus the 4 intentional
+Swift deprecation markers (`selectionHighlightStyle = .sourceList`,
+`legacyUnarchive`, `legacyArchivedData` ×2). Zero is now gated purely on the
+deferred projects below.
+
 ## Deferred (own projects, not part of this burn-down)
 
 - **SPKeychain SecKeychain* API (~15)** — migrate to `SecItem*` with in-place
@@ -462,10 +489,11 @@ markers (14), and the intentional Swift deprecation markers (4:
   message now reads "building for macOS-13.5", but the committed dylibs were
   not rebuilt. `build-libmysqlclient.sh` *was* updated to 13.5, so whenever the
   rebuild happens it will produce a consistent binary.
-- **Intentional markers, keep**: SAArchiving `legacyUnarchive` (by design),
-  `#warning` TODOs (collation-menu perf hog SPTableStructure:1994, duplicate
-  code SPDataImport:1167 / SPCustomQuery:3761, private-ivar note
-  SPImageView:50 (#2978)) — convert to GitHub issues if we want a clean zero.
+- **Intentional markers, keep**: SAArchiving `legacyUnarchive` /
+  `legacyArchivedData` (by design — the deprecation attribute *is* the
+  guard-rail) and `selectionHighlightStyle = .sourceList` (replacement changes
+  row metrics; wants a visual pass). The `#warning` TODOs were converted to
+  tracked issues in step 12.
 
 ## Expected trajectory
 


### PR DESCRIPTION
> **Stacked on #2602.** Base is `infra/reduce-build-warnings-batch4`, so the diff shows only new work and the counts are additive. GitHub retargets this to `main` automatically once #2602 merges.

## Changes:
- Executes the plan's stated path past the `#warning` markers: all **15 `#warning` sites** in the codebase are now `// TODO (#issue):` comments pointing at newly created, properly scoped Sequel-Ace issues:
  - #2603 — cross-class ivar access via KVC (SPWindowAdditions, SPImageView ×2)
  - #2604 — SPMySQLFramework encoding assumptions + duplicated byte-to-string conversion (Conversion.m, Querying & Preparation.m, SPMySQLResult.m)
  - #2605 — CSV import EOL detection breaks for multibyte encodings (SPDataImport.m:934)
  - #2606 — SPDataImport cleanup: per-row progress updates, triplicated progress code, outlets shared across xibs (4 markers)
  - #2607 — dedupe result-cell value lookup between SPCustomQuery and SPTableContent
  - #2608 — collation popup menu rebuilt on every cell display pass in the structure view
  - #2609 — SQL export encoding audit: `writeUTF8String:` vs `exportOutputEncoding` + the NSData decode branch
- **The markers' old `#2978`/`#2700` references were upstream sequel-pro issue numbers** — in this repo those numbers resolve to unrelated PRs. The new issues cite `sequelpro/sequelpro#2978` / `sequelpro/sequelpro#2700` explicitly so the history isn't lost.
- Same measurement basis as #2598/#2602 ("Unit Tests" scheme, clean `build-for-testing`, fresh derived data): **78 → 52 raw occurrences, 34 → 20 unique lines**. `-W#warnings` is now at zero.
- Updated `docs/development/warnings-elimination-plan.md`: Step 12 recorded, and the stale "intentional markers" bullet rewritten — the remaining 20 lines are only the deferred SecKeychain (10) / NSConnection (6) migrations plus the 4 intentional Swift deprecation markers.

## Closes following issues:
- None (creates #2603–#2609 as tracked follow-ups)

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.5

## Screenshots:
N/A — comment-only change, no code or UI behavior touched.

## Additional notes:
- Strictly behavior-preserving: every hunk replaces a `#warning` directive with an equivalent `//` comment (wording preserved, issue number added). No executable code changed.
- Full suite green: **1142 tests, 0 failures** (63 environment-skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)