### PR TITLE
#fixed Report a peer that closes before the request is written as no reply

### DIFF
--- a/Source/Other/SSHTunnel/SASSHTunnelSocketClient.swift
+++ b/Source/Other/SSHTunnel/SASSHTunnelSocketClient.swift
@@ -45,9 +45,14 @@ struct SASSHTunnelSocketClient {
         case connectFailed(Int32)
         /// The listener did not pass `peerPolicy`; nothing was sent.
         case peerRejected
+        /// The request could not be written for a reason other than the app
+        /// having closed the connection (that is `noReply`).
         case sendFailed(Int32)
         /// The app closed without answering — it refused the connection or
-        /// could not read the request. Fail closed.
+        /// could not read the request. Fail closed. Whether the close lands
+        /// before the request is written (the write fails with EPIPE) or
+        /// after it (the read sees EOF) is a race the app's refusal cannot
+        /// control, so both surface here.
         case noReply
         case malformedReply(SASSHTunnelAuthWireError)
     }
@@ -69,7 +74,9 @@ struct SASSHTunnelSocketClient {
         guard peerPolicy(fd) else { throw Error.peerRejected }
 
         guard SASSHTunnelSocketIO.writeAll(fd, SASSHTunnelAuthWire.encode(request)) else {
-            throw Error.sendFailed(errno)
+            let code = errno
+            if code == EPIPE || code == ECONNRESET { throw Error.noReply }
+            throw Error.sendFailed(code)
         }
         // The reply has no timeout: the app may be waiting on the user.
         guard let line = SASSHTunnelSocketIO.readLine(fd) else { throw Error.noReply }

--- a/UnitTests/SASSHTunnelSocketTransportTests.swift
+++ b/UnitTests/SASSHTunnelSocketTransportTests.swift
@@ -182,6 +182,32 @@ final class SASSHTunnelSocketTransportTests: XCTestCase {
         XCTAssertEqual(handled, 0)
     }
 
+    func testPeerClosingBeforeTheRequestIsWrittenIsAlsoNoReply() throws {
+        // The app rejects a peer without reading, so its close races the
+        // assistant's write: either the write lands and the read sees EOF, or
+        // the write itself fails with EPIPE. Both are the app closing without
+        // an answer and must surface the same way. The client's policy hook
+        // runs between connect and write, so parking it until the listener
+        // has closed makes the losing side of the race deterministic.
+        let path = NSTemporaryDirectory() + "sa-test-\(UUID().uuidString.prefix(8)).sock"
+        let listener = try rawListener(at: path)
+        defer { close(listener); unlink(path) }
+        let peerClosed = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            let connection = accept(listener, nil, nil)
+            if connection >= 0 { close(connection) }
+            peerClosed.signal()
+        }
+        var client = SASSHTunnelSocketClient(path: path)
+        client.peerPolicy = { _ in
+            XCTAssertEqual(peerClosed.wait(timeout: .now() + 5), .success, "the listener never closed the connection")
+            return true
+        }
+        XCTAssertThrowsError(try client.send(.question("q"))) { error in
+            XCTAssertEqual(error as? SASSHTunnelSocketClient.Error, .noReply)
+        }
+    }
+
     func testClientRejectingThePeerSendsNothing() throws {
         var handled = 0
         let server = try startServer { request in handled += 1; return Self.echo(request) }


### PR DESCRIPTION
## Summary

`testServerRejectingThePeerClosesWithoutAReply` was flaky in CI: two "PR Tests" runs on 71a7ae8b0 gave one pass and one failure with `sendFailed(32)` (EPIPE) instead of `noReply`.

The app rejects an askpass peer without reading, so its close races the assistant's write. Usually the write lands and the read sees EOF (`noReply`); sometimes the close wins and the write itself fails with EPIPE (`sendFailed(32)`). Both tests that hit this (`testServerRejectingThePeerClosesWithoutAReply` and the peer validator's `testServerPolicyRejectionReachesTheClientAsNoReply`) run against the real `SASSHTunnelSocketServer`, so the race is the product's, not the test's.

## Change

- `SASSHTunnelSocketClient.send` now surfaces EPIPE and ECONNRESET on the write as `noReply`, which is exactly what that case already documents ("the app closed without answering — it refused the connection or could not read the request"). Other write errors stay `sendFailed`. The assistant therefore logs one consistent diagnostic for a refused peer instead of a timing-dependent errno.
- New test `testPeerClosingBeforeTheRequestIsWrittenIsAlsoNoReply` parks the client's peer-policy hook (which runs between connect and write) until a raw listener has accepted and closed the connection, so the write always hits EPIPE. Against the unfixed client it fails with the exact CI message.

## Verification

Run with a separate `-derivedDataPath` and `CODE_SIGNING_ALLOWED=NO`:

| Run | Result |
|---|---|
| New test on the unfixed client | fails with `sendFailed(32)` |
| The three peer-rejection tests, `-test-iterations 40 -run-tests-until-failure` | 120 passes, 0 failures |
| SSH tunnel suites (transport, peer validator, askpass) | 53 tests, 0 failures |
| Full Unit Tests scheme | 1395 tests, 0 failures |

Based on `main` rather than stacked on #2623 (step 5b): that PR touches the same files but different hunks and merges cleanly with this (checked with `git merge-tree`), and it is a draft held until 5a has soaked a release, whereas this flake affects every PR's CI now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an SSH tunnel peer closes the connection before receiving a request.
  * These cases are now consistently reported as receiving no reply rather than as a generic send failure.

* **Tests**
  * Added coverage for connection closures occurring before a request is written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->