### PR TITLE
#infra SSH tunnel IPC migration step 2: the shared wire format

### DIFF
--- a/Source/Other/SSHTunnel/SASSHTunnelAuthMessage.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAuthMessage.swift
@@ -1,0 +1,166 @@
+//
+//  SASSHTunnelAuthMessage.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+// The wire contract between the SSH tunnel and its askpass assistant —
+// Step 2 of docs/development/ssh-tunnel-xpc-migration-plan.md.
+//
+// Compiled into the app, the SequelAceTunnelAssistant tool and the Unit
+// Tests target, so: pure Foundation, no project Objective-C types, and
+// nothing here needs to be `public` (the assistant's Objective-C `main`
+// never touches these types directly).
+
+/// The one thing an askpass launch asks the app. ssh execs the assistant
+/// once per prompt, so a connection carries exactly one request and one
+/// response.
+enum SASSHTunnelAuthRequest: Equatable {
+    /// A yes/no question — host key mismatches and the like.
+    case question(String)
+    /// The SSH password the app holds (in memory or in the keychain).
+    case password(verificationHash: String)
+    /// A key passphrase, a SecurID code, or any other prompt ssh raises.
+    case query(String, verificationHash: String)
+}
+
+enum SASSHTunnelAuthResponse: Equatable {
+    /// The answer to a `question`.
+    case answer(Bool)
+    /// The secret for a `password` or `query` request.
+    case secret(String)
+    /// No secret: wrong hash, nothing stored, or the user cancelled. The
+    /// assistant exits non-zero (or, for a keychain miss, re-asks through the
+    /// GUI) — never prints an empty line for ssh to read as an empty password.
+    case refused
+}
+
+enum SASSHTunnelAuthWireError: Error, Equatable {
+    case malformed
+    case unsupportedVersion(Int)
+    case unknownKind(String)
+    case missingField(String)
+}
+
+/// Line-delimited JSON: one object per line, no raw newlines inside a line
+/// (JSON escapes them, and ssh prompts do contain them). Keys are sorted so
+/// the encoding is byte-stable and the fixtures in the tests can pin it.
+///
+/// Every message carries `v`, currently 1. A reader refuses any other
+/// version rather than guessing.
+enum SASSHTunnelAuthWire {
+
+    static let version = 1
+
+    // MARK: Encoding
+
+    static func encode(_ request: SASSHTunnelAuthRequest) -> Data {
+        switch request {
+        case .question(let text):
+            return encode(["kind": "question", "text": text])
+        case .password(let verificationHash):
+            return encode(["kind": "password", "hash": verificationHash])
+        case .query(let text, let verificationHash):
+            return encode(["kind": "query", "text": text, "hash": verificationHash])
+        }
+    }
+
+    static func encode(_ response: SASSHTunnelAuthResponse) -> Data {
+        switch response {
+        case .answer(let answer):
+            return encode(["kind": "answer", "answer": answer])
+        case .secret(let secret):
+            return encode(["kind": "secret", "secret": secret])
+        case .refused:
+            return encode(["kind": "refused"])
+        }
+    }
+
+    private static func encode(_ fields: [String: Any]) -> Data {
+        var object = fields
+        object["v"] = version
+        // Only strings, bools and an Int go in, so serialization cannot fail.
+        var data = (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])) ?? Data()
+        data.append(0x0A)
+        return data
+    }
+
+    // MARK: Decoding
+
+    static func decodeRequest(_ line: Data) throws -> SASSHTunnelAuthRequest {
+        let object = try decodeObject(line)
+        switch try kind(of: object) {
+        case "question":
+            return .question(try string("text", in: object))
+        case "password":
+            return .password(verificationHash: try string("hash", in: object))
+        case "query":
+            return .query(try string("text", in: object), verificationHash: try string("hash", in: object))
+        case let other:
+            throw SASSHTunnelAuthWireError.unknownKind(other)
+        }
+    }
+
+    static func decodeResponse(_ line: Data) throws -> SASSHTunnelAuthResponse {
+        let object = try decodeObject(line)
+        switch try kind(of: object) {
+        case "answer":
+            guard let answer = object["answer"] as? Bool else { throw SASSHTunnelAuthWireError.missingField("answer") }
+            return .answer(answer)
+        case "secret":
+            return .secret(try string("secret", in: object))
+        case "refused":
+            return .refused
+        case let other:
+            throw SASSHTunnelAuthWireError.unknownKind(other)
+        }
+    }
+
+    private static func decodeObject(_ line: Data) throws -> [String: Any] {
+        var trimmed = line
+        while trimmed.last == 0x0A || trimmed.last == 0x0D { trimmed.removeLast() }
+        guard !trimmed.isEmpty,
+              let parsed = try? JSONSerialization.jsonObject(with: trimmed),
+              let object = parsed as? [String: Any] else {
+            throw SASSHTunnelAuthWireError.malformed
+        }
+        guard let version = object["v"] as? Int else { throw SASSHTunnelAuthWireError.missingField("v") }
+        guard version == Self.version else { throw SASSHTunnelAuthWireError.unsupportedVersion(version) }
+        return object
+    }
+
+    private static func kind(of object: [String: Any]) throws -> String {
+        try string("kind", in: object)
+    }
+
+    private static func string(_ key: String, in object: [String: Any]) throws -> String {
+        guard let value = object[key] as? String else { throw SASSHTunnelAuthWireError.missingField(key) }
+        return value
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelAuthMessage.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAuthMessage.swift
@@ -131,8 +131,7 @@ enum SASSHTunnelAuthWire {
         let object = try decodeObject(line)
         switch try kind(of: object) {
         case "answer":
-            guard let answer = object["answer"] as? Bool else { throw SASSHTunnelAuthWireError.missingField("answer") }
-            return .answer(answer)
+            return .answer(try bool("answer", in: object))
         case "secret":
             return .secret(try string("secret", in: object))
         case "refused":
@@ -150,7 +149,7 @@ enum SASSHTunnelAuthWire {
               let object = parsed as? [String: Any] else {
             throw SASSHTunnelAuthWireError.malformed
         }
-        guard let version = object["v"] as? Int else { throw SASSHTunnelAuthWireError.missingField("v") }
+        let version = try int("v", in: object)
         guard version == Self.version else { throw SASSHTunnelAuthWireError.unsupportedVersion(version) }
         return object
     }
@@ -162,5 +161,27 @@ enum SASSHTunnelAuthWire {
     private static func string(_ key: String, in object: [String: Any]) throws -> String {
         guard let value = object[key] as? String else { throw SASSHTunnelAuthWireError.missingField(key) }
         return value
+    }
+
+    // JSONSerialization hands back NSNumber for every scalar, and Swift's
+    // bridging happily reads 1 as true and true as 1. A mistyped field must
+    // fail, not coerce (Codex review on the wire format), so the underlying
+    // JSON type is checked: a Bool must be a JSON boolean, an Int a JSON
+    // integer.
+
+    private static func bool(_ key: String, in object: [String: Any]) throws -> Bool {
+        guard let number = object[key] as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() else {
+            throw SASSHTunnelAuthWireError.missingField(key)
+        }
+        return number.boolValue
+    }
+
+    private static func int(_ key: String, in object: [String: Any]) throws -> Int {
+        guard let number = object[key] as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID(),
+              !CFNumberIsFloatType(number) else {
+            throw SASSHTunnelAuthWireError.missingField(key)
+        }
+        return number.intValue
     }
 }

--- a/Source/Other/SSHTunnel/SASSHTunnelAuthService.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAuthService.swift
@@ -93,6 +93,22 @@ import Foundation
         return source.promptForPassword(forQuery: query)
     }
 
+    // MARK: - Wire dispatch
+
+    /// The socket transport's entry point: one request in, one response out,
+    /// mapped onto the three calls above. Transport-agnostic on purpose so
+    /// the server stays plumbing only (SSH tunnel IPC plan, Step 2).
+    func handle(_ request: SASSHTunnelAuthRequest) -> SASSHTunnelAuthResponse {
+        switch request {
+        case .question(let text):
+            return .answer(response(forQuestion: text))
+        case .password(let verificationHash):
+            return password(verificationHash: verificationHash).map { .secret($0) } ?? .refused
+        case .query(let text, let verificationHash):
+            return password(forQuery: text, verificationHash: verificationHash).map { .secret($0) } ?? .refused
+        }
+    }
+
     // MARK: - Stored passphrases
 
     /// The stored `"SSH"/<key name>` passphrase for an askpass query, or nil

--- a/UnitTests/SASSHTunnelAuthMessageTests.swift
+++ b/UnitTests/SASSHTunnelAuthMessageTests.swift
@@ -1,0 +1,184 @@
+//
+//  SASSHTunnelAuthMessageTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+/// Pins the tunnel/assistant wire format byte for byte (Step 2 of the SSH
+/// tunnel IPC plan). A fixture changing here means the format changed, which
+/// means both ends must ship together.
+final class SASSHTunnelAuthMessageTests: XCTestCase {
+
+    private func line(_ text: String) -> Data { Data((text + "\n").utf8) }
+
+    // MARK: - Request fixtures
+
+    func testQuestionRequestEncoding() {
+        let request = SASSHTunnelAuthRequest.question("Are you sure you want to continue connecting (yes/no/[fingerprint])? ")
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(request),
+                       line(#"{"kind":"question","text":"Are you sure you want to continue connecting (yes/no/[fingerprint])? ","v":1}"#))
+    }
+
+    func testPasswordRequestEncoding() {
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.password(verificationHash: "1234567890")),
+                       line(#"{"hash":"1234567890","kind":"password","v":1}"#))
+    }
+
+    func testQueryRequestEncoding() {
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.query("Enter passphrase for key '/Users/me/.ssh/id_ed25519': ", verificationHash: "42")),
+                       line(#"{"hash":"42","kind":"query","text":"Enter passphrase for key '/Users/me/.ssh/id_ed25519': ","v":1}"#))
+    }
+
+    // MARK: - Response fixtures
+
+    func testAnswerResponseEncoding() {
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.answer(true)), line(#"{"answer":true,"kind":"answer","v":1}"#))
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.answer(false)), line(#"{"answer":false,"kind":"answer","v":1}"#))
+    }
+
+    func testSecretResponseEncoding() {
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.secret("hunter2")), line(#"{"kind":"secret","secret":"hunter2","v":1}"#))
+    }
+
+    func testRefusedResponseEncoding() {
+        XCTAssertEqual(SASSHTunnelAuthWire.encode(.refused), line(#"{"kind":"refused","v":1}"#))
+    }
+
+    // MARK: - Round trips
+
+    func testEveryRequestRoundTrips() throws {
+        let requests: [SASSHTunnelAuthRequest] = [
+            .question("q"),
+            .password(verificationHash: "h"),
+            .query("text", verificationHash: "h"),
+        ]
+        for request in requests {
+            XCTAssertEqual(try SASSHTunnelAuthWire.decodeRequest(SASSHTunnelAuthWire.encode(request)), request)
+        }
+    }
+
+    func testEveryResponseRoundTrips() throws {
+        let responses: [SASSHTunnelAuthResponse] = [.answer(true), .answer(false), .secret("s"), .secret(""), .refused]
+        for response in responses {
+            XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(SASSHTunnelAuthWire.encode(response)), response)
+        }
+    }
+
+    func testMultilinePromptsAndUnicodeStayOnOneLine() throws {
+        let prompt = "The authenticity of host 'db (10.0.0.1)' can't be established.\nED25519 key fingerprint is SHA256:abc/def+ghi=.\nAre you sure you want to continue connecting (yes/no/[fingerprint])? "
+        let secret = "pässwörd \u{1F511} \"quoted\" back\\slash"
+        let encodedPrompt = SASSHTunnelAuthWire.encode(.question(prompt))
+        let encodedSecret = SASSHTunnelAuthWire.encode(.secret(secret))
+
+        // Exactly one newline each, at the very end.
+        XCTAssertEqual(encodedPrompt.filter { $0 == 0x0A }.count, 1)
+        XCTAssertEqual(encodedPrompt.last, 0x0A)
+        XCTAssertEqual(encodedSecret.filter { $0 == 0x0A }.count, 1)
+
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeRequest(encodedPrompt), .question(prompt))
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(encodedSecret), .secret(secret))
+    }
+
+    func testTrailingCarriageReturnAndMissingNewlineAreTolerated() throws {
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(Data(#"{"kind":"refused","v":1}"#.utf8)), .refused)
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(Data("{\"kind\":\"refused\",\"v\":1}\r\n".utf8)), .refused)
+    }
+
+    // MARK: - Refusals
+
+    func testGarbageIsMalformed() {
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(Data())) { XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .malformed) }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(Data("not json\n".utf8))) { XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .malformed) }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(Data("[1,2]\n".utf8))) { XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .malformed) }
+    }
+
+    func testOtherVersionsAreRefusedNotGuessed() {
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(line(#"{"kind":"question","text":"q","v":2}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .unsupportedVersion(2))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(#"{"kind":"refused"}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("v"))
+        }
+    }
+
+    func testUnknownKindsAreRefused() {
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(line(#"{"kind":"disconnect","v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .unknownKind("disconnect"))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(#"{"kind":"question","text":"q","v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .unknownKind("question"))
+        }
+    }
+
+    func testMissingFieldsAreRefused() {
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(line(#"{"kind":"password","v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("hash"))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(line(#"{"hash":"h","kind":"query","v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("text"))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(#"{"kind":"answer","v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("answer"))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(#"{"kind":"secret","secret":null,"v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("secret"))
+        }
+        XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeRequest(line(#"{"kind":"password","hash":5,"v":1}"#))) {
+            XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("hash"))
+        }
+    }
+
+    // MARK: - Dispatch onto the service
+
+    func testServiceHandlesEachRequestKind() {
+        let tunnel = DispatchTunnel()
+        let service = SASSHTunnelAuthService(source: tunnel, keychain: InertKeychain())
+
+        tunnel.questionAnswer = true
+        XCTAssertEqual(service.handle(.question("q")), .answer(true))
+        XCTAssertEqual(tunnel.questionsAsked, ["q"])
+
+        tunnel.heldPassword = "pw"
+        XCTAssertEqual(service.handle(.password(verificationHash: DispatchTunnel.hash)), .secret("pw"))
+        XCTAssertEqual(service.handle(.password(verificationHash: "wrong")), .refused)
+
+        tunnel.passphraseAnswer = "pp"
+        XCTAssertEqual(service.handle(.query("Enter PASSCODE:", verificationHash: DispatchTunnel.hash)), .secret("pp"))
+        tunnel.passphraseAnswer = nil
+        XCTAssertEqual(service.handle(.query("Enter PASSCODE:", verificationHash: DispatchTunnel.hash)), .refused)
+    }
+}
+
+// MARK: - Fakes
+
+private final class DispatchTunnel: NSObject, SASSHTunnelAuthSource {
+    static let hash = "h"
+    var verificationHash = DispatchTunnel.hash
+    var heldPassword: String?
+    var usesKeychainPassword = false
+    var keychainItemName: String?
+    var keychainItemAccount: String?
+    var passwordPromptCancelled = false
+    var questionAnswer = false
+    var questionsAsked: [String] = []
+    var passphraseAnswer: String?
+    func promptForResponse(toQuestion question: String) -> Bool { questionsAsked.append(question); return questionAnswer }
+    func promptForPassword(forQuery query: String) -> String? { passphraseAnswer }
+}
+
+private final class InertKeychain: NSObject, SAKeychainProviding {
+    func add(password: String?, name: String?, account: String?) {}
+    func add(password: String?, name: String?, account: String?, label: String?) {}
+    func password(name: String?, account: String?) -> String? { nil }
+    func deletePassword(name: String?, account: String?) {}
+    func passwordExists(name: String?, account: String?) -> Bool { false }
+    func updateItem(name: String?, account: String?, toName newName: String?, newAccount: String?, password: String?) {}
+    func name(favoriteName: String?, id favoriteID: Any?) -> String? { nil }
+    func account(user: String?, host: String?, database: String?) -> String? { nil }
+    func sshName(favoriteName: String?, id favoriteID: Any?) -> String? { nil }
+    func sshAccount(user: String?, host: String?) -> String? { nil }
+}

--- a/UnitTests/SASSHTunnelAuthMessageTests.swift
+++ b/UnitTests/SASSHTunnelAuthMessageTests.swift
@@ -132,6 +132,24 @@ final class SASSHTunnelAuthMessageTests: XCTestCase {
         }
     }
 
+    func testNumbersAndBoolsDoNotCoerceIntoEachOther() {
+        // JSONSerialization returns NSNumber for both; `as? Bool` would read 1
+        // as true and `as? Int` would read true as 1. Mistyped means refused.
+        for payload in [#"{"answer":1,"kind":"answer","v":1}"#, #"{"answer":0,"kind":"answer","v":1}"#,
+                        #"{"answer":"true","kind":"answer","v":1}"#, #"{"answer":1.0,"kind":"answer","v":1}"#] {
+            XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(payload)), payload) {
+                XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("answer"), payload)
+            }
+        }
+        for payload in [#"{"kind":"refused","v":true}"#, #"{"kind":"refused","v":"1"}"#, #"{"kind":"refused","v":1.0}"#] {
+            XCTAssertThrowsError(try SASSHTunnelAuthWire.decodeResponse(line(payload)), payload) {
+                XCTAssertEqual($0 as? SASSHTunnelAuthWireError, .missingField("v"), payload)
+            }
+        }
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(line(#"{"answer":true,"kind":"answer","v":1}"#)), .answer(true))
+        XCTAssertEqual(try SASSHTunnelAuthWire.decodeResponse(line(#"{"answer":false,"kind":"answer","v":1}"#)), .answer(false))
+    }
+
     // MARK: - Dispatch onto the service
 
     func testServiceHandlesEachRequestKind() {

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -257,7 +257,7 @@ deterministically — `disconnect()` fails outstanding prompts closed (reply
 Cover cancellation and app termination during *both* prompt methods; a hang
 here means the user cannot connect and cannot cancel.
 
-## Step 2 — Shared wire format
+## Step 2 — Shared wire format — ✅ Done
 
 The XPC version of this step was an `@objc` protocol; on a socket the
 contract is a message format instead. New file compiled into **all three**
@@ -281,6 +281,18 @@ and the dispatch.
 Both ends must fail **closed**: on any transport or decoding error the
 assistant exits non-zero rather than print an empty line, which ssh would
 read as an empty password.
+
+Execution notes (2026-09-01): landed as `SASSHTunnelAuthMessage.swift` —
+`SASSHTunnelAuthRequest` / `SASSHTunnelAuthResponse` enums and a
+`SASSHTunnelAuthWire` codec over `JSONSerialization` with sorted keys and
+unescaped slashes, so the bytes are stable and key paths read naturally in
+the fixtures. `SASSHTunnelAuthService.handle(_:)` is the dispatch. 15 tests in
+`SASSHTunnelAuthMessageTests`: a byte-exact fixture for each of the six
+message shapes, round trips, multi-line and non-ASCII text staying on one
+line, CR/LF tolerance, and the refusals (garbage, other versions, unknown
+kinds, missing or mistyped fields — including `"secret": null`, which is
+refused rather than read as empty). Nothing in the file is `public`: the
+assistant's Objective-C `main` never touches these types.
 
 ## Step 3 — Socket alongside DO, behind a default
 

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -303,8 +303,13 @@ the fixtures. `SASSHTunnelAuthService.handle(_:)` is the dispatch. 15 tests in
 message shapes, round trips, multi-line and non-ASCII text staying on one
 line, CR/LF tolerance, and the refusals (garbage, other versions, unknown
 kinds, missing or mistyped fields — including `"secret": null`, which is
-refused rather than read as empty). Nothing in the file is `public`: the
-assistant's Objective-C `main` never touches these types.
+refused rather than read as empty). Review (Codex) added the scalar-type
+rule: `JSONSerialization` returns `NSNumber` for every scalar and Swift's
+bridge reads `1` as `true` and `true` as `1`, so the decoder checks the
+underlying JSON type — a Bool must be a JSON boolean, `v` a JSON integer —
+and a numeric `answer` is refused rather than read as "yes". Nothing in the
+file is `public`: the assistant's Objective-C `main` never touches these
+types.
 
 ## Step 3 — Socket alongside DO, behind a default
 

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,22 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1196D9FED5B52DE6CD6B0C76 /* SASSHTunnelAuthSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */; };
-		51AC3B6D30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */; };
-		51AC3B7230475EAD00BCE2B9 /* SASSHTunnelAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */; };
-		51AC3B7430475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */; };
-		EDDD0AB23E0A1F4A5AE67091 /* SASSHTunnelAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */; };
+		07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
 		03B3C091388E27E56C58B846 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
+		090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
+		0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */; };
+		0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
 		0F2381A80270EFDE50D73890 /* SAParserUtilsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
 		10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
 		1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
+		1196D9FED5B52DE6CD6B0C76 /* SASSHTunnelAuthSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */; };
 		1198F5B31174EDD500670590 /* SPDatabaseCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1198F5B21174EDD500670590 /* SPDatabaseCopy.m */; };
 		11ACD43BE52B0351BBFE518F /* AWSSSOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAD424F195B2E207BF7C604 /* AWSSSOClient.swift */; };
 		11B55BFE1189E3B2009EF465 /* SPDatabaseAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 11B55BFD1189E3B2009EF465 /* SPDatabaseAction.m */; };
 		11C211301180EC9A00758039 /* SPDatabaseRename.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C2109D1180E70800758039 /* SPDatabaseRename.m */; };
 		14F0CC5AC96DE9CCC0213237 /* SAUserManagerPrivilegeNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5C9FD78A565D5260B38E55 /* SAUserManagerPrivilegeNormalizer.swift */; };
+		158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */; };
 		16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644FFD84B58CEAE73585045B /* SAKeyboardShortcut.swift */; };
 		171312CE109D23C700FB465F /* SPTableTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 171312CD109D23C700FB465F /* SPTableTextFieldCell.m */; };
 		1717FA401558313A0065C036 /* RegexKitLite.m in Sources */ = {isa = PBXBuildFile; fileRef = 296DC8AB0F909194002A3258 /* RegexKitLite.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -85,16 +86,6 @@
 		17E641640EF01F15001BC333 /* SPTableInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6415F0EF01F15001BC333 /* SPTableInfo.m */; };
 		17E641650EF01F15001BC333 /* SPTablesList.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641610EF01F15001BC333 /* SPTablesList.m */; };
 		17E6416C0EF01F37001BC333 /* ImageAndTextCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641690EF01F37001BC333 /* ImageAndTextCell.m */; };
-		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
-		090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
-		FA4FC2907FC19A9EA23B2465 /* SAKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE09C59624F6AC834DAD7675 /* SAKeychain.swift */; };
-		442DC8CE81CCD45D45F19DE7 /* SAKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE09C59624F6AC834DAD7675 /* SAKeychain.swift */; };
-		239009D40D234AB74434A7F3 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
-		6220954A97524B17D37B4D09 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
-		CD5AFDE14AA44B4AB444DD59 /* SAKeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4471240789125E4D4033602A /* SAKeychainAccess.swift */; };
-		0EFB3862D086C3F4C5716B85 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
-		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
-		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		17E641830EF01FA8001BC333 /* SPImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6417F0EF01FA8001BC333 /* SPImageView.m */; };
 		17E641840EF01FA8001BC333 /* SPTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641810EF01FA8001BC333 /* SPTextView.m */; };
 		17E641D10EF02036001BC333 /* grabber-horizontal.png in Resources */ = {isa = PBXBuildFile; fileRef = 17E6419D0EF02036001BC333 /* grabber-horizontal.png */; };
@@ -181,6 +172,7 @@
 		1B1C4038B2DE3B11B53868BB /* SACompletionWindowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */; };
 		1C7055887A73B6C4D4C13D51 /* SPDuplicateImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA7A8F76494CE39908140FA /* SPDuplicateImportViewController.swift */; };
 		1E4E58D8ABEA1E269DC46FD2 /* AWSSSOClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAD424F195B2E207BF7C604 /* AWSSSOClient.swift */; };
+		239009D40D234AB74434A7F3 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
 		2456FC7DD02544F7BFE23596 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
 		265446DF24A1616900376B48 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C613721C8977E600B3B6EF /* libz.tbd */; };
 		26BBEDE8A7A7D1C9DA602D39 /* SPMCPHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91D4A5EC24F24F7A7BCA7D /* SPMCPHTTP.swift */; };
@@ -208,6 +200,7 @@
 		410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */; };
 		44011FFBC7DF57126761313F /* SQLitePinnedTableManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44011DFD0DC2836DB08A0619 /* SQLitePinnedTableManager.swift */; };
 		441E45F5DCF87A54D8FEC130 /* SADatabaseScopedValueCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */; };
+		442DC8CE81CCD45D45F19DE7 /* SAKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE09C59624F6AC834DAD7675 /* SAKeychain.swift */; };
 		49B1A8182FC5FCC2000A4916 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 49B1A8172FC5FCC2000A4916 /* AppIcon.icon */; };
 		4C74760160E21F5256343A70 /* SAUserManagerPrivilegeNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62F323F4DE28E7459898F09 /* SAUserManagerPrivilegeNormalizerTests.swift */; };
 		4D90B79A101E0CDF00D116A1 /* SPUserManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D90B799101E0CDF00D116A1 /* SPUserManager.m */; };
@@ -287,9 +280,6 @@
 		514DD98925FACF1500EA3B3B /* SPDatabaseDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514DD98825FACF1500EA3B3B /* SPDatabaseDocument.swift */; };
 		517412382573E8F900EB6935 /* EditorQuickLookTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */; };
 		517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */; };
-		9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */; };
-		0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */; };
-		158CE2B8B92310647A1BF0B4 /* SAKeychainNamingCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */; };
 		517E4512257A954000ED333B /* ContentFilters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 517E4511257A954000ED333B /* ContentFilters.plist */; };
 		5193502F2567D2FB001272B5 /* CollectionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5193502E2567D2FB001272B5 /* CollectionExtension.swift */; };
 		519350302567D2FB001272B5 /* CollectionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5193502E2567D2FB001272B5 /* CollectionExtension.swift */; };
@@ -297,6 +287,12 @@
 		51AA84022FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
 		51AA84032FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
 		51AA84052FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84042FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift */; };
+		51AC3B6D30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */; };
+		51AC3B7230475EAD00BCE2B9 /* SASSHTunnelAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */; };
+		51AC3B7430475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */; };
+		51AC3B7A304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
+		51AC3B7B304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
+		51AC3B80304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */; };
 		51B09FC92F7677AA003BAFFF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */; };
 		51B09FD12F7677EB003BAFFF /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD02F7677EB003BAFFF /* FirebaseAnalyticsCore */; };
 		51B09FD32F7677EB003BAFFF /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD22F7677EB003BAFFF /* FirebaseCrashlytics */; };
@@ -463,15 +459,19 @@
 		5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */; };
 		5BA8A1F0564883162D4A80F2 /* SAUserManagerPrivilegeNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5C9FD78A565D5260B38E55 /* SAUserManagerPrivilegeNormalizer.swift */; };
 		60111925195F940E7252B376 /* SAHelpViewerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */; };
+		6220954A97524B17D37B4D09 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
+		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		624E13DFBB2F343500B94705 /* SADatabaseScopedValueCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81815809CB9EBE53E9D2AA2A /* SADatabaseScopedValueCacheTests.swift */; };
 		65F52CC824AE21D600FED3CB /* SPFilePreferencePane.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */; };
 		6ABF364B03D0324617CFABCC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
 		6CB1977AAE8D7D64B7593E66 /* SPBundleManagerAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */; };
 		6F0EA8ED272F33B700514FF1 /* SPBundleManagerAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA8EC272F33B700514FF1 /* SPBundleManagerAdditions.swift */; };
 		6F0EA9242734ABE200514FF1 /* SABundleRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EA9232734ABE200514FF1 /* SABundleRunner.m */; };
+		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */; };
 		73F70A961E4E547500636550 /* SPJSONFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73F70A951E4E547500636550 /* SPJSONFormatter.m */; };
 		794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */; };
+		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
 		7EE575894C57515419B0A30A /* SPMCPPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F0964487758A57DA339AF2 /* SPMCPPreferencePane.swift */; };
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
@@ -524,6 +524,7 @@
 		9BE765682376A00C82FB93AA /* SPHelpViewerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE764320CE8E86E8F63647B /* SPHelpViewerClient.m */; };
 		9BE765EBBDFD2F121C13D274 /* SPFillView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE768F3989033CEDDC2027E /* SPFillView.m */; };
 		9BE76F2886901784E4FD2321 /* SPFilterTableController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE76A3D5C9830E2F7738770 /* SPFilterTableController.m */; };
+		9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */; };
 		9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
 		A57A61739BA9FEC6706473D6 /* SPAppController+MCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC51026DDFB4980A84A78F1 /* SPAppController+MCP.swift */; };
 		A69CC1B9E445E5FCF1484A09 /* SAAnalyticsConsentPolicy+Firebase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F001AB41C248FB0C94ECB906 /* SAAnalyticsConsentPolicy+Firebase.swift */; };
@@ -599,6 +600,7 @@
 		C9F92712162D39E60051CB2E /* toolbar-switch-to-browse.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92711162D39E60051CB2E /* toolbar-switch-to-browse.png */; };
 		C9F92714162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C9F92713162D39FE0051CB2E /* toolbar-switch-to-browse@2x.png */; };
 		CACA94EDDD5F7ADE62E4CA71 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
+		CD5AFDE14AA44B4AB444DD59 /* SAKeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4471240789125E4D4033602A /* SAKeychainAccess.swift */; };
 		CF0000012F8C000600C4C14A /* SACellFilterOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000022F8C000600C4C14A /* SACellFilterOperatorTests.swift */; };
 		CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
 		CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000042F8C000600C4C14A /* SACellFilterOperator.swift */; };
@@ -631,6 +633,7 @@
 		EB9FF92F188F0B4AA444A892 /* SAConnectionInfo+ConnectionString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54146A7693E8D862D06856BF /* SAConnectionInfo+ConnectionString.swift */; };
 		ED3C9DE94BCF6D3F17DACBCA /* AWSLoginCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB06F6EE917719170B0804B /* AWSLoginCredentialsProvider.swift */; };
 		ED73B484E6B129113C1C8221 /* SAAnalyticsConsentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5B97BE9E063395AB12888 /* SAAnalyticsConsentPolicy.swift */; };
+		EDDD0AB23E0A1F4A5AE67091 /* SASSHTunnelAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */; };
 		F3A4B8C191E14E7094C9A111 /* AWSCredentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A101 /* AWSCredentialsTests.swift */; };
 		F3A4B8C191E14E7094C9A112 /* RDSIAMAuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A102 /* RDSIAMAuthenticationTests.swift */; };
 		F3A4B8C191E14E7094C9A113 /* AWSDirectoryBookmarkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B8C191E14E7094C9A103 /* AWSDirectoryBookmarkManagerTests.swift */; };
@@ -664,6 +667,7 @@
 		FA1B2C3D4E5F6A7B8C9D0E1E /* SAVaultRoleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E09 /* SAVaultRoleFilter.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E1F /* SAVaultRoleFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0A /* SAVaultRoleFilterTests.swift */; };
 		FA1B2C3D4E5F6A7B8C9D0E20 /* SAVaultRoleListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B2C3D4E5F6A7B8C9D0E0B /* SAVaultRoleListController.swift */; };
+		FA4FC2907FC19A9EA23B2465 /* SAKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE09C59624F6AC834DAD7675 /* SAKeychain.swift */; };
 		FA9D8FF0B7ABD591E1A9170E /* SADragPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */; };
 		FD0E72EA2C38DEA1007EF348 /* SATableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */; };
 		FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0E72EB2C391F44007EF348 /* SQLiteDisplayFormatManager.swift */; };
@@ -797,9 +801,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthSource.swift; sourceTree = "<group>"; };
-		51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthService.swift; sourceTree = "<group>"; };
-		51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthServiceTests.swift; sourceTree = "<group>"; };
+		01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainStoreCharacterizationTests.swift; sourceTree = "<group>"; };
 		0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SACompletionWindowLayout.swift; sourceTree = "<group>"; };
 		1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		112730551180788A000737FD /* SPTableCopyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTableCopyTest.m; sourceTree = "<group>"; };
@@ -808,6 +810,7 @@
 		1198F5B11174EDD500670590 /* SPDatabaseCopy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDatabaseCopy.h; sourceTree = "<group>"; };
 		1198F5B21174EDD500670590 /* SPDatabaseCopy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseCopy.m; sourceTree = "<group>"; };
 		1198F5C31174EF3F00670590 /* SPDatabaseCopyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseCopyTest.m; sourceTree = "<group>"; };
+		11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainProviding.swift; sourceTree = "<group>"; };
 		11B55BFC1189E3B2009EF465 /* SPDatabaseAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDatabaseAction.h; sourceTree = "<group>"; };
 		11B55BFD1189E3B2009EF465 /* SPDatabaseAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPDatabaseAction.m; sourceTree = "<group>"; };
 		11C2109C1180E70800758039 /* SPDatabaseRename.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPDatabaseRename.h; sourceTree = "<group>"; };
@@ -935,12 +938,6 @@
 		17E641610EF01F15001BC333 /* SPTablesList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTablesList.m; sourceTree = "<group>"; };
 		17E641680EF01F37001BC333 /* ImageAndTextCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageAndTextCell.h; sourceTree = "<group>"; };
 		17E641690EF01F37001BC333 /* ImageAndTextCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageAndTextCell.m; sourceTree = "<group>"; };
-		11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainProviding.swift; sourceTree = "<group>"; };
-		4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabled.swift; sourceTree = "<group>"; };
-		BE09C59624F6AC834DAD7675 /* SAKeychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychain.swift; sourceTree = "<group>"; };
-		52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNaming.swift; sourceTree = "<group>"; };
-		4471240789125E4D4033602A /* SAKeychainAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainAccess.swift; sourceTree = "<group>"; };
-		A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabledTests.swift; sourceTree = "<group>"; };
 		17E6417E0EF01FA8001BC333 /* SPImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPImageView.h; sourceTree = "<group>"; };
 		17E6417F0EF01FA8001BC333 /* SPImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPImageView.m; sourceTree = "<group>"; };
 		17E641800EF01FA8001BC333 /* SPTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextView.h; sourceTree = "<group>"; };
@@ -1066,7 +1063,9 @@
 		3E242D4E20FEB44D0015470D /* button_bar_spacer_dark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "button_bar_spacer_dark@2x.png"; sourceTree = "<group>"; };
 		4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SABundleVersionUpdater.swift; sourceTree = "<group>"; };
 		44011DFD0DC2836DB08A0619 /* SQLitePinnedTableManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLitePinnedTableManager.swift; sourceTree = "<group>"; };
+		4471240789125E4D4033602A /* SAKeychainAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainAccess.swift; sourceTree = "<group>"; };
 		49B1A8172FC5FCC2000A4916 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabled.swift; sourceTree = "<group>"; };
 		4D90B798101E0CDF00D116A1 /* SPUserManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUserManager.h; sourceTree = "<group>"; };
 		4D90B799101E0CDF00D116A1 /* SPUserManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUserManager.m; sourceTree = "<group>"; };
 		4D90B79B101E0CF200D116A1 /* SPUserManager.xcdatamodel */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = wrapper.xcdatamodel; path = SPUserManager.xcdatamodel; sourceTree = "<group>"; };
@@ -1148,9 +1147,6 @@
 		51731E7B27DFB99A00D81B98 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		517412372573E8F900EB6935 /* EditorQuickLookTypes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EditorQuickLookTypes.plist; sourceTree = "<group>"; };
 		517BFF432F7DA38F00F6D812 /* SAConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionServiceTests.swift; sourceTree = "<group>"; };
-		01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainStoreCharacterizationTests.swift; sourceTree = "<group>"; };
-		8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainTestSupport.swift; sourceTree = "<group>"; };
-		7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNamingCharacterizationTests.swift; sourceTree = "<group>"; };
 		517E44C2257A8F2C00ED333B /* AppleScriptObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppleScriptObjC.framework; path = System/Library/Frameworks/AppleScriptObjC.framework; sourceTree = SDKROOT; };
 		517E4511257A954000ED333B /* ContentFilters.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = ContentFilters.plist; path = Plists/ContentFilters.plist; sourceTree = "<group>"; };
 		51905622267DFF1700212442 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1160,6 +1156,11 @@
 		51A709382565B99F001F1D2F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAutoIncrementRuleSupport.swift; sourceTree = "<group>"; };
 		51AA84042FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAutoIncrementRuleSupportTests.swift; sourceTree = "<group>"; };
+		51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthSource.swift; sourceTree = "<group>"; };
+		51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthService.swift; sourceTree = "<group>"; };
+		51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthServiceTests.swift; sourceTree = "<group>"; };
+		51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthMessage.swift; sourceTree = "<group>"; };
+		51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthMessageTests.swift; sourceTree = "<group>"; };
 		51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfo.swift; sourceTree = "<group>"; };
 		51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDelegate.swift; sourceTree = "<group>"; };
@@ -1226,6 +1227,7 @@
 		51F41FB625F56A5900594BA5 /* MainWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		51F4AFBD24B26665006144D5 /* Sequel-Ace-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sequel-Ace-Bridging-Header.h"; sourceTree = "<group>"; };
 		51F4AFBE24B26665006144D5 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
+		52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNaming.swift; sourceTree = "<group>"; };
 		54146A7693E8D862D06856BF /* SAConnectionInfo+ConnectionString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SAConnectionInfo+ConnectionString.swift"; sourceTree = "<group>"; };
 		5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAStaleBookmarkAlertContentTests.swift; sourceTree = "<group>"; };
 		55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SACompletionWindowLayoutTests.swift; sourceTree = "<group>"; };
@@ -1359,8 +1361,10 @@
 		73F70A951E4E547500636550 /* SPJSONFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPJSONFormatter.m; sourceTree = "<group>"; };
 		7409B60D0436BCD43BD208D4 /* SADragPasteboardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADragPasteboardTests.swift; sourceTree = "<group>"; };
 		7AC51026DDFB4980A84A78F1 /* SPAppController+MCP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SPAppController+MCP.swift"; sourceTree = "<group>"; };
+		7D53166D77A40496B91F45A9 /* SAKeychainNamingCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainNamingCharacterizationTests.swift; sourceTree = "<group>"; };
 		812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAQueryFavoriteStoreTests.swift; sourceTree = "<group>"; };
 		81815809CB9EBE53E9D2AA2A /* SADatabaseScopedValueCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADatabaseScopedValueCacheTests.swift; sourceTree = "<group>"; };
+		8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainTestSupport.swift; sourceTree = "<group>"; };
 		8831EFA5224011B700D10172 /* button_addTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_addTemplate.pdf; sourceTree = "<group>"; };
 		8831EFA92240128600D10172 /* button_removeTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_removeTemplate.pdf; sourceTree = "<group>"; };
 		8831EFAB2240131400D10172 /* button_editTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = button_editTemplate.pdf; sourceTree = "<group>"; };
@@ -1407,6 +1411,7 @@
 		9BE76A3D5C9830E2F7738770 /* SPFilterTableController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFilterTableController.m; sourceTree = "<group>"; };
 		9BE76CC0CCE3A4A74E3E8D5E /* SPFillView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFillView.h; sourceTree = "<group>"; };
 		9BE76F9BF9BDA2921CDD05AF /* SPFilterTableController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFilterTableController.h; sourceTree = "<group>"; };
+		A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainDisabledTests.swift; sourceTree = "<group>"; };
 		AA000001000000000000001A /* SAAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutView.swift; sourceTree = "<group>"; };
 		AA000001000000000000001C /* SAAboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAboutWindowController.swift; sourceTree = "<group>"; };
 		AAA7A8F76494CE39908140FA /* SPDuplicateImportViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPDuplicateImportViewController.swift; sourceTree = "<group>"; };
@@ -1487,6 +1492,7 @@
 		BCD0AD4A0FBBFC480066EA5C /* SPSQLTokenizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPSQLTokenizer.h; sourceTree = "<group>"; };
 		BCE0025B11173D2A009DA533 /* SPFieldMapperController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPFieldMapperController.h; sourceTree = "<group>"; };
 		BCE0025C11173D2A009DA533 /* SPFieldMapperController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFieldMapperController.m; sourceTree = "<group>"; };
+		BE09C59624F6AC834DAD7675 /* SAKeychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychain.swift; sourceTree = "<group>"; };
 		C0F17A1A2B3C4D5E6F708092 /* SPTableContentColumnFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPTableContentColumnFilterTests.swift; sourceTree = "<group>"; };
 		C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConnectionStringParser.swift; sourceTree = "<group>"; };
 		C7CAA1A274071383C33F2E4C /* SPBundleManagerAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBundleManagerAdditionsTests.swift; sourceTree = "<group>"; };
@@ -2352,6 +2358,7 @@
 				51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */,
 				51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */,
 				58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */,
+				51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */,
 			);
 			name = "SSH Tunnel";
 			path = SSHTunnel;
@@ -2765,6 +2772,7 @@
 				51BE68E13017552B00AF389C /* SAImageRendererTests.swift */,
 				51DD6924303C2F99004792F0 /* SAFavoriteDuplicateMatcherTests.swift */,
 				51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */,
+				51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3392,6 +3400,7 @@
 				71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */,
 				B01E10DB2BF1A67138C32D0C /* SAFavoriteDuplicateMatcher.swift in Sources */,
 				1A9498C125517191000BC793 /* DateExtension.swift in Sources */,
+				51AC3B7B304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */,
 				1ADEA5A424BF1FFB00D2140B /* SPDateAdditions.m in Sources */,
 				50837F771E50E007004FAE8A /* SPJSONFormatter.m in Sources */,
 				505F568F1BCEE485007467DD /* SPFunctions.m in Sources */,
@@ -3420,6 +3429,7 @@
 				1A70BC9225EF7EE9004BB992 /* FileManagerExtension.swift in Sources */,
 				1A1667112584D94800A9686E /* SPURLAdditionsTests.m in Sources */,
 				503B02D21AE95E010060CAB1 /* SPConstants.m in Sources */,
+				51AC3B80304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift in Sources */,
 				1A4152F125AF531000B17249 /* GeneralSwiftTests.swift in Sources */,
 				503B02D11AE95DD40060CAB1 /* SPTableFilterParser.m in Sources */,
 				51AA84032FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */,
@@ -3584,6 +3594,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */,
 				17D41A8221700F8200B1888D /* SPFunctions.m in Sources */,
 				1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */,
 				58CDB3410FCE141900F8ACA3 /* SequelAceTunnelAssistant.m in Sources */,
@@ -3633,6 +3644,7 @@
 				623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */,
 				17E641830EF01FA8001BC333 /* SPImageView.m in Sources */,
 				17E641840EF01FA8001BC333 /* SPTextView.m in Sources */,
+				51AC3B7A304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */,
 				58FEF16D0F23D66600518E8E /* SPSQLParser.m in Sources */,
 				1789343C0F30C1DD0097539A /* SPStringAdditions.m in Sources */,
 				1A1EE9582551249C0056FECD /* NumberFormatterExtension.swift in Sources */,


### PR DESCRIPTION
## Summary

Step 2 of `docs/development/ssh-tunnel-xpc-migration-plan.md`, stacked on #2618 (the diff shows only this step's changes once that merges).

The XPC version of this step was an `@objc` protocol; on the socket transport the contract is a message format. `SASSHTunnelAuthMessage.swift` — pure Foundation, compiled into the app, `SequelAceTunnelAssistant` **and** the Unit Tests target — defines:

- `SASSHTunnelAuthRequest`: `question(text)`, `password(verificationHash)`, `query(text, verificationHash)` — the three calls the assistant makes, one per launch (ssh execs it once per prompt).
- `SASSHTunnelAuthResponse`: `answer(Bool)`, `secret(String)`, `refused` — `refused` is explicit so the assistant can never print an empty line for ssh to read as an empty password.
- `SASSHTunnelAuthWire`: line-delimited JSON with a `v` field, sorted keys and unescaped slashes so the encoding is byte-stable; a reader refuses any other version, unknown kind, or missing/mistyped field (including `"secret": null`) rather than guessing.

`SASSHTunnelAuthService.handle(_:)` maps a request onto the three Step 1 methods, so Step 3's socket server will be plumbing only. Nothing here is `public`; the assistant's Objective-C `main` never touches these types (its Swift side will, in Step 3).

The pbxproj diff also carries Xcode's canonical re-sort of the `PBXBuildFile` / `PBXFileReference` sections — the keychain entries had been inserted out of order — with no membership changes beyond the new file (app + assistant + Unit Tests) and its tests.

## Test plan

- [x] 15 new tests in `SASSHTunnelAuthMessageTests`: a byte-exact fixture per message shape (six), round trips, multi-line + non-ASCII text staying on one line, CR/LF tolerance, refusals (garbage, other versions, unknown kinds, missing/mistyped fields), and dispatch through the service.
- [x] Step 1 suite still green (21); clean Debug build with the file compiling in all three targets.
- No behaviour change: nothing calls the new types yet.

## Tested
- Processors: Apple Silicon
- macOS: 26.x
- Xcode: 26 beta (SDK 27.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
