### PR TITLE
#fixed Prevent table comments from overlapping table names

### DIFF
--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -1911,6 +1911,9 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 - (void)tableView:(NSTableView *)aTableView  willDisplayCell:(SPTableTextFieldCell
  *)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
+	// Cells are reused for tables without comments and for group headings.
+	[aCell setNote:@""];
+
 	if (rowIndex > 0 && rowIndex < (NSInteger)[filteredTableTypes count] && [[aTableColumn identifier] isEqualToString:@"tables"]) {
 
 		id item = [filteredTables safeObjectAtIndex:rowIndex];
@@ -1954,7 +1957,6 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 
 	} 
 	else {
-		[aCell setNote:@""];
 		[aCell setImage:nil];
 		[aCell setIndentationLevel:0];
 	}

--- a/Source/Views/Cells/SATableListCellRenderer.swift
+++ b/Source/Views/Cells/SATableListCellRenderer.swift
@@ -1,0 +1,88 @@
+//
+//  SATableListCellRenderer.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+@objc final class SATableListCellRenderer: NSObject {
+
+    struct Layout {
+        let nameFrame: NSRect
+        let commentFrame: NSRect
+    }
+
+    /// The table name has priority. A comment can use only the space after the
+    /// name and its text-cell insets, never the same rectangle as the name.
+    static func layout(in frame: NSRect, nameWidth: CGFloat) -> Layout {
+        let availableWidth = max(0, frame.width - 5)
+        let nameFrame = NSRect(
+            x: frame.origin.x,
+            y: frame.origin.y,
+            width: min(availableWidth, ceil(max(0, nameWidth)) + 4),
+            height: max(0, frame.height)
+        )
+        let rightEdge = frame.origin.x + availableWidth
+        let commentX = min(rightEdge, nameFrame.maxX + 8)
+        return Layout(
+            nameFrame: nameFrame,
+            commentFrame: NSRect(
+                x: commentX,
+                y: frame.origin.y,
+                width: max(0, rightEdge - commentX),
+                height: nameFrame.height
+            )
+        )
+    }
+
+    @objc(drawNameCell:commentCell:frame:inView:drawName:)
+    static func draw(
+        nameCell: NSTextFieldCell,
+        commentCell: NSCell?,
+        frame: NSRect,
+        in view: NSView,
+        drawName: (NSRect) -> Void
+    ) {
+        let originalValue = nameCell.attributedStringValue
+        let originalLineBreakMode = nameCell.lineBreakMode
+        defer {
+            nameCell.lineBreakMode = originalLineBreakMode
+            nameCell.attributedStringValue = originalValue
+        }
+
+        let layout = layout(in: frame, nameWidth: originalValue.size().width)
+        nameCell.lineBreakMode = .byTruncatingTail
+        if layout.nameFrame.width > 0 {
+            drawName(layout.nameFrame)
+        }
+
+        guard let commentCell, !commentCell.stringValue.isEmpty,
+              layout.commentFrame.width > 0 else { return }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byTruncatingTail
+        paragraph.alignment = .left
+        let comment = commentCell.stringValue
+            .components(separatedBy: .newlines).joined(separator: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+        let color: NSColor = nameCell.interiorBackgroundStyle == .emphasized
+            ? .selectedControlTextColor : .secondaryLabelColor
+        commentCell.font = nameCell.font
+        commentCell.alignment = .left
+        commentCell.lineBreakMode = .byTruncatingTail
+        commentCell.usesSingleLineMode = true
+        commentCell.attributedStringValue = NSAttributedString(string: comment, attributes: [
+            .font: nameCell.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
+            .foregroundColor: color,
+            .paragraphStyle: paragraph
+        ])
+
+        // AppKit may draw glyph overhang outside a text cell's nominal bounds.
+        NSGraphicsContext.saveGraphicsState()
+        layout.commentFrame.clip()
+        commentCell.drawInterior(withFrame: layout.commentFrame, in: view)
+        NSGraphicsContext.restoreGraphicsState()
+    }
+}

--- a/Source/Views/Cells/SPTableTextFieldCell.m
+++ b/Source/Views/Cells/SPTableTextFieldCell.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPTableTextFieldCell.h"
+#import "sequel-ace-Swift.h"
 
 @implementation SPTableTextFieldCell
 
@@ -38,7 +39,7 @@
 - (id) initWithCoder:(NSCoder *)coder
 {
 	if (self = [super initWithCoder:coder]) {
-		noteButton = [[NSCell alloc] init];
+		noteButton = [[NSTextFieldCell alloc] initTextCell:@""];
 		[noteButton setTitle:@""];
 		[noteButton setBordered:NO];
 		[noteButton setAlignment:NSTextAlignmentRight];
@@ -65,41 +66,13 @@
 }
 
 /**
- * Implements nicer cell truncating by appending '...' to the table name, before asking super to draw it.
+ * Draw the name and optional comment in separate, non-overlapping rectangles.
  */
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
-{			
-	// Construct and get the sub text attributed string
-	NSAttributedString *string = [self attributedStringValue];
-
-	NSUInteger i;
-	CGFloat maxWidth = cellFrame.size.width;
-	CGFloat stringWidth = [string size].width;
-
-	// Set a right padding
-	maxWidth -= 5;
-
-	if (maxWidth < stringWidth) {
-		for (i = 0; i <= [string length]; i++) {
-			if (([[string attributedSubstringFromRange:NSMakeRange(0, i)] size].width >= maxWidth) && (i >= 3)) {
-				string = [[NSMutableAttributedString alloc] initWithString:[[[string attributedSubstringFromRange:NSMakeRange(0, i - 3)] string] stringByAppendingString:@"..."] attributes:[string attributesAtIndex:0 effectiveRange:NULL]];
-				break;
-			}
-		}
-	}
-
-	[self setAttributedStringValue:string];
-	[super drawInteriorWithFrame:cellFrame inView:controlView];
-
-	
-	// Set up new rects
-	
-	if (noteButton != nil)
-	{
-		NSRect linkRect = NSMakeRect(cellFrame.origin.x, cellFrame.origin.y, cellFrame.size.width, cellFrame.size.height);
-		[noteButton drawInteriorWithFrame:linkRect inView:controlView];
-	}
-	
+{
+	[SATableListCellRenderer drawNameCell:self commentCell:noteButton frame:cellFrame inView:controlView drawName:^(NSRect nameFrame) {
+		[super drawInteriorWithFrame:nameFrame inView:controlView];
+	}];
 }
 
 - (void)setNote:(NSString *)lableText

--- a/UnitTests/SATableListCellRendererTests.swift
+++ b/UnitTests/SATableListCellRendererTests.swift
@@ -1,0 +1,181 @@
+//
+//  SATableListCellRendererTests.swift
+//  Unit Tests
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+final class SATableListCellRendererTests: XCTestCase {
+
+    func testCommentStartsAfterTheCompleteName() throws {
+        let name = makeName("customers")
+        let comment = RecordingCommentCell(textCell: "Customer records and contact details")
+        var nameFrame = NSRect.zero
+
+        render(name: name, comment: comment, width: 420) { nameFrame = $0 }
+
+        XCTAssertGreaterThanOrEqual(nameFrame.width, name.attributedStringValue.size().width)
+        XCTAssertGreaterThan(try XCTUnwrap(comment.drawnFrame).minX, nameFrame.maxX)
+        XCTAssertLessThanOrEqual(try XCTUnwrap(comment.drawnFrame).maxX, 420)
+    }
+
+    func testLongNameTakesPriorityOverCommentInNarrowSidebar() {
+        let name = makeName("a_long_table_name_that_fills_the_entire_sidebar")
+        let comment = RecordingCommentCell(textCell: "Must not cover the name")
+        var didDrawName = false
+
+        render(name: name, comment: comment, width: 90) { _ in didDrawName = true }
+
+        XCTAssertTrue(didDrawName)
+        XCTAssertNil(comment.drawnFrame)
+    }
+
+    func testDrawingDoesNotPermanentlyTruncateNameWhenSidebarIsResized() {
+        let name = makeName("monthly_customer_order_history")
+        name.lineBreakMode = .byClipping
+        let original = name.attributedStringValue
+
+        for width: CGFloat in [70, 500] {
+            render(name: name, comment: nil, width: width) { _ in
+                XCTAssertEqual(name.lineBreakMode, .byTruncatingTail)
+                XCTAssertEqual(name.stringValue, original.string)
+            }
+            XCTAssertEqual(name.attributedStringValue, original)
+            XCTAssertEqual(name.lineBreakMode, .byClipping)
+        }
+    }
+
+    func testEmptyCommentIsNotDrawn() {
+        let comment = RecordingCommentCell(textCell: "")
+        render(name: makeName("customers"), comment: comment)
+        XCTAssertNil(comment.drawnFrame)
+    }
+
+    func testClearingAReusedCommentCellRemovesItsPreviousText() {
+        let comment = RecordingCommentCell(textCell: "Previous table's comment")
+        render(name: makeName("customers"), comment: comment)
+        XCTAssertNotNil(comment.drawnFrame)
+
+        comment.stringValue = ""
+        comment.drawnFrame = nil
+        render(name: makeName("orders"), comment: comment)
+        XCTAssertNil(comment.drawnFrame)
+    }
+
+    func testCommentTracksTheNameFontAfterPreferenceChanges() {
+        let name = makeName("orders")
+        let comment = RecordingCommentCell(textCell: "Order details")
+
+        for size: CGFloat in [11, 18, 28] {
+            name.font = NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+            render(name: name, comment: comment, width: 600)
+            XCTAssertEqual(comment.font, name.font)
+            XCTAssertEqual(comment.attributedStringValue.attribute(.font, at: 0, effectiveRange: nil) as? NSFont, name.font)
+        }
+    }
+
+    func testCommentIsASingleLeftAlignedTruncatedLine() {
+        let comment = RecordingCommentCell(textCell: "First line\nSecond line\r\nThird\tcolumn")
+        render(name: makeName("orders"), comment: comment)
+
+        XCTAssertFalse(comment.stringValue.contains("\n"))
+        XCTAssertFalse(comment.stringValue.contains("\r"))
+        XCTAssertFalse(comment.stringValue.contains("\t"))
+        XCTAssertTrue(comment.usesSingleLineMode)
+        XCTAssertEqual(comment.alignment, .left)
+        XCTAssertEqual(comment.lineBreakMode, .byTruncatingTail)
+        let paragraph = comment.attributedStringValue.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertEqual(paragraph?.lineBreakMode, .byTruncatingTail)
+    }
+
+    func testSelectedCommentUsesReadableTextColor() {
+        let name = EmphasizedNameCell(textCell: "orders")
+        let comment = RecordingCommentCell(textCell: "Order details")
+        render(name: name, comment: comment)
+
+        XCTAssertEqual(comment.attributedStringValue.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor, .selectedControlTextColor)
+    }
+
+    func testUnselectedCommentUsesSecondaryTextColor() {
+        let comment = RecordingCommentCell(textCell: "Order details")
+        render(name: makeName("orders"), comment: comment)
+
+        XCTAssertEqual(comment.attributedStringValue.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor, .secondaryLabelColor)
+    }
+
+    func testLayoutHandlesTinyWidthsAndNonzeroOrigins() {
+        for width: CGFloat in [0, 1, 4, 5, 10, 100, 500] {
+            let frame = NSRect(x: 27, y: 40, width: width, height: 24)
+            let layout = SATableListCellRenderer.layout(in: frame, nameWidth: 83.5)
+            for textFrame in [layout.nameFrame, layout.commentFrame] {
+                XCTAssertGreaterThanOrEqual(textFrame.width, 0)
+                XCTAssertGreaterThanOrEqual(textFrame.minX, frame.minX)
+                XCTAssertLessThanOrEqual(textFrame.maxX, frame.maxX)
+                XCTAssertEqual(textFrame.minY, frame.minY)
+                XCTAssertEqual(textFrame.height, frame.height)
+            }
+            XCTAssertLessThanOrEqual(layout.nameFrame.maxX, layout.commentFrame.minX)
+        }
+    }
+
+    func testUnicodeAndProportionalFontsKeepTextRegionsSeparate() throws {
+        for title in ["WWWWWWW", "iiiiiii", "客户订单", "cafe\u{301}_orders"] {
+            for size: CGFloat in [11, 18, 28] {
+                let name = makeName(title)
+                name.font = NSFont.systemFont(ofSize: size)
+                let comment = RecordingCommentCell(textCell: "Additional details")
+                var nameFrame = NSRect.zero
+                render(name: name, comment: comment, width: 600) { nameFrame = $0 }
+                XCTAssertGreaterThan(try XCTUnwrap(comment.drawnFrame).minX, nameFrame.maxX)
+                XCTAssertGreaterThanOrEqual(nameFrame.width, name.attributedStringValue.size().width)
+            }
+        }
+    }
+
+    func testZeroWidthDoesNotDrawEitherTextCell() {
+        let comment = RecordingCommentCell(textCell: "Order details")
+        render(name: makeName("orders"), comment: comment, width: 0) { _ in
+            XCTFail("A zero-width cell must not draw its name")
+        }
+        XCTAssertNil(comment.drawnFrame)
+    }
+
+    private func makeName(_ text: String) -> NSTextFieldCell {
+        let cell = NSTextFieldCell(textCell: text)
+        cell.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        return cell
+    }
+
+    private func render(
+        name: NSTextFieldCell,
+        comment: NSCell?,
+        width: CGFloat = 420,
+        drawName: (NSRect) -> Void = { _ in }
+    ) {
+        let image = NSImage(size: NSSize(width: 640, height: 60))
+        image.lockFocus()
+        defer { image.unlockFocus() }
+        SATableListCellRenderer.draw(
+            nameCell: name,
+            commentCell: comment,
+            frame: NSRect(x: 0, y: 0, width: width, height: 50),
+            in: NSView(),
+            drawName: drawName
+        )
+    }
+}
+
+private final class RecordingCommentCell: NSTextFieldCell {
+    var drawnFrame: NSRect?
+
+    override func drawInterior(withFrame cellFrame: NSRect, in controlView: NSView) {
+        drawnFrame = cellFrame
+    }
+}
+
+private final class EmphasizedNameCell: NSTextFieldCell {
+    override var interiorBackgroundStyle: NSView.BackgroundStyle { .emphasized }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		5AF0C4000000000000000003 /* SAConnectionInfo+Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000001 /* SAConnectionInfo+Favorite.swift */; };
 		5AF0C4000000000000000012 /* SAConnectionInfoFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4000000000000000011 /* SAConnectionInfoFavoriteTests.swift */; };
 		5BA8A1F0564883162D4A80F2 /* SAUserManagerPrivilegeNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5C9FD78A565D5260B38E55 /* SAUserManagerPrivilegeNormalizer.swift */; };
+		5DB3C7CF73628DF0DA31F02E /* SATableListCellRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AA6EC7ADA69D8FCD7F2CAF /* SATableListCellRenderer.swift */; };
 		60111925195F940E7252B376 /* SAHelpViewerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6549DFDEB75EC2BCCFA93A85 /* SAHelpViewerModelTests.swift */; };
 		6220954A97524B17D37B4D09 /* SAKeychainNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C5955B8DBBB2BDAED5886E /* SAKeychainNaming.swift */; };
 		623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
@@ -493,7 +494,9 @@
 		71F6E6D2037EB14ED8623A81 /* SAKeychainProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B2B2C637F5D0AF5FE35EEF /* SAKeychainProviding.swift */; };
 		72B694CE0DF16C2D0A54F29C /* ConnectionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57CA10F3F4B37E186CF7EF9 /* ConnectionStringParser.swift */; };
 		73F70A961E4E547500636550 /* SPJSONFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 73F70A951E4E547500636550 /* SPJSONFormatter.m */; };
+		77BAF2BFA8B8163A11014DA5 /* SATableListCellRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AA6EC7ADA69D8FCD7F2CAF /* SATableListCellRenderer.swift */; };
 		794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */; };
+		7B182E1F0D6218CA522A86D4 /* SATableListCellRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BD851B6D129D345188D5E5 /* SATableListCellRendererTests.swift */; };
 		7E75432072457939574AC25A /* SAKeychainDisabledTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0232F338F68F67E4063B3EC /* SAKeychainDisabledTests.swift */; };
 		7EE575894C57515419B0A30A /* SPMCPPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F0964487758A57DA339AF2 /* SPMCPPreferencePane.swift */; };
 		806D36A543D1AAFC5E992B08 /* SABundleVersionUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4262EAB6230F7996EC17A13A /* SABundleVersionUpdater.swift */; };
@@ -1435,6 +1438,7 @@
 		8F7D127BB5BCD94B0E794C5E /* SAHelpViewerWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAHelpViewerWindowController.swift; sourceTree = "<group>"; };
 		91D7AFC91F1CEBB3ED2242CC /* SADatabaseScopedValueCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADatabaseScopedValueCache.swift; sourceTree = "<group>"; };
 		93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAFieldEditorCommitPolicyTests.swift; sourceTree = "<group>"; };
+		95AA6EC7ADA69D8FCD7F2CAF /* SATableListCellRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SATableListCellRenderer.swift; sourceTree = "<group>"; };
 		961210D1302E7233009A9A2A /* SAGitHubReleaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAGitHubReleaseTests.swift; sourceTree = "<group>"; };
 		963DA1C22CACC6F000B5A544 /* QuickLookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLookUI.framework; path = System/Library/Frameworks/QuickLookUI.framework; sourceTree = SDKROOT; };
 		964908C4249A77CF0052FC4A /* ssh_config */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ssh_config; sourceTree = "<group>"; };
@@ -1570,6 +1574,7 @@
 		CF0000342F8C000600C4C14A /* SARuleFilterRootConjunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SARuleFilterRootConjunctionTests.swift; sourceTree = "<group>"; };
 		CF0000272F8C000600C4C14A /* SACellFilterColumnIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACellFilterColumnIdentifierTests.swift; sourceTree = "<group>"; };
 		D35577F42728C6CF002B3989 /* SPWindowTabAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPWindowTabAccessory.swift; sourceTree = "<group>"; };
+		D5BD851B6D129D345188D5E5 /* SATableListCellRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SATableListCellRendererTests.swift; sourceTree = "<group>"; };
 		D62F323F4DE28E7459898F09 /* SAUserManagerPrivilegeNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAUserManagerPrivilegeNormalizerTests.swift; sourceTree = "<group>"; };
 		DD00DD00DD00DD00DD000002 /* SPFilterRuleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleTextField.swift; sourceTree = "<group>"; };
 		DD00DD00DD00DD00DD000004 /* SPFilterRuleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPFilterRuleEditor.swift; sourceTree = "<group>"; };
@@ -1762,6 +1767,7 @@
 				1A564C0C0FFB444D2E5CA447 /* SPPillAttachmentCell.h */,
 				500DA4B51BEFF877000773FE /* SPComboBoxCell.h */,
 				500DA4B61BEFF877000773FE /* SPComboBoxCell.m */,
+				95AA6EC7ADA69D8FCD7F2CAF /* SATableListCellRenderer.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -2735,6 +2741,7 @@
 				55DC09E6A57ECBC54B00BDDD /* SACompletionWindowLayoutTests.swift */,
 				812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */,
 				93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */,
+				D5BD851B6D129D345188D5E5 /* SATableListCellRendererTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3662,6 +3669,8 @@
 				6E60DF55568BE1B2F63D74E3 /* SASSHTunnelFailure.swift in Sources */,
 				8350D00F7955DDAE277DC218 /* SAFieldEditorCommitPolicy.swift in Sources */,
 				6437BC4ED2B743D251F18C2F /* SAFieldEditorCommitPolicyTests.swift in Sources */,
+				77BAF2BFA8B8163A11014DA5 /* SATableListCellRenderer.swift in Sources */,
+				7B182E1F0D6218CA522A86D4 /* SATableListCellRendererTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4000,6 +4009,7 @@
 				A69CC1B9E445E5FCF1484A09 /* SAAnalyticsConsentPolicy+Firebase.swift in Sources */,
 				6C5D707FD9947026F90C868A /* SASSHTunnelFailure.swift in Sources */,
 				FE96153A16ECBA48C12BCA09 /* SAFieldEditorCommitPolicy.swift in Sources */,
+				5DB3C7CF73628DF0DA31F02E /* SATableListCellRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes:
With “Display comments in tables list” enabled, long comments can cover table names because both are drawn in the same rectangle. Reserve space for the complete name first, then draw a left-aligned, tail-truncated comment only in the remaining space. If the name fills the sidebar, omit the comment.

- Match the comment font to the table-name font and keep multiline comments on one line.
- Preserve the full name while drawing, so narrowing and widening the sidebar does not retain a truncated value.
- Clear the previous comment before configuring a reused row, including group headings and rows without comments.
- Keep the new layout/drawing logic in Swift with a small bridge from the existing cell.

## Closes following issues:
Closes #2166

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other
- Xcode Version: 26.6
- [Full Unit Tests scheme](https://github.com/dgallaway/Sequel-Ace/actions/runs/33882703532): 1,407 tests executed, 64 skipped, zero failures, including all 12 new `SATableListCellRendererTests`.
- [Complete Sequel Ace Debug app build](https://github.com/dgallaway/Sequel-Ace/actions/runs/33882794189): passed.
- Launched the built app separately on macOS 26.6.2 and connected to a local MariaDB 10.6.22 sample database. Verified selection, narrow/wide sidebar resizing, pinned tables, filtering, and rows with empty comments.
- Rendered the actual cell implementations with sample data in light/dark appearances at 13- and 20-point fonts.
- Project and English localization plist validation passed.

## Screenshots:
These before/after captures use the actual cell implementations in a small AppKit fixture with invented table names and comments. Full-app interaction was verified separately as described above.

| Before | After |
| --- | --- |
| ![Overlapping table names and comments](https://raw.githubusercontent.com/dgallaway/Sequel-Ace/85634ce8b5e548cff0e261c5dfc758147ffa0539/Validation/issue-2166/before-narrow.png) | ![Names and comments occupy separate space](https://raw.githubusercontent.com/dgallaway/Sequel-Ace/85634ce8b5e548cff0e261c5dfc758147ffa0539/Validation/issue-2166/after-narrow.png) |

[Wider sidebar](https://raw.githubusercontent.com/dgallaway/Sequel-Ace/85634ce8b5e548cff0e261c5dfc758147ffa0539/Validation/issue-2166/after-wide.png) · [Larger font in light appearance](https://raw.githubusercontent.com/dgallaway/Sequel-Ace/85634ce8b5e548cff0e261c5dfc758147ffa0539/Validation/issue-2166/after-large-font.png)

## Additional notes:
The manual test used a fresh connection without restoring a selected table. An earlier selected-table restoration attempt blocked in the unchanged `SPNavigatorController` initialization lock; that path is outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table list rendering so names take priority over comments in narrow spaces.
  * Prevented stale comments from appearing when table list cells are reused.
  * Improved truncation, resizing behavior, formatting, selection colors, and comment visibility across table list layouts.

* **Tests**
  * Added coverage for table names, comments, resizing, narrow layouts, Unicode text, and cell reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->