### PR TITLE
#fixed Preserve ENUM popup edits in sheet mode

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4206,9 +4206,10 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 {
 	if (tableView == tableContentView) {
 		NSInteger columnIndex = [[tableColumn identifier] integerValue];
-		// If the current cell should have been edited in a sheet, do nothing - field closing will have already
-		// updated the field.
-		if ([tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL]) {
+		// Ignore the unchanged value sent while inline text editing redirects to a sheet. Popup cells send the
+		// user's real selection through this callback even when sheet editing is enabled, so retain those commits.
+		BOOL fieldEditorRequired = [tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL];
+		if ([SAFieldEditorCommitPolicy shouldIgnoreInlineCommitWithFieldEditorRequired:fieldEditorRequired cell:tableColumn.dataCell]) {
 			return;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -492,6 +492,9 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		newTableName = [tableDetails objectForKey:@"name"];
 	}
 	BOOL tableChanged = ![selectedTable isEqualToString:newTableName];
+	// Column identifiers are storage indexes. Start the generation boundary
+	// before UI teardown can end editing and emit a callback from the old model.
+	[_comboBoxSelectionTracker tableColumnModelWillChange];
 
 	// Ensure the pagination view hides itself if visible, after a tiny delay for smoothness
 	[self performSelector:@selector(setPaginationViewVisibility:) withObject:nil afterDelay:0.1];
@@ -546,10 +549,6 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 		maxNumRowsIsEstimate = YES;
 	}
-
-	// Column identifiers are storage indexes. Rebuilding the model invalidates
-	// deferred edits even if a following data query fails and leaves rows intact.
-	[_comboBoxSelectionTracker tableColumnModelWillChange];
 
 	// Reset data column store
 	[dataColumns removeAllObjects];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4210,8 +4210,15 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		id storedValue = nil;
 		id displayValue = nil;
 		if (fieldEditorRequired && [tableColumn.dataCell isKindOfClass:[NSComboBoxCell class]]) {
-			storedValue = [tableValues cellDataAtRow:rowIndex column:columnIndex];
 			NSInteger visibleColumnIndex = [tableContentView columnWithIdentifier:[tableColumn identifier]];
+			// A field-editor handoff can finish after the table has reloaded. The old path returned before
+			// touching storage, so preserve that safety while inspecting changed combo-box callbacks.
+			if (isWorking || rowIndex < 0 || columnIndex < 0 || visibleColumnIndex < 0
+				|| (NSUInteger)rowIndex >= [tableValues count]
+				|| (NSUInteger)columnIndex >= [tableValues columnCount]) {
+				return;
+			}
+			storedValue = [tableValues cellDataAtRow:(NSUInteger)rowIndex column:(NSUInteger)columnIndex];
 			displayValue = [tableContentView displayStringForRow:rowIndex column:visibleColumnIndex];
 		}
 		// Ignore callbacks produced while inline editing redirects to a sheet. A changed popup selection is the

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -122,6 +122,8 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 - (NSString *)_recordViewStringForValue:(id)value tableColumn:(NSTableColumn *)tableColumn;
 - (NSInteger)_recordViewSelectedRow;
 - (NSTableColumn *)_recordViewColumnAtIndex:(NSInteger)fieldIndex;
+- (void)_tableDataReloadDidFinish;
+- (void)_resumeDeferredComboBoxEdit;
 
 #pragma mark - SPTableContentDataSource_Private_API
 
@@ -1113,7 +1115,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
         }
 		[[filterTableController onMainThread] setFilterError:0 message:nil sqlstate:nil];
 	}
-	[_comboBoxSelectionTracker tableDataReloadDidFinish];
+	[self _tableDataReloadDidFinish];
 }
 
 /**
@@ -1361,6 +1363,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
  */
 - (IBAction)reloadTable:(id)sender
 {
+	// Reserve the reload before detaching its worker so popup callbacks cannot
+	// slip through between a schema-mismatch load and its queued full reload.
+	[_comboBoxSelectionTracker tableDataReloadWillBegin];
 	[tableDocumentInstance startTaskWithDescription:NSLocalizedString(@"Reloading data...", @"Reloading data task description")];
 
 	if ([NSThread isMainThread]) {
@@ -1390,7 +1395,32 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		}
 
 		[tableDocumentInstance endTask];
+		[self _tableDataReloadDidFinish];
 	}
+}
+
+- (void)_tableDataReloadDidFinish
+{
+	if (![_comboBoxSelectionTracker tableDataReloadDidFinish]) return;
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self _resumeDeferredComboBoxEdit];
+	});
+}
+
+- (void)_resumeDeferredComboBoxEdit
+{
+	// An enclosing document task can outlive its data query. Its end
+	// notification calls this method again once table editing is safe.
+	if (isWorking) return;
+
+	SADeferredComboBoxEdit *edit = [_comboBoxSelectionTracker takeDeferredEditIfReady];
+	if (!edit) return;
+
+	[self tableView:tableContentView
+	  setObjectValue:edit.proposedValue
+	  forTableColumn:edit.tableColumn
+	  row:edit.row];
 }
 
 /**
@@ -3992,6 +4022,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 - (void) endDocumentTaskForTab:(NSNotification *)aNotification
 {
 	isWorking = NO;
+	[self _resumeDeferredComboBoxEdit];
 
 	// Only proceed if this view is selected.
 	if (![[tableDocumentInstance selectedToolbarItemIdentifier] isEqualToString:SPMainToolbarTableContent])
@@ -4025,6 +4056,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
         if (tableDocumentInstance == document) {
             // if a result load is in progress we must stop the timer or it may try to call invalid IBOutlets
             [self clearTableLoadTimer];
+            [_comboBoxSelectionTracker discardPendingSelection];
         }
     }
 }
@@ -4238,7 +4270,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		NSCell *dataCell = tableColumn.dataCell;
 		SAComboBoxSelectionState popupSelectionState = SAComboBoxSelectionStateNotTracked;
 		if ([dataCell isKindOfClass:[NSComboBoxCell class]]) {
-			popupSelectionState = [_comboBoxSelectionTracker consumeSelectionMatching:object];
+			popupSelectionState = [_comboBoxSelectionTracker consumeSelectionMatching:object
+			                                                               tableColumn:tableColumn
+			                                                                       row:rowIndex];
 		} else {
 			[_comboBoxSelectionTracker discardPendingSelection];
 		}

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -102,10 +102,11 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 // Formal conformance for methods AppKit moved off the informal NSObject
 // categories; implementing them without it is deprecated. No behavior change.
-@interface SPTableContent () <SATableHeaderViewDelegate, NSMenuItemValidation>
+@interface SPTableContent () <SATableHeaderViewDelegate, NSMenuItemValidation, SPComboBoxCellDelegate>
 
 @property (assign, nonatomic) BOOL deferRecordViewRefreshUntilTableLoadCompletes;
 @property (assign, nonatomic) BOOL suppressRecordViewTaskRefresh;
+@property (strong, nonatomic) SAComboBoxSelectionTracker *comboBoxSelectionTracker;
 
 - (BOOL)cancelRowEditing;
 - (void)documentWillClose:(NSNotification *)notification;
@@ -143,6 +144,7 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		tableValues       = [[SPDataStorage alloc] init];
 		dataColumns       = [[NSMutableArray alloc] init];
 		oldRow            = [[NSMutableArray alloc] init];
+		_comboBoxSelectionTracker = [[SAComboBoxSelectionTracker alloc] init];
 
 		tableRowsCount         = 0;
 		previousTableRowsCount = 0;
@@ -768,6 +770,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
     if ([typegroup isEqualToString:@"enum"]) {
         cell = [[SPComboBoxCell alloc] initTextCell:@""];
+        [cell setSpDelegate:tc];
         [cell setButtonBordered:NO];
         [cell setBezeled:NO];
         [cell setDrawsBackground:NO];
@@ -837,6 +840,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
  */
 - (void) clearTableValues
 {
+	[_comboBoxSelectionTracker tableDataWillReload];
 	if ([NSThread isMainThread]) {
 		[recordViewController clear];
 	} else {
@@ -861,6 +865,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 {
 	// If no table is selected, return
 	if (!selectedTable) return;
+	[_comboBoxSelectionTracker tableDataWillReload];
 
 	NSMutableString *queryString;
 	NSString *queryStringBeforeLimit = nil;
@@ -1120,6 +1125,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	tableLoadTargetRowCount = targetRowCount;
 
 	// Update the data storage, updating the current store if appropriate
+	// Invalidate again at the mutation boundary. This covers a popup opened after a load started but before
+	// the streaming result replaced an existing store with another result of the same dimensions.
+	[_comboBoxSelectionTracker tableDataWillReload];
 	pthread_mutex_lock(&tableValuesLock);
 	tableRowsCount = 0;
 	[tableValues setDataStorage:theResultStore updatingExisting:!![tableValues count]];
@@ -4121,6 +4129,19 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 }
 
 #pragma mark -
+#pragma mark Combo box delegate methods
+
+- (void)comboBoxCell:(SPComboBoxCell *)cell willPopUpWindow:(NSWindow *)window
+{
+	[_comboBoxSelectionTracker comboBoxWillOpen];
+}
+
+- (void)comboBoxCellSelectionDidChange:(SPComboBoxCell *)cell
+{
+	[_comboBoxSelectionTracker comboBoxSelectionDidChange:[cell objectValueOfSelectedItem]];
+}
+
+#pragma mark -
 #pragma mark TableView datasource methods
 
 - (NSInteger)numberOfRowsInTableView:(SPCopyTable *)tableView
@@ -4207,12 +4228,19 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	if (tableView == tableContentView) {
 		NSInteger columnIndex = [[tableColumn identifier] integerValue];
 		BOOL fieldEditorRequired = [tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL];
+		NSCell *dataCell = tableColumn.dataCell;
+		BOOL popupSelectionIsCurrent = NO;
+		if ([dataCell isKindOfClass:[NSComboBoxCell class]]) {
+			popupSelectionIsCurrent = [_comboBoxSelectionTracker consumeCurrentSelectionMatching:object];
+		} else {
+			[_comboBoxSelectionTracker discardPendingSelection];
+		}
 		id storedValue = nil;
 		id displayValue = nil;
-		if (fieldEditorRequired && [tableColumn.dataCell isKindOfClass:[NSComboBoxCell class]]) {
+		if (fieldEditorRequired && popupSelectionIsCurrent) {
 			NSInteger visibleColumnIndex = [tableContentView columnWithIdentifier:[tableColumn identifier]];
-			// A field-editor handoff can finish after the table has reloaded. The old path returned before
-			// touching storage, so preserve that safety while inspecting changed combo-box callbacks.
+			// The authenticated popup selection can still finish after its row has disappeared. Preserve the
+			// old handoff path's bounds safety before comparing against the current snapshot.
 			if (isWorking || rowIndex < 0 || columnIndex < 0 || visibleColumnIndex < 0
 				|| (NSUInteger)rowIndex >= [tableValues count]
 				|| (NSUInteger)columnIndex >= [tableValues columnCount]) {
@@ -4225,10 +4253,11 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		// one inline action that must still commit. Compare its proposed value with both full stored and display
 		// representations so long strings, NULL placeholders, and formatter-backed values remain unchanged.
 		if ([SAFieldEditorCommitPolicy shouldIgnoreInlineCommitWithFieldEditorRequired:fieldEditorRequired
-		                                                                          cell:tableColumn.dataCell
+		                                                                          cell:dataCell
 		                                                                proposedValue:object
 		                                                                    storedValue:storedValue
-		                                                                   displayValue:displayValue]) {
+		                                                                   displayValue:displayValue
+		                                                        popupSelectionIsCurrent:popupSelectionIsCurrent]) {
 			return;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4133,12 +4133,17 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 
 - (void)comboBoxCell:(SPComboBoxCell *)cell willPopUpWindow:(NSWindow *)window
 {
-	[_comboBoxSelectionTracker comboBoxWillOpen];
+	[_comboBoxSelectionTracker comboBoxWillOpenWithValue:[cell objectValue]];
 }
 
 - (void)comboBoxCellSelectionDidChange:(SPComboBoxCell *)cell
 {
 	[_comboBoxSelectionTracker comboBoxSelectionDidChange:[cell objectValueOfSelectedItem]];
+}
+
+- (void)comboBoxCellDidDismissPopUp:(SPComboBoxCell *)cell
+{
+	[_comboBoxSelectionTracker comboBoxDidCloseWithValue:[cell objectValue]];
 }
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4206,10 +4206,13 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 {
 	if (tableView == tableContentView) {
 		NSInteger columnIndex = [[tableColumn identifier] integerValue];
-		// Ignore the unchanged value sent while inline text editing redirects to a sheet. Popup cells send the
-		// user's real selection through this callback even when sheet editing is enabled, so retain those commits.
+		id currentObject = [self tableView:tableContentView objectValueForTableColumn:tableColumn row:rowIndex];
+		// Ignore the unchanged value sent while inline editing redirects to a sheet. Popup selections send their
+		// changed value through the same callback even when sheet editing is enabled, so retain those commits.
 		BOOL fieldEditorRequired = [tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL];
-		if ([SAFieldEditorCommitPolicy shouldIgnoreInlineCommitWithFieldEditorRequired:fieldEditorRequired cell:tableColumn.dataCell]) {
+		if ([SAFieldEditorCommitPolicy shouldIgnoreInlineCommitWithFieldEditorRequired:fieldEditorRequired
+		                                                                proposedValue:object
+		                                                                 currentValue:currentObject]) {
 			return;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4206,13 +4206,22 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 {
 	if (tableView == tableContentView) {
 		NSInteger columnIndex = [[tableColumn identifier] integerValue];
-		id currentObject = [self tableView:tableContentView objectValueForTableColumn:tableColumn row:rowIndex];
-		// Ignore the unchanged value sent while inline editing redirects to a sheet. Popup selections send their
-		// changed value through the same callback even when sheet editing is enabled, so retain those commits.
 		BOOL fieldEditorRequired = [tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL];
+		id storedValue = nil;
+		id displayValue = nil;
+		if (fieldEditorRequired && [tableColumn.dataCell isKindOfClass:[NSComboBoxCell class]]) {
+			storedValue = [tableValues cellDataAtRow:rowIndex column:columnIndex];
+			NSInteger visibleColumnIndex = [tableContentView columnWithIdentifier:[tableColumn identifier]];
+			displayValue = [tableContentView displayStringForRow:rowIndex column:visibleColumnIndex];
+		}
+		// Ignore callbacks produced while inline editing redirects to a sheet. A changed popup selection is the
+		// one inline action that must still commit. Compare its proposed value with both full stored and display
+		// representations so long strings, NULL placeholders, and formatter-backed values remain unchanged.
 		if ([SAFieldEditorCommitPolicy shouldIgnoreInlineCommitWithFieldEditorRequired:fieldEditorRequired
+		                                                                          cell:tableColumn.dataCell
 		                                                                proposedValue:object
-		                                                                 currentValue:currentObject]) {
+		                                                                    storedValue:storedValue
+		                                                                   displayValue:displayValue]) {
 			return;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -840,7 +840,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
  */
 - (void) clearTableValues
 {
-	[_comboBoxSelectionTracker tableDataWillReload];
+	[_comboBoxSelectionTracker tableDataWillChange];
 	if ([NSThread isMainThread]) {
 		[recordViewController clear];
 	} else {
@@ -865,7 +865,8 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 {
 	// If no table is selected, return
 	if (!selectedTable) return;
-	[_comboBoxSelectionTracker tableDataWillReload];
+	// Conservatively block popup commits until this load either mutates the snapshot or finishes unchanged.
+	[_comboBoxSelectionTracker tableDataReloadWillBegin];
 
 	NSMutableString *queryString;
 	NSString *queryStringBeforeLimit = nil;
@@ -1112,6 +1113,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
         }
 		[[filterTableController onMainThread] setFilterError:0 message:nil sqlstate:nil];
 	}
+	[_comboBoxSelectionTracker tableDataReloadDidFinish];
 }
 
 /**
@@ -1125,9 +1127,9 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 	tableLoadTargetRowCount = targetRowCount;
 
 	// Update the data storage, updating the current store if appropriate
-	// Invalidate again at the mutation boundary. This covers a popup opened after a load started but before
+	// Invalidate at the mutation boundary. This covers a popup opened after a load started but before
 	// the streaming result replaced an existing store with another result of the same dimensions.
-	[_comboBoxSelectionTracker tableDataWillReload];
+	[_comboBoxSelectionTracker tableDataWillChange];
 	pthread_mutex_lock(&tableValuesLock);
 	tableRowsCount = 0;
 	[tableValues setDataStorage:theResultStore updatingExisting:!![tableValues count]];

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -4229,15 +4229,15 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		NSInteger columnIndex = [[tableColumn identifier] integerValue];
 		BOOL fieldEditorRequired = [tableContentView shouldUseFieldEditorForRow:rowIndex column:columnIndex checkWithLock:NULL];
 		NSCell *dataCell = tableColumn.dataCell;
-		BOOL popupSelectionIsCurrent = NO;
+		SAComboBoxSelectionState popupSelectionState = SAComboBoxSelectionStateNotTracked;
 		if ([dataCell isKindOfClass:[NSComboBoxCell class]]) {
-			popupSelectionIsCurrent = [_comboBoxSelectionTracker consumeCurrentSelectionMatching:object];
+			popupSelectionState = [_comboBoxSelectionTracker consumeSelectionMatching:object];
 		} else {
 			[_comboBoxSelectionTracker discardPendingSelection];
 		}
 		id storedValue = nil;
 		id displayValue = nil;
-		if (fieldEditorRequired && popupSelectionIsCurrent) {
+		if (fieldEditorRequired && popupSelectionState == SAComboBoxSelectionStateCurrent) {
 			NSInteger visibleColumnIndex = [tableContentView columnWithIdentifier:[tableColumn identifier]];
 			// The authenticated popup selection can still finish after its row has disappeared. Preserve the
 			// old handoff path's bounds safety before comparing against the current snapshot.
@@ -4257,7 +4257,7 @@ static id configureDataCell(SPTableContent *tc, NSDictionary *colDefs, NSString 
 		                                                                proposedValue:object
 		                                                                    storedValue:storedValue
 		                                                                   displayValue:displayValue
-		                                                        popupSelectionIsCurrent:popupSelectionIsCurrent]) {
+		                                                           popupSelectionState:popupSelectionState]) {
 			return;
 		}
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -547,6 +547,10 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 		maxNumRowsIsEstimate = YES;
 	}
 
+	// Column identifiers are storage indexes. Rebuilding the model invalidates
+	// deferred edits even if a following data query fails and leaves rows intact.
+	[_comboBoxSelectionTracker tableColumnModelWillChange];
+
 	// Reset data column store
 	[dataColumns removeAllObjects];
 

--- a/Source/Views/Cells/SPComboBoxCell.h
+++ b/Source/Views/Cells/SPComboBoxCell.h
@@ -38,6 +38,7 @@
 - (void)comboBoxCell:(SPComboBoxCell *)cell willPopUpWindow:(NSWindow *)win;
 - (void)comboBoxCell:(SPComboBoxCell *)cell willDismissWindow:(NSWindow *)win;
 - (void)comboBoxCellSelectionDidChange:(SPComboBoxCell *)cell;
+- (void)comboBoxCellDidDismissPopUp:(SPComboBoxCell *)cell;
 
 @end
 

--- a/Source/Views/Cells/SPComboBoxCell.m
+++ b/Source/Views/Cells/SPComboBoxCell.m
@@ -104,6 +104,11 @@ static NSString *_CellWillDismissNotification = @"NSComboBoxCellWillDismissNotif
 	[[NSNotificationCenter defaultCenter] removeObserver:self
 													name:_CellWillDismissNotification
 												  object:self];
+
+	// The cell's object value is final only after the popup event loop returns.
+	if([[self spDelegate] respondsToSelector:@selector(comboBoxCellDidDismissPopUp:)]) {
+		[[self spDelegate] comboBoxCellDidDismissPopUp:self];
+	}
 }
 
 - (void)sp_selectionDidChange:(NSNotification *)notification

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -20,6 +20,8 @@ import AppKit
     private let lock = NSLock()
     private var dataGeneration: UInt = 0
     private var popupGeneration: UInt?
+    private var openingValue: NSObject?
+    private var hasOpeningValue = false
     private var pendingSelection: NSObject?
     private var hasPendingSelection = false
 
@@ -32,11 +34,14 @@ import AppKit
         dataGeneration &+= 1
     }
 
-    @objc func comboBoxWillOpen() {
+    @objc(comboBoxWillOpenWithValue:)
+    func comboBoxWillOpen(with value: NSObject?) {
         lock.lock()
         defer { lock.unlock() }
 
         popupGeneration = dataGeneration
+        openingValue = value
+        hasOpeningValue = true
         pendingSelection = nil
         hasPendingSelection = false
     }
@@ -53,6 +58,24 @@ import AppKit
         hasPendingSelection = true
     }
 
+    @objc(comboBoxDidCloseWithValue:)
+    func comboBoxDidClose(with value: NSObject?) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Selection-change notifications describe the highlighted popup row,
+        // even when Escape later restores the opening value. Retain provenance
+        // only when a changed candidate became the cell's final object value.
+        guard popupGeneration != nil,
+              hasOpeningValue,
+              hasPendingSelection,
+              valuesMatch(pendingSelection, value),
+              !valuesMatch(openingValue, pendingSelection) else {
+            clearPendingSelection()
+            return
+        }
+    }
+
     @objc(consumeSelectionMatching:)
     func consumeSelection(matching proposedValue: NSObject?) -> SAComboBoxSelectionState {
         lock.lock()
@@ -67,10 +90,7 @@ import AppKit
         guard popupGeneration == dataGeneration else {
             return .invalidated
         }
-        guard let pendingSelection else {
-            return proposedValue == nil ? .current : .notTracked
-        }
-        return pendingSelection.isEqual(proposedValue) ? .current : .notTracked
+        return valuesMatch(pendingSelection, proposedValue) ? .current : .notTracked
     }
 
     @objc func discardPendingSelection() {
@@ -81,8 +101,17 @@ import AppKit
 
     private func clearPendingSelection() {
         popupGeneration = nil
+        openingValue = nil
+        hasOpeningValue = false
         pendingSelection = nil
         hasPendingSelection = false
+    }
+
+    private func valuesMatch(_ lhs: NSObject?, _ rhs: NSObject?) -> Bool {
+        guard let lhs else {
+            return rhs == nil
+        }
+        return lhs.isEqual(rhs)
     }
 }
 

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -61,14 +61,11 @@ import AppKit
             lock.unlock()
         }
 
-        guard let popupGeneration else {
+        guard let popupGeneration, hasPendingSelection else {
             return .notTracked
         }
         guard popupGeneration == dataGeneration else {
             return .invalidated
-        }
-        guard hasPendingSelection else {
-            return .notTracked
         }
         guard let pendingSelection else {
             return proposedValue == nil ? .current : .notTracked

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -7,6 +7,12 @@
 
 import AppKit
 
+@objc enum SAComboBoxSelectionState: Int {
+    case notTracked
+    case current
+    case invalidated
+}
+
 /// Authenticates combo-box callbacks against the table snapshot in which the
 /// popup selection occurred. AppKit otherwise supplies only row/column indexes.
 @objc final class SAComboBoxSelectionTracker: NSObject {
@@ -21,8 +27,9 @@ import AppKit
         lock.lock()
         defer { lock.unlock() }
 
+        // Retain the popup generation until its callback is consumed so an
+        // invalidated popup remains distinguishable from ordinary inline input.
         dataGeneration &+= 1
-        clearPendingSelection()
     }
 
     @objc func comboBoxWillOpen() {
@@ -39,22 +46,34 @@ import AppKit
         lock.lock()
         defer { lock.unlock() }
 
-        guard popupGeneration != nil else { return }
+        guard popupGeneration != nil else {
+            return
+        }
         pendingSelection = value
         hasPendingSelection = true
     }
 
-    @objc(consumeCurrentSelectionMatching:)
-    func consumeCurrentSelection(matching proposedValue: NSObject?) -> Bool {
+    @objc(consumeSelectionMatching:)
+    func consumeSelection(matching proposedValue: NSObject?) -> SAComboBoxSelectionState {
         lock.lock()
         defer {
             clearPendingSelection()
             lock.unlock()
         }
 
-        guard hasPendingSelection, popupGeneration == dataGeneration else { return false }
-        guard let pendingSelection else { return proposedValue == nil }
-        return pendingSelection.isEqual(proposedValue)
+        guard let popupGeneration else {
+            return .notTracked
+        }
+        guard popupGeneration == dataGeneration else {
+            return .invalidated
+        }
+        guard hasPendingSelection else {
+            return .notTracked
+        }
+        guard let pendingSelection else {
+            return proposedValue == nil ? .current : .notTracked
+        }
+        return pendingSelection.isEqual(proposedValue) ? .current : .notTracked
     }
 
     @objc func discardPendingSelection() {
@@ -74,20 +93,29 @@ import AppKit
 
     /// Inline editing is aborted before the field editor sheet opens. Ignore
     /// callbacks from that handoff unless a combo box supplied a changed value.
-    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:proposedValue:storedValue:displayValue:popupSelectionIsCurrent:)
+    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:proposedValue:storedValue:displayValue:popupSelectionState:)
     static func shouldIgnoreInlineCommit(
         fieldEditorRequired: Bool,
         cell: NSCell,
         proposedValue: NSObject?,
         storedValue: NSObject?,
         displayValue: NSObject?,
-        popupSelectionIsCurrent: Bool
+        popupSelectionState: SAComboBoxSelectionState
     ) -> Bool {
-        guard fieldEditorRequired else { return false }
-        guard cell is NSComboBoxCell, popupSelectionIsCurrent else { return true }
+        if popupSelectionState == .invalidated {
+            return true
+        }
+        guard fieldEditorRequired else {
+            return false
+        }
+        guard cell is NSComboBoxCell, popupSelectionState == .current else {
+            return true
+        }
 
         let proposedValueMatches: (NSObject?) -> Bool = { currentValue in
-            guard let proposedValue else { return currentValue == nil }
+            guard let proposedValue else {
+                return currentValue == nil
+            }
             return proposedValue.isEqual(currentValue)
         }
         return proposedValueMatches(storedValue) || proposedValueMatches(displayValue)

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -19,19 +19,35 @@ import AppKit
 
     private let lock = NSLock()
     private var dataGeneration: UInt = 0
+    private var reloadsInProgress = 0
     private var popupGeneration: UInt?
     private var openingValue: NSObject?
     private var hasOpeningValue = false
     private var pendingSelection: NSObject?
     private var hasPendingSelection = false
 
-    @objc func tableDataWillReload() {
+    @objc func tableDataWillChange() {
         lock.lock()
         defer { lock.unlock() }
 
-        // Retain the popup generation until its callback is consumed so an
-        // invalidated popup remains distinguishable from ordinary inline input.
         dataGeneration &+= 1
+    }
+
+    @objc func tableDataReloadWillBegin() {
+        lock.lock()
+        defer { lock.unlock() }
+        // A query can fail without changing the current snapshot. Block popup
+        // callbacks while its outcome is unknown without advancing the revision.
+        reloadsInProgress += 1
+    }
+
+    @objc func tableDataReloadDidFinish() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard reloadsInProgress > 0 else {
+            return
+        }
+        reloadsInProgress -= 1
     }
 
     @objc(comboBoxWillOpenWithValue:)
@@ -86,6 +102,10 @@ import AppKit
 
         guard let popupGeneration, hasPendingSelection else {
             return .notTracked
+        }
+        // Never write while a reload could still replace the indexed row.
+        guard reloadsInProgress == 0 else {
+            return .invalidated
         }
         guard popupGeneration == dataGeneration else {
             return .invalidated

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -1,0 +1,22 @@
+//
+//  SAFieldEditorCommitPolicy.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objc final class SAFieldEditorCommitPolicy: NSObject {
+
+    /// Inline text editing is aborted before the field editor sheet opens, and
+    /// AppKit can send the unchanged cell value during that handoff. Popup
+    /// cells instead send the user's selected value and must be committed.
+    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:)
+    static func shouldIgnoreInlineCommit(
+        fieldEditorRequired: Bool,
+        cell: NSCell
+    ) -> Bool {
+        fieldEditorRequired && !(cell is NSComboBoxCell)
+    }
+}

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -10,7 +10,24 @@ import AppKit
 @objc enum SAComboBoxSelectionState: Int {
     case notTracked
     case current
+    case deferred
     case invalidated
+}
+
+/// The table coordinates AppKit supplied for a popup selection whose reload
+/// outcome is not known yet. The tracker releases this only while the same
+/// table snapshot is still current.
+@objc final class SADeferredComboBoxEdit: NSObject {
+
+    @objc let proposedValue: NSObject?
+    @objc let tableColumn: NSTableColumn
+    @objc let row: Int
+
+    init(proposedValue: NSObject?, tableColumn: NSTableColumn, row: Int) {
+        self.proposedValue = proposedValue
+        self.tableColumn = tableColumn
+        self.row = row
+    }
 }
 
 /// Authenticates combo-box callbacks against the table snapshot in which the
@@ -25,6 +42,7 @@ import AppKit
     private var hasOpeningValue = false
     private var pendingSelection: NSObject?
     private var hasPendingSelection = false
+    private var deferredEdit: SADeferredComboBoxEdit?
 
     @objc func tableDataWillChange() {
         lock.lock()
@@ -41,13 +59,23 @@ import AppKit
         reloadsInProgress += 1
     }
 
-    @objc func tableDataReloadDidFinish() {
+    /// Returns whether a deferred edit may now be retried. The caller still
+    /// obtains it through `takeDeferredEditIfReady()` so a reload beginning
+    /// before the main-thread retry keeps the edit deferred.
+    @objc func tableDataReloadDidFinish() -> Bool {
         lock.lock()
         defer { lock.unlock() }
         guard reloadsInProgress > 0 else {
-            return
+            return false
         }
         reloadsInProgress -= 1
+        if reloadsInProgress == 0,
+           deferredEdit != nil,
+           popupGeneration != dataGeneration {
+            clearPendingSelection()
+            return false
+        }
+        return reloadsInProgress == 0 && deferredEdit != nil
     }
 
     @objc(comboBoxWillOpenWithValue:)
@@ -55,11 +83,10 @@ import AppKit
         lock.lock()
         defer { lock.unlock() }
 
+        clearPendingSelection()
         popupGeneration = dataGeneration
         openingValue = value
         hasOpeningValue = true
-        pendingSelection = nil
-        hasPendingSelection = false
     }
 
     @objc(comboBoxSelectionDidChange:)
@@ -92,25 +119,59 @@ import AppKit
         }
     }
 
-    @objc(consumeSelectionMatching:)
-    func consumeSelection(matching proposedValue: NSObject?) -> SAComboBoxSelectionState {
+    @objc(consumeSelectionMatching:tableColumn:row:)
+    func consumeSelection(
+        matching proposedValue: NSObject?,
+        tableColumn: NSTableColumn,
+        row: Int
+    ) -> SAComboBoxSelectionState {
         lock.lock()
-        defer {
-            clearPendingSelection()
-            lock.unlock()
-        }
+        defer { lock.unlock() }
 
         guard let popupGeneration, hasPendingSelection else {
             return .notTracked
         }
-        // Never write while a reload could still replace the indexed row.
-        guard reloadsInProgress == 0 else {
+        guard popupGeneration == dataGeneration else {
+            clearPendingSelection()
             return .invalidated
+        }
+        guard valuesMatch(pendingSelection, proposedValue) else {
+            clearPendingSelection()
+            return reloadsInProgress == 0 ? .notTracked : .invalidated
+        }
+
+        // AppKit does not repeat this callback if an in-flight reload later
+        // fails. Retain both its authenticated value and coordinates until the
+        // reload either changes the snapshot or finishes unchanged.
+        guard reloadsInProgress == 0 else {
+            deferredEdit = SADeferredComboBoxEdit(
+                proposedValue: proposedValue,
+                tableColumn: tableColumn,
+                row: row
+            )
+            return .deferred
+        }
+
+        clearPendingSelection()
+        return .current
+    }
+
+    /// Atomically takes a deferred edit only after every overlapping reload
+    /// has finished and only if no table-data mutation has occurred.
+    @objc func takeDeferredEditIfReady() -> SADeferredComboBoxEdit? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard reloadsInProgress == 0, let deferredEdit else {
+            return nil
         }
         guard popupGeneration == dataGeneration else {
-            return .invalidated
+            clearPendingSelection()
+            return nil
         }
-        return valuesMatch(pendingSelection, proposedValue) ? .current : .notTracked
+
+        self.deferredEdit = nil
+        return deferredEdit
     }
 
     @objc func discardPendingSelection() {
@@ -125,6 +186,7 @@ import AppKit
         hasOpeningValue = false
         pendingSelection = nil
         hasPendingSelection = false
+        deferredEdit = nil
     }
 
     private func valuesMatch(_ lhs: NSObject?, _ rhs: NSObject?) -> Bool {
@@ -148,7 +210,7 @@ import AppKit
         displayValue: NSObject?,
         popupSelectionState: SAComboBoxSelectionState
     ) -> Bool {
-        if popupSelectionState == .invalidated {
+        if popupSelectionState == .deferred || popupSelectionState == .invalidated {
             return true
         }
         guard fieldEditorRequired else {

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -45,6 +45,14 @@ import AppKit
     private var deferredEdit: SADeferredComboBoxEdit?
 
     @objc func tableDataWillChange() {
+        advanceTableGeneration()
+    }
+
+    @objc func tableColumnModelWillChange() {
+        advanceTableGeneration()
+    }
+
+    private func advanceTableGeneration() {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -7,20 +7,84 @@
 
 import AppKit
 
+/// Authenticates combo-box callbacks against the table snapshot in which the
+/// popup selection occurred. AppKit otherwise supplies only row/column indexes.
+@objc final class SAComboBoxSelectionTracker: NSObject {
+
+    private let lock = NSLock()
+    private var dataGeneration: UInt = 0
+    private var popupGeneration: UInt?
+    private var pendingSelection: NSObject?
+    private var hasPendingSelection = false
+
+    @objc func tableDataWillReload() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        dataGeneration &+= 1
+        clearPendingSelection()
+    }
+
+    @objc func comboBoxWillOpen() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        popupGeneration = dataGeneration
+        pendingSelection = nil
+        hasPendingSelection = false
+    }
+
+    @objc(comboBoxSelectionDidChange:)
+    func comboBoxSelectionDidChange(_ value: NSObject?) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard popupGeneration != nil else { return }
+        pendingSelection = value
+        hasPendingSelection = true
+    }
+
+    @objc(consumeCurrentSelectionMatching:)
+    func consumeCurrentSelection(matching proposedValue: NSObject?) -> Bool {
+        lock.lock()
+        defer {
+            clearPendingSelection()
+            lock.unlock()
+        }
+
+        guard hasPendingSelection, popupGeneration == dataGeneration else { return false }
+        guard let pendingSelection else { return proposedValue == nil }
+        return pendingSelection.isEqual(proposedValue)
+    }
+
+    @objc func discardPendingSelection() {
+        lock.lock()
+        defer { lock.unlock() }
+        clearPendingSelection()
+    }
+
+    private func clearPendingSelection() {
+        popupGeneration = nil
+        pendingSelection = nil
+        hasPendingSelection = false
+    }
+}
+
 @objc final class SAFieldEditorCommitPolicy: NSObject {
 
     /// Inline editing is aborted before the field editor sheet opens. Ignore
     /// callbacks from that handoff unless a combo box supplied a changed value.
-    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:proposedValue:storedValue:displayValue:)
+    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:proposedValue:storedValue:displayValue:popupSelectionIsCurrent:)
     static func shouldIgnoreInlineCommit(
         fieldEditorRequired: Bool,
         cell: NSCell,
         proposedValue: NSObject?,
         storedValue: NSObject?,
-        displayValue: NSObject?
+        displayValue: NSObject?,
+        popupSelectionIsCurrent: Bool
     ) -> Bool {
         guard fieldEditorRequired else { return false }
-        guard cell is NSComboBoxCell else { return true }
+        guard cell is NSComboBoxCell, popupSelectionIsCurrent else { return true }
 
         let proposedValueMatches: (NSObject?) -> Bool = { currentValue in
             guard let proposedValue else { return currentValue == nil }

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -5,21 +5,27 @@
 //  Copyright © 2026 Sequel-Ace. All rights reserved.
 //
 
-import Foundation
+import AppKit
 
 @objc final class SAFieldEditorCommitPolicy: NSObject {
 
-    /// Inline editing is aborted before the field editor sheet opens, and
-    /// AppKit can send the unchanged cell value during that handoff. A changed
-    /// value came from a completed inline control action and must be committed.
-    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:proposedValue:currentValue:)
+    /// Inline editing is aborted before the field editor sheet opens. Ignore
+    /// callbacks from that handoff unless a combo box supplied a changed value.
+    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:proposedValue:storedValue:displayValue:)
     static func shouldIgnoreInlineCommit(
         fieldEditorRequired: Bool,
+        cell: NSCell,
         proposedValue: NSObject?,
-        currentValue: NSObject?
+        storedValue: NSObject?,
+        displayValue: NSObject?
     ) -> Bool {
         guard fieldEditorRequired else { return false }
-        guard let proposedValue else { return currentValue == nil }
-        return proposedValue.isEqual(currentValue)
+        guard cell is NSComboBoxCell else { return true }
+
+        let proposedValueMatches: (NSObject?) -> Bool = { currentValue in
+            guard let proposedValue else { return currentValue == nil }
+            return proposedValue.isEqual(currentValue)
+        }
+        return proposedValueMatches(storedValue) || proposedValueMatches(displayValue)
     }
 }

--- a/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
+++ b/Source/Views/TableViews/SAFieldEditorCommitPolicy.swift
@@ -5,18 +5,21 @@
 //  Copyright © 2026 Sequel-Ace. All rights reserved.
 //
 
-import AppKit
+import Foundation
 
 @objc final class SAFieldEditorCommitPolicy: NSObject {
 
-    /// Inline text editing is aborted before the field editor sheet opens, and
-    /// AppKit can send the unchanged cell value during that handoff. Popup
-    /// cells instead send the user's selected value and must be committed.
-    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:cell:)
+    /// Inline editing is aborted before the field editor sheet opens, and
+    /// AppKit can send the unchanged cell value during that handoff. A changed
+    /// value came from a completed inline control action and must be committed.
+    @objc(shouldIgnoreInlineCommitWithFieldEditorRequired:proposedValue:currentValue:)
     static func shouldIgnoreInlineCommit(
         fieldEditorRequired: Bool,
-        cell: NSCell
+        proposedValue: NSObject?,
+        currentValue: NSObject?
     ) -> Bool {
-        fieldEditorRequired && !(cell is NSComboBoxCell)
+        guard fieldEditorRequired else { return false }
+        guard let proposedValue else { return currentValue == nil }
+        return proposedValue.isEqual(currentValue)
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -9,27 +9,77 @@ import XCTest
 
 final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
-    func testChangedValueIsCommittedWhenFieldEditorIsPreferred() {
+    func testChangedComboValueIsCommittedWhenFieldEditorIsPreferred() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
             proposedValue: "published" as NSString,
-            currentValue: "draft" as NSString
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString
         ))
     }
 
-    func testUnchangedValueIsIgnoredDuringFieldEditorHandoff() {
+    func testUnchangedComboValueIsIgnoredDuringFieldEditorHandoff() {
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
             proposedValue: "draft" as NSString,
-            currentValue: "draft" as NSString
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString
+        ))
+    }
+
+    func testLongUnchangedComboValueIsIgnoredDuringFieldEditorHandoff() {
+        let value = String(repeating: "a", count: 151) as NSString
+
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: value,
+            storedValue: value,
+            displayValue: value
+        ))
+    }
+
+    func testNullDisplayValueIsIgnoredDuringFieldEditorHandoff() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "NULL" as NSString,
+            storedValue: NSNull(),
+            displayValue: "NULL" as NSString
+        ))
+    }
+
+    func testFormatterObjectValueIsIgnoredDuringFieldEditorHandoff() {
+        let value = Data([0x01, 0x02]) as NSData
+
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: value,
+            storedValue: value,
+            displayValue: "formatted" as NSString
+        ))
+    }
+
+    func testChangedTextValueIsIgnoredDuringFieldEditorHandoff() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSTextFieldCell(textCell: ""),
+            proposedValue: "edited" as NSString,
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString
         ))
     }
 
     func testUnchangedValueIsAcceptedWhenFieldEditorIsNotRequired() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
+            cell: NSTextFieldCell(textCell: ""),
             proposedValue: "draft" as NSString,
-            currentValue: "draft" as NSString
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString
         ))
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 Sequel-Ace. All rights reserved.
 //
 
+import AppKit
 import XCTest
 
 final class SAFieldEditorCommitPolicyTests: XCTestCase {

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -15,7 +15,19 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: "published" as NSString,
             storedValue: "draft" as NSString,
-            displayValue: "draft" as NSString
+            displayValue: "draft" as NSString,
+            popupSelectionIsCurrent: true
+        ))
+    }
+
+    func testChangedComboValueWithoutCurrentPopupSelectionIsIgnored() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "published" as NSString,
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString,
+            popupSelectionIsCurrent: false
         ))
     }
 
@@ -25,7 +37,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: "draft" as NSString,
             storedValue: "draft" as NSString,
-            displayValue: "draft" as NSString
+            displayValue: "draft" as NSString,
+            popupSelectionIsCurrent: true
         ))
     }
 
@@ -38,7 +51,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: value,
             storedValue: value,
-            displayValue: truncatedPreview
+            displayValue: truncatedPreview,
+            popupSelectionIsCurrent: true
         ))
     }
 
@@ -48,7 +62,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: "NULL" as NSString,
             storedValue: NSNull(),
-            displayValue: "NULL" as NSString
+            displayValue: "NULL" as NSString,
+            popupSelectionIsCurrent: true
         ))
     }
 
@@ -58,7 +73,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: "formatted" as NSString,
             storedValue: Data([0x01, 0x02]) as NSData,
-            displayValue: "formatted" as NSString
+            displayValue: "formatted" as NSString,
+            popupSelectionIsCurrent: true
         ))
     }
 
@@ -70,7 +86,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: value,
             storedValue: value,
-            displayValue: "formatted" as NSString
+            displayValue: "formatted" as NSString,
+            popupSelectionIsCurrent: true
         ))
     }
 
@@ -80,7 +97,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSTextFieldCell(textCell: ""),
             proposedValue: "edited" as NSString,
             storedValue: "draft" as NSString,
-            displayValue: "draft" as NSString
+            displayValue: "draft" as NSString,
+            popupSelectionIsCurrent: false
         ))
     }
 
@@ -90,7 +108,27 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             cell: NSTextFieldCell(textCell: ""),
             proposedValue: "draft" as NSString,
             storedValue: "draft" as NSString,
-            displayValue: "draft" as NSString
+            displayValue: "draft" as NSString,
+            popupSelectionIsCurrent: false
         ))
+    }
+
+    func testCurrentPopupSelectionCanOnlyBeConsumedOnce() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen()
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+
+        XCTAssertTrue(tracker.consumeCurrentSelection(matching: "published" as NSString))
+        XCTAssertFalse(tracker.consumeCurrentSelection(matching: "published" as NSString))
+    }
+
+    func testReloadInvalidatesPopupSelectionWhenDimensionsCouldStayTheSame() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen()
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+
+        tracker.tableDataWillReload()
+
+        XCTAssertFalse(tracker.consumeCurrentSelection(matching: "published" as NSString))
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -129,6 +129,21 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         ))
     }
 
+    func testReloadAfterCancelledPopupDoesNotInvalidateNextInlineEdit() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen()
+        tracker.tableDataWillReload()
+
+        XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: false,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "published" as NSString,
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString,
+            popupSelectionState: tracker.consumeSelection(matching: "published" as NSString)
+        ))
+    }
+
     func testUntrackedComboValueIsAcceptedWhenFieldEditorIsNotRequired() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -117,8 +117,10 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         let tracker = SAComboBoxSelectionTracker()
         tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
-        tracker.tableDataWillReload()
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataWillChange()
         tracker.comboBoxDidClose(with: "published" as NSString)
+        tracker.tableDataReloadDidFinish()
 
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
@@ -134,8 +136,10 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         let tracker = SAComboBoxSelectionTracker()
         tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
-        tracker.tableDataWillReload()
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataWillChange()
         tracker.comboBoxDidClose(with: "draft" as NSString)
+        tracker.tableDataReloadDidFinish()
 
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
@@ -174,8 +178,54 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.comboBoxDidClose(with: "published" as NSString)
 
-        tracker.tableDataWillReload()
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataWillChange()
+        tracker.tableDataReloadDidFinish()
 
         XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
+    }
+
+    func testReloadWithoutDataMutationKeepsPopupSelectionCurrent() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataReloadDidFinish()
+
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
+    }
+
+    func testPendingReloadConservativelyInvalidatesPopupSelection() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        tracker.tableDataReloadWillBegin()
+
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
+        tracker.tableDataReloadDidFinish()
+    }
+
+    func testNestedReloadsRemainPendingUntilEveryLoadFinishes() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataReloadDidFinish()
+
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
+        tracker.tableDataReloadDidFinish()
+
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -9,24 +9,27 @@ import XCTest
 
 final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
-    func testPopupSelectionIsCommittedWhenFieldEditorIsPreferred() {
+    func testChangedValueIsCommittedWhenFieldEditorIsPreferred() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
-            cell: NSComboBoxCell(textCell: "")
+            proposedValue: "published" as NSString,
+            currentValue: "draft" as NSString
         ))
     }
 
-    func testTextCommitIsIgnoredDuringFieldEditorHandoff() {
+    func testUnchangedValueIsIgnoredDuringFieldEditorHandoff() {
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
-            cell: NSTextFieldCell(textCell: "")
+            proposedValue: "draft" as NSString,
+            currentValue: "draft" as NSString
         ))
     }
 
-    func testInlineCommitIsAcceptedWhenFieldEditorIsNotRequired() {
+    func testUnchangedValueIsAcceptedWhenFieldEditorIsNotRequired() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
-            cell: NSTextFieldCell(textCell: "")
+            proposedValue: "draft" as NSString,
+            currentValue: "draft" as NSString
         ))
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -16,7 +16,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "published" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -27,7 +27,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "published" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionIsCurrent: false
+            popupSelectionState: .notTracked
         ))
     }
 
@@ -38,7 +38,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "draft" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -52,7 +52,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: value,
             storedValue: value,
             displayValue: truncatedPreview,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -63,7 +63,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "NULL" as NSString,
             storedValue: NSNull(),
             displayValue: "NULL" as NSString,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -74,7 +74,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "formatted" as NSString,
             storedValue: Data([0x01, 0x02]) as NSData,
             displayValue: "formatted" as NSString,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -87,7 +87,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: value,
             storedValue: value,
             displayValue: "formatted" as NSString,
-            popupSelectionIsCurrent: true
+            popupSelectionState: .current
         ))
     }
 
@@ -98,7 +98,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "edited" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionIsCurrent: false
+            popupSelectionState: .notTracked
         ))
     }
 
@@ -109,7 +109,34 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "draft" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionIsCurrent: false
+            popupSelectionState: .notTracked
+        ))
+    }
+
+    func testInvalidatedPopupSelectionIsIgnoredWhenFieldEditorIsNotRequired() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen()
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.tableDataWillReload()
+
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: false,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "published" as NSString,
+            storedValue: "replacement-row" as NSString,
+            displayValue: "replacement-row" as NSString,
+            popupSelectionState: tracker.consumeSelection(matching: "published" as NSString)
+        ))
+    }
+
+    func testUntrackedComboValueIsAcceptedWhenFieldEditorIsNotRequired() {
+        XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: false,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "published" as NSString,
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString,
+            popupSelectionState: .notTracked
         ))
     }
 
@@ -118,8 +145,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         tracker.comboBoxWillOpen()
         tracker.comboBoxSelectionDidChange("published" as NSString)
 
-        XCTAssertTrue(tracker.consumeCurrentSelection(matching: "published" as NSString))
-        XCTAssertFalse(tracker.consumeCurrentSelection(matching: "published" as NSString))
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .notTracked)
     }
 
     func testReloadInvalidatesPopupSelectionWhenDimensionsCouldStayTheSame() {
@@ -129,6 +156,6 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
         tracker.tableDataWillReload()
 
-        XCTAssertFalse(tracker.consumeCurrentSelection(matching: "published" as NSString))
+        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -115,9 +115,10 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
     func testInvalidatedPopupSelectionIsIgnoredWhenFieldEditorIsNotRequired() {
         let tracker = SAComboBoxSelectionTracker()
-        tracker.comboBoxWillOpen()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.tableDataWillReload()
+        tracker.comboBoxDidClose(with: "published" as NSString)
 
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
@@ -129,10 +130,12 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         ))
     }
 
-    func testReloadAfterCancelledPopupDoesNotInvalidateNextInlineEdit() {
+    func testReloadAfterCancelledHighlightedSelectionDoesNotInvalidateNextInlineEdit() {
         let tracker = SAComboBoxSelectionTracker()
-        tracker.comboBoxWillOpen()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.tableDataWillReload()
+        tracker.comboBoxDidClose(with: "draft" as NSString)
 
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: false,
@@ -157,8 +160,9 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
     func testCurrentPopupSelectionCanOnlyBeConsumedOnce() {
         let tracker = SAComboBoxSelectionTracker()
-        tracker.comboBoxWillOpen()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
 
         XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
         XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .notTracked)
@@ -166,8 +170,9 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
     func testReloadInvalidatesPopupSelectionWhenDimensionsCouldStayTheSame() {
         let tracker = SAComboBoxSelectionTracker()
-        tracker.comboBoxWillOpen()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
 
         tracker.tableDataWillReload()
 

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -277,6 +277,21 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .notTracked)
     }
 
+    func testColumnModelRebuildDiscardsDeferredPopupSelection() {
+        let tracker = SAComboBoxSelectionTracker()
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+        tracker.tableDataReloadWillBegin()
+
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .deferred)
+        tracker.tableColumnModelWillChange()
+
+        XCTAssertFalse(tracker.tableDataReloadDidFinish())
+        XCTAssertNil(tracker.takeDeferredEditIfReady())
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .notTracked)
+    }
+
     func testReloadBeginningBeforeDeferredRetryKeepsSelectionQueued() {
         let tracker = SAComboBoxSelectionTracker()
         tracker.comboBoxWillOpen(with: "draft" as NSString)

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -31,13 +31,14 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
     func testLongUnchangedComboValueIsIgnoredDuringFieldEditorHandoff() {
         let value = String(repeating: "a", count: 151) as NSString
+        let truncatedPreview = String(repeating: "a", count: 150) as NSString
 
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
             cell: NSComboBoxCell(textCell: ""),
             proposedValue: value,
             storedValue: value,
-            displayValue: value
+            displayValue: truncatedPreview
         ))
     }
 
@@ -51,7 +52,17 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         ))
     }
 
-    func testFormatterObjectValueIsIgnoredDuringFieldEditorHandoff() {
+    func testFormatterDisplayValueIsIgnoredDuringFieldEditorHandoff() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "formatted" as NSString,
+            storedValue: Data([0x01, 0x02]) as NSData,
+            displayValue: "formatted" as NSString
+        ))
+    }
+
+    func testFormatterRawObjectValueIsIgnoredDuringFieldEditorHandoff() {
         let value = Data([0x01, 0x02]) as NSData
 
         XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -9,6 +9,15 @@ import XCTest
 
 final class SAFieldEditorCommitPolicyTests: XCTestCase {
 
+    private func selectionState(
+        from tracker: SAComboBoxSelectionTracker,
+        matching value: NSObject?,
+        tableColumn: NSTableColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("status")),
+        row: Int = 0
+    ) -> SAComboBoxSelectionState {
+        tracker.consumeSelection(matching: value, tableColumn: tableColumn, row: row)
+    }
+
     func testChangedComboValueIsCommittedWhenFieldEditorIsPreferred() {
         XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
             fieldEditorRequired: true,
@@ -128,7 +137,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "published" as NSString,
             storedValue: "replacement-row" as NSString,
             displayValue: "replacement-row" as NSString,
-            popupSelectionState: tracker.consumeSelection(matching: "published" as NSString)
+            popupSelectionState: selectionState(from: tracker, matching: "published" as NSString)
         ))
     }
 
@@ -147,7 +156,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
             proposedValue: "published" as NSString,
             storedValue: "draft" as NSString,
             displayValue: "draft" as NSString,
-            popupSelectionState: tracker.consumeSelection(matching: "published" as NSString)
+            popupSelectionState: selectionState(from: tracker, matching: "published" as NSString)
         ))
     }
 
@@ -168,8 +177,8 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.comboBoxDidClose(with: "published" as NSString)
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .notTracked)
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .current)
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .notTracked)
     }
 
     func testReloadInvalidatesPopupSelectionWhenDimensionsCouldStayTheSame() {
@@ -182,7 +191,7 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         tracker.tableDataWillChange()
         tracker.tableDataReloadDidFinish()
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .invalidated)
     }
 
     func testReloadWithoutDataMutationKeepsPopupSelectionCurrent() {
@@ -192,40 +201,118 @@ final class SAFieldEditorCommitPolicyTests: XCTestCase {
         tracker.comboBoxDidClose(with: "published" as NSString)
 
         tracker.tableDataReloadWillBegin()
-        tracker.tableDataReloadDidFinish()
+        XCTAssertFalse(tracker.tableDataReloadDidFinish())
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .current)
     }
 
-    func testPendingReloadConservativelyInvalidatesPopupSelection() {
+    func testPendingReloadDefersPopupSelectionUntilUnchangedOutcome() {
+        let tracker = SAComboBoxSelectionTracker()
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("status"))
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        tracker.tableDataReloadWillBegin()
+
+        XCTAssertEqual(
+            selectionState(from: tracker, matching: "published" as NSString, tableColumn: column, row: 4),
+            .deferred
+        )
+        XCTAssertTrue(tracker.tableDataReloadDidFinish())
+
+        let deferredEdit = tracker.takeDeferredEditIfReady()
+        XCTAssertEqual(deferredEdit?.proposedValue, "published" as NSString)
+        XCTAssertTrue(deferredEdit?.tableColumn === column)
+        XCTAssertEqual(deferredEdit?.row, 4)
+        XCTAssertEqual(
+            selectionState(from: tracker, matching: deferredEdit?.proposedValue, tableColumn: column, row: 4),
+            .current
+        )
+    }
+
+    func testScheduledReloadReservationClosesDetachedWorkerGap() {
+        let tracker = SAComboBoxSelectionTracker()
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("status"))
+        tracker.comboBoxWillOpen(with: "draft" as NSString)
+        tracker.comboBoxSelectionDidChange("published" as NSString)
+        tracker.comboBoxDidClose(with: "published" as NSString)
+
+        // The outer load schedules a full reload before it finishes. The task
+        // reservation begins synchronously; its nested load starts later.
+        tracker.tableDataReloadWillBegin()
+        tracker.tableDataReloadWillBegin()
+        XCTAssertFalse(tracker.tableDataReloadDidFinish())
+
+        XCTAssertEqual(
+            selectionState(from: tracker, matching: "published" as NSString, tableColumn: column),
+            .deferred
+        )
+
+        tracker.tableDataReloadWillBegin()
+        XCTAssertFalse(tracker.tableDataReloadDidFinish())
+        XCTAssertTrue(tracker.tableDataReloadDidFinish())
+
+        let deferredEdit = tracker.takeDeferredEditIfReady()
+        XCTAssertNotNil(deferredEdit)
+        XCTAssertEqual(
+            selectionState(from: tracker, matching: deferredEdit?.proposedValue, tableColumn: column),
+            .current
+        )
+    }
+
+    func testDataMutationDiscardsDeferredPopupSelection() {
         let tracker = SAComboBoxSelectionTracker()
         tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.comboBoxDidClose(with: "published" as NSString)
-
         tracker.tableDataReloadWillBegin()
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
-        tracker.tableDataReloadDidFinish()
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .deferred)
+        tracker.tableDataWillChange()
+
+        XCTAssertFalse(tracker.tableDataReloadDidFinish())
+        XCTAssertNil(tracker.takeDeferredEditIfReady())
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .notTracked)
     }
 
-    func testNestedReloadsRemainPendingUntilEveryLoadFinishes() {
+    func testReloadBeginningBeforeDeferredRetryKeepsSelectionQueued() {
         let tracker = SAComboBoxSelectionTracker()
-        tracker.tableDataReloadWillBegin()
-        tracker.tableDataReloadWillBegin()
-        tracker.tableDataReloadDidFinish()
-
         tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.comboBoxDidClose(with: "published" as NSString)
+        tracker.tableDataReloadWillBegin()
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .deferred)
+        XCTAssertTrue(tracker.tableDataReloadDidFinish())
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .invalidated)
-        tracker.tableDataReloadDidFinish()
+        tracker.tableDataReloadWillBegin()
+        XCTAssertNil(tracker.takeDeferredEditIfReady())
+        XCTAssertTrue(tracker.tableDataReloadDidFinish())
+        XCTAssertNotNil(tracker.takeDeferredEditIfReady())
+    }
 
+    func testNewPopupDiscardsAnOlderDeferredEdit() {
+        let tracker = SAComboBoxSelectionTracker()
         tracker.comboBoxWillOpen(with: "draft" as NSString)
         tracker.comboBoxSelectionDidChange("published" as NSString)
         tracker.comboBoxDidClose(with: "published" as NSString)
+        tracker.tableDataReloadWillBegin()
+        XCTAssertEqual(selectionState(from: tracker, matching: "published" as NSString), .deferred)
+        XCTAssertTrue(tracker.tableDataReloadDidFinish())
 
-        XCTAssertEqual(tracker.consumeSelection(matching: "published" as NSString), .current)
+        tracker.comboBoxWillOpen(with: "queued" as NSString)
+
+        XCTAssertNil(tracker.takeDeferredEditIfReady())
+    }
+
+    func testDeferredPopupStateIsIgnoredByCommitPolicy() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: false,
+            cell: NSComboBoxCell(textCell: ""),
+            proposedValue: "published" as NSString,
+            storedValue: "draft" as NSString,
+            displayValue: "draft" as NSString,
+            popupSelectionState: .deferred
+        ))
     }
 }

--- a/UnitTests/SAFieldEditorCommitPolicyTests.swift
+++ b/UnitTests/SAFieldEditorCommitPolicyTests.swift
@@ -1,0 +1,32 @@
+//
+//  SAFieldEditorCommitPolicyTests.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import XCTest
+
+final class SAFieldEditorCommitPolicyTests: XCTestCase {
+
+    func testPopupSelectionIsCommittedWhenFieldEditorIsPreferred() {
+        XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSComboBoxCell(textCell: "")
+        ))
+    }
+
+    func testTextCommitIsIgnoredDuringFieldEditorHandoff() {
+        XCTAssertTrue(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: true,
+            cell: NSTextFieldCell(textCell: "")
+        ))
+    }
+
+    func testInlineCommitIsAcceptedWhenFieldEditorIsNotRequired() {
+        XCTAssertFalse(SAFieldEditorCommitPolicy.shouldIgnoreInlineCommit(
+            fieldEditorRequired: false,
+            cell: NSTextFieldCell(textCell: "")
+        ))
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		6220954A97524B17D37B4D09 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
 		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		624E13DFBB2F343500B94705 /* SADatabaseScopedValueCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81815809CB9EBE53E9D2AA2A /* SADatabaseScopedValueCacheTests.swift */; };
+		6437BC4ED2B743D251F18C2F /* SAFieldEditorCommitPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */; };
 		65F52CC824AE21D600FED3CB /* SPFilePreferencePane.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F52CC724AE21D600FED3CB /* SPFilePreferencePane.m */; };
 		67D6D5054AF5FECC0EFE4EFF /* SASSHTunnelSocketIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B83304761F800BCE2B9 /* SASSHTunnelSocketIO.swift */; };
 		6ABF364B03D0324617CFABCC /* SPMCPFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E51CBFF347BD58D412A988F /* SPMCPFavorite.swift */; };
@@ -497,6 +498,7 @@
 		7EE575894C57515419B0A30A /* SPMCPPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F0964487758A57DA339AF2 /* SPMCPPreferencePane.swift */; };
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
 		81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B773F7950F031B094BBF53 /* SAHelpViewerModel.swift */; };
+		8350D00F7955DDAE277DC218 /* SAFieldEditorCommitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCCC96AB0752412886E41B0 /* SAFieldEditorCommitPolicy.swift */; };
 		85846AF0695EAD27F908811D /* SADatabaseScopedValueCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */; };
 		8763A84EDF069AC161FD0438 /* SAQueryFavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7878B22CA20B0D814D30C42 /* SAQueryFavoriteStore.swift */; };
 		8831EFA8224011B700D10172 /* button_addTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 8831EFA5224011B700D10172 /* button_addTemplate.pdf */; };
@@ -705,6 +707,7 @@
 		FD8099A82C59DDF70084646F /* SAUuidFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18C8982C3C9B2F002A5D57 /* SAUuidFormatter.swift */; };
 		FD8099A92C59DE1D0084646F /* SABaseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2056042C3A7E90008DD271 /* SABaseFormatter.swift */; };
 		FDCF55E52788278500D30655 /* TableSortHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEACD304316A0931DF8ED26 /* TableSortHelper.swift */; };
+		FE96153A16ECBA48C12BCA09 /* SAFieldEditorCommitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCCC96AB0752412886E41B0 /* SAFieldEditorCommitPolicy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1431,6 +1434,7 @@
 		8D15AC370486D014006FF6A4 /* Sequel Ace.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sequel Ace.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F7D127BB5BCD94B0E794C5E /* SAHelpViewerWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAHelpViewerWindowController.swift; sourceTree = "<group>"; };
 		91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADatabaseScopedValueCache.swift; sourceTree = "<group>"; };
+		93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAFieldEditorCommitPolicyTests.swift; sourceTree = "<group>"; };
 		961210D1302E7233009A9A2A /* SAGitHubReleaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAGitHubReleaseTests.swift; sourceTree = "<group>"; };
 		963DA1C22CACC6F000B5A544 /* QuickLookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLookUI.framework; path = System/Library/Frameworks/QuickLookUI.framework; sourceTree = SDKROOT; };
 		964908C4249A77CF0052FC4A /* ssh_config */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ssh_config; sourceTree = "<group>"; };
@@ -1445,6 +1449,7 @@
 		96B0A1502493DF16007BB270 /* ShortcutRecorder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ShortcutRecorder.framework; path = Frameworks/ShortcutRecorder.framework; sourceTree = "<group>"; };
 		96B0A1532493F43B007BB270 /* TunnelAssistant-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "TunnelAssistant-Info.plist"; path = "Plists/TunnelAssistant-Info.plist"; sourceTree = "<group>"; };
 		96CA8F9B2783A8FE0061C2D1 /* Menlo.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; name = Menlo.ttc; path = Fonts/Menlo.ttc; sourceTree = "<group>"; };
+		9BCCC96AB0752412886E41B0 /* SAFieldEditorCommitPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAFieldEditorCommitPolicy.swift; sourceTree = "<group>"; };
 		9BE761AE45D4F6B9B90E67DE /* SPHelpViewerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPHelpViewerClient.h; sourceTree = "<group>"; };
 		9BE764320CE8E86E8F63647B /* SPHelpViewerClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPHelpViewerClient.m; sourceTree = "<group>"; };
 		9BE768F3989033CEDDC2027E /* SPFillView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPFillView.m; sourceTree = "<group>"; };
@@ -2182,6 +2187,7 @@
 				BC398A2C121D526200BE3EF4 /* SPCopyTable.m */,
 				171C398D16BD634600209EC6 /* SPDatabaseContentViewDelegate.h */,
 				FD0E72E92C38DC0E007EF348 /* SATableHeaderView.swift */,
+				9BCCC96AB0752412886E41B0 /* SAFieldEditorCommitPolicy.swift */,
 			);
 			name = "Table Views";
 			path = TableViews;
@@ -2728,6 +2734,7 @@
 				6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */,
 				55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */,
 				812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */,
+				93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3653,6 +3660,8 @@
 				5BA8A1F0564883162D4A80F2 /* SAUserManagerPrivilegeNormalizer.swift in Sources */,
 				4C74760160E21F5256343A70 /* SAUserManagerPrivilegeNormalizerTests.swift in Sources */,
 				6E60DF55568BE1B2F63D74E3 /* SASSHTunnelFailure.swift in Sources */,
+				8350D00F7955DDAE277DC218 /* SAFieldEditorCommitPolicy.swift in Sources */,
+				6437BC4ED2B743D251F18C2F /* SAFieldEditorCommitPolicyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3990,6 +3999,7 @@
 				14F0CC5AC96DE9CCC0213237 /* SAUserManagerPrivilegeNormalizer.swift in Sources */,
 				A69CC1B9E445E5FCF1484A09 /* SAAnalyticsConsentPolicy+Firebase.swift in Sources */,
 				6C5D707FD9947026F90C868A /* SASSHTunnelFailure.swift in Sources */,
+				FE96153A16ECBA48C12BCA09 /* SAFieldEditorCommitPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
- Preserve changed `ENUM` and `SET` popup selections when Content routes text editing through the field editor sheet.
- Authenticate the callback through `SPComboBoxCell`'s popup-open and selection-change events; typed text and generic sheet handoffs cannot opt into the commit path.
- Bind each popup selection to a table-data generation and consume it once. An in-flight reload defers the exact value, row, and column while its outcome is unknown; a result-store mutation or column-model rebuild invalidates that edit, while a failed or cancelled load against the unchanged snapshot resumes it after the enclosing document task ends.
- Represent popup provenance explicitly as untracked, current, deferred, or invalidated. Deferred and invalidated callbacks are rejected before field-editor routing is considered, while ordinary untracked inline combo edits remain accepted. Finalize a candidate only after the popup event loop returns, so interim highlights and cancelled popups cannot authenticate a later edit.
- Compare authenticated selections against both the full stored object and full display representation, retaining unchanged-value protection for long/truncated values, SQL `NULL`, and formatter-backed values.
- Add focused Swift regressions for changed/unchanged popup values, unauthenticated callbacks, one-shot consumption, same-dimension reload invalidation, text handoffs, long values, `NULL`, formatter representations, cancellation, failed/cancelled reload recovery, detached-worker scheduling gaps, overlapping reloads, and row-store mutations, column-model rebuilds, or new popups that invalidate a queued edit.

## Closes following issues:
- Closes: #2616

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [x] Other (English/Romania, `en_RO`)
- Xcode Version:
  - 26.6 (17F113)

## Screenshots:
- Not applicable; this changes commit routing without changing UI.

## Additional notes:
- Reproduced against Oracle MySQL 8.4.8 using the issue's exact table and session settings on macOS 26.6.2. The missing trigger was the Content toolbar's **Edit in Sheet** toggle: with it enabled, AppKit returned the combo-box popup selection through the table data-source callback, but the generic sheet-handoff guard discarded it before row editing began.
- Before the fix, `draft → published` remained `draft` and produced no update. With the fix, the same controller-level popup sequence persisted `published`.
- This is not keyed to MySQL 8.4, `utf8mb3`, or the reporter's schema. Both MySQL `ENUM_FLAG` and `SET_FLAG` map to the same combo-backed Content cell, and the same commit path serves ordinary tables and editable views. Custom Query and non-combo text editing remain unchanged.
- The original sheet-handoff guard prevented large text from being truncated when AppKit closed inline editing. The policy preserves that behavior for all non-combo callbacks and unchanged combo callbacks.
- Popup provenance is captured by the existing `SPComboBoxCellDelegate` notifications copied onto AppKit's transient data cell. Selection-change notifications are treated only as candidates; after the popup returns, the cell's final object value must match a changed candidate before it is authenticated. A lock-protected generation token makes that selection one-shot and marks callbacks from an older result snapshot invalid before any storage read or write. A counted in-flight reload reservation begins before detached work is scheduled, so nested schema reloads have no unguarded gap. If AppKit's callback arrives while the result is unknown, its exact coordinates are queued; only unchanged row and column generations plus an idle document can release it.
- Full stored and display representations are compared independently, covering truncated grid previews, SQL `NULL` placeholders, and formatter-backed values.
- Verified the fix through the exact 5.4.0/20109 source path and a current-main Debug build. A local AppKit lifecycle probe also confirmed that highlighting changes only the selected popup item, Escape restores the opening object value, and Return exposes the chosen object value after `popUp:` returns.
- Focused regression tests: 22 passed.
- Full Unit Tests target: 1,394 executed, 61 environment-skipped, 0 failures.
- `Sequel Ace Debug` build, `plutil -lint`, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline editing during transitions to and from field editors.
  - Prevented stale or invalid edits after table data reloads or column changes.
  - Ensured combo-box changes are committed only for current popup selections.
  - Deferred valid combo-box edits until table loading finishes.
  - Avoided committing unchanged combo-box values while preserving valid selections.
  - Continued supporting standard inline edits when no field-editor transition is required.

- **Tests**
  - Added coverage for combo-box handoffs, reload scenarios, formatted and truncated values, NULL values, raw data, and standard inline commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->