### PR TITLE
#infra Keychain SecItem migration steps 0-1: design plan + characterization suite

### DIFF
--- a/Source/Other/Keychain/SAKeychainProviding.swift
+++ b/Source/Other/Keychain/SAKeychainProviding.swift
@@ -48,7 +48,8 @@ import Foundation
 
     /// Adds a password with the item's label defaulting to `name`.
     /// Silently does nothing when an item for (`name`, `account`) already
-    /// exists, or when any argument is nil/empty.
+    /// exists, when the name or account is nil/empty, or when the password
+    /// is nil — an *empty* password is stored (and round-trips as `""`).
     @objc(addPassword:forName:account:)
     func add(password: String?, name: String?, account: String?)
 

--- a/Source/Other/Keychain/SAKeychainProviding.swift
+++ b/Source/Other/Keychain/SAKeychainProviding.swift
@@ -1,0 +1,102 @@
+//
+//  SAKeychainProviding.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The keychain surface shared by the legacy `SPKeychain` (Objective-C,
+/// `SecKeychain*`) and its planned `SecItem*` replacement — see
+/// `docs/development/keychain-secitem-migration-plan.md`.
+///
+/// The selectors mirror `SPKeychain.h` exactly so the legacy class conforms
+/// without any change to its methods; the characterization suite is written
+/// against this protocol so the identical tests can later run against both
+/// implementations (the migration plan's cross-compatibility matrix).
+///
+/// Public rather than internal so it appears in every target's generated
+/// `sequel-ace-Swift.h` — `SPKeychain.m` compiles into the app, the
+/// SequelAceTunnelAssistant, and (for the characterization suite) the Unit
+/// Tests target, and only public declarations are emitted into the generated
+/// header for targets that have no Objective-C bridging header.
+@objc public protocol SAKeychainProviding {
+
+    /// Adds a password with the item's label defaulting to `name`.
+    /// Silently does nothing when an item for (`name`, `account`) already
+    /// exists, or when any argument is nil/empty.
+    @objc(addPassword:forName:account:)
+    func add(password: String?, name: String?, account: String?)
+
+    /// Adds a password with an explicit item label (nil label → empty).
+    @objc(addPassword:forName:account:withLabel:)
+    func add(password: String?, name: String?, account: String?, label: String?)
+
+    /// Returns the stored password, or nil when the item does not exist or
+    /// the arguments are nil/empty.
+    @objc(getPasswordForName:account:)
+    func password(name: String?, account: String?) -> String?
+
+    /// Deletes the item when it exists; otherwise does nothing.
+    @objc(deletePasswordForName:account:)
+    func deletePassword(name: String?, account: String?)
+
+    @objc(passwordExistsForName:account:)
+    func passwordExists(name: String?, account: String?) -> Bool
+
+    /// Renames an item and replaces its password in place (preserving its
+    /// access list). Falls back to add when the source item is missing, and
+    /// replaces the destination when it already exists.
+    @objc(updateItemWithName:account:toName:account:password:)
+    func updateItem(name: String?, account: String?, toName newName: String?, newAccount: String?, password: String?)
+
+    /// ⚠️ Characterized as defective (migration plan, defect 1): the legacy
+    /// implementation forwards its arguments to the five-argument variant in
+    /// scrambled order. Currently has no production callers; scheduled for
+    /// deletion in Step 2 of the migration plan.
+    @objc(updateItemWithName:account:toPassword:)
+    func updateItem(name: String?, account: String?, toPassword password: String?)
+
+    /// `"Sequel Ace : <favoriteName> (<id as long long>)"`, or nil for a
+    /// nil/empty name or nil id.
+    @objc(nameForFavoriteName:id:)
+    func name(favoriteName: String?, id favoriteID: String?) -> String?
+
+    /// `"<user>@<host>/<database>"` (nil database → empty), or nil for a
+    /// nil/empty user or host.
+    @objc(accountForUser:host:database:)
+    func account(user: String?, host: String?, database: String?) -> String?
+
+    /// `"Sequel Ace SSHTunnel : <favoriteName> (<id as long long>)"`, or nil
+    /// for a nil/empty name or nil id.
+    @objc(nameForSSHForFavoriteName:id:)
+    func sshName(favoriteName: String?, id favoriteID: String?) -> String?
+
+    /// `"<user>@<host>"`, or nil for a nil/empty user or host.
+    @objc(accountForSSHUser:sshHost:)
+    func sshAccount(user: String?, host: String?) -> String?
+}

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -34,6 +34,16 @@
 #import <Security/Security.h>
 #import <CoreFoundation/CoreFoundation.h>
 
+#import "sequel-ace-Swift.h"
+
+// SPKeychain is the legacy SecKeychain*-based implementation of the shared
+// keychain surface. Conforming to SAKeychainProviding lets the
+// characterization suite — and, once the SecItem* replacement exists, the
+// call sites — treat the two implementations interchangeably. See
+// docs/development/keychain-secitem-migration-plan.md.
+@interface SPKeychain () <SAKeychainProviding>
+@end
+
 @implementation SPKeychain
 
 - (instancetype)init

--- a/UnitTests/SAKeychainNamingCharacterizationTests.swift
+++ b/UnitTests/SAKeychainNamingCharacterizationTests.swift
@@ -1,0 +1,112 @@
+//
+//  SAKeychainNamingCharacterizationTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Step 1 of docs/development/keychain-secitem-migration-plan.md: pin the
+//  four keychain name/account format strings byte-exactly. These formats are
+//  the keychain wire format — they are persisted in every user's login
+//  keychain, and `.spf` documents store the resulting strings verbatim — so
+//  any drift silently orphans saved passwords. The SecItem* replacement must
+//  reproduce every assertion in this file unchanged.
+//
+
+import XCTest
+
+final class SAKeychainNamingCharacterizationTests: SAKeychainCharacterizationTestCase {
+
+    override var needsKeychainAccess: Bool { false }
+
+    // MARK: - nameForFavoriteName:id:
+
+    func testFavoriteNameFormatsNameAndNumericID() {
+        XCTAssertEqual(store.name(favoriteName: "Prod DB", id: "12345"),
+                       "Sequel Ace : Prod DB (12345)")
+    }
+
+    func testFavoriteNameCoercesIDThroughLongLong() {
+        // The id goes through -longLongValue: non-numeric strings become 0,
+        // numeric prefixes are taken as far as they parse, and 64-bit values
+        // survive. Changing any of this would orphan existing items.
+        XCTAssertEqual(store.name(favoriteName: "F", id: "abc"), "Sequel Ace : F (0)")
+        XCTAssertEqual(store.name(favoriteName: "F", id: ""), "Sequel Ace : F (0)")
+        XCTAssertEqual(store.name(favoriteName: "F", id: "42abc"), "Sequel Ace : F (42)")
+        XCTAssertEqual(store.name(favoriteName: "F", id: "-3"), "Sequel Ace : F (-3)")
+        XCTAssertEqual(store.name(favoriteName: "F", id: "9223372036854775807"),
+                       "Sequel Ace : F (9223372036854775807)")
+    }
+
+    func testFavoriteNameRejectsMissingInputs() {
+        XCTAssertNil(store.name(favoriteName: nil, id: "1"))
+        XCTAssertNil(store.name(favoriteName: "", id: "1"))
+        XCTAssertNil(store.name(favoriteName: "F", id: nil))
+    }
+
+    func testFavoriteNamePassesNameThroughLiterally() {
+        // Names containing format-looking characters are not re-interpreted.
+        XCTAssertEqual(store.name(favoriteName: "100% weird %@ name", id: "7"),
+                       "Sequel Ace : 100% weird %@ name (7)")
+    }
+
+    // MARK: - accountForUser:host:database:
+
+    func testAccountFormatsUserHostDatabase() {
+        XCTAssertEqual(store.account(user: "user", host: "db.example.com", database: "shop"),
+                       "user@db.example.com/shop")
+    }
+
+    func testAccountNilOrEmptyDatabaseYieldsTrailingSlash() {
+        XCTAssertEqual(store.account(user: "user", host: "host", database: nil), "user@host/")
+        XCTAssertEqual(store.account(user: "user", host: "host", database: ""), "user@host/")
+    }
+
+    func testAccountRejectsMissingUserOrHost() {
+        XCTAssertNil(store.account(user: nil, host: "host", database: "db"))
+        XCTAssertNil(store.account(user: "", host: "host", database: "db"))
+        XCTAssertNil(store.account(user: "user", host: nil, database: "db"))
+        XCTAssertNil(store.account(user: "user", host: "", database: "db"))
+    }
+
+    // MARK: - nameForSSHForFavoriteName:id:
+
+    func testSSHNameFormatsNameAndNumericID() {
+        XCTAssertEqual(store.sshName(favoriteName: "Prod DB", id: "12345"),
+                       "Sequel Ace SSHTunnel : Prod DB (12345)")
+    }
+
+    func testSSHNameCoercesIDThroughLongLong() {
+        XCTAssertEqual(store.sshName(favoriteName: "F", id: "abc"),
+                       "Sequel Ace SSHTunnel : F (0)")
+    }
+
+    func testSSHNameRejectsMissingInputs() {
+        XCTAssertNil(store.sshName(favoriteName: nil, id: "1"))
+        XCTAssertNil(store.sshName(favoriteName: "", id: "1"))
+        XCTAssertNil(store.sshName(favoriteName: "F", id: nil))
+    }
+
+    // MARK: - accountForSSHUser:sshHost:
+
+    func testSSHAccountFormatsUserAndHost() {
+        XCTAssertEqual(store.sshAccount(user: "tunneluser", host: "bastion.example.com"),
+                       "tunneluser@bastion.example.com")
+    }
+
+    func testSSHAccountRejectsMissingUserOrHost() {
+        XCTAssertNil(store.sshAccount(user: nil, host: "host"))
+        XCTAssertNil(store.sshAccount(user: "", host: "host"))
+        XCTAssertNil(store.sshAccount(user: "user", host: nil))
+        XCTAssertNil(store.sshAccount(user: "user", host: ""))
+    }
+
+    // MARK: - Unicode
+
+    func testFormatsPreserveUnicode() {
+        XCTAssertEqual(store.name(favoriteName: "Datenbänk 🗄️", id: "9"),
+                       "Sequel Ace : Datenbänk 🗄️ (9)")
+        XCTAssertEqual(store.account(user: "üser", host: "høst", database: "database名"),
+                       "üser@høst/database名")
+    }
+}

--- a/UnitTests/SAKeychainStoreCharacterizationTests.swift
+++ b/UnitTests/SAKeychainStoreCharacterizationTests.swift
@@ -16,6 +16,7 @@
 //  modal NSAlerts, which would hang the runner (migration plan, defect 4).
 //
 
+import Security
 import XCTest
 
 final class SAKeychainStoreCharacterizationTests: SAKeychainCharacterizationTestCase {

--- a/UnitTests/SAKeychainStoreCharacterizationTests.swift
+++ b/UnitTests/SAKeychainStoreCharacterizationTests.swift
@@ -1,0 +1,229 @@
+//
+//  SAKeychainStoreCharacterizationTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Step 1 of docs/development/keychain-secitem-migration-plan.md: pin the
+//  legacy SPKeychain store behaviour exactly as it is — recovery branches,
+//  quirks and defects included. Where a pinned behaviour is a defect, the
+//  test says so and names the Step 2 fix that will flip it.
+//
+//  Every item is created under the SAKeychainTestSupport namespace against
+//  the real login keychain (see that file for the isolation story). The
+//  suite deliberately never drives SPKeychain's failure paths: those run
+//  modal NSAlerts, which would hang the runner (migration plan, defect 4).
+//
+
+import XCTest
+
+final class SAKeychainStoreCharacterizationTests: SAKeychainCharacterizationTestCase {
+
+    private func service(_ label: String, _ function: StaticString = #function) -> String {
+        SAKeychainTestSupport.service("\(function) \(label)")
+    }
+
+    // MARK: - Basic CRUD
+
+    func testAddThenGetRoundTrips() {
+        let name = service("item"), account = "user@host/db"
+        store.add(password: "secret-123", name: name, account: account)
+        XCTAssertEqual(store.password(name: name, account: account), "secret-123")
+    }
+
+    func testGetForMissingItemReturnsNil() {
+        XCTAssertNil(store.password(name: service("never created"), account: "user@host/"))
+    }
+
+    func testPasswordExistsReflectsPresence() {
+        let name = service("item"), account = "user@host/"
+        XCTAssertFalse(store.passwordExists(name: name, account: account))
+        store.add(password: "pw", name: name, account: account)
+        XCTAssertTrue(store.passwordExists(name: name, account: account))
+    }
+
+    func testExistsDistinguishesAccounts() {
+        let name = service("item")
+        store.add(password: "pw", name: name, account: "a@h/")
+        XCTAssertFalse(store.passwordExists(name: name, account: "b@h/"))
+        XCTAssertNil(store.password(name: name, account: "b@h/"))
+    }
+
+    func testDeleteRemovesItem() {
+        let name = service("item"), account = "user@host/"
+        store.add(password: "pw", name: name, account: account)
+        store.deletePassword(name: name, account: account)
+        XCTAssertFalse(store.passwordExists(name: name, account: account))
+        XCTAssertNil(store.password(name: name, account: account))
+    }
+
+    func testDeleteForMissingItemIsANoOp() {
+        store.deletePassword(name: service("never created"), account: "user@host/")
+    }
+
+    func testAddWhenItemExistsIsASilentNoOp() {
+        // Callers rely on this: SPConnectionController branches on
+        // passwordExists and routes changes through the update path.
+        let name = service("item"), account = "user@host/"
+        store.add(password: "first", name: name, account: account)
+        store.add(password: "second", name: name, account: account)
+        XCTAssertEqual(store.password(name: name, account: account), "first")
+    }
+
+    // MARK: - Persisted item shape
+
+    func testAddStoresServiceAccountLabelAndGenericAttribute() throws {
+        let name = service("item"), account = "user@host/db"
+        store.add(password: "pw", name: name, account: account)
+
+        let attrs = try XCTUnwrap(SAKeychainTestSupport.attributes(service: name, account: account))
+        XCTAssertEqual(attrs[kSecAttrService as String] as? String, name)
+        XCTAssertEqual(attrs[kSecAttrAccount as String] as? String, account)
+        // The three-argument add defaults the label to the name.
+        XCTAssertEqual(attrs[kSecAttrLabel as String] as? String, name)
+        // kSecGenericItemAttr carries the literal "application password"
+        // (SPKeychain.m hardcodes the 20-byte string).
+        let generic = try XCTUnwrap(attrs[kSecAttrGeneric as String] as? Data)
+        XCTAssertEqual(String(data: generic, encoding: .utf8), "application password")
+    }
+
+    func testAddWithExplicitLabelStoresIt() throws {
+        let name = service("item"), account = "user@host/"
+        store.add(password: "pw", name: name, account: account, label: "Custom Label")
+        let attrs = try XCTUnwrap(SAKeychainTestSupport.attributes(service: name, account: account))
+        XCTAssertEqual(attrs[kSecAttrLabel as String] as? String, "Custom Label")
+    }
+
+    // MARK: - Payload edge cases
+
+    func testUnicodePasswordRoundTrips() {
+        let name = service("item"), account = "user@host/"
+        let password = "pässwörd-🔑-密码"
+        store.add(password: password, name: name, account: account)
+        XCTAssertEqual(store.password(name: name, account: account), password)
+    }
+
+    func testUnicodeServiceAndAccountRoundTrip() {
+        let name = service("Ünïcode 名前"), account = "üser@høst/db名"
+        store.add(password: "pw", name: name, account: account)
+        XCTAssertEqual(store.password(name: name, account: account), "pw")
+        XCTAssertTrue(store.passwordExists(name: name, account: account))
+    }
+
+    func testEmptyPasswordRoundTripsAsEmptyString() {
+        let name = service("item"), account = "user@host/"
+        store.add(password: "", name: name, account: account)
+        XCTAssertTrue(store.passwordExists(name: name, account: account))
+        XCTAssertEqual(store.password(name: name, account: account), "")
+    }
+
+    func testLongPasswordRoundTrips() {
+        let name = service("item"), account = "user@host/"
+        let password = String(repeating: "x", count: 4096)
+        store.add(password: password, name: name, account: account)
+        XCTAssertEqual(store.password(name: name, account: account), password)
+    }
+
+    // MARK: - nil / empty argument handling
+
+    func testNilAndEmptyArgumentsAreRejectedWithoutCrashing() {
+        let name = service("item")
+        store.add(password: "pw", name: nil, account: "a")
+        store.add(password: "pw", name: name, account: nil)
+        store.add(password: "pw", name: "", account: "a")
+        store.add(password: nil, name: name, account: "a")
+        XCTAssertFalse(store.passwordExists(name: name, account: "a"))
+
+        XCTAssertNil(store.password(name: nil, account: "a"))
+        XCTAssertNil(store.password(name: name, account: nil))
+        XCTAssertFalse(store.passwordExists(name: nil, account: "a"))
+        store.deletePassword(name: nil, account: "a")
+        store.updateItem(name: nil, account: "a", toName: "b", newAccount: "c", password: "pw")
+    }
+
+    // MARK: - Five-argument update
+
+    func testUpdateRenamesItemAndReplacesPassword() {
+        let oldName = service("old"), newName = service("new")
+        store.add(password: "pw-1", name: oldName, account: "old@host/")
+        store.updateItem(name: oldName, account: "old@host/",
+                         toName: newName, newAccount: "new@host/", password: "pw-2")
+
+        XCTAssertFalse(store.passwordExists(name: oldName, account: "old@host/"))
+        XCTAssertEqual(store.password(name: newName, account: "new@host/"), "pw-2")
+    }
+
+    func testUpdateLeavesLabelBehindOnRename() throws {
+        // Quirk: the update path modifies only service, account and secret —
+        // the label keeps the pre-rename favorite name, which is what users
+        // see in Keychain Access. Pinned so the SecItem* implementation
+        // reproduces it (changing it is a Step 4 review decision, not an
+        // accident).
+        let oldName = service("old"), newName = service("new")
+        store.add(password: "pw", name: oldName, account: "a@h/")
+        store.updateItem(name: oldName, account: "a@h/",
+                         toName: newName, newAccount: "a@h/", password: "pw")
+        let attrs = try XCTUnwrap(SAKeychainTestSupport.attributes(service: newName, account: "a@h/"))
+        XCTAssertEqual(attrs[kSecAttrLabel as String] as? String, oldName)
+    }
+
+    func testUpdateWithSameNameAndAccountReplacesPasswordOnly() {
+        let name = service("item"), account = "user@host/"
+        store.add(password: "pw-1", name: name, account: account)
+        store.updateItem(name: name, account: account,
+                         toName: name, newAccount: account, password: "pw-2")
+        XCTAssertEqual(store.password(name: name, account: account), "pw-2")
+    }
+
+    func testUpdateOfMissingItemFallsBackToAdd() {
+        // The errSecItemNotFound (-25300) branch: a safe delete, then a
+        // fresh add under the *new* name and account.
+        let oldName = service("never existed"), newName = service("created by update")
+        store.updateItem(name: oldName, account: "old@host/",
+                         toName: newName, newAccount: "new@host/", password: "pw")
+        XCTAssertEqual(store.password(name: newName, account: "new@host/"), "pw")
+        XCTAssertFalse(store.passwordExists(name: oldName, account: "old@host/"))
+    }
+
+    func testUpdateOntoExistingDestinationReplacesIt() {
+        // The errSecDuplicateItem (-25299) branch: the existing destination
+        // item is deleted and the update retried, so the source item wins.
+        let source = service("source"), destination = service("destination")
+        store.add(password: "source-pw", name: source, account: "s@h/")
+        store.add(password: "old-destination-pw", name: destination, account: "d@h/")
+
+        store.updateItem(name: source, account: "s@h/",
+                         toName: destination, newAccount: "d@h/", password: "moved-pw")
+
+        XCTAssertEqual(store.password(name: destination, account: "d@h/"), "moved-pw")
+        XCTAssertFalse(store.passwordExists(name: source, account: "s@h/"))
+    }
+
+    // MARK: - Three-argument update (pinned defect)
+
+    func testThreeArgumentUpdateScramblesItsArguments() {
+        // ⚠️ Defect 1 in the migration plan, pinned deliberately: the
+        // toPassword: variant forwards to the five-argument update in
+        // scrambled order — the item is renamed to the *password*, its
+        // account becomes the *name*, and the stored secret becomes the
+        // *account*. It has no production callers (all four call sites use
+        // the five-argument form); Step 2 deletes it. This test documents
+        // exactly what it would do to a caller and will be removed with the
+        // method.
+        let name = service("victim"), account = "user@host/"
+        // The "password" must be namespaced too — the scramble turns it into
+        // a service name, and the sweep must be able to delete that item.
+        let newPassword = service("scrambled destination")
+
+        store.add(password: "original-pw", name: name, account: account)
+        store.updateItem(name: name, account: account, toPassword: newPassword)
+
+        // The original item is gone…
+        XCTAssertFalse(store.passwordExists(name: name, account: account))
+        // …and what exists instead is an item whose service is the password
+        // argument, whose account is the old name, and whose secret is the
+        // old account string.
+        XCTAssertEqual(store.password(name: newPassword, account: name), account)
+    }
+}

--- a/UnitTests/SAKeychainTestSupport.swift
+++ b/UnitTests/SAKeychainTestSupport.swift
@@ -1,0 +1,180 @@
+//
+//  SAKeychainTestSupport.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Test harness for keychain-touching tests — Step 0 of
+//  docs/development/keychain-secitem-migration-plan.md.
+//
+//  The suites run against the real login keychain of the machine, under a
+//  unique per-run namespace: every service name is prefixed
+//  "Sequel Ace Test <token> : " so nothing can collide with real user items,
+//  and the sweep deletes every "Sequel Ace Test" item — including leftovers
+//  from aborted earlier runs. Items created by the test process itself read
+//  back without ACL prompts, so the suites are prompt-free; on machines where
+//  the login keychain is locked or unavailable (some SSH sessions, hardened
+//  CI), the probe fails and the store suites skip.
+//
+
+import Foundation
+import Security
+import XCTest
+
+enum SAKeychainTestSupport {
+
+    /// Every keychain item any test creates must carry this service prefix —
+    /// it is what the sweep matches on.
+    static let testServicePrefix = "Sequel Ace Test"
+
+    /// Per-run token so concurrent/consecutive runs cannot see each other's
+    /// items even before the sweep runs.
+    static let runToken: String = String(UUID().uuidString.prefix(8))
+
+    /// A namespaced service name for one test's item.
+    static func service(_ label: String) -> String {
+        "\(testServicePrefix) \(runToken) : \(label)"
+    }
+
+    /// The legacy SPKeychain, reached via the runtime because the Unit Tests
+    /// target has no Objective-C bridging header (see "Test-target ObjC
+    /// visibility — known sharp edge" in the modernization plan). SPKeychain
+    /// declares SAKeychainProviding conformance in its .m, so the cast is a
+    /// real runtime conformance check, not a bit-cast.
+    static func makeLegacyStore() -> SAKeychainProviding? {
+        guard let cls = NSClassFromString("SPKeychain") as? NSObject.Type else { return nil }
+        return cls.init() as? SAKeychainProviding
+    }
+
+    /// True when the login keychain accepts a write + read-back + delete from
+    /// this process. Uses raw SecItem* calls (never SPKeychain) so a locked
+    /// keychain surfaces as a status code here rather than as SPKeychain's
+    /// modal error alert hanging the test runner.
+    static func probeKeychainUsable() -> Bool {
+        let probeService = service("availability probe")
+        let probeAccount = "probe@probe/probe"
+        let add: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: probeService,
+            kSecAttrAccount as String: probeAccount,
+            kSecValueData as String: Data("probe".utf8),
+        ]
+        guard SecItemAdd(add as CFDictionary, nil) == errSecSuccess else { return false }
+        defer { deleteItem(service: probeService, account: probeAccount) }
+        return passwordData(service: probeService, account: probeAccount) == Data("probe".utf8)
+    }
+
+    /// Raw attribute read for asserting the persisted item shape.
+    static func attributes(service: String, account: String) -> [String: Any]? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else { return nil }
+        return result as? [String: Any]
+    }
+
+    /// Raw secret read, bypassing SPKeychain's C-string round-trip.
+    static func passwordData(service: String, account: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    static func deleteItem(service: String, account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    /// Deletes every generic-password item whose service starts with the test
+    /// prefix — this run's items and any leftovers from aborted runs. Reads
+    /// only attributes (never secrets), so it cannot prompt.
+    static func sweepTestItems() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[String: Any]] else { return }
+        for item in items {
+            guard let service = item[kSecAttrService as String] as? String,
+                  service.hasPrefix(testServicePrefix) else { continue }
+            if let account = item[kSecAttrAccount as String] as? String {
+                deleteItem(service: service, account: account)
+            }
+        }
+    }
+}
+
+/// Shared setup for suites that construct the legacy store: the env-guard and
+/// keychain-availability skips, the namespace sweep, and the store itself.
+/// Subclassed rather than parameterized so the identical characterization
+/// tests can later run against the SecItem* implementation by overriding
+/// `makeStore()` (the migration plan's cross-compatibility matrix).
+class SAKeychainCharacterizationTestCase: XCTestCase {
+
+    private static var probeResult: Bool?
+
+    var store: SAKeychainProviding!
+
+    /// Whether this suite touches the keychain (store CRUD) or only the pure
+    /// naming helpers. Naming-only suites skip the availability probe.
+    var needsKeychainAccess: Bool { true }
+
+    func makeStore() -> SAKeychainProviding? {
+        SAKeychainTestSupport.makeLegacyStore()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        SAKeychainTestSupport.sweepTestItems()
+    }
+
+    override class func tearDown() {
+        SAKeychainTestSupport.sweepTestItems()
+        super.tearDown()
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // SPKeychain's init returns nil under this env var (issue #2437), so
+        // no store can be constructed at all. The guard itself is
+        // characterized in the migration plan as defect 3 (the nil init is a
+        // trap for Swift callers) and gets a proper testable seam in Step 2;
+        // NSProcessInfo caches the environment, so flipping the variable
+        // in-process would not be deterministic enough to pin here.
+        if ProcessInfo.processInfo.environment["LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN"] != nil {
+            throw XCTSkip("keychain access is disabled while LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN is set")
+        }
+        if needsKeychainAccess {
+            if Self.probeResult == nil {
+                Self.probeResult = SAKeychainTestSupport.probeKeychainUsable()
+            }
+            guard Self.probeResult == true else {
+                throw XCTSkip("login keychain is locked or unavailable on this machine")
+            }
+        }
+        store = try XCTUnwrap(
+            makeStore(),
+            "keychain store missing — is the implementation compiled into the Unit Tests target and conforming to SAKeychainProviding?"
+        )
+    }
+}

--- a/UnitTests/SAKeychainTestSupport.swift
+++ b/UnitTests/SAKeychainTestSupport.swift
@@ -25,8 +25,11 @@ import XCTest
 enum SAKeychainTestSupport {
 
     /// Every keychain item any test creates must carry this service prefix —
-    /// it is what the sweep matches on.
-    static let testServicePrefix = "Sequel Ace Test"
+    /// it is what the sweep matches on. The fixed random token makes the
+    /// namespace collision-proof: the sweep deletes every matching item
+    /// (aborted-run leftovers included), so the prefix must be one nothing
+    /// else could plausibly use.
+    static let testServicePrefix = "Sequel Ace Unit Test 8C41F2D6"
 
     /// Per-run token so concurrent/consecutive runs cannot see each other's
     /// items even before the sweep runs.

--- a/docs/development/keychain-secitem-migration-plan.md
+++ b/docs/development/keychain-secitem-migration-plan.md
@@ -1,0 +1,396 @@
+# SPKeychain → SecItem Migration Plan
+
+> **Drafted 2026-08-30.** This is the design the warnings plan deferred to
+> ("SPKeychain SecKeychain* API — highest risk item in the codebase; needs its
+> own design"). Siblings: `warnings-elimination-plan.md` (this project owns 10
+> of its remaining 20 warning lines), `ssh-tunnel-xpc-migration-plan.md` (open
+> question 3 there asks for the sequencing decision made here),
+> `modernization-followup-plan.md`, ground rules in `AGENTS.md`.
+
+## Why this is the highest-risk file in the codebase
+
+`Source/Other/Keychain/SPKeychain.m` (387 lines, unchanged in shape since the
+Sequel Pro era, one method already on `SecItem*`) is the sole owner of every
+saved MySQL and SSH password. It has **zero tests**. Its wire format — the
+service/account strings under which items are stored — is persisted in users'
+login keychains, so any behavioural drift silently orphans passwords
+(issue #1253 shows how sensitive users are to exactly that failure mode), and
+the #2491 keychain-handoff regression shows the integration surface is easy to
+break. It compiles into **two targets**: the app and `SequelAceTunnelAssistant`
+(the SSH askpass helper), which is why the deprecated ACL machinery exists at
+all.
+
+Deprecated API in use (all deprecated as of macOS 12 / 10.15):
+
+| API | Sites |
+|---|---|
+| `SecKeychainItemCreateFromContent` | :116 (add) |
+| `SecKeychainFindGenericPassword` | :158 (get), :205 (delete), :278 (update) |
+| `SecKeychainItemFreeContent` | :180 |
+| `SecKeychainItemDelete` | :217 |
+| `SecKeychainItemModifyAttributesAndData` | :314 |
+| `SecTrustedApplicationCreateFromPath` ×2, `SecAccessCreate` | :86-91 (add-path ACL) |
+
+→ the "SecKeychain (10 unique lines)" block in the warnings plan's floor.
+
+## Current behaviour that must not change (the wire format)
+
+These four format strings are the keychain wire format. They are persisted in
+every user's login keychain and are also constructed *outside* SPKeychain
+(`SAConnectionInfo+ConnectionString.swift` builds lookups through the same
+methods; `.spf` files store the resulting name/account strings verbatim):
+
+| Helper | Format |
+|---|---|
+| `nameForFavoriteName:id:` | `Sequel Ace : %@ (%lld)` |
+| `accountForUser:host:database:` | `%@@%@/%@` (nil database → empty) |
+| `nameForSSHForFavoriteName:id:` | `Sequel Ace SSHTunnel : %@ (%lld)` |
+| `accountForSSHUser:sshHost:` | `%@@%@` |
+
+Plus storage attributes: generic-password class, service = name, account =
+account, label = name (or explicit label), and the legacy
+`kSecGenericItemAttr` = `"application password"` (20 bytes). New items get an
+ACL trusting the app + the tunnel assistant.
+
+Behavioural quirks callers currently rely on:
+
+- `addPassword:` **silently no-ops if the item already exists** — callers
+  branch on `passwordExistsForName:` and use the update path instead.
+- `updateItemWithName:...password:` recovers from `errSecItemNotFound`
+  (-25300) by delete+add, and from `errSecDuplicateItem` (-25299) by deleting
+  the *destination* and retrying.
+- `getPasswordForName:` returns nil (not empty) for a missing item.
+- `init` returns **nil** when `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` is set
+  (issue #2437) — keychain access disabled wholesale.
+- All name/account inputs are validated as non-nil + non-empty
+  (`isValidName:acount:` [sic]); helpers return nil on invalid input.
+
+## Known and suspected defects (to be pinned or fixed in Step 1/2)
+
+Found by reading; Step 1's characterization tests confirm each before Step 2
+fixes it. Every fix is its own commit with a test that fails first.
+
+1. **`updateItemWithName:account:toPassword:` scrambles its arguments**
+   (:260): it forwards `toName:password account:name password:account` — i.e.
+   renames the item to the *password*, sets the account to the *name*, and
+   stores the *account* as the secret. Currently dead (all four call sites in
+   `SPConnectionController.m` use the five-arg form), but it is a public
+   method one refactor away from destroying a user's keychain item. Delete it
+   (preferred — it has no callers) or fix + test it.
+2. **nil password → `strlen(NULL)` crash** in the five-arg update (:314). The
+   attribute lengths guard `newName`/`newAccount` against nil but the password
+   is dereferenced unguarded. Callers happen to guard today.
+3. **`SPKeychain()` from Swift crashes when keychain access is disabled.**
+   The unannotated ObjC `init` imports as `init!`; with
+   `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` set it returns nil and the unguarded
+   Swift call sites (`SAConnectionInfo+ConnectionString.swift:146/206`,
+   `SAConnectionWindowController`) trap on first use. The nil-returning-init
+   pattern is also invisible at every ObjC call site (messages to nil just do
+   nothing — quietly skipping password saves). Needs an explicit design: a
+   disabled-mode null object, not a nil init.
+4. **`NSAlert runModal` from non-main threads**: add/update failure paths run
+   modal alerts directly (:130, :294, :328), and connection setup calls these
+   from background threads. AppKit off-main — undefined behaviour that has
+   presumably survived by rarity of the error paths.
+5. **Password read truncates at an embedded NUL** and returns nil for
+   non-UTF-8 data (:172-177 `strncpy` + `stringWithCString:`). Edge case;
+   decide (probably: pin as-is for parity, since a password that survived a
+   round-trip can't contain NUL anyway — the write path's `strlen` truncates
+   it first. Document *that* instead).
+6. **`favoriteId` coerced via `longLongValue`** — a non-numeric id becomes
+   `(0)` in the item name. Pin as characterization (changing it would orphan
+   existing items).
+
+## The design decision
+
+### Rewrite in Swift — yes
+
+Per AGENTS.md this isn't optional: new code is Swift. New type
+`SAKeychain` (`@objc final class SAKeychain: NSObject`), plus a protocol
+(`SAKeychainProviding`) so call sites and tests can inject. The four
+name/account helpers move to a **pure** `SAKeychainNaming` struct (no
+Security framework, compiles into the Unit Tests target unconditionally, same
+pattern as `SAConnectionFormHelpers`) — SPKeychain/SAKeychain delegate to it,
+and the Swift call sites that today instantiate `SPKeychain` just to compute
+names can use it directly.
+
+### Which keychain — stay on the file-based login keychain (for now)
+
+Two candidate stores for the `SecItem*` rewrite:
+
+**A. File-based login keychain** (`SecItem*` calls with no
+`kSecUseDataProtectionKeychain`): the same physical store the legacy API
+writes. Existing items are found, read, updated and deleted **in place — zero
+data migration**. Item ACLs are preserved by `SecItemUpdate`. Unit-testable
+without code signing. This is the chosen target.
+
+**B. Data-protection keychain** (`kSecUseDataProtectionKeychain: true` + the
+`$(AppIdentifierPrefix)com.sequel-ace.sequel-ace` access group already in the
+app's entitlements): the fully modern store, no ACLs, no prompts ever. Ruled
+out for this project because:
+
+- The tunnel assistant reads passwords **directly** from the keychain
+  (`SequelAceTunnelAssistant.m:97`) and its sandbox entitlement is
+  `com.apple.security.inherit`, which (per App Store sandbox rules) must not
+  be combined with additional entitlements — so it can never carry the
+  keychain access group and could never read a DP-keychain item.
+- The unit-test runner builds with `CODE_SIGNING_ALLOWED=NO`; DP-keychain
+  calls fail with `errSecMissingEntitlement` from an unsigned process, so the
+  entire storage layer would be untestable by exactly the tests this plan
+  exists to add.
+- It requires a real one-shot data migration of every user's saved passwords —
+  the single most dangerous operation available to this codebase — for zero
+  user-visible benefit.
+
+Moving to B stays possible later (Step 6 records what it would take); nothing
+in this plan burns that bridge.
+
+### The ACL problem, and the tunnel assistant
+
+The one thing `SecItem*` on the file keychain **cannot** do is reproduce the
+trusted-application ACL: `SecAccessCreate`/`SecTrustedApplication*` have no
+modern equivalent. Items created by `SecItemAdd` are readable only by the
+creating app; the assistant reading such an item triggers a user-facing
+keychain prompt (or a denial). So the migration forks on one question: *does
+the assistant keep reading the keychain itself?*
+
+Answer: **no — retire the assistant's direct keychain read (Step 3).** The
+plumbing for the alternative already exists: in "ask UI" mode the assistant
+already fetches the password from the app over the DO channel
+(`getPasswordWithVerificationHash:`), and the keychain mode is merely an
+optimization that bypasses the app. Change `SPSSHTunnel` so keychain-backed
+connections resolve the password app-side at connect time and serve it over
+the same in-memory path. Consequences:
+
+- No ACL is ever needed again → `SecAccessCreate`/`SecTrustedApplication*`
+  deleted, not migrated.
+- `SPKeychain.m` leaves the SequelAceTunnelAssistant target → the dual-target
+  warning duplication disappears, and the assistant loses its Security
+  dependency entirely.
+- This is the same step whether the channel is today's DO or the future XPC —
+  which **answers the XPC plan's open question 3**: the two projects no longer
+  care about ordering. If XPC lands first, its Step 1 (narrow the vended
+  surface) simply has one fewer password mode to carry; if this lands first,
+  the XPC migration inherits a smaller matrix (its manual test row 2/3,
+  "assistant never contacts the app", collapses into row 1).
+- Security note for the PR: the SSH password now transits the DO channel in
+  keychain mode too. That channel already carries it in every other mode with
+  the same verification-hash check, and hardening the channel itself is the
+  XPC project's job. Net exposure change ≈ 0; the XPC plan's threat analysis
+  already treats the channel as the thing to fix.
+
+## Steps
+
+Ground rules apply throughout: one focused PR per step, behaviour-preserving
+except where a step names the change, full suite green, `#infra` tag.
+
+### Step 0 — Test harness for keychain-touching tests
+
+Decide and build the isolation strategy once, before any test exists:
+
+- Tests run against the **real login keychain** of the machine, under a
+  unique per-run namespace: service names prefixed
+  `Sequel Ace Test <UUID> :` via the same naming helpers, so nothing can
+  collide with real user items. `tearDown` deletes every item it created
+  *and* a defensive sweep deletes any leftover `Sequel Ace Test` items from
+  aborted runs.
+- Items the test process itself created read back without ACL prompts, so
+  this is prompt-free locally and on CI (GitHub Actions runners have an
+  unlocked login keychain; a `SecKeychainGetStatus`-free probe — write one
+  item, read it back — gates the suite with `XCTSkip` on any machine where
+  the keychain is locked or unavailable, e.g. some SSH sessions).
+- The suite must also pass with `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` **unset**
+  — the init guard means these tests construct the store *after* asserting
+  the env var is absent, and one dedicated test covers the guard itself.
+- These tests live in a new `UnitTests/SAKeychainStoreTests.swift` (naming
+  says what it is; "integration-ish" unit tests). Pure-logic tests (naming,
+  validation) go in ordinary suites and never touch the keychain.
+
+### Step 1 — Characterization tests for the current implementation
+
+Pin `SPKeychain` exactly as it behaves, bugs and all (a characterization test
+asserts current behaviour; where the behaviour is a defect the test carries a
+comment naming the Step 2 fix that will flip it):
+
+- **Naming helpers, byte-exact** (pure, no keychain): all four format
+  strings, nil/empty rejection matrix, `longLongValue` coercion including the
+  non-numeric → `(0)` case, nil-database → trailing `/`.
+- **CRUD round-trips** against the harness namespace: add → exists → get →
+  delete → gone; get for missing item returns nil; add with existing item is
+  a silent no-op (password unchanged); add stores service/account/label/
+  generic-attr as documented (verified via `SecItemCopyMatching` with
+  `kSecReturnAttributes`).
+- **Update paths**: five-arg rename+repassword moves the item (old
+  name/account gone, new present, password readable); the -25300 fallback
+  (update of a missing item creates it); the -25299 fallback (update onto an
+  existing destination replaces it).
+- **Unicode/edge payloads**: multibyte UTF-8 passwords and service names
+  round-trip; empty password; very long password.
+- **The defects**: a disabled test (or one asserting the *buggy* output, per
+  taste — but it must exist) for the three-arg update scramble; nil-password
+  update crash documented via an `XCTExpectFailure`-style pin is not possible
+  for a crasher, so that one is asserted post-fix only; the Swift
+  `init!`-nil behaviour under the env var.
+- **Cross-implementation seam**: these tests are written against the
+  `SAKeychainProviding` protocol surface from day one, parameterized over the
+  implementation, so Step 4 reruns the identical suite against `SAKeychain`
+  for free.
+
+### Step 2 — Fix the confirmed defects in the ObjC implementation
+
+Smallest possible diffs, each with the Step 1 test flipped from
+pinned-buggy to correct:
+
+- Delete `updateItemWithName:account:toPassword:` (no callers) — or fix the
+  forwarding if review prefers keeping the API.
+- Guard nil password in the five-arg update (early return + log, matching the
+  class's existing style).
+- Replace the nil-returning init with an explicit disabled mode: annotate the
+  header nullable as an interim fix, guard the Swift call sites, and route
+  "keychain disabled" through a null-object (`SAKeychainDisabled` conforming
+  to the protocol, returning nil/NO everywhere) so no caller ever holds nil.
+- Marshal the three failure alerts onto the main thread (or better: convert
+  them to a delegate/callback the caller presents — decide by blast radius,
+  smallest change wins in this step).
+- Header gains `NS_ASSUME_NONNULL` + explicit `nullable` while it's open
+  (same pattern as the Step 3 nullability audit in the warnings plan).
+
+Ship this as its own PR and let it soak a release if the schedule allows —
+these fixes de-risk the rewrite regardless of when the rewrite lands.
+
+### Step 3 — Retire the tunnel assistant's direct keychain read
+
+- `SPSSHTunnel`: in keychain mode, resolve the password via `SPKeychain` at
+  connect time (app side, where the item's ACL already trusts the app) and
+  hold/serve it exactly as the ask-UI path does. `SP_PASSWORD_METHOD`'s
+  keychain value and `SP_KEYCHAIN_ITEM_{NAME,ACCOUNT}` env vars die.
+- `SequelAceTunnelAssistant.m` loses its `SPKeychain` import and lookup
+  branch; `SPKeychain.m` leaves the assistant target.
+- `addPassword:`'s ACL block (`SecTrustedApplication*`, `SecAccessCreate`)
+  is deleted — from this point new items need no trusted-apps list. (Reads of
+  *existing* user items are unaffected; their ACLs already include the app.)
+- Manual verification is the SSH matrix from the XPC plan rows 2/3/8:
+  password-in-keychain connect, passphrase-in-keychain connect, keychain-miss
+  → UI prompt fallback. Plus one no-regression run of ask-UI mode.
+- Coordinate with the XPC branch if it is in flight; the diff is small either
+  way, and whichever lands second rebases trivially.
+
+### Step 4 — `SAKeychain`: the Swift `SecItem*` implementation
+
+New `Source/Other/Keychain/SAKeychain.swift` (+ `SAKeychainNaming.swift`,
+pure, both targets — the store itself is app-target only):
+
+- API surface = the existing protocol, ObjC-visible, drop-in for every call
+  site. Mapping: `SecItemAdd` (service/account/label + `kSecAttrGeneric` =
+  `"application password"` for Keychain Access display parity),
+  `SecItemCopyMatching` with `kSecReturnData`, `SecItemUpdate` (which
+  preserves existing items' ACLs — this is what makes in-place operation on
+  legacy items safe), `SecItemDelete`. No `kSecUseDataProtectionKeychain`
+  anywhere.
+- Reproduce the pinned semantics exactly: add-is-no-op-when-present, update's
+  -25300/-25299 recovery branches (now spelled `errSecItemNotFound` /
+  `errSecDuplicateItem`), nil-for-missing get, validation rules, disabled
+  mode.
+- Password encode/decode via `Data(utf8)` both ways — kills the
+  `strlen`/`strncpy`/VLA edge cases outright.
+- Errors surface as values (OSStatus in the log + a callback for the two
+  user-facing alert cases), presented on main.
+- **The proof obligation is the cross-implementation matrix**, which is the
+  whole reason Step 1 parameterized the suite:
+  1. identical characterization suite green against `SAKeychain`;
+  2. **legacy-writes → Swift-reads**: item created via `SPKeychain` is found,
+     read, updated and deleted by `SAKeychain` — this simulates *every
+     existing user item on upgrade* and is the test that makes "zero data
+     migration" a verified claim instead of a hope;
+  3. **Swift-writes → legacy-reads**: proves downgrade safety (user runs an
+     older build after this ships);
+  4. attribute-level diff: dump both implementations' items via
+     `SecItemCopyMatching` attributes and assert the persisted shape matches
+     field-for-field (same mechanical-diff spirit as the C3
+     `apply(to:)`/`_buildConnectionInfo` check — the risk is omission).
+
+### Step 5 — Flip the call sites, delete SPKeychain
+
+- Swap the ~8 constructing call sites (`SPConnectionController`,
+  `SPDatabaseDocument`, `SPSSHTunnel`, `SAConnectionService`,
+  `SAConnectionInfo+ConnectionString`, `SAConnectionWindowController`,
+  export/favorites paths) to the protocol; naming-only Swift call sites move
+  to `SAKeychainNaming` directly.
+- Delete `SPKeychain.h/.m`. The warnings plan's SecKeychain block (10 unique
+  lines) goes to zero; remaining floor is NSConnection (6) + the 4
+  intentional markers.
+- Manual verification matrix (once before merge, once on the release build):
+
+  | # | Scenario |
+  |---|---|
+  | 1 | New favorite + save password → connect → item visible in Keychain Access with correct name/account/kind |
+  | 2 | Existing (pre-migration) favorite's password auto-fills and connects |
+  | 3 | Rename favorite → keychain item follows (update path), old name gone |
+  | 4 | Change password on existing favorite → connects with new password |
+  | 5 | Delete favorite (with "remove password") → item gone |
+  | 6 | SSH favorite with saved SSH password → tunnel connects, no prompt |
+  | 7 | Favorites import/export round-trip preserves password linkage |
+  | 8 | `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1` → keychain disabled, no crash, no saves |
+  | 9 | Downgrade check: item created by the new build readable by the previous release |
+
+- Soak one release before any follow-on keychain work, mirroring the XPC
+  plan's flip-and-soak.
+
+### Step 6 — (Deferred, recorded only) Data-protection keychain
+
+Not part of this project. What it would take, so the option stays priced:
+assistant must no longer touch the keychain (done in Step 3), a signed test
+host or a manual-only test story for the storage layer, an explicit one-shot
++ lazy-fallback migration of existing login-keychain items with telemetry-free
+failure accounting, and a decision on `kSecAttrSynchronizable` (today's items
+never sync; silently enabling iCloud sync for database passwords is a product
+decision, not a refactor).
+
+## Risks
+
+- **Losing user passwords** is the headline risk; the mitigations are the
+  in-place store choice (no migration to get wrong), the
+  legacy↔Swift cross-compat matrix in Step 4, and the downgrade row in the
+  manual matrix.
+- **ACL prompts**: `SecItemUpdate` preserving ACLs is what protects existing
+  items. Should a code-path pair `SecItemDelete`+`SecItemAdd` where the
+  legacy code updated in place, existing items would silently lose their ACL
+  and, in a partial-rollout world, break the assistant. Step 3's ordering
+  (assistant read retired *before* the rewrite) removes the consumer that
+  cares, but the update-in-place semantics are pinned by test anyway.
+- **Test flakiness against a real keychain**: mitigated by the Step 0
+  namespace + skip-gate; if CI proves hostile, the keychain-touching suite
+  gets an env-var opt-in like the planned B1 MySQL tests, and local runs
+  remain the gate.
+- **The assistant change (Step 3) touches SSH connections** — the same blast
+  radius the XPC plan flags. It is deliberately its own small PR with its own
+  manual matrix, and it reuses a code path (app-held password over the
+  channel) that every non-keychain SSH connection exercises daily.
+
+## Estimate
+
+| Step | Size |
+|---|---|
+| 0 — harness | 0.5 day |
+| 1 — characterization suite | 1–1.5 days |
+| 2 — defect fixes | 0.5–1 day |
+| 3 — assistant read retirement | 1 day + manual SSH matrix |
+| 4 — SAKeychain + cross-compat matrix | 1.5–2 days |
+| 5 — flip, delete, manual matrix | 1 day |
+
+**~6–7 days** across 5 PRs, spread over at least two releases (Step 2 and
+Step 5 each deserve soak).
+
+## Open questions
+
+1. **Alert UX on keychain errors** (Step 2/4): keep modal alerts (main-thread
+   marshalled) or degrade to log-only with a non-modal notice? Current modal
+   behaviour dates from an era when keychain corruption was common; a modal
+   from a background connect flow is hostile. Default: keep behaviour in
+   Step 2 (marshalled), decide properly in Step 4's review.
+2. **Does CI's login keychain cooperate?** Step 0's probe answers this
+   empirically on the first PR; the fallback (opt-in env var) is already
+   scoped.
+3. **Step 3 vs the XPC branch order** — no longer a dependency either way
+   (see design section), but whichever is second rebases, so agree who goes
+   first when both are in flight.

--- a/docs/development/keychain-secitem-migration-plan.md
+++ b/docs/development/keychain-secitem-migration-plan.md
@@ -11,7 +11,7 @@
 
 `Source/Other/Keychain/SPKeychain.m` (387 lines, unchanged in shape since the
 Sequel Pro era, one method already on `SecItem*`) is the sole owner of every
-saved MySQL and SSH password. It has **zero tests**. Its wire format — the
+saved MySQL and SSH password. It had **zero tests** before this plan's Step 1. Its wire format — the
 service/account strings under which items are stored — is persisted in users'
 login keychains, so any behavioural drift silently orphans passwords
 (issue #1253 shows how sensitive users are to exactly that failure mode), and
@@ -202,7 +202,7 @@ Decide and build the isolation strategy once, before any test exists:
 - The suite must also pass with `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` **unset**
   — the init guard means these tests construct the store *after* asserting
   the env var is absent, and one dedicated test covers the guard itself.
-- These tests live in a new `UnitTests/SAKeychainStoreTests.swift` (naming
+- These tests live in a new `UnitTests/SAKeychainStoreCharacterizationTests.swift` (naming
   says what it is; "integration-ish" unit tests). Pure-logic tests (naming,
   validation) go in ordinary suites and never touch the keychain.
 
@@ -210,7 +210,9 @@ Decide and build the isolation strategy once, before any test exists:
 
 Pin `SPKeychain` exactly as it behaves, bugs and all (a characterization test
 asserts current behaviour; where the behaviour is a defect the test carries a
-comment naming the Step 2 fix that will flip it):
+comment naming the Step 2 fix that will flip it). Every *testable* defect is
+confirmed this way — the one crasher (nil password, defect 2) cannot be
+pinned as a passing test, so it is asserted post-fix in Step 2 instead:
 
 - **Naming helpers, byte-exact** (pure, no keychain): all four format
   strings, nil/empty rejection matrix, `longLongValue` coercion including the

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -7,8 +7,8 @@
 > in `docs/development/macos-13-minimum-plan.md` (executed, merged as #2587),
 > the SSH-tunnel IPC design in `docs/development/ssh-tunnel-xpc-migration-plan.md`
 > (not started), the keychain `SecItem*` design in
-> `docs/development/keychain-secitem-migration-plan.md` (not started), agent
-> ground rules in `AGENTS.md`.
+> `docs/development/keychain-secitem-migration-plan.md` (design complete;
+> execution starting with its Steps 0-1), agent ground rules in `AGENTS.md`.
 
 ## State of the world (2026-08-24 revision)
 

--- a/docs/development/modernization-followup-plan.md
+++ b/docs/development/modernization-followup-plan.md
@@ -6,7 +6,9 @@
 > `docs/development/help-viewer-rewrite-plan.md` (executed), the platform floor
 > in `docs/development/macos-13-minimum-plan.md` (executed, merged as #2587),
 > the SSH-tunnel IPC design in `docs/development/ssh-tunnel-xpc-migration-plan.md`
-> (not started), agent ground rules in `AGENTS.md`.
+> (not started), the keychain `SecItem*` design in
+> `docs/development/keychain-secitem-migration-plan.md` (not started), agent
+> ground rules in `AGENTS.md`.
 
 ## State of the world (2026-08-24 revision)
 
@@ -685,9 +687,9 @@ all landed since.)
    highest-value target on the list.
 2. **Finish the warnings burn-down** — ✅ sweeps done. #2584 (532 -> 358) and
    #2586 (358 -> 162) have both landed. What remains is the *deferred* set,
-   which is project work rather than a sweep: SPKeychain `SecItem*`, the
-   NSConnection -> XPC migration, and the bundled OpenSSL rebuild. See the
-   warnings plan.
+   which is project work rather than a sweep: SPKeychain `SecItem*` (now
+   designed — `keychain-secitem-migration-plan.md`), the NSConnection -> XPC
+   migration, and the bundled OpenSSL rebuild. See the warnings plan.
 3. **SSH tunnel IPC: NSConnection -> NSXPCConnection** — now unblocked. The
    macOS 13.5 floor was adopted specifically so Step 4 (peer validation via
    `setConnectionCodeSigningRequirement:`) is a real security win rather than a

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -472,8 +472,9 @@ deferred projects below.
 
 ## Deferred (own projects, not part of this burn-down)
 
-- **SPKeychain SecKeychain* API (~15)** — migrate to `SecItem*` with in-place
-  migration of users' stored passwords. Highest risk item in the codebase;
+- **SPKeychain SecKeychain* API (~15)** — migrate the keychain *code* to
+  `SecItem*` in place; users' stored password records are retained as-is (the
+  design needs no record migration). Highest risk item in the codebase;
   **now designed**: see `docs/development/keychain-secitem-migration-plan.md`
   (characterize-first, stays on the file-based login keychain so no data
   migration, retires the tunnel assistant's direct keychain read — which also

--- a/docs/development/warnings-elimination-plan.md
+++ b/docs/development/warnings-elimination-plan.md
@@ -474,8 +474,10 @@ deferred projects below.
 
 - **SPKeychain SecKeychain* API (~15)** — migrate to `SecItem*` with in-place
   migration of users' stored passwords. Highest risk item in the codebase;
-  needs its own design (and pairs with the NSConnection item below since the
-  tunnel assistant reads passwords).
+  **now designed**: see `docs/development/keychain-secitem-migration-plan.md`
+  (characterize-first, stays on the file-based login keychain so no data
+  migration, retires the tunnel assistant's direct keychain read — which also
+  resolves the pairing with the NSConnection item below). Not started.
 - **NSConnection → NSXPCConnection** (SequelAceTunnelAssistant.m:117/168) —
   reworks the SSH-password IPC between app and helper tool. **Now designed and
   unblocked**: see `docs/development/ssh-tunnel-xpc-migration-plan.md`. The

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		17E641650EF01F15001BC333 /* SPTablesList.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641610EF01F15001BC333 /* SPTablesList.m */; };
 		17E6416C0EF01F37001BC333 /* ImageAndTextCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641690EF01F37001BC333 /* ImageAndTextCell.m */; };
 		17E641750EF01F80001BC333 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
+		98203642272CF04DBDC94A70 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
+		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
+		221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
+		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		17E641830EF01FA8001BC333 /* SPImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6417F0EF01FA8001BC333 /* SPImageView.m */; };
 		17E641840EF01FA8001BC333 /* SPTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641810EF01FA8001BC333 /* SPTextView.m */; };
 		17E641D10EF02036001BC333 /* grabber-horizontal.png in Resources */ = {isa = PBXBuildFile; fileRef = 17E6419D0EF02036001BC333 /* grabber-horizontal.png */; };
@@ -915,6 +919,7 @@
 		17E641690EF01F37001BC333 /* ImageAndTextCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageAndTextCell.m; sourceTree = "<group>"; };
 		17E641730EF01F80001BC333 /* SPKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPKeychain.h; sourceTree = "<group>"; };
 		17E641740EF01F80001BC333 /* SPKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPKeychain.m; sourceTree = "<group>"; };
+		11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainProviding.swift; sourceTree = "<group>"; };
 		17E6417E0EF01FA8001BC333 /* SPImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPImageView.h; sourceTree = "<group>"; };
 		17E6417F0EF01FA8001BC333 /* SPImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPImageView.m; sourceTree = "<group>"; };
 		17E641800EF01FA8001BC333 /* SPTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextView.h; sourceTree = "<group>"; };
@@ -2306,6 +2311,7 @@
 			children = (
 				17E641730EF01F80001BC333 /* SPKeychain.h */,
 				17E641740EF01F80001BC333 /* SPKeychain.m */,
+				11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -3343,6 +3349,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98203642272CF04DBDC94A70 /* SPKeychain.m in Sources */,
+				71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */,
 				B01E10DB2BF1A67138C32D0C /* SAFavoriteDuplicateMatcher.swift in Sources */,
 				1A9498C125517191000BC793 /* DateExtension.swift in Sources */,
 				1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */,
@@ -3532,6 +3540,7 @@
 				1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */,
 				58CDB3410FCE141900F8ACA3 /* SequelAceTunnelAssistant.m in Sources */,
 				58CDB3420FCE142500F8ACA3 /* SPKeychain.m in Sources */,
+				221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */,
 				584D88AA1515034200F24774 /* NSNotificationCenterThreadingAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3572,6 +3581,7 @@
 				51BB84022FDE000200C4C14A /* SAForeignKeyReferenceRuleSupport.swift in Sources */,
 				51B09FE12F767A5E003BAFFF /* SAFavoritesProviding.swift in Sources */,
 				17E641750EF01F80001BC333 /* SPKeychain.m in Sources */,
+				623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */,
 				17E641830EF01FA8001BC333 /* SPImageView.m in Sources */,
 				17E641840EF01FA8001BC333 /* SPTextView.m in Sources */,
 				58FEF16D0F23D66600518E8E /* SPSQLParser.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -277,6 +277,8 @@
 		514DD98925FACF1500EA3B3B /* SPDatabaseDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514DD98825FACF1500EA3B3B /* SPDatabaseDocument.swift */; };
 		517412382573E8F900EB6935 /* EditorQuickLookTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */; };
 		517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */; };
+		0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */; };
+		158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */; };
 		517E4512257A954000ED333B /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
 		5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5193502E2567D2FB001272B5 /* CollectionExtension.swift */; };
 		519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5193502E2567D2FB001272B5 /* CollectionExtension.swift */; };
@@ -1126,6 +1128,8 @@
 		51731E7B27DFB99A00D81B98 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EditorQuickLookTypes.plist; sourceTree = "<group>"; };
 		517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionServiceTests.swift; sourceTree = "<group>"; };
+		8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainTestSupport.swift; sourceTree = "<group>"; };
+		7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNamingCharacterizationTests.swift; sourceTree = "<group>"; };
 		517E44C2257A8F2C00ED333B /* AppleScriptObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppleScriptObjC.framework; path = System/Library/Frameworks/AppleScriptObjC.framework; sourceTree = SDKROOT; };
 		517E4511257A954000ED333B /* ContentFilters.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = ContentFilters.plist; path = Plists/ContentFilters.plist; sourceTree = "<group>"; };
 		51905622267DFF1700212442 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2710,6 +2714,8 @@
 				5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */,
 				5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */,
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
+				8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */,
+				7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
@@ -3359,6 +3365,8 @@
 				FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */,
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
+				0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */,
+				158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				51BE68DD3017550E00AF389C /* SAImageRenderer.swift in Sources */,
 				C812F06F0D4A95968C1B0154 /* SABundleVersionUpdater.swift in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		514DD98925FACF1500EA3B3B /* SPDatabaseDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514DD98825FACF1500EA3B3B /* SPDatabaseDocument.swift */; };
 		517412382573E8F900EB6935 /* EditorQuickLookTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */; };
 		517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */; };
+		9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */; };
 		0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */; };
 		158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */; };
 		517E4512257A954000ED333B /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
@@ -1128,6 +1129,7 @@
 		51731E7B27DFB99A00D81B98 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EditorQuickLookTypes.plist; sourceTree = "<group>"; };
 		517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionServiceTests.swift; sourceTree = "<group>"; };
+		01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainStoreCharacterizationTests.swift; sourceTree = "<group>"; };
 		8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainTestSupport.swift; sourceTree = "<group>"; };
 		7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNamingCharacterizationTests.swift; sourceTree = "<group>"; };
 		517E44C2257A8F2C00ED333B /* AppleScriptObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppleScriptObjC.framework; path = System/Library/Frameworks/AppleScriptObjC.framework; sourceTree = SDKROOT; };
@@ -2714,6 +2716,7 @@
 				5146E0472F7A640C00C4C14A /* SAConnectionInfoTests.swift */,
 				5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */,
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
+				01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */,
 				8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */,
 				7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
@@ -3365,6 +3368,7 @@
 				FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */,
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
+				9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */,
 				0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */,
 				158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,


### PR DESCRIPTION
## Summary

First PR of the SPKeychain → `SecItem*` migration (the warnings plan's highest-risk deferred item). This lands the design plan plus Steps 0–1: the keychain test harness and a characterization suite pinning the legacy `SecKeychain*` implementation exactly as it behaves — defects included — before anything changes. Steps 0 and 1 share this PR because the harness only exists for these tests; every later step is its own PR.

- **`docs/development/keychain-secitem-migration-plan.md`** — the full design: characterize-first, stay on the file-based login keychain (zero data migration), retire the tunnel assistant's direct keychain read (which also answers the XPC plan's open question 3), then a Swift `SAKeychain` proven by a legacy↔Swift cross-compatibility matrix. Cross-linked from the warnings and modernization plans.
- **`SAKeychainProviding`** — public `@objc` Swift protocol mirroring SPKeychain's selectors, adopted by SPKeychain via a class extension. This is how Swift tests reach SPKeychain without giving the test target a bridging header (the documented B2b sharp edge): `NSClassFromString` + a real runtime conformance check. It is also the seam the future `SAKeychain` implements, so the identical suite reruns against both.
- **`SAKeychainTestSupport`** — keychain tests run against the real login keychain under a unique per-run `Sequel Ace Test <token>` namespace, with a defensive sweep (aborted-run leftovers included) and a raw-`SecItem` availability probe that skips the store suite where the keychain is locked — deliberately probing without SPKeychain so its modal error alerts can never hang the runner.
- **33 characterization tests**: the four persisted name/account format strings byte-exact (the keychain wire format), CRUD round-trips, add-is-a-silent-no-op-when-present, persisted item shape (service/account/label/`kSecAttrGeneric`), unicode/empty/long payloads, nil rejection, both update recovery branches (−25300 → fresh add, −25299 → replace destination), and the label-stays-behind-on-rename quirk.

**Confirmed live, previously only suspected**: `updateItemWithName:account:toPassword:` scrambles its arguments — the item is renamed to the *password*, its account becomes the *name*, and the stored secret becomes the *account*. No production callers (all four call sites use the five-argument form); the pinning test documents it and Step 2 deletes it.

## Warnings accounting

SPKeychain.m now also compiles into the Unit Tests target, so its 10 deprecation warnings appear a third time (52 → 62 raw on the test scheme; **unique lines unchanged at 20**). Temporary — Step 5 deletes the file and the whole block goes to zero.

## Test plan

- [x] Full "Unit Tests" scheme: 1178 tests, 0 failures (63 pre-existing env-gated skips); both new suites ran (not skipped)
- [x] Clean `build-for-testing`: 0 errors, no new unique warnings
- [x] Login keychain verified free of test items after the run (namespace sweep works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared keychain interface for consistent credential storage operations.
  * Preserved existing credential formats and behavior while preparing for modern keychain storage.

* **Tests**
  * Added coverage for naming, account formatting, CRUD operations, metadata, Unicode, boundary cases, and updates.
  * Added utilities to safely check keychain availability and clean up test data.

* **Documentation**
  * Added a migration roadmap for modernizing keychain storage.
  * Updated modernization and warnings plans to reflect the migration status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->