### PR TITLE
#infra Keychain SecItem migration step 3: retire the tunnel assistant's keychain read

### DIFF
--- a/Source/Other/Keychain/SPKeychain.m
+++ b/Source/Other/Keychain/SPKeychain.m
@@ -80,8 +80,6 @@
     }
     
 	OSStatus status;
-	SecTrustedApplicationRef sequelProRef, sequelProHelperRef;
-	SecAccessRef passwordAccessRef = NULL;
 	SecKeychainAttribute attributes[4];
 	SecKeychainAttributeList attList;
 
@@ -91,22 +89,12 @@
 	// Check if password already exists before adding
 	if (![self passwordExistsForName:name account:account]) {
 
-		// Create a trusted access list with two items - ourselves and the SSH pass app
-		NSString *helperPath = [[NSBundle mainBundle] pathForAuxiliaryExecutable:@"SequelAceTunnelAssistant"];
+		// New items rely on the default access list (the creating app).
+		// The explicit SecAccessCreate/SecTrustedApplication* list naming
+		// the SequelAceTunnelAssistant is gone with the assistant's direct
+		// keychain read: the helper now obtains passwords from the app over
+		// the connection, so no second process ever reads these items.
 
-		if ((SecTrustedApplicationCreateFromPath(NULL, &sequelProRef) == noErr) &&
-			(SecTrustedApplicationCreateFromPath([helperPath UTF8String], &sequelProHelperRef) == noErr)) {
-
-			NSArray *trustedApps = [NSArray arrayWithObjects:(__bridge id)sequelProRef, (__bridge id)sequelProHelperRef, nil];
-
-			status = SecAccessCreate((CFStringRef)name, (CFArrayRef)trustedApps, &passwordAccessRef);
-
-			if (status != noErr) {
-				NSLog(@"Error (%i) while trying to create access list for name: %@ account: %@", (int)status, name, account);
-				passwordAccessRef = NULL;
-			}
-		}
-		
 		// Set up the item attributes
 		attributes[0].tag = kSecGenericItemAttr;
 		attributes[0].data = "application password";
@@ -130,11 +118,9 @@
 			(UInt32)strlen([password UTF8String]),	// Length of password
 			[password UTF8String],					// Password data
 			NULL,									// Default keychain
-			passwordAccessRef,						// Access list for this keychain
+			NULL,									// Default access list (creating app only)
 			NULL);									// The item reference
 
-		if (passwordAccessRef) CFRelease(passwordAccessRef);
-		
 		if (status != noErr) {
 			NSLog(@"Error (%i) while trying to add password for name: %@ account: %@", (int)status, name, account);
 

--- a/Source/Other/SSHTunnel/SASSHTunnelSecretResolver.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelSecretResolver.swift
@@ -1,0 +1,75 @@
+//
+//  SASSHTunnelSecretResolver.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on August 31, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The app-side keychain lookups the SSH tunnel serves over its channel —
+/// Step 3 of `docs/development/keychain-secitem-migration-plan.md` moved
+/// these here from the tunnel assistant, and SPSSHTunnel calls them through
+/// thin trampolines (per the language policy: new logic in Swift, a bridge
+/// in the legacy file).
+@objc final class SASSHTunnelSecretResolver: NSObject {
+
+    /// The ssh askpass prompt for an encrypted key, as emitted by OpenSSH.
+    /// Same pattern the tunnel's own passphrase dialog parses.
+    private static let passphraseQueryPattern = "^\\s*Enter passphrase for key \\'(.*)\\':\\s*$"
+
+    /// The password for a keychain-backed tunnel connection, resolved at ask
+    /// time so the secret never has to be readable by a second process. A
+    /// missing item returns nil, which the assistant turns into its
+    /// keychain-specific UI fallback prompt.
+    @objc(passwordForKeychainName:account:)
+    static func password(forKeychainName name: String?, account: String?) -> String? {
+        SAKeychainAccess.make().password(name: name, account: account)
+    }
+
+    /// The stored `"SSH"/<key name>` passphrase for an askpass query, or nil
+    /// when the query is not a key-passphrase prompt or no item is stored —
+    /// the caller then raises its UI prompt. The exists-then-get shape
+    /// mirrors the retired assistant-side check for exact behavioural
+    /// parity.
+    @objc(storedPassphraseForQuery:)
+    static func storedPassphrase(forQuery query: String?) -> String? {
+        guard let query, let keyName = passphraseKeyName(in: query), !keyName.isEmpty else { return nil }
+        let keychain = SAKeychainAccess.make()
+        guard keychain.passwordExists(name: "SSH", account: keyName) else { return nil }
+        return keychain.password(name: "SSH", account: keyName)
+    }
+
+    private static func passphraseKeyName(in query: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: passphraseQueryPattern),
+              let match = regex.firstMatch(in: query, range: NSRange(query.startIndex..., in: query)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: query) else { return nil }
+        return String(query[range])
+    }
+
+    private override init() {}
+}

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -788,12 +788,10 @@ static unsigned short getRandomPort(void);
 
 	// Keychain-backed connections resolve the password here, at ask time, on
 	// the app side of the channel: the assistant no longer reads the keychain
-	// itself (keychain migration plan, Step 3), so the secret never has to be
-	// readable by a second process. A missing item returns nil, which the
-	// assistant turns into its keychain-specific UI fallback prompt.
+	// itself (keychain migration plan, Step 3). The lookup lives in
+	// SASSHTunnelSecretResolver (new logic in Swift, thin bridge here).
 	if (passwordInKeychain) {
-		SPKeychain *keychain = [[SPKeychain alloc] init];
-		return [keychain getPasswordForName:keychainName account:keychainAccount];
+		return [SASSHTunnelSecretResolver passwordForKeychainName:keychainName account:keychainAccount];
 	}
 
 	return password;
@@ -867,15 +865,10 @@ static unsigned short getRandomPort(void);
 	// SSH key passphrases: check the user's stored "SSH"/<key name> item on
 	// the app side before raising the UI prompt. This check lived in the
 	// assistant while it still read the keychain directly (keychain
-	// migration plan, Step 3); the exists-then-get shape is kept for exact
-	// behavioural parity with that code.
-	NSString *storedKeyName = [theQuery captureGroupForRegex:@"^\\s*Enter passphrase for key \\'(.*)\\':\\s*$"];
-	if (storedKeyName.length > 0) {
-		SPKeychain *keychain = [[SPKeychain alloc] init];
-		if ([keychain passwordExistsForName:@"SSH" account:storedKeyName]) {
-			return [keychain getPasswordForName:@"SSH" account:storedKeyName];
-		}
-	}
+	// migration plan, Step 3); SASSHTunnelSecretResolver keeps its
+	// exists-then-get shape.
+	NSString *storedPassphrase = [SASSHTunnelSecretResolver storedPassphraseForQuery:theQuery];
+	if (storedPassphrase) return storedPassphrase;
 
 	// Lock the answer available lock
 	[[answerAvailableLock onMainThread] lock];

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -782,8 +782,18 @@ static unsigned short getRandomPort(void);
  */
 - (NSString *)getPasswordWithVerificationHash:(NSString *)theHash
 {
-	if (passwordInKeychain) return nil;
 	if (![theHash isEqualToString:tunnelConnectionVerifyHash]) return nil;
+
+	// Keychain-backed connections resolve the password here, at ask time, on
+	// the app side of the channel: the assistant no longer reads the keychain
+	// itself (keychain migration plan, Step 3), so the secret never has to be
+	// readable by a second process. A missing item returns nil, which the
+	// assistant turns into its keychain-specific UI fallback prompt.
+	if (passwordInKeychain) {
+		SPKeychain *keychain = [[SPKeychain alloc] init];
+		return [keychain getPasswordForName:keychainName account:keychainAccount];
+	}
+
 	return password;
 }
 
@@ -849,8 +859,21 @@ static unsigned short getRandomPort(void);
 - (NSString *)getPasswordForQuery:(NSString *)theQuery verificationHash:(NSString *)theHash
 {
 	if (![theHash isEqualToString:tunnelConnectionVerifyHash]) return nil;
-	
+
 	if (passwordPromptCancelled) return nil;
+
+	// SSH key passphrases: check the user's stored "SSH"/<key name> item on
+	// the app side before raising the UI prompt. This check lived in the
+	// assistant while it still read the keychain directly (keychain
+	// migration plan, Step 3); the exists-then-get shape is kept for exact
+	// behavioural parity with that code.
+	NSString *storedKeyName = [theQuery captureGroupForRegex:@"^\\s*Enter passphrase for key \\'(.*)\\':\\s*$"];
+	if (storedKeyName.length > 0) {
+		SPKeychain *keychain = [[SPKeychain alloc] init];
+		if ([keychain passwordExistsForName:@"SSH" account:storedKeyName]) {
+			return [keychain getPasswordForName:@"SSH" account:storedKeyName];
+		}
+	}
 
 	// Lock the answer available lock
 	[[answerAvailableLock onMainThread] lock];

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -529,9 +529,11 @@ static unsigned short getRandomPort(void);
 		[taskEnvironment safeSetObject:tunnelConnectionName forKey:@"SP_CONNECTION_NAME"];
 		[taskEnvironment safeSetObject:tunnelConnectionVerifyHash forKey:@"SP_CONNECTION_VERIFY_HASH"];
 		if (passwordInKeychain) {
+			// The keychain item's name and account deliberately stay out of
+			// the environment: the assistant no longer reads the keychain —
+			// it asks getPasswordWithVerificationHash: over the connection,
+			// and the app resolves the item at ask time.
             [taskEnvironment safeSetObject:[[NSNumber numberWithInteger:SPSSHPasswordUsesKeychain] stringValue] forKey:@"SP_PASSWORD_METHOD"];
-			[taskEnvironment safeSetObject:[keychainName stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet] forKey:@"SP_KEYCHAIN_ITEM_NAME"];
-			[taskEnvironment safeSetObject:[keychainAccount stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet] forKey:@"SP_KEYCHAIN_ITEM_ACCOUNT"];
 		} else if (password) {
 			[taskEnvironment safeSetObject:[[NSNumber numberWithInteger:SPSSHPasswordAsksUI] stringValue] forKey:@"SP_PASSWORD_METHOD"];
 		} else {

--- a/Source/Other/SSHTunnel/SequelAceTunnelAssistant.m
+++ b/Source/Other/SSHTunnel/SequelAceTunnelAssistant.m
@@ -30,7 +30,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import "SPKeychain.h"
 #import "SPSSHTunnel.h"
 #import "SPConstants.h"
 #import "sequel-ace-Swift.h"
@@ -76,37 +75,16 @@ int main(int argc, const char *argv[])
 			return 0;
 		}
 
-		// Check whether we're being asked for a standard SSH password - if so, use the app-entered value.
+		// Check whether we're being asked for a standard SSH password - if so, request it from the app.
 		if (argument && [[argument lowercaseString] rangeOfString:@"password:"].location != NSNotFound ) {
+			NSInteger passwordMethod = [[environment objectForKey:@"SP_PASSWORD_METHOD"] integerValue];
 
-			// If the password method is set to use the keychain, use the supplied keychain name to
-			// request the password
-			if ([[environment objectForKey:@"SP_PASSWORD_METHOD"] integerValue] == SPSSHPasswordUsesKeychain) {
-				SPKeychain *keychain;
-				// think we can risk these stringByRemovingPercentEncoding rather than linking swift
-				NSString *keychainName = [[environment objectForKey:@"SP_KEYCHAIN_ITEM_NAME"] stringByRemovingPercentEncoding];
-				NSString *keychainAccount = [[environment objectForKey:@"SP_KEYCHAIN_ITEM_ACCOUNT"] stringByRemovingPercentEncoding];
-
-				if (!keychainName || !keychainAccount) {
-					NSLog(@"SSH Tunnel: keychain authentication specified but insufficient internal details supplied");
-					return 1;
-				}
-
-				keychain = [[SPKeychain alloc] init];
-
-				if ([keychain passwordExistsForName:keychainName account:keychainAccount]) {
-					printf("%s\n", [[keychain getPasswordForName:keychainName account:keychainAccount] UTF8String]);
-					return 0;
-				}
-
-				// If retrieving the password failed, log an error and fall back to requesting from the GUI
-				NSLog(@"SSH Tunnel: specified keychain password not found");
-
-				argument = [NSString stringWithFormat:NSLocalizedString(@"The SSH password could not be loaded from the keychain; please enter the SSH password for %@:", @"Prompt for SSH password when keychain fetch failed"), connectionName];
-			}
-
-			// If the password method is set to request the password from the tunnel instance, do so.
-			if ([[environment objectForKey:@"SP_PASSWORD_METHOD"] integerValue] == SPSSHPasswordAsksUI) {
+			// Both password methods ask the app over the connection: it
+			// either holds the password in memory (AsksUI) or resolves it
+			// from the keychain at ask time (UsesKeychain). This helper no
+			// longer reads the keychain itself — see the keychain migration
+			// plan, Step 3.
+			if (passwordMethod == SPSSHPasswordUsesKeychain || passwordMethod == SPSSHPasswordAsksUI) {
 				NSString *password;
 
 				if (!connectionName || !verificationHash) {
@@ -128,61 +106,23 @@ int main(int argc, const char *argv[])
 					return 0;
 				}
 
-				// If retrieving the password failed, log an error and fall back to requesting from the GUI
-				NSLog(@"SSH Tunnel: unable to successfully request password from Sequel Ace for internal authentication");
-
-				argument = [NSString stringWithFormat:NSLocalizedString(@"The SSH password could not be loaded; please enter the SSH password for %@:", @"Prompt for SSH password when direct fetch failed"), connectionName];
-			}
-		}
-
-
-		// Check whether we're being asked for a SSH key passphrase
-		if (argument && [[argument lowercaseString] rangeOfString:@"enter passphrase for"].location != NSNotFound ) {
-			NSString *passphrase;
-
-            NSString *keyName = [argument captureGroupForRegex:@"^\\s*Enter passphrase for key \\'(.*)\\':\\s*$"];
-
-			if (keyName.length > 0) {
-
-                SPLog(@"keyName: %@", keyName);
-
-				// Check whether the passphrase is in the keychain, using standard OS X sshagent name and account
-				SPKeychain *keychain = [[SPKeychain alloc] init];
-
-				if ([keychain passwordExistsForName:@"SSH" account:keyName]) {
-					printf("%s\n", [[keychain getPasswordForName:@"SSH" account:keyName] UTF8String]);
-					return 0;
+				// If retrieving the password failed, log an error and fall
+				// back to requesting from the GUI, explaining per method.
+				if (passwordMethod == SPSSHPasswordUsesKeychain) {
+					NSLog(@"SSH Tunnel: specified keychain password not found");
+					argument = [NSString stringWithFormat:NSLocalizedString(@"The SSH password could not be loaded from the keychain; please enter the SSH password for %@:", @"Prompt for SSH password when keychain fetch failed"), connectionName];
+				}
+				else {
+					NSLog(@"SSH Tunnel: unable to successfully request password from Sequel Ace for internal authentication");
+					argument = [NSString stringWithFormat:NSLocalizedString(@"The SSH password could not be loaded; please enter the SSH password for %@:", @"Prompt for SSH password when direct fetch failed"), connectionName];
 				}
 			}
-            else{
-                SPLog(@"key not found in [%@]", argument);
-            }
-
-			// Not found in the keychain - we need to ask the GUI.
-
-			if (!verificationHash) {
-				NSLog(@"SSH Tunnel: key passphrase authentication required but insufficient details supplied to connect to GUI");
-				return 1;
-			}
-
-			sequelProTunnel = (SPSSHTunnel *)[NSConnection rootProxyForConnectionWithRegisteredName:connectionName host:nil];
-
-			if (!sequelProTunnel) {
-				NSLog(@"SSH Tunnel: unable to connect to Sequel Ace to show SSH question");
-				return 1;
-			}
-			passphrase = [sequelProTunnel getPasswordForQuery:argument verificationHash:verificationHash];
-
-			if (!passphrase) {
-				return 1;
-			}
-
-			printf("%s\n", [passphrase UTF8String]);
-
-			return 0;
 		}
 
-		// SSH has some other question. Show that directly to the user. This is an attempt to support RSA SecurID
+		// Key passphrases, and any other question SSH asks, go to the app's
+		// GUI prompt via getPasswordForQuery: — the app checks the stored
+		// "SSH"/<key name> passphrase item before showing its prompt, which
+		// used to be this helper's keychain read. Also covers RSA SecurID.
 		if (argument) {
 			NSString *passphrase;
 

--- a/docs/development/keychain-secitem-migration-plan.md
+++ b/docs/development/keychain-secitem-migration-plan.md
@@ -272,7 +272,21 @@ pinned-buggy to correct:
 Ship this as its own PR and let it soak a release if the schedule allows —
 these fixes de-risk the rewrite regardless of when the rewrite lands.
 
-### Step 3 — Retire the tunnel assistant's direct keychain read
+### Step 3 — Retire the tunnel assistant's direct keychain read — ✅ Done
+
+Execution notes (2026-08-31): executed as three working-tree-at-every-commit
+commits — app-side serving first, assistant switch second, ACL deletion
+last. Refinements over the plan text: the password is resolved **at ask
+time** inside `getPasswordWithVerificationHash:` (the secret never enters
+the app-held state either, let alone the environment), `SP_PASSWORD_METHOD`
+*keeps* its UsesKeychain value so the assistant can still show its
+keychain-specific fallback prompt on a miss (only the item name/account env
+vars died), and the assistant's key-passphrase keychain check moved into
+`getPasswordForQuery:` (same regex, same exists-then-get shape) — which
+collapsed the assistant's passphrase branch into the generic GUI branch,
+its exact remaining body. The hash check now runs before the keychain
+branch in `getPasswordWithVerificationHash:` (previously keychain mode
+returned nil before verifying — strictly no looser).
 
 - `SPSSHTunnel`: in keychain mode, resolve the password via `SPKeychain` at
   connect time (app side, where the item's ACL already trusts the app) and

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -268,8 +268,8 @@ on a **signed, sandboxed** build, not a debug build:
 | # | Scenario |
 |---|---|
 | 1 | Password held in app (`SP_PASSWORD_METHOD` = AsksUI) |
-| 2 | Password in keychain (assistant never contacts the app) |
-| 3 | Key passphrase in keychain |
+| 2 | Password in keychain (app resolves the item at ask time and serves it over the channel) |
+| 3 | Key passphrase in keychain (app-side pre-prompt check in `getPasswordForQuery:`) |
 | 4 | Key passphrase prompted in UI |
 | 5 | Host-key mismatch yes/no |
 | 6 | Unrecognised prompt / SecurID fallback |

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -312,7 +312,14 @@ day and captures most of the security benefit.
 2. ~~**Can we require macOS 13?**~~ Answered: yes. The deployment target moved
    to 13.5 (`macos-13-minimum-plan.md`), so Step 4 is a real win, not a partial
    one.
-3. **Sequencing against the SPKeychain `SecItem` migration.** Both change how
-   the assistant gets passwords. Suggest this project goes first: it is smaller,
-   and it leaves the keychain work with a narrow, testable auth surface instead
-   of a DO proxy. Worth confirming rather than assuming.
+3. ~~**Sequencing against the SPKeychain `SecItem` migration.**~~ Answered by
+   that migration's Step 3 (see
+   `docs/development/keychain-secitem-migration-plan.md`): the assistant no
+   longer reads the keychain at all — `SPSSHTunnel` resolves keychain-backed
+   passwords app-side inside `getPasswordWithVerificationHash:`, and the
+   key-passphrase pre-prompt check moved into `getPasswordForQuery:`. The two
+   projects no longer depend on each other's order. For this plan that means:
+   the vended surface to narrow is one mode smaller, the manual matrix rows 2
+   and 3 now exercise the same DO/XPC ask-the-app path as row 1 (still worth
+   running — they cover the app-side keychain resolution), and
+   `SP_KEYCHAIN_ITEM_{NAME,ACCOUNT}` no longer exist in the environment.

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		58B9097B11C3A4A2000826E5 /* xibLocalizationPostprocessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B9095B11C3A3EC000826E5 /* xibLocalizationPostprocessor.m */; };
 		58C56EF50F438E120035701E /* SPDataCellFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C56EF40F438E120035701E /* SPDataCellFormatter.m */; };
 		58CDB3300FCE138D00F8ACA3 /* SPSSHTunnel.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDB32F0FCE138D00F8ACA3 /* SPSSHTunnel.m */; };
+		5442636C17706594404F1300 /* SASSHTunnelSecretResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8212E8F5BED60F2D9D1130D8 /* SASSHTunnelSecretResolver.swift */; };
 		58CDB3400FCE13EF00F8ACA3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5EAC0FC0EC87FF900CC579C /* Security.framework */; };
 		58CDB3410FCE141900F8ACA3 /* SequelAceTunnelAssistant.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */; };
 		58D2A6A716FBDEFF002EB401 /* SPComboPopupButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D2A6A616FBDEFF002EB401 /* SPComboPopupButton.m */; };
@@ -1294,6 +1295,7 @@
 		58C56EF40F438E120035701E /* SPDataCellFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDataCellFormatter.m; sourceTree = "<group>"; };
 		58CDB32E0FCE138D00F8ACA3 /* SPSSHTunnel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPSSHTunnel.h; sourceTree = "<group>"; };
 		58CDB32F0FCE138D00F8ACA3 /* SPSSHTunnel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSSHTunnel.m; sourceTree = "<group>"; };
+		8212E8F5BED60F2D9D1130D8 /* SASSHTunnelSecretResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SASSHTunnelSecretResolver.swift; sourceTree = "<group>"; };
 		58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SequelAceTunnelAssistant.m; sourceTree = "<group>"; };
 		58CDB3360FCE13C900F8ACA3 /* SequelAceTunnelAssistant */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SequelAceTunnelAssistant; sourceTree = BUILT_PRODUCTS_DIR; };
 		58D2A6A516FBDEFF002EB401 /* SPComboPopupButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPComboPopupButton.h; sourceTree = "<group>"; };
@@ -2334,6 +2336,7 @@
 			children = (
 				58CDB32E0FCE138D00F8ACA3 /* SPSSHTunnel.h */,
 				58CDB32F0FCE138D00F8ACA3 /* SPSSHTunnel.m */,
+				8212E8F5BED60F2D9D1130D8 /* SASSHTunnelSecretResolver.swift */,
 				58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */,
 			);
 			name = "SSH Tunnel";
@@ -3666,6 +3669,7 @@
 				177E7A230FCB6A2E00E9E122 /* SPExtendedTableInfo.m in Sources */,
 				73F70A961E4E547500636550 /* SPJSONFormatter.m in Sources */,
 				58CDB3300FCE138D00F8ACA3 /* SPSSHTunnel.m in Sources */,
+				5442636C17706594404F1300 /* SASSHTunnelSecretResolver.swift in Sources */,
 				1A70BC6B25EF439F004BB992 /* FileManagerExtension.swift in Sources */,
 				BC1847EA0FE6EC8400094BFB /* SPEditSheetTextView.m in Sources */,
 				BC2C16D40FEBEDF10003993B /* SPDataAdditions.m in Sources */,

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		CD5AFDE14AA44B4AB444DD59 /* SAKeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4471240789125E4D4033602A /* SAKeychainAccess.swift */; };
 		0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
 		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
-		221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		17E641830EF01FA8001BC333 /* SPImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6417F0EF01FA8001BC333 /* SPImageView.m */; };
 		17E641840EF01FA8001BC333 /* SPTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641810EF01FA8001BC333 /* SPTextView.m */; };
@@ -426,7 +425,6 @@
 		58CDB3300FCE138D00F8ACA3 /* SPSSHTunnel.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDB32F0FCE138D00F8ACA3 /* SPSSHTunnel.m */; };
 		58CDB3400FCE13EF00F8ACA3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5EAC0FC0EC87FF900CC579C /* Security.framework */; };
 		58CDB3410FCE141900F8ACA3 /* SequelAceTunnelAssistant.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */; };
-		58CDB3420FCE142500F8ACA3 /* SPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641740EF01F80001BC333 /* SPKeychain.m */; };
 		58D2A6A716FBDEFF002EB401 /* SPComboPopupButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D2A6A616FBDEFF002EB401 /* SPComboPopupButton.m */; };
 		58D2E229101222670063EF1D /* SPTextAndLinkCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D2E227101222670063EF1D /* SPTextAndLinkCell.m */; };
 		58D2E22E101222870063EF1D /* link-arrow-clicked.png in Resources */ = {isa = PBXBuildFile; fileRef = 58D2E22B101222870063EF1D /* link-arrow-clicked.png */; };
@@ -3563,8 +3561,6 @@
 				17D41A8221700F8200B1888D /* SPFunctions.m in Sources */,
 				1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */,
 				58CDB3410FCE141900F8ACA3 /* SequelAceTunnelAssistant.m in Sources */,
-				58CDB3420FCE142500F8ACA3 /* SPKeychain.m in Sources */,
-				221C83260BF298E6A8969456 /* SAKeychainProviding.swift in Sources */,
 				584D88AA1515034200F24774 /* NSNotificationCenterThreadingAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary

Step 3 of `docs/development/keychain-secitem-migration-plan.md`, stacked on #2612. The tunnel assistant no longer reads the keychain at all — the app serves both secrets over the existing DO channel — which removes the only reason keychain items ever needed a trusted-app access list, and thereby unblocks the `SecItem*` rewrite (the ACL is the one legacy feature with no modern equivalent). Also answers the XPC plan's open question 3: the two projects no longer depend on each other's order.

Three functional commits, each leaving a fully working tunnel:

1. **App serves keychain-backed secrets.** `getPasswordWithVerificationHash:` resolves a keychain-backed connection's password **at ask time** instead of refusing (hash check now runs first — previously keychain mode returned nil before verifying, so strictly no looser). `getPasswordForQuery:` checks the stored `"SSH"/<key name>` passphrase item before raising the UI prompt — same regex, same exists-then-get shape as the assistant code it replaces.
2. **Assistant switches to the channel.** `SP_PASSWORD_METHOD` keeps its UsesKeychain value so a keychain miss still explains itself in the fallback prompt (message parity, verbatim), but `SP_KEYCHAIN_ITEM_{NAME,ACCOUNT}` no longer enter the environment. The assistant's passphrase branch collapsed into the generic ask-the-GUI branch — its exact remaining body. SPKeychain.m and SAKeychainProviding.swift leave the SequelAceTunnelAssistant target; the helper no longer touches Security at all.
3. **Trusted-app ACL machinery deleted** (`SecTrustedApplicationCreateFromPath` ×2, `SecAccessCreate`): new items rely on the default access list, since no second process ever reads them now. Existing items keep their ACLs — the update path modifies in place.

Security note: in keychain mode the SSH password now transits the DO channel — the same hash-checked channel that already carries it in every other mode. Hardening the channel itself is the XPC project; net exposure change ≈ 0 (the migration plan's design section covers this).

## Warnings

Test-scheme clean build: 62 → 31 raw, 20 → **12 unique** (ACL sites gone; tunnel-target duplication gone).

## Test plan

- [x] Full "Unit Tests" scheme: 1181 tests, 0 failures
- [x] Clean build-for-testing (app + assistant): 0 errors
- [ ] ⚠️ **Manual SSH matrix required before merge** (needs a live SSH host; not run yet): password-in-keychain connect, passphrase-in-keychain connect, keychain-miss → UI prompt fallback (should show the keychain-specific message), ask-UI mode no-regression, passphrase save-to-keychain checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)