### PR TITLE
#infra SSH tunnel IPC migration step 3: the socket transport, behind a default

### DIFF
--- a/Source/Other/SSHTunnel/SASSHTunnelAskpass.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAskpass.swift
@@ -35,11 +35,12 @@ import Foundation
 /// therefore testable (SSH tunnel IPC plan, Step 3). Compiled into the
 /// assistant and the Unit Tests target.
 ///
-/// `connect` is called lazily, at most once per run, in exactly the places
-/// the Objective-C original resolved its proxy; a failure there is "unable
-/// to connect to Sequel Ace", exit 1. A transport error during the request
-/// is also exit 1: the assistant never prints an empty line for ssh to read
-/// as an empty password.
+/// `connect` is called lazily, in exactly the places the Objective-C
+/// original resolved its proxy (twice when a refused password falls back to
+/// the GUI prompt); a failure there is "unable to connect to Sequel Ace",
+/// exit 1. A transport error during any request is also exit 1 — only an
+/// explicit `refused` reaches the fallback — and the assistant never prints
+/// an empty line for ssh to read as an empty password.
 enum SASSHTunnelAskpass {
 
     struct Outcome: Equatable {
@@ -102,10 +103,26 @@ enum SASSHTunnelAskpass {
                     log("SSH Tunnel: unable to connect to Sequel Ace for internal authentication")
                     return Outcome(output: nil, exitCode: 1)
                 }
-                if case .secret(let password)? = try? transport(.password(verificationHash: verificationHash)) {
-                    return Outcome(output: password, exitCode: 0)
+                let response: SASSHTunnelAuthResponse
+                do {
+                    response = try transport(.password(verificationHash: verificationHash))
+                } catch {
+                    // A broken channel is not "no password": fail closed rather
+                    // than open a second connection for the GUI fallback.
+                    log("SSH Tunnel: unable to obtain the password from Sequel Ace (\(error))")
+                    return Outcome(output: nil, exitCode: 1)
                 }
-                // No password: explain per method and fall back to the GUI prompt.
+                switch response {
+                case .secret(let password):
+                    return Outcome(output: password, exitCode: 0)
+                case .refused:
+                    break
+                case .answer:
+                    log("SSH Tunnel: unexpected reply to the password request")
+                    return Outcome(output: nil, exitCode: 1)
+                }
+                // Explicitly refused — no password held or stored: explain per
+                // method and fall back to the GUI prompt.
                 if method == .usesKeychain {
                     log("SSH Tunnel: specified keychain password not found")
                     argument = String(format: NSLocalizedString("The SSH password could not be loaded from the keychain; please enter the SSH password for %@:", comment: "Prompt for SSH password when keychain fetch failed"), connectionName)

--- a/Source/Other/SSHTunnel/SASSHTunnelAskpass.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAskpass.swift
@@ -1,0 +1,139 @@
+//
+//  SASSHTunnelAskpass.swift
+//  SequelAceTunnelAssistant
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// What the askpass assistant does with the prompt ssh handed it — the
+/// decisions of `SequelAceTunnelAssistant.m`, transport-agnostic and
+/// therefore testable (SSH tunnel IPC plan, Step 3). Compiled into the
+/// assistant and the Unit Tests target.
+///
+/// `connect` is called lazily, at most once per run, in exactly the places
+/// the Objective-C original resolved its proxy; a failure there is "unable
+/// to connect to Sequel Ace", exit 1. A transport error during the request
+/// is also exit 1: the assistant never prints an empty line for ssh to read
+/// as an empty password.
+enum SASSHTunnelAskpass {
+
+    struct Outcome: Equatable {
+        /// What to print to stdout (ssh reads it as the answer), or nothing.
+        var output: String?
+        var exitCode: Int32
+    }
+
+    /// Keep in sync with `SPSSHTunnelPasswordMode` in `SPConstants.h`.
+    enum PasswordMethod: Int {
+        case usesKeychain = 0
+        case asksUI = 1
+        case none = 2
+    }
+
+    enum EnvironmentKey {
+        static let passwordMethod = "SP_PASSWORD_METHOD"
+        static let connectionName = "SP_CONNECTION_NAME"
+        static let verificationHash = "SP_CONNECTION_VERIFY_HASH"
+    }
+
+    typealias Transport = (SASSHTunnelAuthRequest) throws -> SASSHTunnelAuthResponse
+    typealias Connect = () throws -> Transport
+
+    static func run(argument: String?,
+                    environment: [String: String],
+                    connect: Connect,
+                    log: (String) -> Void = { NSLog("%@", $0) }) -> Outcome {
+        guard let methodValue = environment[EnvironmentKey.passwordMethod] else {
+            return Outcome(output: nil, exitCode: 1)
+        }
+        let connectionName = environment[EnvironmentKey.connectionName]
+        let verificationHash = environment[EnvironmentKey.verificationHash]
+        var argument = argument
+
+        // A yes/no question (host key mismatches and the like).
+        if let question = argument, question.contains(" (yes/no") {
+            guard let transport = try? connect() else {
+                log("SSH Tunnel: unable to connect to Sequel Ace to show SSH question")
+                return Outcome(output: nil, exitCode: 1)
+            }
+            guard case .answer(let yes)? = try? transport(.question(question)) else {
+                log("SSH Tunnel: unable to obtain an answer from Sequel Ace for SSH question")
+                return Outcome(output: nil, exitCode: 1)
+            }
+            return Outcome(output: yes ? "yes" : "no", exitCode: 0)
+        }
+
+        // The SSH password itself: ask the app, which either holds it or
+        // resolves it from the keychain at ask time.
+        if let prompt = argument, prompt.lowercased().contains("password:") {
+            // -[NSString integerValue] semantics: anything non-numeric is 0.
+            let method = PasswordMethod(rawValue: Int(methodValue) ?? 0)
+            if method == .usesKeychain || method == .asksUI {
+                guard let connectionName, let verificationHash else {
+                    log("SSH Tunnel: internal authentication specified but insufficient details supplied")
+                    return Outcome(output: nil, exitCode: 1)
+                }
+                guard let transport = try? connect() else {
+                    log("SSH Tunnel: unable to connect to Sequel Ace for internal authentication")
+                    return Outcome(output: nil, exitCode: 1)
+                }
+                if case .secret(let password)? = try? transport(.password(verificationHash: verificationHash)) {
+                    return Outcome(output: password, exitCode: 0)
+                }
+                // No password: explain per method and fall back to the GUI prompt.
+                if method == .usesKeychain {
+                    log("SSH Tunnel: specified keychain password not found")
+                    argument = String(format: NSLocalizedString("The SSH password could not be loaded from the keychain; please enter the SSH password for %@:", comment: "Prompt for SSH password when keychain fetch failed"), connectionName)
+                } else {
+                    log("SSH Tunnel: unable to successfully request password from Sequel Ace for internal authentication")
+                    argument = String(format: NSLocalizedString("The SSH password could not be loaded; please enter the SSH password for %@:", comment: "Prompt for SSH password when direct fetch failed"), connectionName)
+                }
+            }
+        }
+
+        // Key passphrases and anything else ssh asks go to the app's GUI
+        // prompt (which serves a stored passphrase first). Also covers RSA
+        // SecurID and the fallback prompts built above.
+        if let query = argument {
+            guard let verificationHash else {
+                log("SSH Tunnel: key passphrase authentication required but insufficient details supplied to connect to GUI")
+                return Outcome(output: nil, exitCode: 1)
+            }
+            guard let transport = try? connect() else {
+                log("SSH Tunnel: unable to connect to Sequel Ace to show SSH question")
+                return Outcome(output: nil, exitCode: 1)
+            }
+            guard case .secret(let passphrase)? = try? transport(.query(query, verificationHash: verificationHash)) else {
+                return Outcome(output: nil, exitCode: 1)
+            }
+            return Outcome(output: passphrase, exitCode: 0)
+        }
+
+        return Outcome(output: nil, exitCode: 1)
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelAssistantSocketMain.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelAssistantSocketMain.swift
@@ -1,0 +1,69 @@
+//
+//  SASSHTunnelAssistantSocketMain.swift
+//  SequelAceTunnelAssistant
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The assistant's socket-transport entry point, called from
+/// `SequelAceTunnelAssistant.m`'s `main` when the app selected the socket
+/// (SSH tunnel IPC plan, Step 3). Assistant target only.
+///
+/// `public` because the assistant has no bridging header, so only public
+/// Swift reaches its generated `sequel-ace-Swift.h`.
+@objc public final class SASSHTunnelAssistantSocketMain: NSObject {
+
+    /// True when the app asked for the socket transport in ssh's environment.
+    @objc public static func isSelectedInEnvironment() -> Bool {
+        ProcessInfo.processInfo.environment[SASSHTunnelSocketIO.EnvironmentKey.transport] == SASSHTunnelSocketIO.TransportValue.socket
+    }
+
+    /// Runs the askpass exchange and returns the process exit code, having
+    /// printed the answer (if any) to stdout for ssh.
+    @objc public static func run() -> Int32 {
+        let environment = ProcessInfo.processInfo.environment
+        let argument = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : nil
+
+        let outcome = SASSHTunnelAskpass.run(argument: argument, environment: environment) {
+            guard let path = environment[SASSHTunnelSocketIO.EnvironmentKey.socketPath] else {
+                throw MissingSocketPath()
+            }
+            let client = SASSHTunnelSocketClient(path: path)
+            return { try client.send($0) }
+        }
+
+        if let output = outcome.output {
+            print(output)
+        }
+        return outcome.exitCode
+    }
+
+    private struct MissingSocketPath: Error {}
+
+    private override init() {}
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelSocketClient.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelSocketClient.swift
@@ -1,0 +1,81 @@
+//
+//  SASSHTunnelSocketClient.swift
+//  SequelAceTunnelAssistant
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The assistant's end of the socket transport (SSH tunnel IPC plan,
+/// Step 3): connect, validate the peer, send one request, read one reply.
+/// Compiled into the assistant and the Unit Tests target.
+struct SASSHTunnelSocketClient {
+
+    /// Decides whether the connected socket's peer is the app. Step 4
+    /// supplies the code-signing check; until then every peer is accepted.
+    typealias PeerPolicy = (Int32) -> Bool
+
+    enum Error: Swift.Error, Equatable {
+        case socketFailed(Int32)
+        case connectFailed(Int32)
+        /// The listener did not pass `peerPolicy`; nothing was sent.
+        case peerRejected
+        case sendFailed(Int32)
+        /// The app closed without answering — it refused the connection or
+        /// could not read the request. Fail closed.
+        case noReply
+        case malformedReply(SASSHTunnelAuthWireError)
+    }
+
+    let path: String
+    var peerPolicy: PeerPolicy = { _ in true }
+
+    func send(_ request: SASSHTunnelAuthRequest) throws -> SASSHTunnelAuthResponse {
+        var address = try SASSHTunnelSocketIO.address(for: path)
+        guard let fd = SASSHTunnelSocketIO.makeSocket() else { throw Error.socketFailed(errno) }
+        defer { Darwin.close(fd) }
+
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else { throw Error.connectFailed(errno) }
+        guard peerPolicy(fd) else { throw Error.peerRejected }
+
+        guard SASSHTunnelSocketIO.writeAll(fd, SASSHTunnelAuthWire.encode(request)) else {
+            throw Error.sendFailed(errno)
+        }
+        // The reply has no timeout: the app may be waiting on the user.
+        guard let line = SASSHTunnelSocketIO.readLine(fd) else { throw Error.noReply }
+        do {
+            return try SASSHTunnelAuthWire.decodeResponse(line)
+        } catch let wireError as SASSHTunnelAuthWireError {
+            throw Error.malformedReply(wireError)
+        }
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelSocketIO.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelSocketIO.swift
@@ -1,0 +1,135 @@
+//
+//  SASSHTunnelSocketIO.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The BSD-socket plumbing both ends of the tunnel/assistant channel share
+/// (SSH tunnel IPC plan, Step 3). Compiled into the app, the assistant and
+/// the Unit Tests target; pure Foundation + Darwin.
+enum SASSHTunnelSocketIO {
+
+    enum Error: Swift.Error, Equatable {
+        /// `sockaddr_un.sun_path` holds 104 bytes including the terminator.
+        case pathTooLong(Int)
+    }
+
+    /// Longest socket path (in UTF-8 bytes) that fits `sun_path`.
+    static let maximumPathLength = 103
+
+    /// The environment keys the app uses to tell the assistant which channel
+    /// to use and where to find it. Keep in sync with the DO keys next to
+    /// them in `SPSSHTunnel.m`.
+    enum EnvironmentKey {
+        static let transport = "SP_CONNECTION_TRANSPORT"
+        static let socketPath = "SP_CONNECTION_SOCKET_PATH"
+    }
+
+    /// Environment values for `EnvironmentKey.transport`.
+    enum TransportValue {
+        static let distributedObjects = "distributedObjects"
+        static let socket = "socket"
+    }
+
+    static func address(for path: String) throws -> sockaddr_un {
+        let length = path.utf8.count
+        guard length <= maximumPathLength else { throw Error.pathTooLong(length) }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let capacity = maximumPathLength + 1
+        withUnsafeMutablePointer(to: &address.sun_path) { tuple in
+            tuple.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                _ = strlcpy(destination, path, capacity)
+            }
+        }
+        return address
+    }
+
+    /// A fresh AF_UNIX stream socket, or nil (errno set) on failure.
+    static func makeSocket() -> Int32? {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        configure(fd)
+        return fd
+    }
+
+    /// Close-on-exec so ssh and its children never inherit the descriptor,
+    /// and no SIGPIPE if the peer went away mid-write (the write just fails).
+    static func configure(_ fd: Int32) {
+        _ = fcntl(fd, F_SETFD, FD_CLOEXEC)
+        var one: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+    }
+
+    static func setBlocking(_ fd: Int32, _ blocking: Bool) {
+        let flags = fcntl(fd, F_GETFL)
+        guard flags >= 0 else { return }
+        _ = fcntl(fd, F_SETFL, blocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK))
+    }
+
+    /// Reads up to and including the first newline. Returns whatever arrived
+    /// before EOF when the peer closed without one, nil on a read error,
+    /// timeout, an empty stream, or a line beyond `limit` bytes.
+    static func readLine(_ fd: Int32, limit: Int = 64 * 1024) -> Data? {
+        var line = Data()
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        while line.count <= limit {
+            let count = read(fd, &chunk, chunk.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                return nil
+            }
+            if count == 0 {
+                return line.isEmpty ? nil : line
+            }
+            line.append(contentsOf: chunk[0..<count])
+            if let newline = line.firstIndex(of: 0x0A) {
+                return line[...newline]
+            }
+        }
+        return nil
+    }
+
+    static func writeAll(_ fd: Int32, _ data: Data) -> Bool {
+        var offset = 0
+        while offset < data.count {
+            let written = data.withUnsafeBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return -1 }
+                return write(fd, base + offset, data.count - offset)
+            }
+            if written < 0 {
+                if errno == EINTR { continue }
+                return false
+            }
+            offset += written
+        }
+        return true
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelSocketServer.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelSocketServer.swift
@@ -1,0 +1,235 @@
+//
+//  SASSHTunnelSocketServer.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// The app's end of the socket transport (SSH tunnel IPC plan, Step 3): a
+/// per-tunnel UNIX domain socket in the sandbox container that the
+/// sandbox-inheriting askpass assistant connects to, one request per
+/// connection.
+///
+/// Transport only. Every accepted connection is checked by `peerPolicy`,
+/// read, decoded, handed to `handler`, answered and closed; the decisions
+/// live in `SASSHTunnelAuthService`. A connection the policy rejects, or
+/// whose request does not decode, is closed without a reply — the assistant
+/// reads EOF and fails closed.
+@objc final class SASSHTunnelSocketServer: NSObject {
+
+    typealias Handler = (SASSHTunnelAuthRequest) -> SASSHTunnelAuthResponse
+
+    /// Decides whether the accepted connection on `fd` may be served. Step 4
+    /// supplies the code-signing check; until then every peer is accepted,
+    /// which matches what Distributed Objects does today.
+    typealias PeerPolicy = (Int32) -> Bool
+
+    enum Error: Swift.Error, Equatable {
+        case noUsableDirectory
+        case socketFailed(Int32)
+        case bindFailed(Int32)
+        case listenFailed(Int32)
+    }
+
+    /// Seconds an accepted connection may take to deliver its request line.
+    /// The reply has no timeout: it waits for the user to answer a prompt.
+    static let requestTimeout: Int = 10
+
+    /// The socket's path, handed to ssh as `SP_CONNECTION_SOCKET_PATH`.
+    @objc let path: String
+
+    private let listeningDescriptor: Int32
+    private let handler: Handler
+    private let peerPolicy: PeerPolicy
+    private let acceptQueue = DispatchQueue(label: "com.sequel-ace.ssh-tunnel.socket.accept")
+    private let serviceQueue = DispatchQueue(label: "com.sequel-ace.ssh-tunnel.socket.serve", attributes: .concurrent)
+    private var acceptSource: DispatchSourceRead?
+    private let stateLock = NSLock()
+    private var isClosed = false
+
+    /// Candidate directories, shortest usable first. Under the sandbox
+    /// `NSTemporaryDirectory()` is the container's tmp, which the
+    /// `com.apple.security.inherit` assistant shares.
+    static func candidateDirectories() -> [String] {
+        [NSTemporaryDirectory()]
+    }
+
+    /// The socket name is short on purpose: `sun_path` allows 103 bytes and
+    /// the container tmp already takes ~60 plus the user name.
+    static func socketFileName() -> String {
+        "ssh-" + String((0..<5).map { _ in String(format: "%02x", Int.random(in: 0...255)) }.joined()) + ".sock"
+    }
+
+    /// Removes sockets a previous app process left behind (a crash or a
+    /// kill skips `close()`): anything in the naming scheme that refuses a
+    /// connection. A live socket accepts, so it is left alone — its server
+    /// just sees one empty connection.
+    static func sweepStaleSockets(in directory: String) {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: directory) else { return }
+        for name in names where name.hasPrefix("ssh-") && name.hasSuffix(".sock") {
+            let candidate = (directory as NSString).appendingPathComponent(name)
+            guard var address = try? SASSHTunnelSocketIO.address(for: candidate),
+                  let fd = SASSHTunnelSocketIO.makeSocket() else { continue }
+            let connected = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            let code = errno
+            Darwin.close(fd)
+            if connected != 0 && code == ECONNREFUSED {
+                unlink(candidate)
+            }
+        }
+    }
+
+    /// Objective-C entry: serve a tunnel's `SASSHTunnelAuthService`.
+    @objc convenience init(service: SASSHTunnelAuthService) throws {
+        try self.init(handler: service.handle)
+    }
+
+    init(directories: [String] = SASSHTunnelSocketServer.candidateDirectories(),
+         handler: @escaping Handler,
+         peerPolicy: @escaping PeerPolicy = { _ in true }) throws {
+        self.handler = handler
+        self.peerPolicy = peerPolicy
+
+        // Pick the first directory whose path leaves room for the name.
+        var chosen: (String, sockaddr_un)?
+        for directory in directories {
+            let base = directory.hasSuffix("/") ? directory : directory + "/"
+            let candidate = base + Self.socketFileName()
+            if let address = try? SASSHTunnelSocketIO.address(for: candidate) {
+                chosen = (candidate, address)
+                break
+            }
+        }
+        guard let (path, address) = chosen else { throw Error.noUsableDirectory }
+        self.path = path
+        Self.sweepStaleSockets(in: (path as NSString).deletingLastPathComponent)
+
+        guard let fd = SASSHTunnelSocketIO.makeSocket() else { throw Error.socketFailed(errno) }
+        var boundAddress = address
+        let bound = withUnsafePointer(to: &boundAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0 else {
+            let code = errno
+            Darwin.close(fd)
+            throw Error.bindFailed(code)
+        }
+        // Belt and braces: the container is private already, the socket
+        // file is owner-only regardless of umask.
+        chmod(path, 0o600)
+        // One askpass launch at a time is the real load; the backlog is generous
+        // because macOS refuses (rather than queues) connects beyond it.
+        guard Darwin.listen(fd, 32) == 0 else {
+            let code = errno
+            Darwin.close(fd)
+            unlink(path)
+            throw Error.listenFailed(code)
+        }
+        SASSHTunnelSocketIO.setBlocking(fd, false)
+        listeningDescriptor = fd
+        super.init()
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: acceptQueue)
+        source.setEventHandler { [weak self] in self?.acceptPending() }
+        source.setCancelHandler {
+            Darwin.close(fd)
+            unlink(path)
+        }
+        source.resume()
+        acceptSource = source
+    }
+
+    deinit {
+        close()
+    }
+
+    /// Stops accepting, closes the listening socket and removes its file.
+    /// Connections already being served finish on their own.
+    @objc func close() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !isClosed else { return }
+        isClosed = true
+        acceptSource?.cancel()
+        acceptSource = nil
+    }
+
+    // MARK: - Accepting
+
+    private func acceptPending() {
+        while true {
+            let client = Darwin.accept(listeningDescriptor, nil, nil)
+            if client < 0 {
+                if errno == EINTR { continue }
+                return  // EWOULDBLOCK: backlog drained; anything else: give up for now
+            }
+            SASSHTunnelSocketIO.configure(client)
+            SASSHTunnelSocketIO.setBlocking(client, true)
+            serviceQueue.async { [handler, peerPolicy] in
+                Self.serve(client, handler: handler, peerPolicy: peerPolicy)
+            }
+        }
+    }
+
+    // MARK: - Serving one connection
+
+    private static func serve(_ client: Int32, handler: Handler, peerPolicy: PeerPolicy) {
+        defer { Darwin.close(client) }
+
+        guard peerPolicy(client) else {
+            NSLog("SSH tunnel: rejected an askpass connection that failed peer validation")
+            return
+        }
+
+        var timeout = timeval(tv_sec: requestTimeout, tv_usec: 0)
+        _ = setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        guard let line = SASSHTunnelSocketIO.readLine(client) else {
+            NSLog("SSH tunnel: askpass connection sent no request")
+            return
+        }
+        let request: SASSHTunnelAuthRequest
+        do {
+            request = try SASSHTunnelAuthWire.decodeRequest(line)
+        } catch {
+            NSLog("SSH tunnel: askpass request not understood (%@)", "\(error)")
+            return
+        }
+
+        let response = handler(request)
+        if !SASSHTunnelSocketIO.writeAll(client, SASSHTunnelAuthWire.encode(response)) {
+            NSLog("SSH tunnel: could not deliver the askpass reply (errno %d)", errno)
+        }
+    }
+}

--- a/Source/Other/SSHTunnel/SASSHTunnelTransport.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelTransport.swift
@@ -1,0 +1,81 @@
+//
+//  SASSHTunnelTransport.swift
+//  Sequel Ace
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+
+import Foundation
+
+/// Which channel a tunnel's askpass assistant answers over (SSH tunnel IPC
+/// plan, Step 3). Selected once per tunnel from a hidden preference and
+/// handed to ssh in its environment, so a tunnel never changes transport
+/// mid-life and support can flip the default without a rebuild:
+///
+///     defaults write com.sequel-ace.sequel-ace SPSSHTunnelUseSocketTransport -bool YES
+///
+/// App and Unit Tests targets.
+@objc enum SASSHTunnelTransport: Int {
+    case distributedObjects
+    case socket
+
+    /// The value written to `SP_CONNECTION_TRANSPORT`.
+    var environmentValue: String {
+        switch self {
+        case .distributedObjects: return SASSHTunnelSocketIO.TransportValue.distributedObjects
+        case .socket: return SASSHTunnelSocketIO.TransportValue.socket
+        }
+    }
+}
+
+@objc final class SASSHTunnelTransportSelection: NSObject {
+
+    /// Hidden preference: a Bool. Absent means `defaultTransport`.
+    static let defaultsKey = "SPSSHTunnelUseSocketTransport"
+
+    /// What a fresh install gets. Distributed Objects while the socket
+    /// transport soaks (Step 3); flipped in Step 5.
+    static let defaultTransport: SASSHTunnelTransport = .distributedObjects
+
+    @objc static let transportEnvironmentKey = SASSHTunnelSocketIO.EnvironmentKey.transport
+    @objc static let socketPathEnvironmentKey = SASSHTunnelSocketIO.EnvironmentKey.socketPath
+
+    static func selectedTransport(from defaults: UserDefaults) -> SASSHTunnelTransport {
+        guard defaults.object(forKey: defaultsKey) != nil else { return defaultTransport }
+        return defaults.bool(forKey: defaultsKey) ? .socket : .distributedObjects
+    }
+
+    @objc static func selectedTransport() -> SASSHTunnelTransport {
+        selectedTransport(from: .standard)
+    }
+
+    @objc(environmentValueForTransport:)
+    static func environmentValue(for transport: SASSHTunnelTransport) -> String {
+        transport.environmentValue
+    }
+
+    private override init() {}
+}

--- a/Source/Other/SSHTunnel/SPSSHTunnel.m
+++ b/Source/Other/SSHTunnel/SPSSHTunnel.m
@@ -63,6 +63,13 @@ static unsigned short getRandomPort(void);
 	// The prompt sheet currently running modally, if any. Main thread only.
 	// Lets teardown dismiss a prompt the assistant is blocked on.
 	NSWindow *activePromptDialog;
+
+	// Which channel this tunnel's assistant answers over (SSH tunnel IPC plan,
+	// Step 3): Distributed Objects above, or the UNIX-socket server below. Fixed
+	// for the tunnel's lifetime and handed to ssh in its environment, so a
+	// preference change cannot strand a running tunnel halfway.
+	SASSHTunnelTransport transport;
+	SASSHTunnelSocketServer *socketServer;
 }
 
 - (void)setLastError:(NSString *)msg;
@@ -121,6 +128,19 @@ static unsigned short getRandomPort(void);
 		if (![tunnelConnection registerName:tunnelConnectionName]) {
 			NSLog(@"Could not start ssh connection. %@", tunnelConnectionName);
 			return nil;
+		}
+
+		// The socket transport, when selected, serves the same authService; a
+		// tunnel whose socket cannot be created falls back to DO for its
+		// lifetime rather than failing.
+		transport = [SASSHTunnelTransportSelection selectedTransport];
+		if (transport == SASSHTunnelTransportSocket) {
+			NSError *socketError = nil;
+			socketServer = [[SASSHTunnelSocketServer alloc] initWithService:authService error:&socketError];
+			if (!socketServer) {
+				NSLog(@"SSH tunnel: socket transport unavailable (%@); using Distributed Objects for this tunnel", socketError);
+				transport = SASSHTunnelTransportDistributedObjects;
+			}
 		}
 		
 		parentWindow = nil;
@@ -539,6 +559,10 @@ static unsigned short getRandomPort(void);
 		[taskEnvironment safeSetObject:@":0" forKey:@"DISPLAY"];
 		[taskEnvironment safeSetObject:tunnelConnectionName forKey:@"SP_CONNECTION_NAME"];
 		[taskEnvironment safeSetObject:tunnelConnectionVerifyHash forKey:@"SP_CONNECTION_VERIFY_HASH"];
+		[taskEnvironment safeSetObject:[SASSHTunnelTransportSelection environmentValueForTransport:transport] forKey:SASSHTunnelTransportSelection.transportEnvironmentKey];
+		if (socketServer) {
+			[taskEnvironment safeSetObject:socketServer.path forKey:SASSHTunnelTransportSelection.socketPathEnvironmentKey];
+		}
 		if (passwordInKeychain) {
 			// The keychain item's name and account deliberately stay out of
 			// the environment: the assistant no longer reads the keychain —
@@ -1049,6 +1073,7 @@ static unsigned short getRandomPort(void);
 	[NSObject cancelPreviousPerformRequestsWithTarget:self];
 	
 	[tunnelConnection invalidate];
+	[socketServer close];
 	
 	[self setLastError:nil];
 	

--- a/Source/Other/SSHTunnel/SequelAceTunnelAssistant.m
+++ b/Source/Other/SSHTunnel/SequelAceTunnelAssistant.m
@@ -38,6 +38,13 @@
 int main(int argc, const char *argv[])
 {
 	@autoreleasepool {
+		// The socket transport (SSH tunnel IPC plan, Step 3) is handled entirely
+		// in Swift; everything below is the Distributed Objects path, kept
+		// verbatim until Step 5 deletes it.
+		if ([SASSHTunnelAssistantSocketMain isSelectedInEnvironment]) {
+			return [SASSHTunnelAssistantSocketMain run];
+		}
+
 		NSDictionary *environment = [[NSProcessInfo processInfo] environment];
 		NSString *argument = nil;
 		SPSSHTunnel *sequelProTunnel;

--- a/UnitTests/SASSHTunnelAskpassTests.swift
+++ b/UnitTests/SASSHTunnelAskpassTests.swift
@@ -122,6 +122,25 @@ final class SASSHTunnelAskpassTests: XCTestCase {
         XCTAssertEqual(channel.logs, ["SSH Tunnel: unable to connect to Sequel Ace for internal authentication"])
     }
 
+    func testPasswordTransportErrorFailsClosedWithoutTheFallback() {
+        // Only an explicit refusal may reach the GUI fallback; a broken channel
+        // must not open a second connection and possibly print a secret.
+        channel.respond = { request in
+            if case .password = request { throw Channel.Failure() }
+            return .secret("must-not-be-printed")
+        }
+        XCTAssertEqual(run("me@bastion's password: "), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.requests, [.password(verificationHash: "hash-1")])
+        XCTAssertEqual(channel.connectAttempts, 1)
+        XCTAssertTrue(channel.logs.last?.contains("unable to obtain the password") == true)
+    }
+
+    func testUnexpectedReplyKindToThePasswordRequestFailsClosed() {
+        channel.respond = { _ in .answer(true) }
+        XCTAssertEqual(run("me@bastion's password: "), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.requests.count, 1)
+    }
+
     func testHeldPasswordMissFallsBackToTheGUIPromptWithTheDirectMessage() {
         channel.respond = { request in
             if case .query(let text, _) = request { return .secret("typed:" + text) }

--- a/UnitTests/SASSHTunnelAskpassTests.swift
+++ b/UnitTests/SASSHTunnelAskpassTests.swift
@@ -1,0 +1,206 @@
+//
+//  SASSHTunnelAskpassTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+/// The askpass assistant's decisions, pinned against a fake channel (Step 3
+/// of the SSH tunnel IPC plan). Each case mirrors a branch of the
+/// Objective-C `main` it was lifted from.
+final class SASSHTunnelAskpassTests: XCTestCase {
+
+    private typealias Outcome = SASSHTunnelAskpass.Outcome
+
+    private final class Channel {
+        var connectAttempts = 0
+        var connectFails = false
+        var requests: [SASSHTunnelAuthRequest] = []
+        var respond: (SASSHTunnelAuthRequest) throws -> SASSHTunnelAuthResponse = { _ in .refused }
+        var logs: [String] = []
+
+        func connect() throws -> SASSHTunnelAskpass.Transport {
+            connectAttempts += 1
+            if connectFails { throw Failure() }
+            return { request in
+                self.requests.append(request)
+                return try self.respond(request)
+            }
+        }
+        struct Failure: Error {}
+    }
+
+    private var channel = Channel()
+
+    private let baseEnvironment = [
+        "SP_PASSWORD_METHOD": "1",
+        "SP_CONNECTION_NAME": "NKQ4HJ66PX.sequel-ace.SequelAce-1",
+        "SP_CONNECTION_VERIFY_HASH": "hash-1",
+    ]
+
+    private func run(_ argument: String?, environment: [String: String]? = nil) -> Outcome {
+        SASSHTunnelAskpass.run(argument: argument, environment: environment ?? baseEnvironment,
+                               connect: channel.connect, log: { self.channel.logs.append($0) })
+    }
+
+    // MARK: - Preconditions
+
+    func testNoPasswordMethodExitsWithoutConnecting() {
+        XCTAssertEqual(run("host's password:", environment: [:]), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.connectAttempts, 0)
+    }
+
+    func testNoArgumentExitsWithoutConnecting() {
+        XCTAssertEqual(run(nil), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.connectAttempts, 0)
+    }
+
+    // MARK: - Questions
+
+    func testQuestionIsAnsweredYesOrNo() {
+        channel.respond = { _ in .answer(true) }
+        XCTAssertEqual(run("Are you sure you want to continue connecting (yes/no/[fingerprint])? "), Outcome(output: "yes", exitCode: 0))
+        channel.respond = { _ in .answer(false) }
+        XCTAssertEqual(run("Are you sure you want to continue connecting (yes/no)? "), Outcome(output: "no", exitCode: 0))
+        XCTAssertEqual(channel.requests, [
+            .question("Are you sure you want to continue connecting (yes/no/[fingerprint])? "),
+            .question("Are you sure you want to continue connecting (yes/no)? "),
+        ])
+    }
+
+    func testQuestionTakesPrecedenceOverAPasswordLookingPrompt() {
+        channel.respond = { _ in .answer(true) }
+        XCTAssertEqual(run("Reset password: continue (yes/no)?").output, "yes")
+        XCTAssertEqual(channel.requests.count, 1)
+        if case .question = channel.requests[0] {} else { XCTFail("expected a question") }
+    }
+
+    func testQuestionFailsClosedWhenTheAppIsUnreachable() {
+        channel.connectFails = true
+        XCTAssertEqual(run("continue (yes/no)?"), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.logs, ["SSH Tunnel: unable to connect to Sequel Ace to show SSH question"])
+    }
+
+    func testQuestionFailsClosedOnATransportErrorOrARefusal() {
+        channel.respond = { _ in throw Channel.Failure() }
+        XCTAssertEqual(run("continue (yes/no)?"), Outcome(output: nil, exitCode: 1))
+        channel.respond = { _ in .refused }
+        XCTAssertEqual(run("continue (yes/no)?"), Outcome(output: nil, exitCode: 1))
+    }
+
+    // MARK: - The SSH password
+
+    func testPasswordIsFetchedFromTheAppWithTheHash() {
+        channel.respond = { _ in .secret("hunter2") }
+        XCTAssertEqual(run("me@bastion's password: "), Outcome(output: "hunter2", exitCode: 0))
+        XCTAssertEqual(channel.requests, [.password(verificationHash: "hash-1")])
+        XCTAssertEqual(channel.connectAttempts, 1)
+    }
+
+    func testPasswordPromptMatchesCaseInsensitively() {
+        channel.respond = { _ in .secret("pw") }
+        XCTAssertEqual(run("PASSWORD:").output, "pw")
+    }
+
+    func testPasswordNeedsBothConnectionDetails() {
+        var environment = baseEnvironment
+        environment.removeValue(forKey: "SP_CONNECTION_VERIFY_HASH")
+        XCTAssertEqual(run("password:", environment: environment), Outcome(output: nil, exitCode: 1))
+        environment = baseEnvironment
+        environment.removeValue(forKey: "SP_CONNECTION_NAME")
+        XCTAssertEqual(run("password:", environment: environment), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.connectAttempts, 0)
+        XCTAssertEqual(channel.logs.last, "SSH Tunnel: internal authentication specified but insufficient details supplied")
+    }
+
+    func testPasswordFailsClosedWhenTheAppIsUnreachable() {
+        channel.connectFails = true
+        XCTAssertEqual(run("password:"), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.logs, ["SSH Tunnel: unable to connect to Sequel Ace for internal authentication"])
+    }
+
+    func testHeldPasswordMissFallsBackToTheGUIPromptWithTheDirectMessage() {
+        channel.respond = { request in
+            if case .query(let text, _) = request { return .secret("typed:" + text) }
+            return .refused
+        }
+        let outcome = run("me@bastion's password: ")
+        let expected = String(format: NSLocalizedString("The SSH password could not be loaded; please enter the SSH password for %@:", comment: ""), "NKQ4HJ66PX.sequel-ace.SequelAce-1")
+        XCTAssertEqual(outcome, Outcome(output: "typed:" + expected, exitCode: 0))
+        XCTAssertEqual(channel.requests, [.password(verificationHash: "hash-1"), .query(expected, verificationHash: "hash-1")])
+        XCTAssertEqual(channel.connectAttempts, 2, "one connection per request, as the Objective-C original re-resolved its proxy")
+        XCTAssertEqual(channel.logs, ["SSH Tunnel: unable to successfully request password from Sequel Ace for internal authentication"])
+    }
+
+    func testKeychainMissFallsBackWithTheKeychainMessage() {
+        var environment = baseEnvironment
+        environment["SP_PASSWORD_METHOD"] = "0"
+        channel.respond = { request in
+            if case .query(let text, _) = request { return .secret("typed:" + text) }
+            return .refused
+        }
+        let outcome = run("password:", environment: environment)
+        let expected = String(format: NSLocalizedString("The SSH password could not be loaded from the keychain; please enter the SSH password for %@:", comment: ""), "NKQ4HJ66PX.sequel-ace.SequelAce-1")
+        XCTAssertEqual(outcome, Outcome(output: "typed:" + expected, exitCode: 0))
+        XCTAssertEqual(channel.logs, ["SSH Tunnel: specified keychain password not found"])
+    }
+
+    func testFallbackPromptCancelExitsNonZero() {
+        channel.respond = { _ in .refused }
+        XCTAssertEqual(run("password:"), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.requests.count, 2)
+    }
+
+    func testPasswordMethodNoneGoesStraightToTheGUIPromptWithTheOriginalText() {
+        var environment = baseEnvironment
+        environment["SP_PASSWORD_METHOD"] = "2"
+        channel.respond = { _ in .secret("typed") }
+        XCTAssertEqual(run("me@bastion's password: ", environment: environment), Outcome(output: "typed", exitCode: 0))
+        XCTAssertEqual(channel.requests, [.query("me@bastion's password: ", verificationHash: "hash-1")])
+    }
+
+    func testNonNumericPasswordMethodReadsAsKeychainLikeIntegerValueDid() {
+        var environment = baseEnvironment
+        environment["SP_PASSWORD_METHOD"] = "keychain"
+        channel.respond = { _ in .refused }
+        _ = run("password:", environment: environment)
+        XCTAssertEqual(channel.logs.first, "SSH Tunnel: specified keychain password not found")
+    }
+
+    // MARK: - Passphrases and everything else
+
+    func testPassphraseQueryGoesToTheGUIPrompt() {
+        channel.respond = { _ in .secret("pp") }
+        XCTAssertEqual(run("Enter passphrase for key '/Users/me/.ssh/id_ed25519': "), Outcome(output: "pp", exitCode: 0))
+        XCTAssertEqual(channel.requests, [.query("Enter passphrase for key '/Users/me/.ssh/id_ed25519': ", verificationHash: "hash-1")])
+    }
+
+    func testAnyOtherPromptGoesToTheGUIPromptToo() {
+        channel.respond = { _ in .secret("123456") }
+        XCTAssertEqual(run("Enter PASSCODE: ").output, "123456")
+    }
+
+    func testQueryRefusedExitsNonZeroWithoutOutput() {
+        channel.respond = { _ in .refused }
+        XCTAssertEqual(run("Enter passphrase for key '/k': "), Outcome(output: nil, exitCode: 1))
+    }
+
+    func testQueryNeedsTheHash() {
+        var environment = baseEnvironment
+        environment.removeValue(forKey: "SP_CONNECTION_VERIFY_HASH")
+        XCTAssertEqual(run("Enter passphrase for key '/k': ", environment: environment), Outcome(output: nil, exitCode: 1))
+        XCTAssertEqual(channel.connectAttempts, 0)
+        XCTAssertEqual(channel.logs, ["SSH Tunnel: key passphrase authentication required but insufficient details supplied to connect to GUI"])
+    }
+
+    func testQueryFailsClosedWhenTheAppIsUnreachableOrTheTransportFails() {
+        channel.connectFails = true
+        XCTAssertEqual(run("Enter passphrase for key '/k': "), Outcome(output: nil, exitCode: 1))
+        channel = Channel()
+        channel.respond = { _ in throw Channel.Failure() }
+        XCTAssertEqual(run("Enter passphrase for key '/k': "), Outcome(output: nil, exitCode: 1))
+    }
+}

--- a/UnitTests/SASSHTunnelSocketTransportTests.swift
+++ b/UnitTests/SASSHTunnelSocketTransportTests.swift
@@ -1,0 +1,272 @@
+//
+//  SASSHTunnelSocketTransportTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+/// Both ends of the socket transport, in-process over a socket in the test
+/// runner's temporary directory (Step 3 of the SSH tunnel IPC plan). Covers
+/// the wire contract end to end and every refusal path; peer validation
+/// itself is Step 4's, exercised here only through the policy hooks.
+final class SASSHTunnelSocketTransportTests: XCTestCase {
+
+    private var servers: [SASSHTunnelSocketServer] = []
+
+    override func tearDown() {
+        servers.forEach { $0.close() }
+        servers = []
+        super.tearDown()
+    }
+
+    private func startServer(peerPolicy: @escaping SASSHTunnelSocketServer.PeerPolicy = { _ in true },
+                             handler: @escaping SASSHTunnelSocketServer.Handler) throws -> SASSHTunnelSocketServer {
+        let server = try SASSHTunnelSocketServer(directories: [NSTemporaryDirectory()], handler: handler, peerPolicy: peerPolicy)
+        servers.append(server)
+        return server
+    }
+
+    private static func echo(_ request: SASSHTunnelAuthRequest) -> SASSHTunnelAuthResponse {
+        switch request {
+        case .question(let text): return .answer(text.contains("yes"))
+        case .password(let hash): return .secret("pw-" + hash)
+        case .query(let text, let hash): return text.isEmpty ? .refused : .secret(text + "|" + hash)
+        }
+    }
+
+    // MARK: - Happy path
+
+    func testEveryRequestKindRoundTrips() throws {
+        let server = try startServer(handler: Self.echo)
+        let client = SASSHTunnelSocketClient(path: server.path)
+
+        XCTAssertEqual(try client.send(.question("continue? yes")), .answer(true))
+        XCTAssertEqual(try client.send(.question("continue?")), .answer(false))
+        XCTAssertEqual(try client.send(.password(verificationHash: "42")), .secret("pw-42"))
+        XCTAssertEqual(try client.send(.query("Enter passphrase for key '/k':", verificationHash: "42")),
+                       .secret("Enter passphrase for key '/k':|42"))
+        XCTAssertEqual(try client.send(.query("", verificationHash: "42")), .refused)
+    }
+
+    func testMultilinePromptSurvivesTheSocket() throws {
+        let prompt = "line one\nline two\nAre you sure (yes/no)? "
+        let server = try startServer { request in
+            guard case .question(let text) = request else { return .refused }
+            return .answer(text == prompt)
+        }
+        XCTAssertEqual(try SASSHTunnelSocketClient(path: server.path).send(.question(prompt)), .answer(true))
+    }
+
+    func testConcurrentConnectionsAreAllServed() throws {
+        let server = try startServer(handler: Self.echo)
+        let client = SASSHTunnelSocketClient(path: server.path)
+        let results = SAAsyncResultBoxLite()
+        DispatchQueue.concurrentPerform(iterations: 12) { index in
+            let response = try? client.send(.password(verificationHash: "\(index)"))
+            results.record(index: index, response: response)
+        }
+        for index in 0..<12 {
+            XCTAssertEqual(results[index], .secret("pw-\(index)"), "connection \(index)")
+        }
+    }
+
+    func testHandlerRunsOffTheAcceptLoopSoASlowPromptDoesNotBlockOthers() throws {
+        let slowStarted = expectation(description: "slow request reached the handler")
+        let release = DispatchSemaphore(value: 0)
+        let server = try startServer { request in
+            if case .question = request {
+                slowStarted.fulfill()
+                release.wait()
+                return .answer(true)
+            }
+            return Self.echo(request)
+        }
+        let client = SASSHTunnelSocketClient(path: server.path)
+
+        let slowDone = expectation(description: "slow request answered")
+        DispatchQueue.global().async {
+            XCTAssertEqual(try? client.send(.question("blocks")), .answer(true))
+            slowDone.fulfill()
+        }
+        wait(for: [slowStarted], timeout: 5)
+
+        // While the first connection is parked in its handler, another is served.
+        XCTAssertEqual(try client.send(.password(verificationHash: "fast")), .secret("pw-fast"))
+
+        release.signal()
+        wait(for: [slowDone], timeout: 5)
+    }
+
+    // MARK: - The socket file
+
+    func testSocketFileIsOwnerOnlyAndRemovedOnClose() throws {
+        let server = try startServer(handler: Self.echo)
+        var status = stat()
+        XCTAssertEqual(stat(server.path, &status), 0)
+        XCTAssertEqual(status.st_mode & S_IFMT, S_IFSOCK)
+        XCTAssertEqual(status.st_mode & 0o777, 0o600)
+        XCTAssertLessThanOrEqual(server.path.utf8.count, SASSHTunnelSocketIO.maximumPathLength)
+
+        server.close()
+        let deadline = Date().addingTimeInterval(3)
+        while FileManager.default.fileExists(atPath: server.path) && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: server.path))
+
+        XCTAssertThrowsError(try SASSHTunnelSocketClient(path: server.path).send(.question("q"))) { error in
+            guard case SASSHTunnelSocketClient.Error.connectFailed = error else { return XCTFail("\(error)") }
+        }
+        XCTAssertNoThrow(server.close(), "closing twice is harmless")
+    }
+
+    func testStaleSocketsFromADeadProcessAreSweptButLiveOnesStay() throws {
+        // A bound-then-closed socket is what a killed app leaves behind.
+        let stale = NSTemporaryDirectory() + "ssh-deadbeef00.sock"
+        unlink(stale)
+        close(try rawListener(at: stale))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stale))
+
+        let live = try startServer(handler: Self.echo)
+        let next = try startServer(handler: Self.echo)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale), "swept when the next server started")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: live.path), "the live socket survived the sweep")
+        XCTAssertEqual(try SASSHTunnelSocketClient(path: live.path).send(.password(verificationHash: "a")), .secret("pw-a"))
+        XCTAssertEqual(try SASSHTunnelSocketClient(path: next.path).send(.password(verificationHash: "b")), .secret("pw-b"))
+    }
+
+    func testTwoServersGetDistinctPaths() throws {
+        let first = try startServer(handler: Self.echo)
+        let second = try startServer(handler: Self.echo)
+        XCTAssertNotEqual(first.path, second.path)
+    }
+
+    func testDirectoryThatCannotFitTheNameIsSkippedAndNoneIsAnError() {
+        let tooLong = "/" + String(repeating: "a", count: 110)
+        XCTAssertThrowsError(try SASSHTunnelSocketServer(directories: [tooLong], handler: Self.echo)) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketServer.Error, .noUsableDirectory)
+        }
+        XCTAssertNoThrow(try SASSHTunnelSocketServer(directories: [tooLong, NSTemporaryDirectory()], handler: Self.echo).close())
+    }
+
+    // MARK: - Refusals
+
+    func testServerRejectingThePeerClosesWithoutAReply() throws {
+        var handled = 0
+        let server = try startServer(peerPolicy: { _ in false }) { request in handled += 1; return Self.echo(request) }
+        XCTAssertThrowsError(try SASSHTunnelSocketClient(path: server.path).send(.password(verificationHash: "h"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketClient.Error, .noReply)
+        }
+        XCTAssertEqual(handled, 0)
+    }
+
+    func testClientRejectingThePeerSendsNothing() throws {
+        var handled = 0
+        let server = try startServer { request in handled += 1; return Self.echo(request) }
+        var client = SASSHTunnelSocketClient(path: server.path)
+        var inspected = 0
+        client.peerPolicy = { _ in inspected += 1; return false }
+        XCTAssertThrowsError(try client.send(.password(verificationHash: "h"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketClient.Error, .peerRejected)
+        }
+        XCTAssertEqual(inspected, 1)
+        Thread.sleep(forTimeInterval: 0.1)
+        XCTAssertEqual(handled, 0)
+    }
+
+    func testMalformedRequestIsDroppedAndTheServerKeepsServing() throws {
+        var handled = 0
+        let server = try startServer { request in handled += 1; return Self.echo(request) }
+
+        let raw = try rawConnection(to: server.path)
+        XCTAssertTrue(SASSHTunnelSocketIO.writeAll(raw, Data("this is not json\n".utf8)))
+        XCTAssertNil(SASSHTunnelSocketIO.readLine(raw), "no reply for garbage — EOF")
+        close(raw)
+        XCTAssertEqual(handled, 0)
+
+        XCTAssertEqual(try SASSHTunnelSocketClient(path: server.path).send(.password(verificationHash: "h")), .secret("pw-h"))
+        XCTAssertEqual(handled, 1)
+    }
+
+    func testUnsupportedVersionIsRefusedNotGuessed() throws {
+        let server = try startServer(handler: Self.echo)
+        let raw = try rawConnection(to: server.path)
+        XCTAssertTrue(SASSHTunnelSocketIO.writeAll(raw, Data((#"{"hash":"h","kind":"password","v":2}"# + "\n").utf8)))
+        XCTAssertNil(SASSHTunnelSocketIO.readLine(raw))
+        close(raw)
+    }
+
+    func testMalformedReplyIsAnErrorForTheClient() throws {
+        // A listener that answers with nonsense.
+        let path = NSTemporaryDirectory() + "sa-test-\(UUID().uuidString.prefix(8)).sock"
+        let listener = try rawListener(at: path)
+        defer { close(listener); unlink(path) }
+        DispatchQueue.global().async {
+            let client = accept(listener, nil, nil)
+            guard client >= 0 else { return }
+            _ = SASSHTunnelSocketIO.readLine(client)
+            _ = SASSHTunnelSocketIO.writeAll(client, Data("{\"v\":1,\"kind\":\"nope\"}\n".utf8))
+            close(client)
+        }
+        XCTAssertThrowsError(try SASSHTunnelSocketClient(path: path).send(.question("q"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketClient.Error, .malformedReply(.unknownKind("nope")))
+        }
+    }
+
+    func testMissingSocketIsAConnectFailure() {
+        XCTAssertThrowsError(try SASSHTunnelSocketClient(path: NSTemporaryDirectory() + "sa-nonexistent.sock").send(.question("q"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketClient.Error, .connectFailed(ENOENT))
+        }
+    }
+
+    func testClientRefusesAPathThatCannotFitSunPath() {
+        let tooLong = "/" + String(repeating: "b", count: 110)
+        XCTAssertThrowsError(try SASSHTunnelSocketClient(path: tooLong).send(.question("q"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketIO.Error, .pathTooLong(111))
+        }
+    }
+
+    // MARK: - Raw socket helpers
+
+    private func rawConnection(to path: String) throws -> Int32 {
+        var address = try SASSHTunnelSocketIO.address(for: path)
+        let fd = try XCTUnwrap(SASSHTunnelSocketIO.makeSocket())
+        let rc = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        XCTAssertEqual(rc, 0, "connect errno \(errno)")
+        return fd
+    }
+
+    private func rawListener(at path: String) throws -> Int32 {
+        var address = try SASSHTunnelSocketIO.address(for: path)
+        let fd = try XCTUnwrap(SASSHTunnelSocketIO.makeSocket())
+        let rc = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        XCTAssertEqual(rc, 0, "bind errno \(errno)")
+        XCTAssertEqual(listen(fd, 2), 0)
+        return fd
+    }
+}
+
+/// Lock-protected result collection for the concurrency test.
+private final class SAAsyncResultBoxLite {
+    private let lock = NSLock()
+    private var responses: [Int: SASSHTunnelAuthResponse?] = [:]
+    func record(index: Int, response: SASSHTunnelAuthResponse?) {
+        lock.lock(); responses[index] = response; lock.unlock()
+    }
+    subscript(index: Int) -> SASSHTunnelAuthResponse? {
+        lock.lock(); defer { lock.unlock() }
+        return responses[index] ?? nil
+    }
+}

--- a/UnitTests/SASSHTunnelTransportTests.swift
+++ b/UnitTests/SASSHTunnelTransportTests.swift
@@ -1,0 +1,48 @@
+//
+//  SASSHTunnelTransportTests.swift
+//  Unit Tests
+//
+//  Created by the Sequel Ace team on September 1, 2026.
+//  Copyright (c) 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+/// The hidden transport preference and its environment encoding (Step 3 of
+/// the SSH tunnel IPC plan).
+final class SASSHTunnelTransportTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suite = "com.sequel-ace.tests.SASSHTunnelTransportTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suite)
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suite)
+        super.tearDown()
+    }
+
+    func testAbsentPreferenceMeansTheDefaultWhichIsDistributedObjectsWhileTheSocketSoaks() {
+        XCTAssertEqual(SASSHTunnelTransportSelection.selectedTransport(from: defaults), .distributedObjects)
+        XCTAssertEqual(SASSHTunnelTransportSelection.defaultTransport, .distributedObjects)
+    }
+
+    func testPreferenceSelectsTheSocketOrDistributedObjects() {
+        defaults.set(true, forKey: SASSHTunnelTransportSelection.defaultsKey)
+        XCTAssertEqual(SASSHTunnelTransportSelection.selectedTransport(from: defaults), .socket)
+        defaults.set(false, forKey: SASSHTunnelTransportSelection.defaultsKey)
+        XCTAssertEqual(SASSHTunnelTransportSelection.selectedTransport(from: defaults), .distributedObjects)
+    }
+
+    func testEnvironmentValuesMatchWhatTheAssistantLooksFor() {
+        XCTAssertEqual(SASSHTunnelTransport.socket.environmentValue, "socket")
+        XCTAssertEqual(SASSHTunnelTransport.distributedObjects.environmentValue, "distributedObjects")
+        XCTAssertEqual(SASSHTunnelTransportSelection.environmentValue(for: .socket), SASSHTunnelSocketIO.TransportValue.socket)
+        XCTAssertEqual(SASSHTunnelTransportSelection.transportEnvironmentKey, "SP_CONNECTION_TRANSPORT")
+        XCTAssertEqual(SASSHTunnelTransportSelection.socketPathEnvironmentKey, "SP_CONNECTION_SOCKET_PATH")
+    }
+}

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -294,7 +294,7 @@ kinds, missing or mistyped fields — including `"secret": null`, which is
 refused rather than read as empty). Nothing in the file is `public`: the
 assistant's Objective-C `main` never touches these types.
 
-## Step 3 — Socket alongside DO, behind a default
+## Step 3 — Socket alongside DO, behind a default — ✅ Done (default still DO)
 
 Both transports built; a hidden `NSUserDefaults` key selects. Default to DO
 in the first release that contains the code, so it can be exercised by early
@@ -328,6 +328,60 @@ and is already per-launch. A tunnel therefore uses one transport for its
 whole life, and flipping the default cannot strand a running tunnel halfway.
 If the socket cannot be created (a `sun_path` over 104 bytes, say) the tunnel
 falls back to DO for that launch and logs it.
+
+Execution notes (2026-09-01):
+
+- Landed as described, with these specifics. The preference is a Bool,
+  `SPSSHTunnelUseSocketTransport` (absent → `SASSHTunnelTransportSelection.defaultTransport`,
+  which is DO for now); the app passes `SP_CONNECTION_TRANSPORT` and
+  `SP_CONNECTION_SOCKET_PATH`. The DO connection is still registered for
+  every tunnel, so a socket failure at init falls back with no gap. The
+  socket file is `ssh-<10 hex>.sock`, mode 0600, in the container tmp: the
+  name is short because that directory already costs ~60 bytes plus the user
+  name against the 103-byte limit — with this naming a user name of up to 19
+  characters fits, and anything longer falls back to DO for now (see
+  Step 5's to-do). `SASSHTunnelSocketServer` also **sweeps stale sockets**
+  when it starts: a killed app skips `close()`, and the first live run left
+  its socket file behind until this was added. Stale means "refuses a
+  connection", so live sockets are untouched.
+- The listen backlog is 32, not the obvious 5: macOS *refuses* rather than
+  queues a UNIX-socket connect beyond the backlog, which the concurrency test
+  hit at 12 parallel askpass launches. Accepted sockets are served on a
+  concurrent queue so one parked prompt never blocks another connection.
+- Assistant side, three Swift files: `SASSHTunnelAskpass` (the decisions,
+  pure, 20 tests mirroring every branch of the Objective-C `main` — including
+  the keychain-miss and direct-miss fallback messages, `integerValue`'s
+  non-numeric-is-0 reading of `SP_PASSWORD_METHOD`, and that a question wins
+  over a prompt that merely contains "password:"), `SASSHTunnelSocketClient`
+  (connect, send one line, read one line), and the `public`
+  `SASSHTunnelAssistantSocketMain` entry the `.m` calls first thing. The DO
+  path in the `.m` is byte-for-byte what it was; it is deleted in Step 5.
+- Tests: 14 in `SASSHTunnelSocketTransportTests` run both ends in-process —
+  every request kind, multi-line prompts, 12 concurrent connections, the
+  slow-prompt-does-not-block-others case, 0600 + unlink-on-close, distinct
+  paths, the stale sweep, and every refusal (server policy → EOF, client
+  policy → nothing sent, garbage/unsupported version → dropped and the server
+  keeps serving, malformed reply, missing socket, over-long path). 3 in
+  `SASSHTunnelTransportTests` for the preference. Full suite 1279 / 0
+  failures.
+- **Live verification, both transports**, against a Docker `openssh-server`
+  (password auth, `AllowTcpForwarding yes`) forwarding to a `mysql:8.4`
+  container, driven by an auto-connect `.spf` and the flag passed via
+  `open --args`: on the socket transport ssh authenticated (`Accepted
+  password` in sshd's log), held the `-L` forward, and the app's MySQL
+  sessions arrived through it; the socket file was present and 0600 during
+  the tunnel's life. Same result on DO with the flag off (no socket file).
+  Manual-matrix row 12 also fell out: with the assistant parked on a
+  passphrase prompt over the socket, killing the app made it exit at once
+  instead of hanging — EOF on the socket fails closed.
+- **Not verified live** (needs a hand on the UI or a real keychain
+  interaction): the passphrase prompt sheet, host-key yes/no, cancel at each
+  prompt, the keychain-miss fallback message, and a stored passphrase served
+  from the keychain — that last one was attempted (item added with
+  `security add-generic-password -T <app>`) and the app blocked on either the
+  keychain ACL prompt or its own sheet, which cannot be told apart or
+  dismissed from a script. The decisions behind all of these are unit-tested;
+  the transport underneath them is the same one the password path proved.
 
 ## Step 4 — Peer validation (the security win)
 
@@ -363,6 +417,14 @@ the `NSConnection` ivar, the assistant's DO shim and its `SPSSHTunnel.h`
 import, and replace `SequelAceTunnelAssistant.m` with `main.swift`. The
 remaining `NSConnection` warnings go to zero at this point — a side effect,
 not the goal.
+
+Before DO can go, the socket must have somewhere to live for *every* user:
+today a container-tmp path over 103 bytes (user names past ~19 characters)
+falls back to DO. Give the server a second candidate directory that is short
+and sandbox-reachable — the per-user `DARWIN_USER_TEMP_DIR` (`/var/folders/…/T/`,
+~50 bytes) is the obvious one if the sandbox permits it for both processes;
+prove it the same way Step 0 did — and turn the fallback into a hard error
+with a clear log line.
 
 ## Swift or not
 

--- a/docs/development/ssh-tunnel-xpc-migration-plan.md
+++ b/docs/development/ssh-tunnel-xpc-migration-plan.md
@@ -368,8 +368,11 @@ Execution notes (2026-09-01):
 - Assistant side, three Swift files: `SASSHTunnelAskpass` (the decisions,
   pure, 20 tests mirroring every branch of the Objective-C `main` — including
   the keychain-miss and direct-miss fallback messages, `integerValue`'s
-  non-numeric-is-0 reading of `SP_PASSWORD_METHOD`, and that a question wins
-  over a prompt that merely contains "password:"), `SASSHTunnelSocketClient`
+  non-numeric-is-0 reading of `SP_PASSWORD_METHOD`, that a question wins
+  over a prompt that merely contains "password:", and — after Codex review —
+  that only an explicit `refused` reaches the GUI fallback: a channel error
+  on the password request is exit 1, never a second connection that might
+  print a secret), `SASSHTunnelSocketClient`
   (connect, send one line, read one line), and the `public`
   `SASSHTunnelAssistantSocketMain` entry the `.m` calls first thing. The DO
   path in the `.m` is byte-for-byte what it was; it is deleted in Step 5.

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,8 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
+		F04AA77A50488C1B938879D7 /* SASSHTunnelAssistantSocketMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B923047624A00BCE2B9 /* SASSHTunnelAssistantSocketMain.swift */; };
+		AC8C26C73E9B45F473139262 /* SASSHTunnelAskpass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B8F3047623E00BCE2B9 /* SASSHTunnelAskpass.swift */; };
+		45FF68FFB401A6EA11C6D134 /* SASSHTunnelSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B8C3047622700BCE2B9 /* SASSHTunnelSocketClient.swift */; };
+		67D6D5054AF5FECC0EFE4EFF /* SASSHTunnelSocketIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */; };
 		03B3C091388E27E56C58B846 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
+		07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
 		090DF1933C6B8C6349D58020 /* SAKeychainDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB073761524C5CB0C4EA801 /* SAKeychainDisabled.swift */; };
 		0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
 		0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427339B03172104D2C98666 /* SAKeychainTestSupport.swift */; };
@@ -293,6 +297,17 @@
 		51AC3B7A304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
 		51AC3B7B304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
 		51AC3B80304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */; };
+		51AC3B84304761F800BCE2B9 /* SASSHTunnelSocketIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */; };
+		51AC3B85304761F800BCE2B9 /* SASSHTunnelSocketIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */; };
+		51AC3B8A3047621900BCE2B9 /* SASSHTunnelSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B893047621900BCE2B9 /* SASSHTunnelSocketServer.swift */; };
+		51AC3B8B3047621900BCE2B9 /* SASSHTunnelSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B893047621900BCE2B9 /* SASSHTunnelSocketServer.swift */; };
+		51AC3B8D3047622700BCE2B9 /* SASSHTunnelSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B8C3047622700BCE2B9 /* SASSHTunnelSocketClient.swift */; };
+		51AC3B903047623E00BCE2B9 /* SASSHTunnelAskpass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B8F3047623E00BCE2B9 /* SASSHTunnelAskpass.swift */; };
+		51AC3B963047625800BCE2B9 /* SASSHTunnelTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B953047625800BCE2B9 /* SASSHTunnelTransport.swift */; };
+		51AC3B973047625800BCE2B9 /* SASSHTunnelTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B953047625800BCE2B9 /* SASSHTunnelTransport.swift */; };
+		51AC3B993047629E00BCE2B9 /* SASSHTunnelSocketTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B983047629E00BCE2B9 /* SASSHTunnelSocketTransportTests.swift */; };
+		51AC3B9B304762C400BCE2B9 /* SASSHTunnelAskpassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B9A304762C400BCE2B9 /* SASSHTunnelAskpassTests.swift */; };
+		51AC3B9D304762CE00BCE2B9 /* SASSHTunnelTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B9C304762CE00BCE2B9 /* SASSHTunnelTransportTests.swift */; };
 		51B09FC92F7677AA003BAFFF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */; };
 		51B09FD12F7677EB003BAFFF /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD02F7677EB003BAFFF /* FirebaseAnalyticsCore */; };
 		51B09FD32F7677EB003BAFFF /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 51B09FD22F7677EB003BAFFF /* FirebaseCrashlytics */; };
@@ -1161,6 +1176,15 @@
 		51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthServiceTests.swift; sourceTree = "<group>"; };
 		51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthMessage.swift; sourceTree = "<group>"; };
 		51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAuthMessageTests.swift; sourceTree = "<group>"; };
+		51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelSocketIO.swift; sourceTree = "<group>"; };
+		51AC3B893047621900BCE2B9 /* SASSHTunnelSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelSocketServer.swift; sourceTree = "<group>"; };
+		51AC3B8C3047622700BCE2B9 /* SASSHTunnelSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelSocketClient.swift; sourceTree = "<group>"; };
+		51AC3B8F3047623E00BCE2B9 /* SASSHTunnelAskpass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAskpass.swift; sourceTree = "<group>"; };
+		51AC3B923047624A00BCE2B9 /* SASSHTunnelAssistantSocketMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAssistantSocketMain.swift; sourceTree = "<group>"; };
+		51AC3B953047625800BCE2B9 /* SASSHTunnelTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelTransport.swift; sourceTree = "<group>"; };
+		51AC3B983047629E00BCE2B9 /* SASSHTunnelSocketTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelSocketTransportTests.swift; sourceTree = "<group>"; };
+		51AC3B9A304762C400BCE2B9 /* SASSHTunnelAskpassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelAskpassTests.swift; sourceTree = "<group>"; };
+		51AC3B9C304762CE00BCE2B9 /* SASSHTunnelTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SASSHTunnelTransportTests.swift; sourceTree = "<group>"; };
 		51B09FC82F7677AA003BAFFF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionInfo.swift; sourceTree = "<group>"; };
 		51B09FDC2F767A4C003BAFFF /* SAConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDelegate.swift; sourceTree = "<group>"; };
@@ -2359,6 +2383,12 @@
 				51AC3B7130475EAD00BCE2B9 /* SASSHTunnelAuthService.swift */,
 				58CDB3310FCE139C00F8ACA3 /* SequelAceTunnelAssistant.m */,
 				51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */,
+				51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */,
+				51AC3B893047621900BCE2B9 /* SASSHTunnelSocketServer.swift */,
+				51AC3B8C3047622700BCE2B9 /* SASSHTunnelSocketClient.swift */,
+				51AC3B8F3047623E00BCE2B9 /* SASSHTunnelAskpass.swift */,
+				51AC3B923047624A00BCE2B9 /* SASSHTunnelAssistantSocketMain.swift */,
+				51AC3B953047625800BCE2B9 /* SASSHTunnelTransport.swift */,
 			);
 			name = "SSH Tunnel";
 			path = SSHTunnel;
@@ -2773,6 +2803,9 @@
 				51DD6924303C2F99004792F0 /* SAFavoriteDuplicateMatcherTests.swift */,
 				51AC3B7330475ED600BCE2B9 /* SASSHTunnelAuthServiceTests.swift */,
 				51AC3B7F304760FD00BCE2B9 /* SASSHTunnelAuthMessageTests.swift */,
+				51AC3B983047629E00BCE2B9 /* SASSHTunnelSocketTransportTests.swift */,
+				51AC3B9A304762C400BCE2B9 /* SASSHTunnelAskpassTests.swift */,
+				51AC3B9C304762CE00BCE2B9 /* SASSHTunnelTransportTests.swift */,
 			);
 			name = Other;
 			sourceTree = "<group>";
@@ -3406,6 +3439,8 @@
 				505F568F1BCEE485007467DD /* SPFunctions.m in Sources */,
 				FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */,
 				502D21F81BA50966000D4CE7 /* SPDataAdditions.m in Sources */,
+				51AC3B8D3047622700BCE2B9 /* SASSHTunnelSocketClient.swift in Sources */,
+				51AC3B8B3047621900BCE2B9 /* SASSHTunnelSocketServer.swift in Sources */,
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
 				9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */,
 				0C794751619B275F42D2A42B /* SAKeychainTestSupport.swift in Sources */,
@@ -3453,6 +3488,9 @@
 				1AB925922551550200063446 /* NumberFormatterExtension.swift in Sources */,
 				50EA926A1AB246B8008D3C4F /* SPDatabaseActionTest.m in Sources */,
 				FD8099A92C59DE1D0084646F /* SABaseFormatter.swift in Sources */,
+				51AC3B85304761F800BCE2B9 /* SASSHTunnelSocketIO.swift in Sources */,
+				51AC3B963047625800BCE2B9 /* SASSHTunnelTransport.swift in Sources */,
+				51AC3B9D304762CE00BCE2B9 /* SASSHTunnelTransportTests.swift in Sources */,
 				50EA92651AB23EC8008D3C4F /* SPDatabaseAction.m in Sources */,
 				C2E7A3B52E5E1A1A00D22990 /* SPDatabaseData.m in Sources */,
 				C2E7A3B62E5E1B3A00D22990 /* NSAlertExtension.swift in Sources */,
@@ -3538,6 +3576,7 @@
 				5AF0C2000000000000000032 /* SAFavoriteItemTests.swift in Sources */,
 				51DD6925303C2F99004792F0 /* SAFavoriteDuplicateMatcherTests.swift in Sources */,
 				5147B00D2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
+				51AC3B903047623E00BCE2B9 /* SASSHTunnelAskpass.swift in Sources */,
 				5147B00F2F8C000300C4C14A /* SAConnectionDetailsValidatorTests.swift in Sources */,
 				961210D2302E7233009A9A2A /* SAGitHubReleaseTests.swift in Sources */,
 				5147B0122F8C000400C4C14A /* SAConnectionFormHelpers.swift in Sources */,
@@ -3549,6 +3588,7 @@
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */,
+				51AC3B993047629E00BCE2B9 /* SASSHTunnelSocketTransportTests.swift in Sources */,
 				1AE6C1CD25B07E9500880D73 /* SPFunctionsTests.m in Sources */,
 				1A9A40D525875EC9009F0E71 /* NSMutableArray-MultipleSort.m in Sources */,
 				51AA84052FDE000100C4C14A /* SAAutoIncrementRuleSupportTests.swift in Sources */,
@@ -3559,6 +3599,7 @@
 				96557E151CF87F3F4EA29A47 /* AWSLoginCredentialsProvider.swift in Sources */,
 				11ACD43BE52B0351BBFE518F /* AWSSSOClient.swift in Sources */,
 				441E45F5DCF87A54D8FEC130 /* SADatabaseScopedValueCache.swift in Sources */,
+				51AC3B9B304762C400BCE2B9 /* SASSHTunnelAskpassTests.swift in Sources */,
 				624E13DFBB2F343500B94705 /* SADatabaseScopedValueCacheTests.swift in Sources */,
 				0B0F0950807A8DF7B38C26AC /* SPMCPFavorite.swift in Sources */,
 				CACA94EDDD5F7ADE62E4CA71 /* SAMCPToolDefinitions.swift in Sources */,
@@ -3594,6 +3635,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F04AA77A50488C1B938879D7 /* SASSHTunnelAssistantSocketMain.swift in Sources */,
+				AC8C26C73E9B45F473139262 /* SASSHTunnelAskpass.swift in Sources */,
+				45FF68FFB401A6EA11C6D134 /* SASSHTunnelSocketClient.swift in Sources */,
+				67D6D5054AF5FECC0EFE4EFF /* SASSHTunnelSocketIO.swift in Sources */,
 				07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */,
 				17D41A8221700F8200B1888D /* SPFunctions.m in Sources */,
 				1A4CB04F2592535300EDF804 /* StringRegexExtension.swift in Sources */,
@@ -3685,6 +3730,7 @@
 				BCD0AD490FBBFC340066EA5C /* SPSQLTokenizer.l in Sources */,
 				1A89558725D6E15D0060CE72 /* GitHub.swift in Sources */,
 				1A11E51625A36C62001CB721 /* HyperlinkTextField.swift in Sources */,
+				51AC3B84304761F800BCE2B9 /* SASSHTunnelSocketIO.swift in Sources */,
 				F3A4B8C191E14E7094C9B011 /* AWSCredentials.swift in Sources */,
 				F3A4B8C191E14E7094C9B012 /* RDSIAMAuthentication.swift in Sources */,
 				F3A4B8C191E14E7094C9B013 /* AWSSTSClient.swift in Sources */,
@@ -3717,6 +3763,7 @@
 				5AF0C1000000000000000002 /* SAFavoritesListView.swift in Sources */,
 				5AF0C2000000000000000002 /* SAFavoriteItem.swift in Sources */,
 				5AF0C2000000000000000012 /* SAFavoriteItem+Tree.swift in Sources */,
+				51AC3B8A3047621900BCE2B9 /* SASSHTunnelSocketServer.swift in Sources */,
 				5AF0C2000000000000000022 /* SAFavoritesList.swift in Sources */,
 				5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00C2F8C000300C4C14A /* SAConnectionDetailsValidator.swift in Sources */,
@@ -3867,6 +3914,7 @@
 				5843E247162B555B00EAA6D1 /* SPThreadAdditions.m in Sources */,
 				58D2A6A716FBDEFF002EB401 /* SPComboPopupButton.m in Sources */,
 				65F52CC824AE21D600FED3CB /* SPFilePreferencePane.m in Sources */,
+				51AC3B973047625800BCE2B9 /* SASSHTunnelTransport.swift in Sources */,
 				501B1D181728A3DA0017C92E /* SPCharsetCollationHelper.m in Sources */,
 				50E217B318174246009D3580 /* SPColorSelectorView.m in Sources */,
 				50E217B618174280009D3580 /* SPFavoriteColorSupport.m in Sources */,


### PR DESCRIPTION
## Summary

Step 3 of `docs/development/ssh-tunnel-xpc-migration-plan.md`, stacked on #2619. Both transports are built; a hidden preference selects one; **the default stays Distributed Objects** so the socket can soak with early adopters and support can flip it without a rebuild:

```
defaults write com.sequel-ace.sequel-ace SPSSHTunnelUseSocketTransport -bool YES
```

**App side.** `SASSHTunnelSocketServer` (Swift, app + Unit Tests) serves a tunnel's `SASSHTunnelAuthService` over a per-tunnel UNIX domain socket in the sandbox container — the directory the `com.apple.security.inherit` assistant shares. `ssh-<10 hex>.sock`, mode 0600, unlinked on close, stale files from a killed app swept at start (stale = refuses a connection, so live sockets are untouched). Accepted connections are served on a concurrent queue (a parked prompt never blocks another), each read with a 10 s request timeout, decoded, handed to `SASSHTunnelAuthService.handle`, answered, closed; anything the peer policy rejects or that does not decode is closed **without a reply**, which the assistant reads as EOF and fails closed. `SPSSHTunnel` creates the server when the socket is selected, keeps the DO connection registered as the fallback (a socket failure at init logs and uses DO for that tunnel), and hands ssh `SP_CONNECTION_TRANSPORT` + `SP_CONNECTION_SOCKET_PATH` next to the existing hash — the assistant cannot read the preference, and a tunnel must never change transport mid-life.

**Assistant side.** The decisions of `SequelAceTunnelAssistant.m` are now `SASSHTunnelAskpass` (Swift, pure, assistant + Unit Tests): which prompt this is, which request to send, what to print, which fallback message on a keychain miss — branch for branch, including `integerValue`'s non-numeric-is-0 reading of `SP_PASSWORD_METHOD` and that a `(yes/no` question wins over a prompt that merely contains "password:". `SASSHTunnelSocketClient` connects, validates the peer (hook only until Step 4), sends one line, reads one line. `SASSHTunnelAssistantSocketMain` is the `public` entry the `.m` calls first thing (public because the tool target has no bridging header). **The DO path in the `.m` is byte-for-byte what it was**; it goes in Step 5 together with `main.swift`, because `NSConnection` is unavailable from Swift.

Two things learned the hard way, both in the plan's execution notes: macOS *refuses* rather than queues a UNIX-socket connect beyond the listen backlog (so it is 32, and the 12-way concurrency test caught it), and the container tmp path already costs ~60 bytes plus the user name against `sun_path`'s 103, hence the short socket name — user names past ~19 characters fall back to DO for now, and the plan records a second-directory to-do that must land before Step 5 can delete DO.

## Test plan

- [x] 14 tests in `SASSHTunnelSocketTransportTests` running both ends in-process: every request kind, multi-line prompts, 12 concurrent connections, slow prompt does not block others, 0600 + unlink on close, distinct paths, the stale sweep, and every refusal path (server policy → EOF, client policy → nothing sent, garbage / unsupported version → dropped and the server keeps serving, malformed reply, missing socket, over-long path).
- [x] 20 tests in `SASSHTunnelAskpassTests` (every branch of the old `main`), 3 in `SASSHTunnelTransportTests`.
- [x] Full "Unit Tests" scheme: 1279 tests, 63 skipped, 0 failures. Clean Debug build (app + assistant).
- [x] **Live, both transports**: Docker `linuxserver/openssh-server` (password auth, `AllowTcpForwarding yes`) forwarding to `mysql:8.4`, driven by an auto-connect `.spf` with the flag passed via `open --args`. Socket: sshd logged `Accepted password`, ssh held the `-L` forward, MySQL showed the app's sessions arriving through the tunnel, socket file present and 0600 meanwhile. DO (flag off): same, no socket file.
- [x] **Manual-matrix row 12** (app quits mid-prompt): with the assistant parked on a passphrase prompt over the socket, killing the app made it exit immediately — no hang.
- [ ] ⚠️ Still needs a hand on the UI before merge: passphrase prompt sheet, host-key yes/no, cancel at each prompt, keychain-miss fallback message, stored passphrase served from the keychain (attempted; the app blocked on a keychain ACL prompt or its sheet, which a script cannot tell apart). All of their decisions are unit-tested and ride the same transport the password path proved.

## Tested
- Processors: Apple Silicon
- macOS: 26.x
- Xcode: 26 beta (SDK 27.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
