### PR TITLE
#fixed Preserve SSH tunnel failure diagnostics

### DIFF
--- a/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
+++ b/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1A96314725B9CE6600BF2E91 /* SPMySQLArrayAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A96314525B9CE6600BF2E91 /* SPMySQLArrayAdditions.m */; };
 		1A96314E25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A96314C25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.m */; };
 		1A96314F25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A96314D25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4042B04787F88BF732CD28B9 /* SAProxyReconnectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */; };
 		507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF1811BC0C64100104523 /* DataConversion_Tests.m */; };
 		507FF23B1BC0E8CA00104523 /* SPMySQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* SPMySQL.framework */; };
 		507FF23D1BC157B500104523 /* SPMySQLStringAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */; };
@@ -129,6 +130,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SAProxyReconnectCoordinator.swift; path = Source/SAProxyReconnectCoordinator.swift; sourceTree = "<group>"; };
 		0867D69BFE84028FC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		0EA5700AA759774A87FC447F /* SPMySQL.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = SPMySQL.modulemap; path = Source/SPMySQL.modulemap; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				386B159A6D535F0686530898 /* SADatabaseAssertion.swift */,
 				0EA5700AA759774A87FC447F /* SPMySQL.modulemap */,
 				1B61BFAD76569C2412169CE7 /* MySQLClient.modulemap */,
+				008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */,
 			);
 			name = "Other Sources";
 			sourceTree = "<group>";
@@ -761,6 +764,7 @@
 				584F16A91752911200D150A6 /* SPMySQLStreamingResultStore.m in Sources */,
 				583C734E17B0778A0056B284 /* Data Conversion.m in Sources */,
 				D88652282912E88D23A56A1C /* SADatabaseAssertion.swift in Sources */,
+				4042B04787F88BF732CD28B9 /* SAProxyReconnectCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Frameworks/SPMySQLFramework/Source/SAProxyReconnectCoordinator.swift
+++ b/Frameworks/SPMySQLFramework/Source/SAProxyReconnectCoordinator.swift
@@ -1,0 +1,62 @@
+//
+//  SAProxyReconnectCoordinator.swift
+//  SPMySQLFramework
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+/// Owns the decisions and proxy routing used while an interrupted MySQL
+/// connection waits for its prerequisite proxy to reconnect.
+@objcMembers
+public final class SAProxyReconnectCoordinator: NSObject {
+
+    /// Returns whether the reconnect must stop before doing more proxy work.
+    @objc(shouldAbortReconnectWithThreadCancelled:userTriggeredDisconnect:)
+    public func shouldAbortReconnect(
+        threadCancelled: Bool,
+        userTriggeredDisconnect: Bool
+    ) -> Bool {
+        threadCancelled || userTriggeredDisconnect
+    }
+
+    /// Reports whether the proxy accepted a connect request but intentionally
+    /// deferred launching it while an earlier attempt finishes cleanup.
+    @objc(connectionAttemptPendingForProxy:)
+    public func connectionAttemptPending(for proxy: SPMySQLConnectionProxy) -> Bool {
+        proxy.connectionAttemptPending?() ?? false
+    }
+
+    /// Excludes user interaction and intentional proxy cleanup from the network
+    /// connection timeout while leaving cancellation as an independent decision.
+    @objc(shouldExcludeWaitTimeForAuthentication:connectionAttemptPending:)
+    public func shouldExcludeWaitTime(
+        waitingForAuthentication: Bool,
+        connectionAttemptPending: Bool
+    ) -> Bool {
+        waitingForAuthentication || connectionAttemptPending
+    }
+
+    /// Routes proxy teardown through the main thread. Internal reconnect cleanup
+    /// preserves a request queued behind the current proxy lifecycle when the
+    /// proxy supports that distinction; explicit teardown always cancels it.
+    @objc(disconnectProxy:preservingReconnect:)
+    public func disconnect(
+        proxy: SPMySQLConnectionProxy,
+        preservingReconnect: Bool
+    ) {
+        let disconnect = {
+            if preservingReconnect, proxy.disconnectForReconnect?() != nil {
+                return
+            }
+            proxy.disconnect()
+        }
+
+        if Thread.isMainThread {
+            disconnect()
+        } else {
+            DispatchQueue.main.sync(execute: disconnect)
+        }
+    }
+}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -58,6 +58,7 @@
 - (BOOL)_reconnectAllowingRetries:(BOOL)canRetry;
 - (BOOL)_reconnectAfterBackgroundConnectionLoss;
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;
+- (BOOL)_abortCancelledReconnectWhileLocked;
 - (void)_disconnect;
 - (void)_disconnectPreservingProxyReconnect:(BOOL)preserveProxyReconnect;
 - (void)_updateConnectionVariables;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -59,6 +59,7 @@
 - (BOOL)_reconnectAfterBackgroundConnectionLoss;
 - (BOOL)_waitForNetworkConnectionWithTimeout:(double)timeoutSeconds;
 - (void)_disconnect;
+- (void)_disconnectPreservingProxyReconnect:(BOOL)preserveProxyReconnect;
 - (void)_updateConnectionVariables;
 - (BOOL)_serverIsProxySQL;
 - (void)_restoreConnectionVariables;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1161,6 +1161,8 @@ asm(".desc ___crashreporter_info__, 0x10");
 			proxyWaitStart_t = _monotonicTime();
 			while (1) {
 				loopIterationStart_t = _monotonicTime();
+				BOOL connectionAttemptPending = [proxy respondsToSelector:@selector(connectionAttemptPending)]
+					&& [proxy connectionAttemptPending];
 
                 SPLog(@"Wait while the proxy connects");
 
@@ -1187,8 +1189,9 @@ asm(".desc ___crashreporter_info__, 0x10");
 					usleep((useconds_t)(250000 - (1000000 * _timeIntervalSinceMonotonicTime(loopIterationStart_t))));
 				}
 
-				// Extend the connection timeout by any interface time
-				if ([proxy state] == SPMySQLProxyWaitingForAuth) {
+				// Extend the connection timeout by interface time and by time that
+				// the proxy intentionally spends waiting to start the requested attempt.
+				if ([proxy state] == SPMySQLProxyWaitingForAuth || connectionAttemptPending) {
 					proxyWaitStart_t += _monotonicTime() - loopIterationStart_t;
 				}
 			}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1108,7 +1108,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		if (proxy) proxyStateChangeNotificationsIgnored = YES;
 
 		// Close the connection if it's active
-		[self _disconnect];
+		[self _disconnectPreservingProxyReconnect:YES];
 
 		// Lock the connection while waiting for network and proxy
 		[self _lockConnection];
@@ -1331,6 +1331,11 @@ asm(".desc ___crashreporter_info__, 0x10");
  */
 - (void)_disconnect
 {
+	[self _disconnectPreservingProxyReconnect:NO];
+}
+
+- (void)_disconnectPreservingProxyReconnect:(BOOL)preserveProxyReconnect
+{
     SPLog(@"_disconnect");
 
 	// If state is connection lost, set state directly to disconnected.
@@ -1376,7 +1381,10 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	// If using a connection proxy, disconnect that too
 	if (proxy) {
-		[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+		SEL disconnectSelector = preserveProxyReconnect && [proxy respondsToSelector:@selector(disconnectForReconnect)]
+			? @selector(disconnectForReconnect)
+			: @selector(disconnect);
+		[proxy performSelectorOnMainThread:disconnectSelector withObject:nil waitUntilDone:YES];
 	}
 }
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1345,6 +1345,12 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	// Only continue if a connection is active
 	if (state != SPMySQLConnected && state != SPMySQLConnecting) {
+		// An explicit disconnect must still reach the proxy so it can cancel an
+		// SSH attempt queued behind cleanup. Internal reconnect teardown keeps
+		// the existing inactive-state behavior and preserves that queued attempt.
+		if (!preserveProxyReconnect && proxy) {
+			[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+		}
 		return;
 	}
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1038,14 +1038,15 @@ asm(".desc ___crashreporter_info__, 0x10");
 }
 
 /**
- * If the current reconnect thread was cancelled while holding the connection
- * lock, cancel any preserved proxy work, restore notifications, and unlock.
+ * If the current reconnect was cancelled by its thread or an explicit
+ * disconnect while holding the connection lock, cancel any preserved proxy
+ * work, restore notifications, and unlock.
  */
 - (BOOL)_abortCancelledReconnectWhileLocked
 {
-	if (![[NSThread currentThread] isCancelled]) return NO;
+	if (![[NSThread currentThread] isCancelled] && !userTriggeredDisconnect) return NO;
 
-	SPLog(@"reconnect thread cancelled; cleaning up proxy attempt");
+	SPLog(@"reconnect cancelled by thread or explicit disconnect; cleaning up proxy attempt");
 	[self _unlockConnection];
 	if (proxy) {
 		// Keep proxy callbacks suppressed until the pending attempt is cancelled,

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -37,10 +37,12 @@
 #import "SPMySQLUtilities.h"
 #import "SPMySQLArrayAdditions.h"
 #import "SPMySQLMutableDictionaryAdditions.h"
+#import <SPMySQL/SPMySQL-Swift.h>
 
 @interface SPMySQLConnection ()
 
 @property (readwrite, copy) NSString *timeZoneIdentifier;
+@property (readonly, strong) SAProxyReconnectCoordinator *proxyReconnectCoordinator;
 
 @end
 
@@ -343,6 +345,7 @@ const SPMySQLClientFlags SPMySQLConnectionOptions =
 		// Start with no proxy
 		proxy = nil;
 		proxyStateChangeNotificationsIgnored = NO;
+		_proxyReconnectCoordinator = [[SAProxyReconnectCoordinator alloc] init];
 
 		// Start with no selected database
 		database = nil;
@@ -1044,14 +1047,16 @@ asm(".desc ___crashreporter_info__, 0x10");
  */
 - (BOOL)_abortCancelledReconnectWhileLocked
 {
-	if (![[NSThread currentThread] isCancelled] && !userTriggeredDisconnect) return NO;
+	BOOL threadCancelled = [[NSThread currentThread] isCancelled];
+	if (![_proxyReconnectCoordinator shouldAbortReconnectWithThreadCancelled:threadCancelled
+	                                              userTriggeredDisconnect:userTriggeredDisconnect]) return NO;
 
 	SPLog(@"reconnect cancelled by thread or explicit disconnect; cleaning up proxy attempt");
 	[self _unlockConnection];
 	if (proxy) {
 		// Keep proxy callbacks suppressed until the pending attempt is cancelled,
 		// then restore the state snapshot and normal notification handling.
-		[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+		[_proxyReconnectCoordinator disconnectProxy:proxy preservingReconnect:NO];
 		previousProxyState = [proxy state];
 	}
 	proxyStateChangeNotificationsIgnored = NO;
@@ -1180,8 +1185,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 			while (1) {
 				if ([self _abortCancelledReconnectWhileLocked]) return NO;
 				loopIterationStart_t = _monotonicTime();
-				BOOL connectionAttemptPending = [proxy respondsToSelector:@selector(connectionAttemptPending)]
-					&& [proxy connectionAttemptPending];
+				BOOL connectionAttemptPending = [_proxyReconnectCoordinator connectionAttemptPendingForProxy:proxy];
 
                 SPLog(@"Wait while the proxy connects");
 
@@ -1196,7 +1200,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 				// If the proxy connection attempt time has exceeded the timeout, break of of the loop.
 				if (_timeIntervalSinceMonotonicTime(proxyWaitStart_t) > (timeout + 1)) {
                     SPLog(@"proxy connection attempt time has exceeded the timeout, break of of the loop, calling proxy disconnect");
-					[proxy disconnect];
+					[_proxyReconnectCoordinator disconnectProxy:proxy preservingReconnect:YES];
 					break;
 				}
 
@@ -1210,7 +1214,9 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 				// Extend the connection timeout by interface time and by time that
 				// the proxy intentionally spends waiting to start the requested attempt.
-				if ([proxy state] == SPMySQLProxyWaitingForAuth || connectionAttemptPending) {
+				if ([_proxyReconnectCoordinator
+						shouldExcludeWaitTimeForAuthentication:([proxy state] == SPMySQLProxyWaitingForAuth)
+						connectionAttemptPending:connectionAttemptPending]) {
 					proxyWaitStart_t += _monotonicTime() - loopIterationStart_t;
 				}
 			}
@@ -1228,7 +1234,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		if (![[NSThread currentThread] isCancelled] && (!proxy || [proxy state] == SPMySQLProxyConnected)) {
 			[self _connect];
 		} else if ([[NSThread currentThread] isCancelled] && proxy) {
-			[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+			[_proxyReconnectCoordinator disconnectProxy:proxy preservingReconnect:NO];
 		}
 
 		// If the reconnection succeeded, restore the connection state as appropriate
@@ -1371,7 +1377,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		// SSH attempt queued behind cleanup. Internal reconnect teardown keeps
 		// the existing inactive-state behavior and preserves that queued attempt.
 		if (!preserveProxyReconnect && proxy) {
-			[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+			[_proxyReconnectCoordinator disconnectProxy:proxy preservingReconnect:NO];
 		}
 		return;
 	}
@@ -1409,10 +1415,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 	// If using a connection proxy, disconnect that too
 	if (proxy) {
-		SEL disconnectSelector = preserveProxyReconnect && [proxy respondsToSelector:@selector(disconnectForReconnect)]
-			? @selector(disconnectForReconnect)
-			: @selector(disconnect);
-		[proxy performSelectorOnMainThread:disconnectSelector withObject:nil waitUntilDone:YES];
+		[_proxyReconnectCoordinator disconnectProxy:proxy preservingReconnect:preserveProxyReconnect];
 	}
 }
 

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection.m
@@ -1038,6 +1038,27 @@ asm(".desc ___crashreporter_info__, 0x10");
 }
 
 /**
+ * If the current reconnect thread was cancelled while holding the connection
+ * lock, cancel any preserved proxy work, restore notifications, and unlock.
+ */
+- (BOOL)_abortCancelledReconnectWhileLocked
+{
+	if (![[NSThread currentThread] isCancelled]) return NO;
+
+	SPLog(@"reconnect thread cancelled; cleaning up proxy attempt");
+	[self _unlockConnection];
+	if (proxy) {
+		// Keep proxy callbacks suppressed until the pending attempt is cancelled,
+		// then restore the state snapshot and normal notification handling.
+		[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
+		previousProxyState = [proxy state];
+	}
+	proxyStateChangeNotificationsIgnored = NO;
+	reconnectingThread = NULL;
+	return YES;
+}
+
+/**
  * Perform a reconnection task, either once-only or looping as requested.  If looping is
  * permitted and this method fails, it will ask how to proceed and loop depending on
  * the status, not returning control until either a connection has been established or
@@ -1116,13 +1137,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 		// If no network is present, wait for a short time for one to become available
 		[self _waitForNetworkConnectionWithTimeout:10];
 
-		if ([[NSThread currentThread] isCancelled]) {
-            SPLog(@"NSThread currentThread] isCancelled, returning");
-
-			[self _unlockConnection];
-			reconnectingThread = NULL;
-			return NO;
-		}
+		if ([self _abortCancelledReconnectWhileLocked]) return NO;
 
 		// If there is a proxy, attempt to reconnect it in blocking fashion
 		if (proxy) {
@@ -1139,6 +1154,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 				proxyWaitStart_t = _monotonicTime();
 				while ([proxy state] != SPMySQLProxyIdle) {
+					if ([self _abortCancelledReconnectWhileLocked]) return NO;
 					loopIterationStart_t = _monotonicTime();
 
 					// If the connection timeout has passed, break out of the loop
@@ -1151,6 +1167,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 					}
 				}
 			}
+			if ([self _abortCancelledReconnectWhileLocked]) return NO;
 
 			// Request that the proxy re-establishes its connection
             SPLog(@"Request that the proxy re-establishes its connection, calling proxy connect");
@@ -1160,6 +1177,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 			// Wait while the proxy connects
 			proxyWaitStart_t = _monotonicTime();
 			while (1) {
+				if ([self _abortCancelledReconnectWhileLocked]) return NO;
 				loopIterationStart_t = _monotonicTime();
 				BOOL connectionAttemptPending = [proxy respondsToSelector:@selector(connectionAttemptPending)]
 					&& [proxy connectionAttemptPending];
@@ -1195,6 +1213,7 @@ asm(".desc ___crashreporter_info__, 0x10");
 					proxyWaitStart_t += _monotonicTime() - loopIterationStart_t;
 				}
 			}
+			if ([self _abortCancelledReconnectWhileLocked]) return NO;
 
 			// Having in theory performed the proxy connect, update state
 			previousProxyState = [proxy state];
@@ -1205,8 +1224,10 @@ asm(".desc ___crashreporter_info__, 0x10");
 		[self _unlockConnection];
 
 		// If not using a proxy, or if the proxy successfully connected, trigger a connection
-		if (!proxy || [proxy state] == SPMySQLProxyConnected) {
+		if (![[NSThread currentThread] isCancelled] && (!proxy || [proxy state] == SPMySQLProxyConnected)) {
 			[self _connect];
+		} else if ([[NSThread currentThread] isCancelled] && proxy) {
+			[proxy performSelectorOnMainThread:@selector(disconnect) withObject:nil waitUntilDone:YES];
 		}
 
 		// If the reconnection succeeded, restore the connection state as appropriate

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionProxy.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionProxy.h
@@ -43,7 +43,7 @@ typedef enum {
 @protocol SPMySQLConnectionProxy <NSObject>
 
 /**
- * All the methods for this protocol are required.
+ * All the methods for this protocol are required unless marked optional.
  */
 
 /**
@@ -70,5 +70,13 @@ typedef enum {
  * Sets the method the proxy should call whenever the state of the connection changes.
  */
 - (BOOL)setConnectionStateChangeSelector:(SEL)theStateChangeSelector delegate:(id)theDelegate;
+
+@optional
+
+/**
+ * Whether a requested connection attempt is intentionally waiting to start.
+ * Time spent pending is excluded from the proxy connection timeout.
+ */
+- (BOOL)connectionAttemptPending;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionProxy.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnectionProxy.h
@@ -79,4 +79,10 @@ typedef enum {
  */
 - (BOOL)connectionAttemptPending;
 
+/**
+ * Disconnect the current proxy process as preparation for an immediate
+ * reconnect, preserving any request already queued behind proxy cleanup.
+ */
+- (void)disconnectForReconnect;
+
 @end

--- a/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
+++ b/Source/Controllers/MainViewControllers/ConnectionView/SPConnectionController.m
@@ -582,7 +582,7 @@ sslCACertFileLocationEnabled:(sslCACertFileLocationEnabled != NSControlStateValu
             NSString *failTitle = result.errorTitle ?: NSLocalizedString(@"Unable to connect", @"connection failed title");
             // rawErrorMessage is populated for MySQL errors; errorMessage for SSH tunnel errors
             NSString *failMessage = (result.rawErrorMessage.length > 0) ? result.rawErrorMessage : (result.errorMessage ?: @"");
-            NSString *failDetail = nil;
+            NSString *failDetail = result.errorDetail;
 
             // Format detailed error based on connection type and error code
             if (result.sshDebugMessages.length > 0 && strongSelf->sshTunnel) {

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -3,6 +3,8 @@
 //  Sequel Ace
 //
 
+import Foundation
+
 /// Carries the user-facing SSH error and OpenSSH output together across the
 /// connection-service boundary so callers can classify and present failures.
 struct SASSHTunnelFailure {
@@ -11,5 +13,78 @@ struct SASSHTunnelFailure {
 
     var errorDetail: String? {
         debugMessages.isEmpty ? nil : debugMessages
+    }
+}
+
+/// Coordinates the stderr-drain boundary for an SSH failure. OpenSSH output is
+/// preferred through pipe EOF, with a bounded fallback for custom binaries or
+/// descendants that retain the inherited stderr writer.
+@objc final class SASSHStderrDrainCoordinator: NSObject {
+    private static let defaultTimeout: TimeInterval = 5
+
+    private let timeout: TimeInterval
+    private let stateLock = NSLock()
+    private var reachedEOF = false
+    private var diagnosticsReady = true
+
+    override convenience init() {
+        self.init(timeout: Self.defaultTimeout)
+    }
+
+    init(timeout: TimeInterval) {
+        self.timeout = timeout
+        super.init()
+    }
+
+    @objc var failureDiagnosticsReady: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return diagnosticsReady
+    }
+
+    @objc func beginAttempt() {
+        stateLock.lock()
+        reachedEOF = false
+        diagnosticsReady = false
+        stateLock.unlock()
+    }
+
+    @objc func finishWithoutStandardErrorPipe() {
+        stateLock.lock()
+        diagnosticsReady = true
+        stateLock.unlock()
+    }
+
+    /// Returns whether the one-shot file-handle notification should be re-armed.
+    @objc(recordStandardErrorReadWithByteCount:)
+    func recordStandardErrorRead(byteCount: Int) -> Bool {
+        stateLock.lock()
+        if byteCount == 0 {
+            reachedEOF = true
+        }
+        stateLock.unlock()
+        return byteCount > 0
+    }
+
+    /// Drains the current thread's run loop until stderr reaches EOF or the
+    /// bounded fallback expires. Returns whether EOF was observed.
+    @objc func finishAfterStandardErrorDrain() -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+
+        while !hasReachedEOF && deadline.timeIntervalSinceNow > 0 {
+            RunLoop.current.run(mode: .default, before: deadline)
+        }
+
+        stateLock.lock()
+        diagnosticsReady = true
+        let didReachEOF = reachedEOF
+        stateLock.unlock()
+        return didReachEOF
+    }
+
+    private var hasReachedEOF: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return reachedEOF
     }
 }

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -1,0 +1,15 @@
+//
+//  SASSHTunnelFailure.swift
+//  Sequel Ace
+//
+
+/// Carries the user-facing SSH error and OpenSSH output together across the
+/// connection-service boundary so callers can classify and present failures.
+struct SASSHTunnelFailure {
+    let message: String
+    let debugMessages: String
+
+    var errorDetail: String? {
+        debugMessages.isEmpty ? nil : debugMessages
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -16,16 +16,30 @@ struct SASSHTunnelFailure {
     }
 }
 
+@objc enum SASSHAttemptRequestDisposition: Int {
+    case start
+    case queued
+    case ignored
+}
+
 /// Coordinates the stderr-drain boundary for an SSH failure. OpenSSH output is
 /// preferred through pipe EOF, with a bounded fallback for custom binaries or
 /// descendants that retain the inherited stderr writer.
 @objc final class SASSHStderrDrainCoordinator: NSObject {
+    private enum Phase {
+        case ready
+        case running
+        case draining
+        case completing
+    }
+
     private static let defaultTimeout: TimeInterval = 5
 
     private let timeout: TimeInterval
     private let stateLock = NSLock()
     private var reachedEOF = false
-    private var diagnosticsReady = true
+    private var phase = Phase.ready
+    private var pendingAttempt = false
 
     override convenience init() {
         self.init(timeout: Self.defaultTimeout)
@@ -39,26 +53,42 @@ struct SASSHTunnelFailure {
     @objc var failureDiagnosticsReady: Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return diagnosticsReady
+        return phase == .ready || phase == .completing
     }
 
-    /// Atomically begins an attempt only after the prior diagnostics lifecycle
-    /// has completed, preventing stale drain callbacks from reaching a new pipe.
-    @objc func beginAttemptIfReady() -> Bool {
+    /// Atomically starts an idle tunnel, coalesces requests made while failure
+    /// diagnostics drain, and ignores duplicate requests while SSH is running.
+    @objc func requestAttempt() -> SASSHAttemptRequestDisposition {
         stateLock.lock()
-        guard diagnosticsReady else {
-            stateLock.unlock()
-            return false
+        defer { stateLock.unlock() }
+
+        switch phase {
+        case .ready:
+            reachedEOF = false
+            phase = .running
+            return .start
+        case .running:
+            return .ignored
+        case .draining, .completing:
+            pendingAttempt = true
+            return .queued
         }
-        reachedEOF = false
-        diagnosticsReady = false
+    }
+
+    /// Marks the point after which an idle-state reconnect request must be
+    /// retained until the current stderr pipe is finished.
+    @objc func beginStandardErrorDrain() {
+        stateLock.lock()
+        if phase == .running {
+            phase = .draining
+        }
         stateLock.unlock()
-        return true
     }
 
     @objc func finishWithoutStandardErrorPipe() {
         stateLock.lock()
-        diagnosticsReady = true
+        phase = .ready
+        pendingAttempt = false
         stateLock.unlock()
     }
 
@@ -74,7 +104,8 @@ struct SASSHTunnelFailure {
     }
 
     /// Drains the current thread's run loop until stderr reaches EOF or the
-    /// bounded fallback expires. Returns whether EOF was observed.
+    /// bounded fallback expires. The coordinator remains in a completing phase
+    /// so a reconnect cannot clear diagnostics before the delegate snapshots them.
     @objc func finishAfterStandardErrorDrain() -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout)
 
@@ -83,10 +114,29 @@ struct SASSHTunnelFailure {
         }
 
         stateLock.lock()
-        diagnosticsReady = true
         let didReachEOF = reachedEOF
+        phase = .completing
         stateLock.unlock()
+
         return didReachEOF
+    }
+
+    /// Ends the snapshot boundary and atomically reserves a queued reconnect.
+    @objc func completeDrainNotificationAndReservePendingAttempt() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard phase == .completing else { return false }
+
+        let shouldStartPendingAttempt = pendingAttempt
+        pendingAttempt = false
+        if shouldStartPendingAttempt {
+            reachedEOF = false
+            phase = .running
+        } else {
+            phase = .ready
+        }
+        return shouldStartPendingAttempt
     }
 
     private var hasReachedEOF: Bool {

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -40,6 +40,7 @@ struct SASSHTunnelFailure {
     private var reachedEOF = false
     private var phase = Phase.ready
     private var pendingAttempt = false
+    private var cancellationRequested = false
 
     override convenience init() {
         self.init(timeout: Self.defaultTimeout)
@@ -62,6 +63,12 @@ struct SASSHTunnelFailure {
         return pendingAttempt
     }
 
+    @objc var attemptCancellationRequested: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return cancellationRequested
+    }
+
     /// Atomically starts an idle tunnel, coalesces requests made while failure
     /// diagnostics drain, and ignores duplicate requests while SSH is running.
     @objc func requestAttempt() -> SASSHAttemptRequestDisposition {
@@ -71,11 +78,13 @@ struct SASSHTunnelFailure {
         switch phase {
         case .ready:
             reachedEOF = false
+            cancellationRequested = false
             phase = .running
             return .start
         case .running:
             return .ignored
         case .draining, .completing:
+            guard !cancellationRequested else { return .ignored }
             pendingAttempt = true
             return .queued
         }
@@ -95,7 +104,22 @@ struct SASSHTunnelFailure {
         stateLock.lock()
         phase = .ready
         pendingAttempt = false
+        cancellationRequested = false
         stateLock.unlock()
+    }
+
+    /// Cancels either a request waiting behind cleanup or a running lifecycle.
+    /// The latter flag is checked before and immediately after SSH launches.
+    @objc func cancelPendingOrRunningAttempt() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        if phase != .ready {
+            pendingAttempt = false
+            cancellationRequested = true
+            return true
+        }
+        return false
     }
 
     /// Returns whether the one-shot file-handle notification should be re-armed.
@@ -138,8 +162,10 @@ struct SASSHTunnelFailure {
         pendingAttempt = false
         if shouldStartPendingAttempt {
             reachedEOF = false
+            cancellationRequested = false
             phase = .running
         } else {
+            cancellationRequested = false
             phase = .ready
         }
         return shouldStartPendingAttempt

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -42,11 +42,18 @@ struct SASSHTunnelFailure {
         return diagnosticsReady
     }
 
-    @objc func beginAttempt() {
+    /// Atomically begins an attempt only after the prior diagnostics lifecycle
+    /// has completed, preventing stale drain callbacks from reaching a new pipe.
+    @objc func beginAttemptIfReady() -> Bool {
         stateLock.lock()
+        guard diagnosticsReady else {
+            stateLock.unlock()
+            return false
+        }
         reachedEOF = false
         diagnosticsReady = false
         stateLock.unlock()
+        return true
     }
 
     @objc func finishWithoutStandardErrorPipe() {

--- a/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelFailure.swift
@@ -56,6 +56,12 @@ struct SASSHTunnelFailure {
         return phase == .ready || phase == .completing
     }
 
+    @objc var connectionAttemptPending: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return pendingAttempt
+    }
+
     /// Atomically starts an idle tunnel, coalesces requests made while failure
     /// diagnostics drain, and ignores duplicate requests while SSH is running.
     @objc func requestAttempt() -> SASSHAttemptRequestDisposition {

--- a/Source/Other/SSHTunnel/SPSSHTunnel.h
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.h
@@ -84,6 +84,8 @@
 @property (readonly) BOOL taskExitedUnexpectedly;
 /// True once the SSH task's pending stderr callbacks have been drained.
 @property (atomic, readonly) BOOL failureDiagnosticsReady;
+/// True while a reconnect request is queued behind stderr cleanup.
+@property (atomic, readonly) BOOL connectionAttemptPending;
 
 @property (readwrite, retain) IBOutlet NSTextField *sshQuestionText;
 @property (readwrite, retain) IBOutlet NSWindow *sshQuestionDialog;

--- a/Source/Other/SSHTunnel/SPSSHTunnel.h
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.h
@@ -106,6 +106,7 @@
 - (NSUInteger)localPort;
 - (NSUInteger)localPortFallback;
 - (void)connect;
+- (void)disconnectForReconnect;
 - (void)launchTask:(id)dummy;
 - (void)disconnect;
 - (void)standardErrorHandler:(NSNotification*)aNotification;

--- a/Source/Other/SSHTunnel/SPSSHTunnel.h
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.h
@@ -71,6 +71,7 @@
 	BOOL passwordInKeychain;
 	BOOL passwordPromptCancelled;
 	BOOL taskExitedUnexpectedly;
+	BOOL failureDiagnosticsReady;
 	
 	IBOutlet NSWindow *sshQuestionDialog;
 	IBOutlet NSTextField *sshQuestionText;
@@ -82,6 +83,8 @@
 
 @property (readonly) BOOL passwordPromptCancelled;
 @property (readonly) BOOL taskExitedUnexpectedly;
+/// True once the SSH task's pending stderr callbacks have been drained.
+@property (atomic, readonly) BOOL failureDiagnosticsReady;
 
 @property (readwrite, retain) IBOutlet NSTextField *sshQuestionText;
 @property (readwrite, retain) IBOutlet NSWindow *sshQuestionDialog;

--- a/Source/Other/SSHTunnel/SPSSHTunnel.h
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.h
@@ -71,7 +71,6 @@
 	BOOL passwordInKeychain;
 	BOOL passwordPromptCancelled;
 	BOOL taskExitedUnexpectedly;
-	BOOL failureDiagnosticsReady;
 	
 	IBOutlet NSWindow *sshQuestionDialog;
 	IBOutlet NSTextField *sshQuestionText;

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -58,6 +58,8 @@ static unsigned short getRandomPort(void);
 }
 
 - (void)setLastError:(NSString *)msg;
+- (void)startConnectionAttempt;
+- (void)completeStandardErrorDrain;
 
 @end
 
@@ -278,12 +280,27 @@ static unsigned short getRandomPort(void);
 {
     SPLog(@"connect in ssh tunnel connection state = %i", connectionState);
 
-	localPort = 0;
-
-	if (connectionState != SPMySQLProxyIdle || ![standardErrorDrainCoordinator beginAttemptIfReady]){
-		SPLog(@"connect ssh connection is active or still draining diagnostics, returning");
+	if (connectionState != SPMySQLProxyIdle) {
+		SPLog(@"connect ssh connection is active, returning");
 		return;
 	}
+
+	SASSHAttemptRequestDisposition requestDisposition = [standardErrorDrainCoordinator requestAttempt];
+	if (requestDisposition == SASSHAttemptRequestDispositionQueued) {
+		SPLog(@"connect queued until SSH failure diagnostics finish draining");
+		return;
+	}
+	if (requestDisposition == SASSHAttemptRequestDispositionIgnored) {
+		SPLog(@"connect ssh connection attempt is already starting, returning");
+		return;
+	}
+
+	[self startConnectionAttempt];
+}
+
+- (void)startConnectionAttempt
+{
+	localPort = 0;
 
 	[debugMessagesLock lock];
 	[debugMessages removeAllObjects];
@@ -294,6 +311,18 @@ static unsigned short getRandomPort(void);
 	                           target:self
 	                         selector:@selector(launchTask:)
 	                           object:nil];
+}
+
+- (void)completeStandardErrorDrain
+{
+	// Keep the final failure snapshot ahead of any queued attempt, which clears
+	// the diagnostic buffer when it starts.
+	if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:YES];
+
+	if ([standardErrorDrainCoordinator completeDrainNotificationAndReservePendingAttempt]) {
+		SPLog(@"starting SSH connection request queued during diagnostics drain");
+		[self startConnectionAttempt];
+	}
 }
 
 /*
@@ -307,6 +336,7 @@ static unsigned short getRandomPort(void);
 
     if (connectionState != SPMySQLProxyIdle){
         SPLog(@"launch task ssh connection state != SPMySQLProxyIdle, returning");
+		[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
         return;
     }
 
@@ -325,9 +355,9 @@ static unsigned short getRandomPort(void);
 
 		// Enforce a parent window being present for dialogs
 		if (!parentWindow) {
-			connectionState = SPMySQLProxyIdle;
 			[self setLastError:@"SSH Tunnel started without a parent window.  A parent window must be present."];
 			[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
+			connectionState = SPMySQLProxyIdle;
 			if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
             SPLog(@"launchTask SSH Tunnel started without a parent window, returning");
 			return;
@@ -348,9 +378,9 @@ static unsigned short getRandomPort(void);
 
 			// Abort if no local free port could be allocated
 			if (!localPort || (useHostFallback && !localPortFallback)) {
-				connectionState = SPMySQLProxyIdle;
 				[self setLastError:NSLocalizedString(@"No local port could be allocated for the SSH Tunnel.", @"SSH tunnel could not be created because no local port could be allocated")];
 				[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
+				connectionState = SPMySQLProxyIdle;
 				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 SPLog(@"launchTask No local port could be allocated for the SSH Tunnel, returning");
 
@@ -457,10 +487,10 @@ static unsigned short getRandomPort(void);
             }
 
             if(alertMessage != nil) {
-                connectionState = SPMySQLProxyIdle;
                 taskExitedUnexpectedly = YES;
                 [self setLastError:alertMessage];
 				[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
+				connectionState = SPMySQLProxyIdle;
 
                 if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 // Run the run loop for a short time to ensure all task/pipe callbacks are dealt with
@@ -633,6 +663,7 @@ static unsigned short getRandomPort(void);
 
 		// On tunnel close, clean up, ready for re-use if the delegate reconnects.
 		
+		[standardErrorDrainCoordinator beginStandardErrorDrain];
 		
 		// If the task closed unexpectedly, alert appropriately
 		if (connectionState != SPMySQLProxyIdle) {
@@ -654,7 +685,9 @@ static unsigned short getRandomPort(void);
 		// but an exited task is always idle. Notify once more only after the immutable
 		// diagnostics snapshot is safe to take.
 		connectionState = SPMySQLProxyIdle;
-		if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
+		[self performSelectorOnMainThread:@selector(completeStandardErrorDrain)
+		                       withObject:nil
+		                    waitUntilDone:NO];
 
 		
 		
@@ -743,17 +776,20 @@ static unsigned short getRandomPort(void);
 			// Terminal states are published once by launchTask: after stderr has
 			// drained, so automatic reconnects cannot start during cleanup.
 			if ([message rangeOfString:@"bind: Address already in use"].location != NSNotFound) {
+				[standardErrorDrainCoordinator beginStandardErrorDrain];
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel was unable to bind to the local port. This error may occur if you already have an SSH connection to the same server and are using a 'LocalForward' setting in your SSH configuration.\n\nWould you like to fall back to a standard connection to localhost in order to use the existing tunnel?", @"SSH tunnel unable to bind to local port message")];
 			}
 
 			if ([message rangeOfString:@"closed by remote host." ].location != NSNotFound) {
+				[standardErrorDrainCoordinator beginStandardErrorDrain];
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel was closed 'by the remote host'. This may indicate a networking issue or a network timeout.", @"SSH tunnel was closed by remote host message")];
 			}
 			if ([message rangeOfString:@"Permission denied (" ].location != NSNotFound || [message rangeOfString:@"No more authentication methods to try" ].location != NSNotFound) {
+				[standardErrorDrainCoordinator beginStandardErrorDrain];
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel could not authenticate with the remote host. Please check your password and ensure you still have access.", @"SSH tunnel authentication failed message")];
@@ -763,6 +799,7 @@ static unsigned short getRandomPort(void);
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel was established successfully, but could not forward data to the remote port as the remote port refused the connection.", @"SSH tunnel forwarding port connection refused message")];
 			}
 			if ([message rangeOfString:@"Operation timed out" ].location != NSNotFound) {
+				[standardErrorDrainCoordinator beginStandardErrorDrain];
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:[NSString stringWithFormat:NSLocalizedString(@"The SSH Tunnel was unable to connect to host %@, or the request timed out.\n\nBe sure that the address is correct and that you have the necessary privileges, or try increasing the connection timeout (currently %ld seconds).", @"SSH tunnel failed or timed out message"), sshHost, (long)[[[NSUserDefaults standardUserDefaults] objectForKey:SPConnectionTimeoutValue] integerValue]]];

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -339,6 +339,13 @@ static unsigned short getRandomPort(void);
     
     SPLog(@"connection state = %i", connectionState);
 
+	if (standardErrorDrainCoordinator.attemptCancellationRequested) {
+		SPLog(@"launch task cancelled before SSH process setup");
+		connectionState = SPMySQLProxyIdle;
+		[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
+		return;
+	}
+
     if (connectionState != SPMySQLProxyIdle){
         SPLog(@"launch task ssh connection state != SPMySQLProxyIdle, returning");
 		[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
@@ -647,6 +654,9 @@ static unsigned short getRandomPort(void);
 		@try {
 			// Launch and run the tunnel
 			[task SPlaunch]; //throws for invalid paths, missing +x permission
+			if (standardErrorDrainCoordinator.attemptCancellationRequested) {
+				[self abortTask];
+			}
 
 			// Listen for output
 			[task waitUntilExit]; // TODO: this leaks
@@ -705,9 +715,14 @@ static unsigned short getRandomPort(void);
 - (void)disconnect
 {
     SPLog(@"ssh tunnel disconnect");
+	BOOL cancelledQueuedOrRunningAttempt = [standardErrorDrainCoordinator cancelPendingOrRunningAttempt];
 
     if (connectionState == SPMySQLProxyIdle){
-        SPLog(@"disconnect connectionState == SPMySQLProxyIdle, returning without disconnecting");
+		if (cancelledQueuedOrRunningAttempt) {
+			SPLog(@"disconnect cancelled a queued or not-yet-launched SSH attempt");
+		} else {
+			SPLog(@"disconnect connectionState == SPMySQLProxyIdle, returning without disconnecting");
+		}
         return;
     }
 

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -280,16 +280,15 @@ static unsigned short getRandomPort(void);
 
 	localPort = 0;
 
-    if (connectionState != SPMySQLProxyIdle){
-        SPLog(@"connect ssh connection state != SPMySQLProxyIdle, returning");
-        return;
-    }
+	if (connectionState != SPMySQLProxyIdle || ![standardErrorDrainCoordinator beginAttemptIfReady]){
+		SPLog(@"connect ssh connection is active or still draining diagnostics, returning");
+		return;
+	}
 
 	[debugMessagesLock lock];
 	[debugMessages removeAllObjects];
 	[debugMessagesLock unlock];
 	taskExitedUnexpectedly = NO;
-	[standardErrorDrainCoordinator beginAttempt];
 
 	[NSThread detachNewThreadWithName:@"SPSSHTunnel SSH binary communication task"
 	                           target:self

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -739,25 +739,24 @@ static unsigned short getRandomPort(void);
 				connectionState = SPMySQLProxyWaitingForAuth;
 				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			}
-			
+
+			// Terminal states are published once by launchTask: after stderr has
+			// drained, so automatic reconnects cannot start during cleanup.
 			if ([message rangeOfString:@"bind: Address already in use"].location != NSNotFound) {
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel was unable to bind to the local port. This error may occur if you already have an SSH connection to the same server and are using a 'LocalForward' setting in your SSH configuration.\n\nWould you like to fall back to a standard connection to localhost in order to use the existing tunnel?", @"SSH tunnel unable to bind to local port message")];
-				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			}
 
 			if ([message rangeOfString:@"closed by remote host." ].location != NSNotFound) {
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel was closed 'by the remote host'. This may indicate a networking issue or a network timeout.", @"SSH tunnel was closed by remote host message")];
-				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			}
 			if ([message rangeOfString:@"Permission denied (" ].location != NSNotFound || [message rangeOfString:@"No more authentication methods to try" ].location != NSNotFound) {
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:NSLocalizedString(@"The SSH Tunnel could not authenticate with the remote host. Please check your password and ensure you still have access.", @"SSH tunnel authentication failed message")];
-				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			}
 			if ([message rangeOfString:@"connect failed: Connection refused" ].location != NSNotFound) {
 				connectionState = SPMySQLProxyForwardingFailed;
@@ -767,7 +766,6 @@ static unsigned short getRandomPort(void);
 				connectionState = SPMySQLProxyIdle;
                 [self abortTask];
 				[self setLastError:[NSString stringWithFormat:NSLocalizedString(@"The SSH Tunnel was unable to connect to host %@, or the request timed out.\n\nBe sure that the address is correct and that you have the necessary privileges, or try increasing the connection timeout (currently %ld seconds).", @"SSH tunnel failed or timed out message"), sshHost, (long)[[[NSUserDefaults standardUserDefaults] objectForKey:SPConnectionTimeoutValue] integerValue]]];
-				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			}
 		}
 	}

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -60,6 +60,7 @@ static unsigned short getRandomPort(void);
 - (void)setLastError:(NSString *)msg;
 - (void)startConnectionAttempt;
 - (void)completeStandardErrorDrain;
+- (void)disconnectPreservingQueuedReconnect:(BOOL)preserveQueuedReconnect;
 
 @end
 
@@ -715,10 +716,25 @@ static unsigned short getRandomPort(void);
 - (void)disconnect
 {
     SPLog(@"ssh tunnel disconnect");
-	BOOL cancelledQueuedOrRunningAttempt = [standardErrorDrainCoordinator cancelPendingOrRunningAttempt];
+	[self disconnectPreservingQueuedReconnect:NO];
+}
+
+- (void)disconnectForReconnect
+{
+	SPLog(@"ssh tunnel disconnect for reconnect");
+	[self disconnectPreservingQueuedReconnect:YES];
+}
+
+- (void)disconnectPreservingQueuedReconnect:(BOOL)preserveQueuedReconnect
+{
+	BOOL cancelledQueuedOrRunningAttempt = preserveQueuedReconnect
+		? NO
+		: [standardErrorDrainCoordinator cancelPendingOrRunningAttempt];
 
     if (connectionState == SPMySQLProxyIdle){
-		if (cancelledQueuedOrRunningAttempt) {
+		if (preserveQueuedReconnect) {
+			SPLog(@"internal reconnect preserved the queued SSH attempt");
+		} else if (cancelledQueuedOrRunningAttempt) {
 			SPLog(@"disconnect cancelled a queued or not-yet-launched SSH attempt");
 		} else {
 			SPLog(@"disconnect connectionState == SPMySQLProxyIdle, returning without disconnecting");

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -54,6 +54,7 @@ static unsigned short getRandomPort(void);
 	// not re-emitted in every translation unit that reaches SPSSHTunnel.h via
 	// the bridging header. Used only in this file.
 	NSConnection *tunnelConnection;
+	BOOL standardErrorReachedEOF;
 }
 
 @property (atomic, readwrite) BOOL failureDiagnosticsReady;
@@ -286,6 +287,7 @@ static unsigned short getRandomPort(void);
 	[debugMessages removeAllObjects];
 	[debugMessagesLock unlock];
 	taskExitedUnexpectedly = NO;
+	standardErrorReachedEOF = NO;
 	self.failureDiagnosticsReady = NO;
 
 	[NSThread detachNewThreadWithName:@"SPSSHTunnel SSH binary communication task"
@@ -617,6 +619,9 @@ static unsigned short getRandomPort(void);
 		@catch (NSException *e) {
 			connectionState = SPMySQLProxyLaunchFailed;
             SPLog(@"launchTask SSH Tunnel NSException, connectionState = SPMySQLProxyLaunchFailed");
+			// No child owns the pipe after a launch failure, so close the local
+			// writer to let the pending data-available read observe EOF.
+			[[standardError fileHandleForWriting] closeFile];
 
 			// Log the exception. Could be improved by showing a dedicated alert instead
 			[debugMessagesLock lock];
@@ -637,8 +642,11 @@ static unsigned short getRandomPort(void);
             SPLog(@"SSH Tunnel has unexpectedly closed");
 		}
 
-		// Run the run loop for a short time to ensure all task/pipe callbacks are dealt with
-		[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+		// Keep the run loop alive until the one-shot data-available notification
+		// chain has consumed stderr through the pipe's actual EOF.
+		while (!standardErrorReachedEOF) {
+			[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+		}
 
 		[[NSNotificationCenter defaultCenter] removeObserver:self
 		                                                name:NSFileHandleDataAvailableNotification
@@ -772,6 +780,8 @@ static unsigned short getRandomPort(void);
 	// read is the pipe's EOF signal and ends the chain.
 	if ([availableData length]) {
 		[[standardError fileHandleForReading] waitForDataInBackgroundAndNotify]; // TODO: leaks
+	} else {
+		standardErrorReachedEOF = YES;
 	}
 }
 

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -141,6 +141,11 @@ static unsigned short getRandomPort(void);
 	return standardErrorDrainCoordinator.failureDiagnosticsReady;
 }
 
+- (BOOL)connectionAttemptPending
+{
+	return standardErrorDrainCoordinator.connectionAttemptPending;
+}
+
 /*
  * Sets the connection callback selector; a function to be called whenever the tunnel state changes.
  * The callback function will be called and passed this SSH Tunnel object..

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -47,6 +47,7 @@
 #import <netinet/in.h>
 
 static unsigned short getRandomPort(void);
+static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 
 @interface SPSSHTunnel ()
 {
@@ -642,10 +643,14 @@ static unsigned short getRandomPort(void);
             SPLog(@"SSH Tunnel has unexpectedly closed");
 		}
 
-		// Keep the run loop alive until the one-shot data-available notification
-		// chain has consumed stderr through the pipe's actual EOF.
-		while (!standardErrorReachedEOF) {
-			[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+		// Prefer the pipe's actual EOF, but do not let a custom SSH binary or a
+		// descendant that inherited stderr keep the connection attempt stuck.
+		NSDate *standardErrorDrainDeadline = [NSDate dateWithTimeIntervalSinceNow:SPSSHTunnelStderrDrainTimeout];
+		while (!standardErrorReachedEOF && [standardErrorDrainDeadline timeIntervalSinceNow] > 0) {
+			[[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:standardErrorDrainDeadline];
+		}
+		if (!standardErrorReachedEOF) {
+			SPLog(@"Timed out waiting for SSH stderr EOF; using the diagnostics collected so far");
 		}
 
 		[[NSNotificationCenter defaultCenter] removeObserver:self

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -704,12 +704,14 @@ static unsigned short getRandomPort(void);
  */
 - (void)standardErrorHandler:(NSNotification*)aNotification
 {
+	NSData *availableData;
 	NSString *notificationText;
 	NSEnumerator *enumerator;
 	NSArray *messages;
 	NSString *message;
 
-	notificationText = [[NSString alloc] initWithData:[[aNotification object] availableData] encoding:NSASCIIStringEncoding];
+	availableData = [[aNotification object] availableData];
+	notificationText = [[NSString alloc] initWithData:availableData encoding:NSASCIIStringEncoding];
 
 	if ([notificationText length]) {
 		messages = [notificationText componentsSeparatedByString:@"\n"];
@@ -765,7 +767,10 @@ static unsigned short getRandomPort(void);
 		}
 	}
 
-	if (connectionState != SPMySQLProxyIdle && [task isRunning]) {
+	// NSFileHandle data-available notifications are one-shot. Keep re-arming
+	// after terminal-state detection so trailing stderr is consumed; an empty
+	// read is the pipe's EOF signal and ends the chain.
+	if ([availableData length]) {
 		[[standardError fileHandleForReading] waitForDataInBackgroundAndNotify]; // TODO: leaks
 	}
 }

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -47,7 +47,6 @@
 #import <netinet/in.h>
 
 static unsigned short getRandomPort(void);
-static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 
 @interface SPSSHTunnel ()
 {
@@ -55,10 +54,8 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 	// not re-emitted in every translation unit that reaches SPSSHTunnel.h via
 	// the bridging header. Used only in this file.
 	NSConnection *tunnelConnection;
-	BOOL standardErrorReachedEOF;
+	SASSHStderrDrainCoordinator *standardErrorDrainCoordinator;
 }
-
-@property (atomic, readwrite) BOOL failureDiagnosticsReady;
 
 - (void)setLastError:(NSString *)msg;
 
@@ -68,7 +65,6 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 
 @synthesize passwordPromptCancelled;
 @synthesize taskExitedUnexpectedly;
-@synthesize failureDiagnosticsReady;
 @synthesize sshQuestionText, sshQuestionDialog, sshPasswordText, sshPasswordDialog, sshPasswordField;
 /*
  * Initialise with the supplied connection details.  Host, login and port should all be provided.
@@ -97,6 +93,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 		debugMessages = [[NSMutableArray alloc] init];
 		debugMessagesLock = [[NSLock alloc] init];
 		answerAvailableLock = [[NSLock alloc] init];
+		standardErrorDrainCoordinator = [[SASSHStderrDrainCoordinator alloc] init];
 
 		// Enable connection muxing on 10.7+, but only if a preference is enabled; this is because
 		// muxing causes connection instability for a large number of users (see Issue #1457)
@@ -132,10 +129,14 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 		requestedResponse = NO;
 		passwordInKeychain = NO;
 		passwordPromptCancelled = NO;
-		self.failureDiagnosticsReady = YES;
 	}
 
 	return self;
+}
+
+- (BOOL)failureDiagnosticsReady
+{
+	return standardErrorDrainCoordinator.failureDiagnosticsReady;
 }
 
 /*
@@ -288,8 +289,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 	[debugMessages removeAllObjects];
 	[debugMessagesLock unlock];
 	taskExitedUnexpectedly = NO;
-	standardErrorReachedEOF = NO;
-	self.failureDiagnosticsReady = NO;
+	[standardErrorDrainCoordinator beginAttempt];
 
 	[NSThread detachNewThreadWithName:@"SPSSHTunnel SSH binary communication task"
 	                           target:self
@@ -328,7 +328,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 		if (!parentWindow) {
 			connectionState = SPMySQLProxyIdle;
 			[self setLastError:@"SSH Tunnel started without a parent window.  A parent window must be present."];
-			self.failureDiagnosticsReady = YES;
+			[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
 			if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
             SPLog(@"launchTask SSH Tunnel started without a parent window, returning");
 			return;
@@ -351,7 +351,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 			if (!localPort || (useHostFallback && !localPortFallback)) {
 				connectionState = SPMySQLProxyIdle;
 				[self setLastError:NSLocalizedString(@"No local port could be allocated for the SSH Tunnel.", @"SSH tunnel could not be created because no local port could be allocated")];
-				self.failureDiagnosticsReady = YES;
+				[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
 				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 SPLog(@"launchTask No local port could be allocated for the SSH Tunnel, returning");
 
@@ -461,7 +461,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
                 connectionState = SPMySQLProxyIdle;
                 taskExitedUnexpectedly = YES;
                 [self setLastError:alertMessage];
-				self.failureDiagnosticsReady = YES;
+				[standardErrorDrainCoordinator finishWithoutStandardErrorPipe];
 
                 if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 // Run the run loop for a short time to ensure all task/pipe callbacks are dealt with
@@ -643,13 +643,7 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
             SPLog(@"SSH Tunnel has unexpectedly closed");
 		}
 
-		// Prefer the pipe's actual EOF, but do not let a custom SSH binary or a
-		// descendant that inherited stderr keep the connection attempt stuck.
-		NSDate *standardErrorDrainDeadline = [NSDate dateWithTimeIntervalSinceNow:SPSSHTunnelStderrDrainTimeout];
-		while (!standardErrorReachedEOF && [standardErrorDrainDeadline timeIntervalSinceNow] > 0) {
-			[[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:standardErrorDrainDeadline];
-		}
-		if (!standardErrorReachedEOF) {
+		if (![standardErrorDrainCoordinator finishAfterStandardErrorDrain]) {
 			SPLog(@"Timed out waiting for SSH stderr EOF; using the diagnostics collected so far");
 		}
 
@@ -661,7 +655,6 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 		// but an exited task is always idle. Notify once more only after the immutable
 		// diagnostics snapshot is safe to take.
 		connectionState = SPMySQLProxyIdle;
-		self.failureDiagnosticsReady = YES;
 		if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 
 		
@@ -783,10 +776,8 @@ static const NSTimeInterval SPSSHTunnelStderrDrainTimeout = 5.0;
 	// NSFileHandle data-available notifications are one-shot. Keep re-arming
 	// after terminal-state detection so trailing stderr is consumed; an empty
 	// read is the pipe's EOF signal and ends the chain.
-	if ([availableData length]) {
+	if ([standardErrorDrainCoordinator recordStandardErrorReadWithByteCount:[availableData length]]) {
 		[[standardError fileHandleForReading] waitForDataInBackgroundAndNotify]; // TODO: leaks
-	} else {
-		standardErrorReachedEOF = YES;
 	}
 }
 

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -56,6 +56,8 @@ static unsigned short getRandomPort(void);
 	NSConnection *tunnelConnection;
 }
 
+@property (atomic, readwrite) BOOL failureDiagnosticsReady;
+
 - (void)setLastError:(NSString *)msg;
 
 @end
@@ -64,6 +66,7 @@ static unsigned short getRandomPort(void);
 
 @synthesize passwordPromptCancelled;
 @synthesize taskExitedUnexpectedly;
+@synthesize failureDiagnosticsReady;
 @synthesize sshQuestionText, sshQuestionDialog, sshPasswordText, sshPasswordDialog, sshPasswordField;
 /*
  * Initialise with the supplied connection details.  Host, login and port should all be provided.
@@ -127,6 +130,7 @@ static unsigned short getRandomPort(void);
 		requestedResponse = NO;
 		passwordInKeychain = NO;
 		passwordPromptCancelled = NO;
+		self.failureDiagnosticsReady = YES;
 	}
 
 	return self;
@@ -282,6 +286,7 @@ static unsigned short getRandomPort(void);
 	[debugMessages removeAllObjects];
 	[debugMessagesLock unlock];
 	taskExitedUnexpectedly = NO;
+	self.failureDiagnosticsReady = NO;
 
 	[NSThread detachNewThreadWithName:@"SPSSHTunnel SSH binary communication task"
 	                           target:self
@@ -319,8 +324,9 @@ static unsigned short getRandomPort(void);
 		// Enforce a parent window being present for dialogs
 		if (!parentWindow) {
 			connectionState = SPMySQLProxyIdle;
-			if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 			[self setLastError:@"SSH Tunnel started without a parent window.  A parent window must be present."];
+			self.failureDiagnosticsReady = YES;
+			if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
             SPLog(@"launchTask SSH Tunnel started without a parent window, returning");
 			return;
 		}
@@ -341,8 +347,9 @@ static unsigned short getRandomPort(void);
 			// Abort if no local free port could be allocated
 			if (!localPort || (useHostFallback && !localPortFallback)) {
 				connectionState = SPMySQLProxyIdle;
-				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 				[self setLastError:NSLocalizedString(@"No local port could be allocated for the SSH Tunnel.", @"SSH tunnel could not be created because no local port could be allocated")];
+				self.failureDiagnosticsReady = YES;
+				if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 SPLog(@"launchTask No local port could be allocated for the SSH Tunnel, returning");
 
 				return;
@@ -451,6 +458,7 @@ static unsigned short getRandomPort(void);
                 connectionState = SPMySQLProxyIdle;
                 taskExitedUnexpectedly = YES;
                 [self setLastError:alertMessage];
+				self.failureDiagnosticsReady = YES;
 
                 if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
                 // Run the run loop for a short time to ensure all task/pipe callbacks are dealt with
@@ -621,22 +629,27 @@ static unsigned short getRandomPort(void);
 		// On tunnel close, clean up, ready for re-use if the delegate reconnects.
 		
 		
-		[[NSNotificationCenter defaultCenter] removeObserver:self
-		                                                name:NSFileHandleDataAvailableNotification
-		                                              object:nil];
-
 		// If the task closed unexpectedly, alert appropriately
 		if (connectionState != SPMySQLProxyIdle) {
 			connectionState = SPMySQLProxyIdle;
 			taskExitedUnexpectedly = YES;
 			[self setLastError:NSLocalizedString(@"The SSH Tunnel has unexpectedly closed.", @"SSH tunnel unexpectedly closed")];
             SPLog(@"SSH Tunnel has unexpectedly closed");
-
-			if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 		}
 
 		// Run the run loop for a short time to ensure all task/pipe callbacks are dealt with
 		[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+
+		[[NSNotificationCenter defaultCenter] removeObserver:self
+		                                                name:NSFileHandleDataAvailableNotification
+		                                              object:nil];
+
+		// A stderr callback may have observed an intermediate state while draining,
+		// but an exited task is always idle. Notify once more only after the immutable
+		// diagnostics snapshot is safe to take.
+		connectionState = SPMySQLProxyIdle;
+		self.failureDiagnosticsReady = YES;
+		if (delegate) [delegate performSelectorOnMainThread:stateChangeSelector withObject:self waitUntilDone:NO];
 
 		
 		
@@ -752,7 +765,7 @@ static unsigned short getRandomPort(void);
 		}
 	}
 
-	if (connectionState != SPMySQLProxyIdle) {
+	if (connectionState != SPMySQLProxyIdle && [task isRunning]) {
 		[[standardError fileHandleForReading] waitForDataInBackgroundAndNotify]; // TODO: leaks
 	}
 }

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -72,6 +72,16 @@ import Foundation
         self.databaseSelectionError = ""
         super.init()
     }
+
+    static func sshFailure(_ failure: SASSHTunnelFailure) -> SAConnectionResult {
+        return SAConnectionResult(
+            errorTitle: NSLocalizedString("SSH connection failed!", comment: ""),
+            errorMessage: failure.message,
+            errorDetail: failure.errorDetail,
+            sshDebugMessages: failure.debugMessages,
+            connectionType: .sshTunnel
+        )
+    }
 }
 
 /// Connection preferences extracted from NSUserDefaults.
@@ -107,6 +117,8 @@ import Foundation
 /// making it testable and reusable from different UI contexts.
 @objc class SAConnectionService: NSObject {
 
+    private typealias SASSHTunnelCompletion = (SPSSHTunnel?, SASSHTunnelFailure?) -> Void
+
     /// The delegate that receives MySQL connection callbacks (query logging, etc).
     @objc weak var mySQLDelegate: (any SPMySQLConnectionDelegate)?
 
@@ -129,11 +141,11 @@ import Foundation
     private var _activeConnection: SPMySQLConnection?
 
     /// Stored completion for SSH tunnel callback.
-    private var sshTunnelCompletion: ((SPSSHTunnel?, String?) -> Void)? {
+    private var sshTunnelCompletion: SASSHTunnelCompletion? {
         get { stateLock.lock(); defer { stateLock.unlock() }; return _sshTunnelCompletion }
         set { stateLock.lock(); _sshTunnelCompletion = newValue; stateLock.unlock() }
     }
-    private var _sshTunnelCompletion: ((SPSSHTunnel?, String?) -> Void)?
+    private var _sshTunnelCompletion: SASSHTunnelCompletion?
 
     private var cancelled: Bool {
         get { stateLock.lock(); defer { stateLock.unlock() }; return _cancelled }
@@ -180,7 +192,7 @@ import Foundation
         stateLock.unlock()
     }
 
-    private func setSSHTunnelCompletion(_ completion: ((SPSSHTunnel?, String?) -> Void)?, for attemptID: UInt64) {
+    private func setSSHTunnelCompletion(_ completion: SASSHTunnelCompletion?, for attemptID: UInt64) {
         stateLock.lock()
         if activeAttemptID == attemptID && !_cancelled {
             _sshTunnelCompletion = completion
@@ -219,25 +231,21 @@ import Foundation
         }
 
         if info.type == .sshTunnel {
-            establishSSHTunnel(info: info, sshPassword: sshPassword, parentWindow: parentWindow, attemptID: attemptID) { [weak self] (tunnel: SPSSHTunnel?, error: String?) in
+            establishSSHTunnel(info: info, sshPassword: sshPassword, parentWindow: parentWindow, attemptID: attemptID) { [weak self] tunnel, failure in
                 guard let self = self, self.isCurrentAttempt(attemptID)
                 else { return }
                 if let tunnel = tunnel {
                     self.setActiveTunnel(tunnel, for: attemptID)
                     self.connectMySQL(info: info, preferences: preferences, password: password, tunnel: tunnel, attemptID: attemptID, completion: safeCompletion)
-                } else if error == nil {
+                } else if let failure {
+                    let result = SAConnectionResult.sshFailure(failure)
+                    DispatchQueue.main.async { safeCompletion(result) }
+                } else {
                     // User cancelled the SSH password prompt — restore UI silently
                     let result = SAConnectionResult(
                         errorTitle: "", errorMessage: nil, errorDetail: nil
                     )
                     result.userCancelled = true
-                    DispatchQueue.main.async { safeCompletion(result) }
-                } else {
-                    let result = SAConnectionResult(
-                        errorTitle: NSLocalizedString("SSH connection failed!", comment: ""),
-                        errorMessage: error,
-                        errorDetail: nil
-                    )
                     DispatchQueue.main.async { safeCompletion(result) }
                 }
             }
@@ -453,16 +461,17 @@ import Foundation
         sshPassword: String,
         parentWindow: NSWindow?,
         attemptID: UInt64,
-        completion: @escaping (SPSSHTunnel?, String?) -> Void
+        completion: @escaping SASSHTunnelCompletion
     ) {
         guard let sshPort = info.info.sshPortOverride else {
-            completion(
-                nil,
-                NSLocalizedString(
+            let failure = SASSHTunnelFailure(
+                message: NSLocalizedString(
                     "Enter an SSH port between 1 and 65535, or leave it blank to use the SSH configuration.",
                     comment: "Invalid SSH port error"
-                )
+                ),
+                debugMessages: ""
             )
+            completion(nil, failure)
             return
         }
         let remoteSocketPath = info.sshRemoteSocketPath.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -477,7 +486,7 @@ import Foundation
             tunnellingToPort: mysqlPort,
             onHost: mysqlHost
         ) else {
-            completion(nil, "Failed to create SSH tunnel")
+            completion(nil, SASSHTunnelFailure(message: "Failed to create SSH tunnel", debugMessages: ""))
             return
         }
 
@@ -531,11 +540,14 @@ import Foundation
                     || state == SPMySQLProxyLaunchFailed
                     || state == SPMySQLProxyForwardingFailed {
             // SPMySQLProxyIdle covers auth failures, timeouts, permission denied, etc.
-            let error = tunnel.lastError() ?? "SSH tunnel failed"
+            let failure = SASSHTunnelFailure(
+                message: tunnel.lastError() ?? "SSH tunnel failed",
+                debugMessages: tunnel.debugMessages() ?? ""
+            )
             let completion = sshTunnelCompletion
             sshTunnelCompletion = nil
             tunnel.disconnect()
-            completion?(nil, error)
+            completion?(nil, failure)
         }
         // Other transient states (e.g. SPMySQLProxyWaitingForAuth) are ignored;
         // the tunnel will eventually transition to connected or idle/failed.

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -540,6 +540,9 @@ import Foundation
                     || state == SPMySQLProxyLaunchFailed
                     || state == SPMySQLProxyForwardingFailed {
             // SPMySQLProxyIdle covers auth failures, timeouts, permission denied, etc.
+            // SPSSHTunnel can report the terminal state before its background
+            // run loop has drained the final OpenSSH stderr notifications.
+            guard tunnel.failureDiagnosticsReady else { return }
             let failure = SASSHTunnelFailure(
                 message: tunnel.lastError() ?? "SSH tunnel failed",
                 debugMessages: tunnel.debugMessages() ?? ""

--- a/Source/Other/Utility/SAConnectionService.swift
+++ b/Source/Other/Utility/SAConnectionService.swift
@@ -74,11 +74,13 @@ import Foundation
     }
 
     static func sshFailure(_ failure: SASSHTunnelFailure) -> SAConnectionResult {
+        // Initial tunnel failures already carry OpenSSH output as their detail.
+        // sshDebugMessages is reserved for MySQL failures after a tunnel connects,
+        // where the controller uses it to classify a port-forwarding failure.
         return SAConnectionResult(
             errorTitle: NSLocalizedString("SSH connection failed!", comment: ""),
             errorMessage: failure.message,
             errorDetail: failure.errorDetail,
-            sshDebugMessages: failure.debugMessages,
             connectionType: .sshTunnel
         )
     }

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -45,18 +45,19 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
 
-        XCTAssertTrue(coordinator.beginAttemptIfReady())
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
         XCTAssertFalse(coordinator.failureDiagnosticsReady)
-        XCTAssertFalse(coordinator.beginAttemptIfReady())
+        XCTAssertEqual(coordinator.requestAttempt(), .ignored)
 
         coordinator.finishWithoutStandardErrorPipe()
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
-        XCTAssertTrue(coordinator.beginAttemptIfReady())
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
     }
 
     func testStandardErrorReadsRearmUntilEOF() {
         let coordinator = SASSHStderrDrainCoordinator(timeout: 1)
-        XCTAssertTrue(coordinator.beginAttemptIfReady())
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
+        coordinator.beginStandardErrorDrain()
 
         XCTAssertTrue(coordinator.recordStandardErrorRead(byteCount: 128))
         XCTAssertFalse(coordinator.failureDiagnosticsReady)
@@ -64,13 +65,37 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(coordinator.finishAfterStandardErrorDrain())
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
+        XCTAssertFalse(coordinator.completeDrainNotificationAndReservePendingAttempt())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
     }
 
     func testDrainTimeoutStillMakesDiagnosticsReady() {
         let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
-        XCTAssertTrue(coordinator.beginAttemptIfReady())
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
+        coordinator.beginStandardErrorDrain()
 
         XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+        XCTAssertFalse(coordinator.completeDrainNotificationAndReservePendingAttempt())
+    }
+
+    func testAttemptRequestedDuringDrainIsReservedAndCoalesced() {
+        let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
+        coordinator.beginStandardErrorDrain()
+
+        XCTAssertEqual(coordinator.requestAttempt(), .queued)
+        XCTAssertEqual(coordinator.requestAttempt(), .queued)
+
+        XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+        XCTAssertEqual(coordinator.requestAttempt(), .queued)
+
+        XCTAssertTrue(coordinator.completeDrainNotificationAndReservePendingAttempt())
+        XCTAssertFalse(coordinator.failureDiagnosticsReady)
+        XCTAssertEqual(coordinator.requestAttempt(), .ignored)
+
+        coordinator.finishWithoutStandardErrorPipe()
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
     }
 }

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -137,9 +137,32 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
 private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionProxy {
     private let stateLock = NSLock()
+    private var storedConnectCallCount = 0
     private var storedDisconnectCallCount = 0
-    var connectionAttemptPendingValue = false
-    var onConnect: (() -> Void)?
+    private var storedReconnectDisconnectCallCount = 0
+    private var storedConnectionAttemptPending = false
+    private var connectSuppressed = false
+    var suppressConnectAfterOrdinaryDisconnect = false
+    var onConnect: ((Int) -> Void)?
+
+    var connectionAttemptPendingValue: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return storedConnectionAttemptPending
+        }
+        set {
+            stateLock.lock()
+            storedConnectionAttemptPending = newValue
+            stateLock.unlock()
+        }
+    }
+
+    var connectCallCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return storedConnectCallCount
+    }
 
     var disconnectCallCount: Int {
         stateLock.lock()
@@ -147,14 +170,39 @@ private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionP
         return storedDisconnectCallCount
     }
 
+    var reconnectDisconnectCallCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return storedReconnectDisconnectCallCount
+    }
+
     func connect() {
-        onConnect?()
+        stateLock.lock()
+        storedConnectCallCount += 1
+        let connectCallCount = storedConnectCallCount
+        let shouldNotify = !connectSuppressed
+        let onConnect = onConnect
+        stateLock.unlock()
+
+        if shouldNotify {
+            onConnect?(connectCallCount)
+        }
     }
 
     func disconnect() {
         stateLock.lock()
         storedDisconnectCallCount += 1
-        connectionAttemptPendingValue = false
+        storedConnectionAttemptPending = false
+        if suppressConnectAfterOrdinaryDisconnect {
+            connectSuppressed = true
+        }
+        stateLock.unlock()
+    }
+
+    func disconnectForReconnect() {
+        stateLock.lock()
+        storedReconnectDisconnectCallCount += 1
+        storedConnectionAttemptPending = false
         stateLock.unlock()
     }
 
@@ -173,7 +221,7 @@ private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionP
     func connectionAttemptPending() -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return connectionAttemptPendingValue
+        return storedConnectionAttemptPending
     }
 }
 
@@ -195,7 +243,7 @@ final class SAConnectionProxyDisconnectTests: XCTestCase {
         let connectStarted = expectation(description: "proxy connect requested")
         let reconnectFinished = expectation(description: "reconnect returned")
         proxy.connectionAttemptPendingValue = true
-        proxy.onConnect = { connectStarted.fulfill() }
+        proxy.onConnect = { _ in connectStarted.fulfill() }
         connection.setProxy(proxy)
 
         let reconnectThread = Thread {
@@ -222,7 +270,7 @@ final class SAConnectionProxyDisconnectTests: XCTestCase {
         let connectStarted = expectation(description: "proxy connect requested")
         let reconnectFinished = expectation(description: "reconnect returned")
         proxy.connectionAttemptPendingValue = true
-        proxy.onConnect = { connectStarted.fulfill() }
+        proxy.onConnect = { _ in connectStarted.fulfill() }
         connection.setProxy(proxy)
 
         let reconnectThread = Thread {
@@ -240,6 +288,36 @@ final class SAConnectionProxyDisconnectTests: XCTestCase {
             connection.value(forKey: "proxyStateChangeNotificationsIgnored") as? Bool,
             false
         )
+    }
+
+    func testProxyTimeoutPreservesTheFollowingReconnectAttempt() {
+        let connection = SPMySQLConnection()
+        connection.timeout = 0
+        let proxy = SAConnectionProxyDisconnectSpy()
+        let secondConnectStarted = expectation(description: "second proxy connect launched")
+        let reconnectFinished = expectation(description: "reconnect returned")
+        proxy.suppressConnectAfterOrdinaryDisconnect = true
+        proxy.onConnect = { connectCallCount in
+            if connectCallCount == 2 {
+                proxy.connectionAttemptPendingValue = true
+                secondConnectStarted.fulfill()
+            }
+        }
+        connection.setProxy(proxy)
+
+        let reconnectThread = Thread {
+            _ = connection.reconnect()
+            reconnectFinished.fulfill()
+        }
+        reconnectThread.start()
+        wait(for: [secondConnectStarted], timeout: 4)
+
+        reconnectThread.cancel()
+        wait(for: [reconnectFinished], timeout: 2)
+
+        XCTAssertGreaterThanOrEqual(proxy.connectCallCount, 2)
+        XCTAssertGreaterThanOrEqual(proxy.reconnectDisconnectCallCount, 1)
+        XCTAssertGreaterThanOrEqual(proxy.disconnectCallCount, 1)
     }
 }
 

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -136,12 +136,26 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 }
 
 private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionProxy {
-    private(set) var disconnectCallCount = 0
+    private let stateLock = NSLock()
+    private var storedDisconnectCallCount = 0
+    var connectionAttemptPendingValue = false
+    var onConnect: (() -> Void)?
 
-    func connect() {}
+    var disconnectCallCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return storedDisconnectCallCount
+    }
+
+    func connect() {
+        onConnect?()
+    }
 
     func disconnect() {
-        disconnectCallCount += 1
+        stateLock.lock()
+        storedDisconnectCallCount += 1
+        connectionAttemptPendingValue = false
+        stateLock.unlock()
     }
 
     func state() -> SPMySQLConnectionProxyState {
@@ -155,6 +169,12 @@ private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionP
     func setConnectionStateChange(_ selector: Selector!, delegate: Any!) -> Bool {
         true
     }
+
+    func connectionAttemptPending() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return connectionAttemptPendingValue
+    }
 }
 
 final class SAConnectionProxyDisconnectTests: XCTestCase {
@@ -167,6 +187,32 @@ final class SAConnectionProxyDisconnectTests: XCTestCase {
         connection.disconnect()
 
         XCTAssertEqual(proxy.disconnectCallCount, 1)
+    }
+
+    func testCancelledReconnectCancelsPendingProxyAttemptAndRestoresNotifications() {
+        let connection = SPMySQLConnection()
+        let proxy = SAConnectionProxyDisconnectSpy()
+        let connectStarted = expectation(description: "proxy connect requested")
+        let reconnectFinished = expectation(description: "reconnect returned")
+        proxy.connectionAttemptPendingValue = true
+        proxy.onConnect = { connectStarted.fulfill() }
+        connection.setProxy(proxy)
+
+        let reconnectThread = Thread {
+            _ = connection.reconnect()
+            reconnectFinished.fulfill()
+        }
+        reconnectThread.start()
+        wait(for: [connectStarted], timeout: 2)
+
+        reconnectThread.cancel()
+        wait(for: [reconnectFinished], timeout: 2)
+
+        XCTAssertEqual(proxy.disconnectCallCount, 1)
+        XCTAssertEqual(
+            connection.value(forKey: "proxyStateChangeNotificationsIgnored") as? Bool,
+            false
+        )
     }
 }
 

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -45,16 +45,18 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
 
-        coordinator.beginAttempt()
+        XCTAssertTrue(coordinator.beginAttemptIfReady())
         XCTAssertFalse(coordinator.failureDiagnosticsReady)
+        XCTAssertFalse(coordinator.beginAttemptIfReady())
 
         coordinator.finishWithoutStandardErrorPipe()
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
+        XCTAssertTrue(coordinator.beginAttemptIfReady())
     }
 
     func testStandardErrorReadsRearmUntilEOF() {
         let coordinator = SASSHStderrDrainCoordinator(timeout: 1)
-        coordinator.beginAttempt()
+        XCTAssertTrue(coordinator.beginAttemptIfReady())
 
         XCTAssertTrue(coordinator.recordStandardErrorRead(byteCount: 128))
         XCTAssertFalse(coordinator.failureDiagnosticsReady)
@@ -66,7 +68,7 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
     func testDrainTimeoutStillMakesDiagnosticsReady() {
         let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
-        coordinator.beginAttempt()
+        XCTAssertTrue(coordinator.beginAttemptIfReady())
 
         XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
         XCTAssertTrue(coordinator.failureDiagnosticsReady)

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -86,12 +86,15 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(coordinator.requestAttempt(), .queued)
         XCTAssertEqual(coordinator.requestAttempt(), .queued)
+        XCTAssertTrue(coordinator.connectionAttemptPending)
 
         XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
         XCTAssertEqual(coordinator.requestAttempt(), .queued)
+        XCTAssertTrue(coordinator.connectionAttemptPending)
 
         XCTAssertTrue(coordinator.completeDrainNotificationAndReservePendingAttempt())
+        XCTAssertFalse(coordinator.connectionAttemptPending)
         XCTAssertFalse(coordinator.failureDiagnosticsReady)
         XCTAssertEqual(coordinator.requestAttempt(), .ignored)
 

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -214,6 +214,33 @@ final class SAConnectionProxyDisconnectTests: XCTestCase {
             false
         )
     }
+
+    func testExplicitDisconnectEndsPendingReconnectWithoutWaitingForTimeout() {
+        let connection = SPMySQLConnection()
+        connection.timeout = 5
+        let proxy = SAConnectionProxyDisconnectSpy()
+        let connectStarted = expectation(description: "proxy connect requested")
+        let reconnectFinished = expectation(description: "reconnect returned")
+        proxy.connectionAttemptPendingValue = true
+        proxy.onConnect = { connectStarted.fulfill() }
+        connection.setProxy(proxy)
+
+        let reconnectThread = Thread {
+            _ = connection.reconnect()
+            reconnectFinished.fulfill()
+        }
+        reconnectThread.start()
+        wait(for: [connectStarted], timeout: 2)
+
+        connection.disconnect()
+        wait(for: [reconnectFinished], timeout: 2)
+
+        XCTAssertGreaterThanOrEqual(proxy.disconnectCallCount, 1)
+        XCTAssertEqual(
+            connection.value(forKey: "proxyStateChangeNotificationsIgnored") as? Bool,
+            false
+        )
+    }
 }
 
 // MARK: - Connection Info Parameter Mapping Tests

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -2,12 +2,41 @@
 //  SAConnectionServiceTests.swift
 //  Unit Tests
 //
-//  Tests for the connection info → service parameter mapping.
+//  Tests for the connection service's pure Swift support types and
+//  connection info → service parameter mapping.
 //  SAConnectionResult and SAConnectionPreferences live in the app target
 //  (depend on SPMySQL), so they're tested via integration, not here.
 //
 
 import XCTest
+
+// MARK: - SSH Tunnel Failure Tests
+
+final class SASSHTunnelFailureTests: XCTestCase {
+
+    func testSSHFailurePreservesTunnelDiagnostics() {
+        let debugMessages = """
+        debug1: Connecting to jump.local [192.168.1.8] port 22.
+        ssh: connect to host jump.local port 22: No route to host
+        """
+
+        let failure = SASSHTunnelFailure(
+            message: "The SSH Tunnel has unexpectedly closed.",
+            debugMessages: debugMessages
+        )
+
+        XCTAssertEqual(failure.message, "The SSH Tunnel has unexpectedly closed.")
+        XCTAssertEqual(failure.errorDetail, debugMessages)
+        XCTAssertEqual(failure.debugMessages, debugMessages)
+    }
+
+    func testSSHFailureOmitsEmptyTunnelDiagnosticsFromDetail() {
+        let failure = SASSHTunnelFailure(message: "Failed to create SSH tunnel", debugMessages: "")
+
+        XCTAssertNil(failure.errorDetail)
+        XCTAssertEqual(failure.debugMessages, "")
+    }
+}
 
 // MARK: - Connection Info Parameter Mapping Tests
 

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -101,6 +101,37 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
         coordinator.finishWithoutStandardErrorPipe()
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
     }
+
+    func testQueuedAttemptCanBeCancelledBeforeReservation() {
+        let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
+        coordinator.beginStandardErrorDrain()
+        XCTAssertEqual(coordinator.requestAttempt(), .queued)
+
+        XCTAssertTrue(coordinator.cancelPendingOrRunningAttempt())
+        XCTAssertFalse(coordinator.connectionAttemptPending)
+        XCTAssertTrue(coordinator.attemptCancellationRequested)
+        XCTAssertEqual(coordinator.requestAttempt(), .ignored)
+        XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertFalse(coordinator.completeDrainNotificationAndReservePendingAttempt())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
+
+    func testReservedAttemptCancellationIsObservedBeforeLaunch() {
+        let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
+        XCTAssertEqual(coordinator.requestAttempt(), .start)
+        coordinator.beginStandardErrorDrain()
+        XCTAssertEqual(coordinator.requestAttempt(), .queued)
+        XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertTrue(coordinator.completeDrainNotificationAndReservePendingAttempt())
+
+        XCTAssertTrue(coordinator.cancelPendingOrRunningAttempt())
+        XCTAssertTrue(coordinator.attemptCancellationRequested)
+
+        coordinator.finishWithoutStandardErrorPipe()
+        XCTAssertFalse(coordinator.attemptCancellationRequested)
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
 }
 
 // MARK: - Connection Info Parameter Mapping Tests

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -9,6 +9,7 @@
 //
 
 import XCTest
+import SPMySQL
 
 // MARK: - SSH Tunnel Failure Tests
 
@@ -131,6 +132,41 @@ final class SASSHStderrDrainCoordinatorTests: XCTestCase {
         coordinator.finishWithoutStandardErrorPipe()
         XCTAssertFalse(coordinator.attemptCancellationRequested)
         XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
+}
+
+private final class SAConnectionProxyDisconnectSpy: NSObject, SPMySQLConnectionProxy {
+    private(set) var disconnectCallCount = 0
+
+    func connect() {}
+
+    func disconnect() {
+        disconnectCallCount += 1
+    }
+
+    func state() -> SPMySQLConnectionProxyState {
+        SPMySQLProxyIdle
+    }
+
+    func localPort() -> UInt {
+        0
+    }
+
+    func setConnectionStateChange(_ selector: Selector!, delegate: Any!) -> Bool {
+        true
+    }
+}
+
+final class SAConnectionProxyDisconnectTests: XCTestCase {
+
+    func testDisconnectReachesProxyWhenMySQLConnectionIsAlreadyInactive() {
+        let connection = SPMySQLConnection()
+        let proxy = SAConnectionProxyDisconnectSpy()
+        connection.setProxy(proxy)
+
+        connection.disconnect()
+
+        XCTAssertEqual(proxy.disconnectCallCount, 1)
     }
 }
 

--- a/UnitTests/SAConnectionServiceTests.swift
+++ b/UnitTests/SAConnectionServiceTests.swift
@@ -38,6 +38,41 @@ final class SASSHTunnelFailureTests: XCTestCase {
     }
 }
 
+final class SASSHStderrDrainCoordinatorTests: XCTestCase {
+
+    func testAttemptLifecycleControlsDiagnosticsReadiness() {
+        let coordinator = SASSHStderrDrainCoordinator()
+
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+
+        coordinator.beginAttempt()
+        XCTAssertFalse(coordinator.failureDiagnosticsReady)
+
+        coordinator.finishWithoutStandardErrorPipe()
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
+
+    func testStandardErrorReadsRearmUntilEOF() {
+        let coordinator = SASSHStderrDrainCoordinator(timeout: 1)
+        coordinator.beginAttempt()
+
+        XCTAssertTrue(coordinator.recordStandardErrorRead(byteCount: 128))
+        XCTAssertFalse(coordinator.failureDiagnosticsReady)
+        XCTAssertFalse(coordinator.recordStandardErrorRead(byteCount: 0))
+
+        XCTAssertTrue(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
+
+    func testDrainTimeoutStillMakesDiagnosticsReady() {
+        let coordinator = SASSHStderrDrainCoordinator(timeout: 0)
+        coordinator.beginAttempt()
+
+        XCTAssertFalse(coordinator.finishAfterStandardErrorDrain())
+        XCTAssertTrue(coordinator.failureDiagnosticsReady)
+    }
+}
+
 // MARK: - Connection Info Parameter Mapping Tests
 
 /// Tests connection parameter storage and the pure Swift mappings that

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -457,7 +457,9 @@
 		624E13DFBB2F343500B94705 /* SADatabaseScopedValueCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81815809CB9EBE53E9D2AA2A /* SADatabaseScopedValueCacheTests.swift */; };
 		65F52CC824AE21D600FED3CB /* SPFilePreferencePane.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */; };
 		6ABF364B03D0324617CFABCC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
+		6C5D707FD9947026F90C868A /* SASSHTunnelFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97F8957A557F13C063625AE /* SASSHTunnelFailure.swift */; };
 		6CB1977AAE8D7D64B7593E66 /* SPBundleManagerAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */; };
+		6E60DF55568BE1B2F63D74E3 /* SASSHTunnelFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97F8957A557F13C063625AE /* SASSHTunnelFailure.swift */; };
 		6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */; };
 		6F0EA9242734ABE200514FF1 /* SABundleRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA9232734ABE200514FF1 /* SABundleRunner.m */; };
 		72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */; };
@@ -1521,6 +1523,7 @@
 		F3A4B8C191E14E7094C9B006 /* AWSDirectoryBookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDirectoryBookmarkManager.swift; sourceTree = "<group>"; };
 		F4C0BDAE2E9F4D5E8A1B0201 /* SecureBookmarkManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBookmarkManagerStub.swift; sourceTree = "<group>"; };
 		F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteStore.swift; sourceTree = "<group>"; };
+		F97F8957A557F13C063625AE /* SASSHTunnelFailure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SASSHTunnelFailure.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E01 /* VaultClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClient.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E02 /* VaultClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultClientTests.swift; sourceTree = "<group>"; };
 		FA1B2C3D4E5F6A7B8C9D0E03 /* VaultOIDCHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultOIDCHandler.swift; sourceTree = "<group>"; };
@@ -2333,6 +2336,7 @@
 				58CDB32E0FCE138D00F8ACA3 /* SPSSHTunnel.h */,
 				58CDB32F0FCE138D00F8ACA3 /* SPSSHTunnel.m */,
 				58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */,
+				F97F8957A557F13C063625AE /* SASSHTunnelFailure.swift */,
 			);
 			name = "SSH Tunnel";
 			path = SSHTunnel;
@@ -3542,6 +3546,7 @@
 				302DF8917DC7950ACEC08BEB /* SAQueryFavoriteStoreTests.swift in Sources */,
 				5BA8A1F0564883162D4A80F2 /* SAUserManagerPrivilegeNormalizer.swift in Sources */,
 				4C74760160E21F5256343A70 /* SAUserManagerPrivilegeNormalizerTests.swift in Sources */,
+				6E60DF55568BE1B2F63D74E3 /* SASSHTunnelFailure.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3862,6 +3867,7 @@
 				8E9430236D26BB3D6FFCD99E /* SAQueryFavoriteSaveWindowController.swift in Sources */,
 				14F0CC5AC96DE9CCC0213237 /* SAUserManagerPrivilegeNormalizer.swift in Sources */,
 				A69CC1B9E445E5FCF1484A09 /* SAAnalyticsConsentPolicy+Firebase.swift in Sources */,
+				6C5D707FD9947026F90C868A /* SASSHTunnelFailure.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- Preserve the SSH tunnel user-facing error and complete OpenSSH stderr together across the connection-service boundary.
- Coordinate stderr draining and reconnect requests in the Swift `SASSHStderrDrainCoordinator`: prefer actual pipe EOF, use a bounded fallback when a custom binary or descendant retains stderr, and queue reconnects until the final diagnostics snapshot is complete.
- Preserve automatic-reconnect semantics by excluding queued cleanup time from the proxy timeout, distinguishing internal reconnect teardown from explicit disconnects, preserving the next retry after an internal proxy timeout, cancelling queued/reserved attempts even when the MySQL side is already inactive, and cleaning up preserved proxy work when a reconnect thread is cancelled or the user explicitly disconnects.
- Keep the new framework reconnect decisions, timeout exclusions, and proxy teardown routing in the Swift `SAProxyReconnectCoordinator`, leaving Objective-C as the bridge to the legacy connection lock and state ivars.
- Carry the diagnostics through `SAConnectionResult` without reclassifying initial SSH failures as port-forwarding failures, honor `errorDetail` in the legacy controller, and add regression coverage for populated/empty payloads plus drain readiness, EOF, timeout, reconnect queueing, and cancellation.

## Closes following issues:
- Closes: N/A

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English (no new strings)
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

- `Sequel Ace Debug` build: passed.
- Focused SSH failure, drain-coordinator, proxy-disconnect, timeout-retry, and reconnect-cancellation regression tests: 12 passed, 0 failed.
- Full Unit Tests scheme: 1,151 passed, 60 environment-skipped, 0 failed (1,211 total).
- `Localizable.strings`, project-file lint, and `git diff --check`: passed.
- Manual regression matrix with the same stored private SSH-key favorite:
  - App Store 5.4.0: connected.
  - 5.5.0 source built as Debug: connected.
  - Clean exact `origin/main` in an isolated worktree: connected.
  - A fresh Debug build of this PR head from a new DerivedData identity: connected.
  - The affected original Debug executable identity: macOS denied the route; the patched diagnostics path presented the existing Local Network recovery alert instead of an SSH-key-looking generic failure.

## Screenshots:

N/A — no new visual UI.

## Additional notes:

The reported connection failure was not caused by a recent SSH command, key-selection, or authentication change. macOS unified logging identified the failing executable path as `Local network prohibited` and `Local network denied by preference`, while clean builds of the same source and released builds were allowed. Multiple installed copies shared the same bundle identifier but had different executable UUIDs. Apple documents that macOS Local Network privacy tracks the app code signature and main-executable UUID, and that multiple installed versions can produce unexpected System Settings behavior: https://developer.apple.com/documentation/Technotes/tn3179-understanding-local-network-privacy

That OS privacy state cannot be repaired or bypassed by Sequel Ace. The application bug addressed here is narrower: the connection-service path reduced the SSH failure to `lastError()` and discarded the OpenSSH diagnostics, so routing, configuration, and authentication failures all appeared unnecessarily generic. This PR preserves the completed stderr stream without changing SSH command construction, key handling, or successful connection behavior.

Reconnect requests that arrive during diagnostics cleanup are queued until the final diagnostics snapshot is complete. Internal reconnect teardown and internal proxy timeouts preserve the queued reconnect. Explicit teardown cancels queued or running attempts. The reviewed changes do not introduce a queued-recovery cancellation path, a stuck-connecting path, or a 10-second cancellation delay.

The remaining risk is intentional. Failure completion can wait for stderr pipe EOF to preserve the final diagnostics snapshot. If EOF is unavailable because stderr remains retained, the drain uses a five-second fallback. This bounded wait does not delay cancellation of a queued reconnect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection failures now display detailed diagnostic information when available.
  * SSH tunnel errors preserve user-facing messages and technical debugging output.
  * Failure reporting waits for final diagnostics, improving error accuracy.
  * SSH diagnostic output is collected more reliably, including unexpected tunnel closures.
  * Reconnect requests are queued reliably during diagnostic cleanup.
  * Duplicate connection attempts are ignored while another attempt is active.
  * Pending reconnects can be cancelled before launch or ended by an explicit disconnect.
  * User-cancelled SSH connections remain silent as expected.
  * Connection timeouts are handled more accurately while waiting for proxy authentication or a pending reconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




