### PR TITLE
#infra Keychain SecItem migration step 2: fix the confirmed defects

### DIFF
--- a/Source/Model/SAConnectionInfo+ConnectionString.swift
+++ b/Source/Model/SAConnectionInfo+ConnectionString.swift
@@ -143,7 +143,7 @@ extension SPFavoriteNode {
 
             // Fetch password from keychain if requested
             if includePassword {
-                let keychain = SPKeychain()
+                let keychain = SAKeychainAccess.make()
                 let favoriteID = favoriteDict[SPFavoriteIDKey] as? NSNumber ?? NSNumber(value: -1)
                 let favoriteName = favoriteDict[SPFavoriteNameKey] as? String ?? ""
                 let host = favoriteDict[SPFavoriteHostKey] as? String ?? ""
@@ -153,10 +153,10 @@ extension SPFavoriteNode {
                 // Normalize host for keychain lookup (socket connections use "localhost")
                 let hostForKeychain = (typeTag == 1) ? "localhost" : host
 
-                let keychainName = keychain.name(forFavoriteName: favoriteName, id: "\(favoriteID)")
-                let keychainAccount = keychain.account(forUser: user, host: hostForKeychain, database: database)
+                let keychainName = keychain.name(favoriteName: favoriteName, id: "\(favoriteID)")
+                let keychainAccount = keychain.account(user: user, host: hostForKeychain, database: database)
 
-                if let password = keychain.getPasswordForName(keychainName, account: keychainAccount), !password.isEmpty {
+                if let password = keychain.password(name: keychainName, account: keychainAccount), !password.isEmpty {
                     components.password = password
                 }
             }
@@ -203,14 +203,14 @@ extension SPFavoriteNode {
             // Fetch SSH password from keychain if requested
             if includePassword, let sshUser = favoriteDict[SPFavoriteSSHUserKey] as? String, !sshUser.isEmpty,
                let sshHost = favoriteDict[SPFavoriteSSHHostKey] as? String, !sshHost.isEmpty {
-                let keychain = SPKeychain()
+                let keychain = SAKeychainAccess.make()
                 let favoriteID = favoriteDict[SPFavoriteIDKey] as? NSNumber ?? NSNumber(value: -1)
                 let favoriteName = favoriteDict[SPFavoriteNameKey] as? String ?? ""
 
-                let keychainName = keychain.nameForSSH(forFavoriteName: favoriteName, id: "\(favoriteID)")
-                let keychainAccount = keychain.account(forSSHUser: sshUser, sshHost: sshHost)
+                let keychainName = keychain.sshName(favoriteName: favoriteName, id: "\(favoriteID)")
+                let keychainAccount = keychain.sshAccount(user: sshUser, host: sshHost)
 
-                if let sshPassword = keychain.getPasswordForName(keychainName, account: keychainAccount), !sshPassword.isEmpty {
+                if let sshPassword = keychain.password(name: keychainName, account: keychainAccount), !sshPassword.isEmpty {
                     queryItems.append(URLQueryItem(name: "ssh_password", value: sshPassword))
                 }
             }

--- a/Source/Other/Keychain/SAKeychainAccess.swift
+++ b/Source/Other/Keychain/SAKeychainAccess.swift
@@ -1,0 +1,57 @@
+//
+//  SAKeychainAccess.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// How Swift code obtains the keychain store.
+///
+/// SPKeychain's init returns nil while keychain access is disabled
+/// (`LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN`, issue #2437); before the header was
+/// annotated, that nil arrived through an `init!` import and trapped on
+/// first use. The factory makes the disabled mode a real object instead —
+/// callers always hold a working `SAKeychainProviding`.
+///
+/// App target only (it names SPKeychain, which the Unit Tests target cannot
+/// see — no bridging header there). Once the SecItem* implementation
+/// replaces SPKeychain (migration plan Step 5), this becomes its one
+/// construction point.
+enum SAKeychainAccess {
+
+    static func make() -> SAKeychainProviding {
+        // The as? is a real runtime conformance check: SPKeychain adopts the
+        // protocol in a class extension inside its .m, which Swift cannot
+        // see statically (the header cannot import the generated Swift
+        // header that defines the protocol — that would be circular).
+        if let store = SPKeychain(), let typed = store as? SAKeychainProviding {
+            return typed
+        }
+        return SAKeychainDisabled()
+    }
+}

--- a/Source/Other/Keychain/SAKeychainDisabled.swift
+++ b/Source/Other/Keychain/SAKeychainDisabled.swift
@@ -1,0 +1,63 @@
+//
+//  SAKeychainDisabled.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The null object for keychain access while it is disabled
+/// (`LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` is set — issue #2437, where SPKeychain
+/// refuses to construct at all).
+///
+/// Its behaviour deliberately mirrors what Objective-C callers already get
+/// from messaging the nil SPKeychain: every operation is a no-op, every
+/// lookup returns nil or false — the naming helpers included. Swift callers
+/// hold this instead of nil (previously the unannotated init imported as
+/// `init!` and the first use trapped — defect 3 in the migration plan).
+@objc final class SAKeychainDisabled: NSObject, SAKeychainProviding {
+
+    func add(password: String?, name: String?, account: String?) {}
+
+    func add(password: String?, name: String?, account: String?, label: String?) {}
+
+    func password(name: String?, account: String?) -> String? { nil }
+
+    func deletePassword(name: String?, account: String?) {}
+
+    func passwordExists(name: String?, account: String?) -> Bool { false }
+
+    func updateItem(name: String?, account: String?, toName newName: String?, newAccount: String?, password: String?) {}
+
+    func name(favoriteName: String?, id favoriteID: String?) -> String? { nil }
+
+    func account(user: String?, host: String?, database: String?) -> String? { nil }
+
+    func sshName(favoriteName: String?, id favoriteID: String?) -> String? { nil }
+
+    func sshAccount(user: String?, host: String?) -> String? { nil }
+}

--- a/Source/Other/Keychain/SAKeychainProviding.swift
+++ b/Source/Other/Keychain/SAKeychainProviding.swift
@@ -74,13 +74,6 @@ import Foundation
     @objc(updateItemWithName:account:toName:account:password:)
     func updateItem(name: String?, account: String?, toName newName: String?, newAccount: String?, password: String?)
 
-    /// ⚠️ Characterized as defective (migration plan, defect 1): the legacy
-    /// implementation forwards its arguments to the five-argument variant in
-    /// scrambled order. Currently has no production callers; scheduled for
-    /// deletion in Step 2 of the migration plan.
-    @objc(updateItemWithName:account:toPassword:)
-    func updateItem(name: String?, account: String?, toPassword password: String?)
-
     /// `"Sequel Ace : <favoriteName> (<id as long long>)"`, or nil for a
     /// nil/empty name or nil id.
     @objc(nameForFavoriteName:id:)

--- a/Source/Other/Keychain/SPKeychain.h
+++ b/Source/Other/Keychain/SPKeychain.h
@@ -29,18 +29,36 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Legacy SecKeychain*-backed keychain store; conforms to SAKeychainProviding
+ * (declared in the .m). Being migrated to SecItem* — see
+ * docs/development/keychain-secitem-migration-plan.md.
+ *
+ * The nullability below deliberately mirrors SAKeychainProviding: every
+ * argument tolerates nil (rejected internally), every lookup can return nil.
+ */
 @interface SPKeychain : NSObject
 
-- (void)addPassword:(NSString *)password forName:(NSString *)name account:(NSString *)account;
-- (void)addPassword:(NSString *)password forName:(NSString *)name account:(NSString *)account withLabel:(NSString *)label;
-- (NSString *)getPasswordForName:(NSString *)name account:(NSString *)account;
-- (void)deletePasswordForName:(NSString *)name account:(NSString *)account;
-- (BOOL)passwordExistsForName:(NSString *)name account:(NSString *)account;
-- (void)updateItemWithName:(NSString *)name account:(NSString *)account toName:(NSString *)newName account:(NSString *)newAccount password:(NSString *)password;
+/// Returns nil when keychain access is disabled via
+/// LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN (issue #2437). Swift callers should use
+/// SAKeychainAccess.make(), which substitutes the SAKeychainDisabled null
+/// object instead of handing out nil.
+- (nullable instancetype)init;
 
-- (NSString *)nameForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId;
-- (NSString *)accountForUser:(NSString *)user host:(NSString *)host database:(NSString *)database;
-- (NSString *)nameForSSHForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId;
-- (NSString *)accountForSSHUser:(NSString *)SSHUser sshHost:(NSString *)SSHHost;
+- (void)addPassword:(nullable NSString *)password forName:(nullable NSString *)name account:(nullable NSString *)account;
+- (void)addPassword:(nullable NSString *)password forName:(nullable NSString *)name account:(nullable NSString *)account withLabel:(nullable NSString *)label;
+- (nullable NSString *)getPasswordForName:(nullable NSString *)name account:(nullable NSString *)account;
+- (void)deletePasswordForName:(nullable NSString *)name account:(nullable NSString *)account;
+- (BOOL)passwordExistsForName:(nullable NSString *)name account:(nullable NSString *)account;
+- (void)updateItemWithName:(nullable NSString *)name account:(nullable NSString *)account toName:(nullable NSString *)newName account:(nullable NSString *)newAccount password:(nullable NSString *)password;
+
+- (nullable NSString *)nameForFavoriteName:(nullable NSString *)favoriteName id:(nullable NSString *)favoriteId;
+- (nullable NSString *)accountForUser:(nullable NSString *)user host:(nullable NSString *)host database:(nullable NSString *)database;
+- (nullable NSString *)nameForSSHForFavoriteName:(nullable NSString *)favoriteName id:(nullable NSString *)favoriteId;
+- (nullable NSString *)accountForSSHUser:(nullable NSString *)SSHUser sshHost:(nullable NSString *)SSHHost;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Other/Keychain/SPKeychain.h
+++ b/Source/Other/Keychain/SPKeychain.h
@@ -36,7 +36,6 @@
 - (NSString *)getPasswordForName:(NSString *)name account:(NSString *)account;
 - (void)deletePasswordForName:(NSString *)name account:(NSString *)account;
 - (BOOL)passwordExistsForName:(NSString *)name account:(NSString *)account;
-- (void)updateItemWithName:(NSString *)name account:(NSString *)account toPassword:(NSString *)password;
 - (void)updateItemWithName:(NSString *)name account:(NSString *)account toName:(NSString *)newName account:(NSString *)newAccount password:(NSString *)password;
 
 - (NSString *)nameForFavoriteName:(NSString *)favoriteName id:(NSString *)favoriteId;

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -269,6 +269,14 @@
     if (![self isValidName:name acount:account]) {
         return;
     }
+
+    // A nil password would reach strlen(NULL) below (and in the
+    // item-not-found fallback would delete the item with nothing to re-add),
+    // so reject it up front and leave the item untouched.
+    if (!password) {
+        NSLog(@"Keychain update rejected: nil password for name: %@ account: %@", name, account);
+        return;
+    }
 	OSStatus status;
 	SecKeychainItemRef itemRef;
 	SecKeychainAttribute attributes[2];

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -261,16 +261,6 @@
 }
 
 /**
- * Change the password for a keychain item.  This should be used instead of
- * deleting and recreating the keychain item, as it allows preservation of
- * access lists and works around Lion cacheing issues.
- */
-- (void)updateItemWithName:(NSString *)name account:(NSString *)account toPassword:(NSString *)password
-{
-	[self updateItemWithName:name account:account toName:password account:name password:account];
-}
-
-/**
  * Change the details for a keychain item.  This should be used instead of
  * deleting and recreating the keychain item, as it allows preservation of
  * access lists and works around Lion cacheing issues.

--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -30,6 +30,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPKeychain.h"
+#import "SPFunctions.h"
 
 #import <Security/Security.h>
 #import <CoreFoundation/CoreFoundation.h>
@@ -137,12 +138,17 @@
 		if (status != noErr) {
 			NSLog(@"Error (%i) while trying to add password for name: %@ account: %@", (int)status, name, account);
 
-			NSAlert *alert = [[NSAlert alloc] init];
-			alert.alertStyle = NSAlertStyleCritical;
-			alert.messageText = NSLocalizedString(@"Error adding password to Keychain", @"error adding password to keychain message");
-			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to add the password to your Keychain. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error adding password to keychain informative message"), status];
-			[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
-			[alert runModal];
+			// The add/update paths run on background connection threads;
+			// AppKit alerts must be presented from the main thread. Sync, to
+			// preserve the legacy blocking behaviour of the inline runModal.
+			SPMainQSync(^{
+				NSAlert *alert = [[NSAlert alloc] init];
+				alert.alertStyle = NSAlertStyleCritical;
+				alert.messageText = NSLocalizedString(@"Error adding password to Keychain", @"error adding password to keychain message");
+				alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to add the password to your Keychain. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error adding password to keychain informative message"), status];
+				[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
+				[alert runModal];
+			});
 		}
 	}
 }
@@ -299,12 +305,15 @@
 
 		NSLog(@"Error (%i) while trying to find keychain item to edit for name: %@ account: %@", (int)status, name, account);
 
-		NSAlert *alert = [[NSAlert alloc] init];
-		alert.alertStyle = NSAlertStyleCritical;
-		alert.messageText = NSLocalizedString(@"Error retrieving Keychain item to edit", @"error finding keychain item to edit message");
-		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to retrieve the Keychain item you're trying to edit. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error finding keychain item to edit informative message"), status];
-		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
-		[alert runModal];
+		// See the add-path note: alerts must present on the main thread.
+		SPMainQSync(^{
+			NSAlert *alert = [[NSAlert alloc] init];
+			alert.alertStyle = NSAlertStyleCritical;
+			alert.messageText = NSLocalizedString(@"Error retrieving Keychain item to edit", @"error finding keychain item to edit message");
+			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to retrieve the Keychain item you're trying to edit. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error finding keychain item to edit informative message"), status];
+			[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
+			[alert runModal];
+		});
 		return;
 	}
 
@@ -333,12 +342,15 @@
 
 		NSLog(@"Error (%i) while updating keychain item for name: %@ account: %@", (int)status, name, account);
 
-		NSAlert *alert = [[NSAlert alloc] init];
-		alert.alertStyle = NSAlertStyleCritical;
-		alert.messageText = NSLocalizedString(@"Error updating Keychain item", @"error updating keychain item message");
-		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to update the Keychain item. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error updating keychain item informative message"), status];
-		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
-		[alert runModal];
+		// See the add-path note: alerts must present on the main thread.
+		SPMainQSync(^{
+			NSAlert *alert = [[NSAlert alloc] init];
+			alert.alertStyle = NSAlertStyleCritical;
+			alert.messageText = NSLocalizedString(@"Error updating Keychain item", @"error updating keychain item message");
+			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while trying to update the Keychain item. Repairing your Keychain might resolve this, but if it doesn't please report it to the Sequel Ace team, supplying the error code %i.", @"error updating keychain item informative message"), status];
+			[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
+			[alert runModal];
+		});
 	}
 }
 

--- a/UnitTests/SAKeychainDisabledTests.swift
+++ b/UnitTests/SAKeychainDisabledTests.swift
@@ -1,0 +1,41 @@
+//
+//  SAKeychainDisabledTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+/// The disabled-mode null object must mirror what Objective-C callers get
+/// from messaging a nil SPKeychain: no-ops, nils and false everywhere —
+/// never a crash, never a stored secret.
+final class SAKeychainDisabledTests: XCTestCase {
+
+    private let store: SAKeychainProviding = SAKeychainDisabled()
+
+    func testStoreOperationsAreInertAndNeverFind() {
+        store.add(password: "pw", name: "name", account: "account")
+        store.add(password: "pw", name: "name", account: "account", label: "label")
+        XCTAssertNil(store.password(name: "name", account: "account"))
+        XCTAssertFalse(store.passwordExists(name: "name", account: "account"))
+        store.updateItem(name: "name", account: "account",
+                         toName: "new", newAccount: "new", password: "pw")
+        store.deletePassword(name: "name", account: "account")
+        XCTAssertNil(store.password(name: "new", account: "new"))
+    }
+
+    func testNamingHelpersReturnNilLikeAMessagedNilSPKeychain() {
+        XCTAssertNil(store.name(favoriteName: "F", id: "1"))
+        XCTAssertNil(store.account(user: "u", host: "h", database: "d"))
+        XCTAssertNil(store.sshName(favoriteName: "F", id: "1"))
+        XCTAssertNil(store.sshAccount(user: "u", host: "h"))
+    }
+
+    func testNilArgumentsAreAccepted() {
+        store.add(password: nil, name: nil, account: nil)
+        XCTAssertNil(store.password(name: nil, account: nil))
+        XCTAssertFalse(store.passwordExists(name: nil, account: nil))
+    }
+}

--- a/UnitTests/SAKeychainStoreCharacterizationTests.swift
+++ b/UnitTests/SAKeychainStoreCharacterizationTests.swift
@@ -177,6 +177,19 @@ final class SAKeychainStoreCharacterizationTests: SAKeychainCharacterizationTest
         XCTAssertEqual(store.password(name: name, account: account), "pw-2")
     }
 
+    func testUpdateToEmptyPasswordStoresEmptyString() {
+        // Blank handling, both directions (review question on #2612): an
+        // *empty* password is legal everywhere — add stores it, update
+        // replaces the secret with zero bytes, and get round-trips "".
+        // Only a nil password is rejected (the Step 2 guard).
+        let name = service("item"), account = "user@host/"
+        store.add(password: "pw-1", name: name, account: account)
+        store.updateItem(name: name, account: account,
+                         toName: name, newAccount: account, password: "")
+        XCTAssertTrue(store.passwordExists(name: name, account: account))
+        XCTAssertEqual(store.password(name: name, account: account), "")
+    }
+
     func testUpdateOfMissingItemFallsBackToAdd() {
         // The errSecItemNotFound (-25300) branch: a safe delete, then a
         // fresh add under the *new* name and account.

--- a/UnitTests/SAKeychainStoreCharacterizationTests.swift
+++ b/UnitTests/SAKeychainStoreCharacterizationTests.swift
@@ -200,30 +200,4 @@ final class SAKeychainStoreCharacterizationTests: SAKeychainCharacterizationTest
         XCTAssertFalse(store.passwordExists(name: source, account: "s@h/"))
     }
 
-    // MARK: - Three-argument update (pinned defect)
-
-    func testThreeArgumentUpdateScramblesItsArguments() {
-        // ⚠️ Defect 1 in the migration plan, pinned deliberately: the
-        // toPassword: variant forwards to the five-argument update in
-        // scrambled order — the item is renamed to the *password*, its
-        // account becomes the *name*, and the stored secret becomes the
-        // *account*. It has no production callers (all four call sites use
-        // the five-argument form); Step 2 deletes it. This test documents
-        // exactly what it would do to a caller and will be removed with the
-        // method.
-        let name = service("victim"), account = "user@host/"
-        // The "password" must be namespaced too — the scramble turns it into
-        // a service name, and the sweep must be able to delete that item.
-        let newPassword = service("scrambled destination")
-
-        store.add(password: "original-pw", name: name, account: account)
-        store.updateItem(name: name, account: account, toPassword: newPassword)
-
-        // The original item is gone…
-        XCTAssertFalse(store.passwordExists(name: name, account: account))
-        // …and what exists instead is an item whose service is the password
-        // argument, whose account is the old name, and whose secret is the
-        // old account string.
-        XCTAssertEqual(store.password(name: newPassword, account: name), account)
-    }
 }

--- a/UnitTests/SAKeychainStoreCharacterizationTests.swift
+++ b/UnitTests/SAKeychainStoreCharacterizationTests.swift
@@ -186,6 +186,18 @@ final class SAKeychainStoreCharacterizationTests: SAKeychainCharacterizationTest
         XCTAssertFalse(store.passwordExists(name: oldName, account: "old@host/"))
     }
 
+    func testUpdateWithNilPasswordLeavesItemUntouched() {
+        // Fixed in Step 2 (defect 2): a nil password used to reach
+        // strlen(NULL). Now the update is rejected and the item is left
+        // exactly as it was.
+        let name = service("item"), account = "user@host/"
+        store.add(password: "pw-1", name: name, account: account)
+        store.updateItem(name: name, account: account,
+                         toName: service("renamed"), newAccount: "new@host/", password: nil)
+        XCTAssertEqual(store.password(name: name, account: account), "pw-1")
+        XCTAssertFalse(store.passwordExists(name: service("renamed"), account: "new@host/"))
+    }
+
     func testUpdateOntoExistingDestinationReplacesIt() {
         // The errSecDuplicateItem (-25299) branch: the existing destination
         // item is deleted and the update retried, so the source item wins.

--- a/docs/development/keychain-secitem-migration-plan.md
+++ b/docs/development/keychain-secitem-migration-plan.md
@@ -236,7 +236,21 @@ comment naming the Step 2 fix that will flip it):
   implementation, so Step 4 reruns the identical suite against `SAKeychain`
   for free.
 
-### Step 2 — Fix the confirmed defects in the ObjC implementation
+### Step 2 — Fix the confirmed defects in the ObjC implementation — ✅ Done
+
+Execution notes (2026-08-31): all four fixes landed as planned, one per
+commit, each with its characterization test flipped or added first. The
+three-arg update was deleted (its scramble-pinning test went with it); nil
+password now rejects with the item untouched; the header got the full
+`NS_ASSUME_NONNULL` wrap with every parameter/return explicitly `nullable`
+(protocol parity — annotating only init would have cascaded completeness
+warnings, the warnings plan's step 3 lesson); `SAKeychainAccess.make()` +
+`SAKeychainDisabled` replaced the Swift `init!` trap, and both
+`SAConnectionInfo+ConnectionString` call sites moved onto the factory and
+the protocol surface; the three alerts marshal through `SPMainQSync`
+(synchronous, preserving the legacy blocking behaviour). The null object
+mirrors nil-messaging semantics exactly — naming helpers return nil too —
+matching what ObjC callers already get from a nil SPKeychain.
 
 Smallest possible diffs, each with the Step 1 test flipped from
 pinned-buggy to correct:

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -83,6 +83,9 @@
 		17E641750EF01F80001BC333 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
 		98203642272CF04DBDC94A70 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
 		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
+		090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
+		0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
+		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
 		221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		17E641830EF01FA8001BC333 /* SPImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6417F0EF01FA8001BC333 /* SPImageView.m */; };
@@ -923,6 +926,8 @@
 		17E641730EF01F80001BC333 /* SPKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPKeychain.h; sourceTree = "<group>"; };
 		17E641740EF01F80001BC333 /* SPKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPKeychain.m; sourceTree = "<group>"; };
 		11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainProviding.swift; sourceTree = "<group>"; };
+		4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabled.swift; sourceTree = "<group>"; };
+		A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabledTests.swift; sourceTree = "<group>"; };
 		17E6417E0EF01FA8001BC333 /* SPImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPImageView.h; sourceTree = "<group>"; };
 		17E6417F0EF01FA8001BC333 /* SPImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPImageView.m; sourceTree = "<group>"; };
 		17E641800EF01FA8001BC333 /* SPTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextView.h; sourceTree = "<group>"; };
@@ -2318,6 +2323,7 @@
 				17E641730EF01F80001BC333 /* SPKeychain.h */,
 				17E641740EF01F80001BC333 /* SPKeychain.m */,
 				11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */,
+				4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -2718,6 +2724,7 @@
 				517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */,
 				01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */,
 				8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */,
+				A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */,
 				7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */,
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
@@ -3370,6 +3377,8 @@
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
 				9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */,
 				0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */,
+				0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */,
+				7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */,
 				158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */,
 				1A9498DE2551776D000BC793 /* DateFormatterExtension.swift in Sources */,
 				51BE68DD3017550E00AF389C /* SAImageRenderer.swift in Sources */,
@@ -3593,6 +3602,7 @@
 				51BB84022FDE000200C4C14A /* SAForeignKeyReferenceRuleSupport.swift in Sources */,
 				51B09FE12F767A5E003BAFFF /* SAFavoritesProviding.swift in Sources */,
 				17E641750EF01F80001BC333 /* SPKeychain.m in Sources */,
+				090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */,
 				623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */,
 				17E641830EF01FA8001BC333 /* SPImageView.m in Sources */,
 				17E641840EF01FA8001BC333 /* SPTextView.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		98203642272CF04DBDC94A70 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
 		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
+		CD5AFDE14AA44B4AB444DD59 /* SAKeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4471240789125E4D4033602A /* SAKeychainAccess.swift */; };
 		0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
 		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
 		221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
@@ -927,6 +928,7 @@
 		17E641740EF01F80001BC333 /* SPKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPKeychain.m; sourceTree = "<group>"; };
 		11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainProviding.swift; sourceTree = "<group>"; };
 		4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabled.swift; sourceTree = "<group>"; };
+		4471240789125E4D4033602A /* SAKeychainAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainAccess.swift; sourceTree = "<group>"; };
 		A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabledTests.swift; sourceTree = "<group>"; };
 		17E6417E0EF01FA8001BC333 /* SPImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPImageView.h; sourceTree = "<group>"; };
 		17E6417F0EF01FA8001BC333 /* SPImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPImageView.m; sourceTree = "<group>"; };
@@ -2324,6 +2326,7 @@
 				17E641740EF01F80001BC333 /* SPKeychain.m */,
 				11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */,
 				4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */,
+				4471240789125E4D4033602A /* SAKeychainAccess.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -3602,6 +3605,7 @@
 				51BB84022FDE000200C4C14A /* SAForeignKeyReferenceRuleSupport.swift in Sources */,
 				51B09FE12F767A5E003BAFFF /* SAFavoritesProviding.swift in Sources */,
 				17E641750EF01F80001BC333 /* SPKeychain.m in Sources */,
+				CD5AFDE14AA44B4AB444DD59 /* SAKeychainAccess.swift in Sources */,
 				090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */,
 				623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */,
 				17E641830EF01FA8001BC333 /* SPImageView.m in Sources */,


### PR DESCRIPTION
## Summary

Step 2 of `docs/development/keychain-secitem-migration-plan.md` — the four defects the Step 1 characterization suite confirmed, fixed in the legacy implementation before the rewrite so they de-risk it regardless of when it lands. Stacked on #2611 (steps 0–1); one fix per commit, each with its characterization test flipped or added.

1. **Deleted `updateItemWithName:account:toPassword:`** — it forwarded to the five-argument update in scrambled order (item renamed to the *password*, account set to the *name*, the *account* stored as the secret; confirmed live by the pinning test, which leaves with the method). No production callers.
2. **Nil password in the five-argument update rejected** instead of reaching `strlen(NULL)` — and instead of the not-found fallback deleting the source item with nothing to re-add. The item is left untouched, with a test.
3. **The disabled-mode nil init is now explicit and safe from Swift.** `SPKeychain.h` gets the full `NS_ASSUME_NONNULL` wrap with every parameter/return explicitly `nullable` (deliberate protocol parity; annotating only init would cascade completeness warnings — the warnings plan's step 3 lesson), init is `nullable`, and Swift constructs via `SAKeychainAccess.make()` — the real store, or the new `SAKeychainDisabled` null object (which mirrors nil-messaging semantics exactly) when `LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN` disables access. Previously both `SAConnectionInfo+ConnectionString` call sites imported the init as `init!` and trapped on first use under that env var; they now use the factory and the protocol surface (where Step 5 wants all callers anyway).
4. **The three failure alerts marshal through `SPMainQSync`** — they ran modal NSAlerts on background connection threads. Synchronous, so the legacy blocking behaviour is preserved; deadlock-safe on the main queue.

## Test plan

- [x] Full "Unit Tests" scheme: 1181 tests, 0 failures (net +3: −1 scramble pin, +1 nil-password, +3 null object)
- [x] Clean build-for-testing: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keychain handling when access is unavailable, preventing crashes during connection and password operations.
  * Prevented invalid password updates from altering stored credentials.
  * Ensured keychain alerts are displayed reliably.
  * Corrected handling of optional keychain values and inputs.

* **Tests**
  * Added coverage for disabled keychain behavior and invalid password updates.

* **Documentation**
  * Updated the keychain migration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->