### PR TITLE
#added Tint the window title bar with the favorite connection color

### DIFF
--- a/Resources/Localization/en.lproj/Localizable.strings
+++ b/Resources/Localization/en.lproj/Localizable.strings
@@ -819,6 +819,12 @@
 /* content tab : rule filter : drop zone tooltip */
 "Click to add a filter, ⌥-click to add an AND/OR group" = "Click to add a filter, ⌥-click to add an AND/OR group";
 
+/* general preferences : appearance : checkbox that colors the window title bar with the connected favorite's color */
+"Color the title bar with the connection color" = "Color the title bar with the connection color";
+
+/* general preferences : appearance : tooltip for the title bar color checkbox */
+"Color the title bar, toolbar and tab bar with the color assigned to the connection's favorite, making it easy to tell a production connection from a development one at a glance." = "Color the title bar, toolbar and tab bar with the color assigned to the connection's favorite, making it easy to tell a production connection from a development one at a glance.";
+
 /* table Content : rule filter editor : compound row : label after the AND/OR popup */
 "combines the conditions in this group" = "combines the conditions in this group";
 

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -133,6 +133,8 @@
 	<false/>
 	<key>DisplayTableViewColumnTypes</key>
 	<true/>
+	<key>DisplayConnectionColorInTitlebar</key>
+	<false/>
 	<key>EditInSheetEnabled</key>
 	<false/>
 	<key>FavoriteColorList</key>

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -3170,9 +3170,15 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
 
     [self.parentWindowController updateWindowWithTitle:result.windowTitle tabTitle:result.tabTitle];
 
-    if (state == SAWindowConnectionStateConnected) {
-        [self.parentWindowController updateWindowAccessoryWithColor:[[SPFavoriteColorSupport sharedInstance] colorForIndex:[connectionController colorIndex]] isSSL:[self.connectionController isConnectedViaSSL]];
-    }
+    // Always update, so that a window which is no longer connected drops the
+    // favourite colour again. A nil colour clears both the tab line and the
+    // title bar tint (#1856); leaving the tint behind would keep a window that
+    // is back on the connection view looking like a live production session.
+    NSColor *favoriteColor = (state == SAWindowConnectionStateConnected)
+        ? [[SPFavoriteColorSupport sharedInstance] colorForIndex:[connectionController colorIndex]]
+        : nil;
+
+    [self.parentWindowController updateWindowAccessoryWithColor:favoriteColor isSSL:[self.connectionController isConnectedViaSSL]];
 }
 
 #pragma mark -

--- a/Source/Controllers/Window/SAWindowTitlebarTint.swift
+++ b/Source/Controllers/Window/SAWindowTitlebarTint.swift
@@ -37,11 +37,17 @@ struct SAWindowTitlebarTint {
     /// a stray line across a coloured strip, so a tinted window drops it.
     let separatorStyle: NSTitlebarSeparatorStyle
 
-    /// Derive the chrome for a connection's favourite colour, or the stock
-    /// title bar when `favoriteColor` is `nil` - meaning the connection has no
-    /// favourite colour, or the document is not connected.
-    init(favoriteColor: NSColor?) {
-        if let favoriteColor = favoriteColor {
+    /// Derive the chrome for a connection's favourite colour.
+    ///
+    /// - Parameters:
+    ///   - favoriteColor: the connection's favourite colour, or `nil` when it
+    ///     has none or the document is not connected.
+    ///   - isEnabled: the user's `DisplayConnectionColorInTitlebar` preference.
+    ///     Off is the default, and always yields the stock title bar - a window
+    ///     then looks exactly as it did before the preference existed, however
+    ///     the connection is coloured.
+    init(favoriteColor: NSColor?, isEnabled: Bool) {
+        if isEnabled, let favoriteColor = favoriteColor {
             backgroundColor = favoriteColor
             titlebarAppearsTransparent = true
             separatorStyle = .none

--- a/Source/Controllers/Window/SAWindowTitlebarTint.swift
+++ b/Source/Controllers/Window/SAWindowTitlebarTint.swift
@@ -1,0 +1,54 @@
+//
+//  SAWindowTitlebarTint.swift
+//  Sequel Ace
+//
+//  The window chrome appearance for a connection's favourite colour.
+//  Split out of SPWindowController so it can be compiled into the Unit
+//  Tests target: AppKit only, no project ObjC types, so the test target
+//  needs no bridging header (same pattern as SAWindowTitleBuilder).
+//
+
+import AppKit
+
+/// How the document window's chrome should look for a given connection colour.
+///
+/// Applying a favourite colour means painting the whole window top - title
+/// bar, unified toolbar and the native tab bar - rather than only the 5pt line
+/// on the tab accessory, which is hidden along with the tab bar (#1856).
+/// `titlebarAppearsTransparent` is what makes that work: it stops the title bar
+/// drawing its own background, so the window background shows through the
+/// entire strip.
+///
+/// The `nil` case is deliberately not "transparent over
+/// `windowBackgroundColor`" - that renders a flat, non-standard title bar
+/// rather than undoing the tint, so all three properties have to be restored.
+struct SAWindowTitlebarTint {
+
+    /// Colour for `NSWindow.backgroundColor`. Kept as the caller's `NSColor`
+    /// rather than a resolved value, so an asset colour with a light/dark pair
+    /// keeps following the effective appearance.
+    let backgroundColor: NSColor
+
+    /// Whether the title bar should stop drawing its own background, letting
+    /// `backgroundColor` show through the title bar, toolbar and tab bar.
+    let titlebarAppearsTransparent: Bool
+
+    /// Whether the hairline below the title bar is drawn. A separator reads as
+    /// a stray line across a coloured strip, so a tinted window drops it.
+    let separatorStyle: NSTitlebarSeparatorStyle
+
+    /// Derive the chrome for a connection's favourite colour, or the stock
+    /// title bar when `favoriteColor` is `nil` - meaning the connection has no
+    /// favourite colour, or the document is not connected.
+    init(favoriteColor: NSColor?) {
+        if let favoriteColor = favoriteColor {
+            backgroundColor = favoriteColor
+            titlebarAppearsTransparent = true
+            separatorStyle = .none
+        } else {
+            backgroundColor = .windowBackgroundColor
+            titlebarAppearsTransparent = false
+            separatorStyle = .automatic
+        }
+    }
+}

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -49,7 +49,17 @@ import SnapKit
 
         setupFramePersistence()
         setupAppearance()
+        observeTitlebarTintPreference()
     }
+
+    /// The favourite colour of the connection in this tab, or `nil` when it has
+    /// none or the tab is not connected. Kept so the title bar can be repainted
+    /// when the preference is toggled, without waiting for a title update.
+    private var favoriteColor: NSColor?
+
+    /// Holds the preference observer for the window's lifetime; the token
+    /// unregisters it on deinit.
+    private var titlebarTintSubscription: NotificationToken?
 
     // MARK: - Accessory
     private lazy var tabAccessoryView: SPWindowTabAccessory = SPWindowTabAccessory()
@@ -126,10 +136,34 @@ private extension SPWindowController {
     func applyTitlebarTint(_ color: NSColor?) {
         guard let window = window else { return }
 
-        let tint = SAWindowTitlebarTint(favoriteColor: color)
+        let tint = SAWindowTitlebarTint(
+            favoriteColor: color,
+            isEnabled: UserDefaults.standard.bool(forKey: SPDisplayConnectionColorInTitlebar)
+        )
+
+        // Every defaults change wakes the observer below, so skip the work -
+        // and the redraw it triggers - unless the chrome actually differs.
+        guard window.titlebarAppearsTransparent != tint.titlebarAppearsTransparent
+                || window.backgroundColor != tint.backgroundColor
+                || window.titlebarSeparatorStyle != tint.separatorStyle else { return }
+
         window.titlebarAppearsTransparent = tint.titlebarAppearsTransparent
         window.backgroundColor = tint.backgroundColor
         window.titlebarSeparatorStyle = tint.separatorStyle
+    }
+
+    /// Repaint the title bar when the preference is toggled, so turning the
+    /// colour on or off reaches open windows immediately rather than at the
+    /// next title update.
+    func observeTitlebarTintPreference() {
+        titlebarTintSubscription = NotificationCenter.default.observe(
+            name: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            self.applyTitlebarTint(self.favoriteColor)
+        }
     }
 }
 
@@ -152,6 +186,7 @@ private extension SPWindowController {
     /// `-[SPDatabaseDocument updateWindowTitle:]`. A `nil` colour means "no
     /// favourite colour, or not connected" and clears the line and the tint.
     func updateWindowAccessory(color: NSColor?, isSSL: Bool) {
+        favoriteColor = color
         tabAccessoryView.update(color: color, isSSL: isSSL)
         applyTitlebarTint(color)
     }

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -54,6 +54,21 @@ import SnapKit
     // MARK: - Accessory
     private lazy var tabAccessoryView: SPWindowTabAccessory = SPWindowTabAccessory()
 
+    /// Opaque backing for the content area. The tinted title bar (see
+    /// `applyTitlebarTint`) is painted by the window's own background, which also
+    /// shows through anywhere the document view doesn't draw - split view gaps,
+    /// the frame or two before subviews catch up with a live resize. This keeps
+    /// the connection colour in the window top instead of leaking below it.
+    /// `NSBox` resolves its fill colour at draw time, so it follows light/dark.
+    private lazy var contentBackground: NSBox = {
+        let box = NSBox()
+        box.boxType = .custom
+        box.titlePosition = .noTitle
+        box.borderWidth = 0
+        box.fillColor = .windowBackgroundColor
+        return box
+    }()
+
     deinit {
         print("Deinit called")
     }
@@ -82,12 +97,43 @@ private extension SPWindowController {
     func setupAppearance() {
         databaseDocument.updateWindowTitle(self)
 
+        if let contentView = window?.contentView {
+            contentBackground.frame = contentView.bounds
+            contentBackground.autoresizingMask = [.width, .height]
+            contentView.addSubview(contentBackground)
+        }
+
         window?.contentView?.addSubview(databaseDocument.databaseView())
         databaseDocument.databaseView().frame = window?.contentView?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 400)
 
         if #available(macOS 10.13, *) {
             window?.tab.accessoryView = tabAccessoryView
         }
+    }
+
+    /// Paint the whole window top - title bar, unified toolbar and the native tab
+    /// bar - in the favourite colour of the connection this tab holds (#1856).
+    /// `titlebarAppearsTransparent` drops the title bar's own background so the
+    /// window background shows through the entire strip. Every tab is its own
+    /// `NSWindow`, so the colour follows whichever tab is selected without any
+    /// extra bookkeeping.
+    ///
+    /// A `nil` colour restores the stock title bar: leaving the title bar
+    /// transparent over `windowBackgroundColor` would render it flat and
+    /// non-standard rather than undoing the tint.
+    func applyTitlebarTint(_ color: NSColor?) {
+        guard let window = window else { return }
+
+        guard let color = color else {
+            window.titlebarAppearsTransparent = false
+            window.backgroundColor = .windowBackgroundColor
+            window.titlebarSeparatorStyle = .automatic
+            return
+        }
+
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = color
+        window.titlebarSeparatorStyle = .none
     }
 }
 
@@ -105,6 +151,7 @@ private extension SPWindowController {
 
     func updateWindowAccessory(color: NSColor?, isSSL: Bool) {
         tabAccessoryView.update(color: color, isSSL: isSSL)
+        applyTitlebarTint(color)
     }
 }
 

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -94,6 +94,11 @@ private extension SPWindowController {
         window?.setFrameUsingName(Self.frameAutosaveName)
     }
 
+    /// Put the document's view into the window and hook up the tab accessory.
+    ///
+    /// The opaque `contentBackground` goes in first so it sits *below* the
+    /// document view: it is the backstop for the tinted window background (see
+    /// `applyTitlebarTint`), not part of the document's own chrome.
     func setupAppearance() {
         databaseDocument.updateWindowTitle(self)
 
@@ -149,6 +154,12 @@ private extension SPWindowController {
         tabAccessoryView.setTitle(title: tabTitle)
     }
 
+    /// Reflect the connection this tab holds in the window chrome: the colour
+    /// line on the tab accessory, the SSL padlock, and the title bar tint.
+    ///
+    /// The single funnel for all three, called from
+    /// `-[SPDatabaseDocument updateWindowTitle:]`. A `nil` colour means "no
+    /// favourite colour, or not connected" and clears the line and the tint.
     func updateWindowAccessory(color: NSColor?, isSSL: Bool) {
         tabAccessoryView.update(color: color, isSSL: isSSL)
         applyTitlebarTint(color)

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -116,29 +116,20 @@ private extension SPWindowController {
         }
     }
 
-    /// Paint the whole window top - title bar, unified toolbar and the native tab
-    /// bar - in the favourite colour of the connection this tab holds (#1856).
-    /// `titlebarAppearsTransparent` drops the title bar's own background so the
-    /// window background shows through the entire strip. Every tab is its own
-    /// `NSWindow`, so the colour follows whichever tab is selected without any
-    /// extra bookkeeping.
+    /// Paint the whole window top - title bar, unified toolbar and the native
+    /// tab bar - in the favourite colour of the connection this tab holds, or
+    /// restore the stock title bar when there is no colour (#1856).
     ///
-    /// A `nil` colour restores the stock title bar: leaving the title bar
-    /// transparent over `windowBackgroundColor` would render it flat and
-    /// non-standard rather than undoing the tint.
+    /// `SAWindowTitlebarTint` decides what the chrome should look like; this
+    /// only applies it. Every tab is its own `NSWindow`, so the colour follows
+    /// whichever tab is selected without any extra bookkeeping.
     func applyTitlebarTint(_ color: NSColor?) {
         guard let window = window else { return }
 
-        guard let color = color else {
-            window.titlebarAppearsTransparent = false
-            window.backgroundColor = .windowBackgroundColor
-            window.titlebarSeparatorStyle = .automatic
-            return
-        }
-
-        window.titlebarAppearsTransparent = true
-        window.backgroundColor = color
-        window.titlebarSeparatorStyle = .none
+        let tint = SAWindowTitlebarTint(favoriteColor: color)
+        window.titlebarAppearsTransparent = tint.titlebarAppearsTransparent
+        window.backgroundColor = tint.backgroundColor
+        window.titlebarSeparatorStyle = tint.separatorStyle
     }
 }
 

--- a/Source/Controllers/Window/SPWindowController.swift
+++ b/Source/Controllers/Window/SPWindowController.swift
@@ -134,7 +134,9 @@ private extension SPWindowController {
     /// only applies it. Every tab is its own `NSWindow`, so the colour follows
     /// whichever tab is selected without any extra bookkeeping.
     func applyTitlebarTint(_ color: NSColor?) {
-        guard let window = window else { return }
+        guard let window = window else {
+            return
+        }
 
         let tint = SAWindowTitlebarTint(
             favoriteColor: color,
@@ -145,7 +147,9 @@ private extension SPWindowController {
         // and the redraw it triggers - unless the chrome actually differs.
         guard window.titlebarAppearsTransparent != tint.titlebarAppearsTransparent
                 || window.backgroundColor != tint.backgroundColor
-                || window.titlebarSeparatorStyle != tint.separatorStyle else { return }
+                || window.titlebarSeparatorStyle != tint.separatorStyle else {
+            return
+        }
 
         window.titlebarAppearsTransparent = tint.titlebarAppearsTransparent
         window.backgroundColor = tint.backgroundColor
@@ -161,7 +165,9 @@ private extension SPWindowController {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self = self else {
+                return
+            }
             self.applyTitlebarTint(self.favoriteColor)
         }
     }

--- a/Source/Interfaces/Preferences.xib
+++ b/Source/Interfaces/Preferences.xib
@@ -639,9 +639,9 @@ Gw
                     </textFieldCell>
                 </textField>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
-                    <rect key="frame" x="0.0" y="114" width="656" height="41"/>
+                    <rect key="frame" x="0.0" y="83" width="656" height="72"/>
                     <view key="contentView" id="8QO-1r-5jB">
-                        <rect key="frame" x="0.0" y="0.0" width="656" height="41"/>
+                        <rect key="frame" x="0.0" y="0.0" width="656" height="72"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="m2t-AW-wZp">
@@ -703,6 +703,19 @@ Gw
                                     </binding>
                                 </connections>
                             </popUpButton>
+                            <button toolTip="Color the title bar, toolbar and tab bar with the color assigned to the connection's favorite, making it easy to tell a production connection from a development one at a glance." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SAt-Tb-Cl1">
+                                <rect key="frame" x="180" y="9" width="456" height="22"/>
+                                <buttonCell key="cell" type="check" title="Color the title bar with the connection color" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="SAt-Tb-Cl2">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <binding destination="117" name="value" keyPath="values.DisplayConnectionColorInTitlebar" id="SAt-Tb-Cl3"/>
+                                </connections>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="22" id="SAt-Tb-Cl6"/>
+                                </constraints>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="m2t-AW-wZp" secondAttribute="trailing" constant="20" id="5va-08-JI4"/>
@@ -712,12 +725,17 @@ Gw
                             <constraint firstItem="A54-fI-5jD" firstAttribute="centerY" secondItem="zSn-Pq-u9O" secondAttribute="centerY" id="RSy-6K-GNB"/>
                             <constraint firstItem="m2t-AW-wZp" firstAttribute="top" secondItem="8QO-1r-5jB" secondAttribute="top" id="cjR-xY-u0O"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="leading" secondItem="zSn-Pq-u9O" secondAttribute="trailing" constant="10" id="jbv-tQ-cWP"/>
-                            <constraint firstAttribute="bottom" secondItem="YpU-KB-oKj" secondAttribute="bottom" constant="9" id="k6U-6l-mIv"/>
+                            <constraint firstAttribute="bottom" secondItem="SAt-Tb-Cl1" secondAttribute="bottom" constant="9" id="k6U-6l-mIv"/>
+                            <constraint firstItem="SAt-Tb-Cl1" firstAttribute="top" secondItem="YpU-KB-oKj" secondAttribute="bottom" constant="9" id="SAt-Tb-Cl4"/>
+                            <constraint firstItem="SAt-Tb-Cl1" firstAttribute="leading" secondItem="YpU-KB-oKj" secondAttribute="leading" id="SAt-Tb-Cl5"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="top" secondItem="m2t-AW-wZp" secondAttribute="bottom" constant="9" id="qvF-s5-WKM"/>
                             <constraint firstAttribute="trailing" secondItem="A54-fI-5jD" secondAttribute="trailing" constant="20" id="wZU-Cc-BI5"/>
                             <constraint firstItem="zSn-Pq-u9O" firstAttribute="leading" secondItem="8QO-1r-5jB" secondAttribute="leading" constant="20" id="wsp-nB-hpQ"/>
                         </constraints>
                     </view>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="72" id="SAt-Tb-Cl8"/>
+                    </constraints>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="F3U-SQ-W2d">
                     <rect key="frame" x="0.0" y="83" width="656" height="31"/>
@@ -906,6 +924,7 @@ Gw
                 <constraint firstItem="569" firstAttribute="trailing" secondItem="XRZ-IQ-R00" secondAttribute="trailing" id="WCa-as-XxN"/>
                 <constraint firstItem="1420" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="WiS-oj-FT3"/>
                 <constraint firstItem="2aR-JM-Lbr" firstAttribute="top" secondItem="XAX-zM-z61" secondAttribute="bottom" constant="9" id="XYl-mN-TCg"/>
+                <constraint firstItem="KJh-ax-qjk" firstAttribute="top" secondItem="2aR-JM-Lbr" secondAttribute="bottom" constant="9" id="SAt-Tb-Cl7"/>
                 <constraint firstItem="957" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="ZaW-If-0qM"/>
                 <constraint firstItem="582" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="aCS-ZA-klL"/>
                 <constraint firstItem="2aR-JM-Lbr" firstAttribute="centerY" secondItem="gcQ-a7-Kqd" secondAttribute="centerY" id="awJ-f0-Gff"/>

--- a/Source/Interfaces/Preferences.xib
+++ b/Source/Interfaces/Preferences.xib
@@ -320,10 +320,10 @@ Gw
             <point key="canvasLocation" x="-364" y="159"/>
         </window>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="17" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="656" height="502"/>
+            <rect key="frame" x="0.0" y="0.0" width="656" height="543"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-IQ-R00">
-                    <rect key="frame" x="180" y="465" width="456" height="22"/>
+                    <rect key="frame" x="180" y="506" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Prompt for confirmation before quitting" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="pLU-wO-HXa">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -336,19 +336,19 @@ Gw
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="FJw-vU-VgL">
-                    <rect key="frame" x="180" y="453" width="456" height="5"/>
+                    <rect key="frame" x="180" y="494" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="o4y-7V-ZEP"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1420">
-                    <rect key="frame" x="180" y="381" width="456" height="5"/>
+                    <rect key="frame" x="180" y="422" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="jHx-SA-a0F"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1419">
-                    <rect key="frame" x="18" y="353" width="154" height="20"/>
+                    <rect key="frame" x="18" y="394" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="8zj-eb-GHj"/>
                         <constraint firstAttribute="height" constant="20" id="GHh-gf-gj6"/>
@@ -360,7 +360,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1418">
-                    <rect key="frame" x="180" y="352" width="456" height="22"/>
+                    <rect key="frame" x="180" y="393" width="456" height="22"/>
                     <popUpButtonCell key="cell" type="push" title="Last Used" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1449" id="1422">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -399,19 +399,19 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="582">
-                    <rect key="frame" x="180" y="299" width="456" height="5"/>
+                    <rect key="frame" x="180" y="340" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="epJ-gi-vWC"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="581">
-                    <rect key="frame" x="180" y="340" width="456" height="5"/>
+                    <rect key="frame" x="180" y="381" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Lfj-js-9td"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="947">
-                    <rect key="frame" x="180" y="246" width="456" height="22"/>
+                    <rect key="frame" x="180" y="287" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Display comments in tables list" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="948">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -424,7 +424,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hMm-gH-Xw4">
-                    <rect key="frame" x="180" y="222" width="456" height="22"/>
+                    <rect key="frame" x="180" y="263" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Save query history individually" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="3B6-Jd-2pW">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -437,7 +437,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="957">
-                    <rect key="frame" x="180" y="270" width="456" height="22"/>
+                    <rect key="frame" x="180" y="311" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Display vertical grid lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="958">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -450,7 +450,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bHb-uY-JgS">
-                    <rect key="frame" x="180" y="199" width="456" height="22"/>
+                    <rect key="frame" x="180" y="240" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Display column types in content and query views" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Z7f-0u-a0e">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -463,7 +463,7 @@ Gw
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="577">
-                    <rect key="frame" x="18" y="312" width="154" height="20"/>
+                    <rect key="frame" x="18" y="353" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="2fJ-uV-yWE"/>
                         <constraint firstAttribute="width" constant="150" id="H3R-fZ-7pu"/>
@@ -475,7 +475,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1465">
-                    <rect key="frame" x="18" y="271" width="154" height="20"/>
+                    <rect key="frame" x="18" y="312" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="Pth-OX-OBR"/>
                         <constraint firstAttribute="height" constant="20" id="jzh-o6-wrC"/>
@@ -487,7 +487,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="569">
-                    <rect key="frame" x="180" y="424" width="456" height="22"/>
+                    <rect key="frame" x="180" y="465" width="456" height="22"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" autoenablesItems="NO" id="570">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -502,7 +502,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="568">
-                    <rect key="frame" x="18" y="425" width="154" height="20"/>
+                    <rect key="frame" x="18" y="466" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iwU-u3-PUC"/>
                         <constraint firstAttribute="height" constant="20" id="y3H-yc-8cM"/>
@@ -514,7 +514,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="567">
-                    <rect key="frame" x="180" y="393" width="456" height="22"/>
+                    <rect key="frame" x="180" y="434" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Connect to default on startup" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="576">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -527,7 +527,7 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="180" y="311" width="456" height="22"/>
+                    <rect key="frame" x="180" y="352" width="456" height="22"/>
                     <popUpButtonCell key="cell" type="push" title="Autodetect" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="50" id="25">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -590,13 +590,13 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="784">
-                    <rect key="frame" x="180" y="189" width="456" height="5"/>
+                    <rect key="frame" x="180" y="230" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="vus-7q-stB"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="790">
-                    <rect key="frame" x="514" y="167" width="124" height="14"/>
+                    <rect key="frame" x="514" y="208" width="124" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="nGd-yZ-I7g"/>
                     </constraints>
@@ -607,7 +607,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="787">
-                    <rect key="frame" x="180" y="163" width="331" height="22"/>
+                    <rect key="frame" x="180" y="204" width="331" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="1Oz-rT-AdX"/>
                     </constraints>
@@ -627,7 +627,7 @@ Gw
                     </connections>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="785">
-                    <rect key="frame" x="18" y="163" width="154" height="20"/>
+                    <rect key="frame" x="18" y="204" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iNE-8S-1ug"/>
                         <constraint firstAttribute="height" constant="20" id="m9i-Kw-gLk"/>
@@ -639,19 +639,19 @@ Gw
                     </textFieldCell>
                 </textField>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
-                    <rect key="frame" x="0.0" y="83" width="656" height="72"/>
+                    <rect key="frame" x="0.0" y="124" width="656" height="72"/>
                     <view key="contentView" id="8QO-1r-5jB">
                         <rect key="frame" x="0.0" y="0.0" width="656" height="72"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="m2t-AW-wZp">
-                                <rect key="frame" x="180" y="38" width="456" height="5"/>
+                                <rect key="frame" x="180" y="69" width="456" height="5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="w2r-U9-xzl"/>
                                 </constraints>
                             </box>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zSn-Pq-u9O">
-                                <rect key="frame" x="18" y="10" width="154" height="20"/>
+                                <rect key="frame" x="18" y="41" width="154" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="KTX-VG-c9A"/>
                                     <constraint firstAttribute="width" constant="150" id="NuT-p2-IHy"/>
@@ -663,7 +663,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <textField hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A54-fI-5jD">
-                                <rect key="frame" x="514" y="12" width="124" height="16"/>
+                                <rect key="frame" x="514" y="43" width="124" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="oJR-dz-ggb"/>
                                 </constraints>
@@ -674,7 +674,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YpU-KB-oKj">
-                                <rect key="frame" x="180" y="9" width="331" height="22"/>
+                                <rect key="frame" x="180" y="40" width="331" height="22"/>
                                 <popUpButtonCell key="cell" type="push" title="Light" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" enabled="NO" state="on" borderStyle="border" tag="1" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="eKV-qw-xZ9" id="qEs-4C-bPo">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="message"/>
@@ -719,6 +719,7 @@ Gw
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="m2t-AW-wZp" secondAttribute="trailing" constant="20" id="5va-08-JI4"/>
+                            <constraint firstAttribute="trailing" secondItem="SAt-Tb-Cl1" secondAttribute="trailing" constant="20" id="SAt-Tb-Cl9"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="leading" secondItem="m2t-AW-wZp" secondAttribute="leading" id="6li-My-U6Q"/>
                             <constraint firstItem="A54-fI-5jD" firstAttribute="leading" secondItem="YpU-KB-oKj" secondAttribute="trailing" constant="5" id="ES9-bt-d8F"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="centerY" secondItem="zSn-Pq-u9O" secondAttribute="centerY" id="NhH-JG-F7e"/>
@@ -733,12 +734,9 @@ Gw
                             <constraint firstItem="zSn-Pq-u9O" firstAttribute="leading" secondItem="8QO-1r-5jB" secondAttribute="leading" constant="20" id="wsp-nB-hpQ"/>
                         </constraints>
                     </view>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="72" id="SAt-Tb-Cl8"/>
-                    </constraints>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="F3U-SQ-W2d">
-                    <rect key="frame" x="0.0" y="83" width="656" height="31"/>
+                    <rect key="frame" x="0.0" y="93" width="656" height="31"/>
                     <view key="contentView" id="typ-rs-Tmp">
                         <rect key="frame" x="0.0" y="0.0" width="656" height="31"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -803,7 +801,7 @@ Gw
                     </view>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gcQ-a7-Kqd">
-                    <rect key="frame" x="18" y="42" width="154" height="20"/>
+                    <rect key="frame" x="18" y="52" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="UXx-vH-pTm"/>
                         <constraint firstAttribute="height" constant="20" id="cZz-2P-Xzw"/>
@@ -815,7 +813,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2aR-JM-Lbr">
-                    <rect key="frame" x="180" y="41" width="456" height="22"/>
+                    <rect key="frame" x="180" y="51" width="456" height="22"/>
                     <buttonCell key="cell" type="check" title="Share usage analytics and crash reports with developers" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="mZ1-oa-LuT">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -828,13 +826,13 @@ Gw
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="XAX-zM-z61">
-                    <rect key="frame" x="180" y="70" width="456" height="5"/>
+                    <rect key="frame" x="180" y="80" width="456" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="GuS-Im-MmS"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-nG-VYi">
-                    <rect key="frame" x="18" y="466" width="154" height="20"/>
+                    <rect key="frame" x="18" y="507" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="I93-gu-1Cg"/>
                         <constraint firstAttribute="height" constant="20" id="Iqw-5P-eDM"/>
@@ -916,7 +914,6 @@ Gw
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="F3U-SQ-W2d" secondAttribute="bottom" constant="70" id="PYb-fK-u5u"/>
                 <constraint firstItem="577" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="QFi-wi-jse"/>
                 <constraint firstItem="FJw-vU-VgL" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Quq-iv-5iD"/>
-                <constraint firstAttribute="height" constant="502" id="SqM-0P-Y3b"/>
                 <constraint firstAttribute="bottom" secondItem="KJh-ax-qjk" secondAttribute="bottom" constant="20" id="T4k-gQ-ZDC"/>
                 <constraint firstItem="7J9-Yp-qMZ" firstAttribute="top" secondItem="787" secondAttribute="bottom" constant="8" id="VDV-pe-DL0"/>
                 <constraint firstItem="784" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="VOf-4w-xgO"/>

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -310,6 +310,7 @@ extern NSString *SPDefaultEncoding;
 extern NSString *SPDisplayTableViewVerticalGridlines;
 extern NSString *SPDisplayTableViewColumnTypes;
 extern NSString *SPDisplayCommentsInTablesList;
+extern NSString *SPDisplayConnectionColorInTitlebar;
 extern NSString *SPCustomQueryMaxHistoryItems;
 extern NSString *SPAppearance;
 

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -116,6 +116,7 @@ NSString *SPApplicationPromptOnQuit              = @"ApplicationPromptOnQuit";
 NSString *SPDisplayTableViewVerticalGridlines    = @"DisplayTableViewVerticalGridlines";
 NSString *SPDisplayTableViewColumnTypes          = @"DisplayTableViewColumnTypes";
 NSString *SPDisplayCommentsInTablesList          = @"DisplayCommentsInTablesList";
+NSString *SPDisplayConnectionColorInTitlebar     = @"DisplayConnectionColorInTitlebar";
 NSString *SPCustomQueryMaxHistoryItems           = @"CustomQueryMaxHistoryItems";
 NSString *SPCustomQuerySaveHistoryIndividually   = @"CustomQuerySaveHistoryIndividually";
 NSString *SPSaveApplicationUsageAnalytics        = @"SaveApplicationUsageAnalytics";

--- a/UnitTests/SAWindowTitlebarTintTests.swift
+++ b/UnitTests/SAWindowTitlebarTintTests.swift
@@ -8,6 +8,10 @@
 //  leaving `titlebarAppearsTransparent` on over `windowBackgroundColor`
 //  produces a flat, non-standard title bar instead of the stock one.
 //
+//  The preference gate is pinned too: off is the default, and a window then
+//  has to look exactly as it did before the preference existed, whatever
+//  colour the connection carries.
+//
 //  Whether the tint *looks* right, and whether it follows the selected tab,
 //  is not testable here (no window server in the test bundle) and stays a
 //  manual check - same split as SAWindowTitleBuilder, which pins the strings
@@ -24,19 +28,19 @@ final class SAWindowTitlebarTintTests: XCTestCase {
     // MARK: - A favourite colour tints the whole window top
 
     func testFavoriteColorMakesTheTitlebarTransparent() {
-        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: true)
 
         XCTAssertTrue(tint.titlebarAppearsTransparent)
     }
 
     func testFavoriteColorBecomesTheWindowBackground() {
-        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: true)
 
         XCTAssertEqual(tint.backgroundColor, favoriteRed)
     }
 
     func testFavoriteColorDropsTheTitlebarSeparator() {
-        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: true)
 
         XCTAssertEqual(tint.separatorStyle, .none)
     }
@@ -49,7 +53,7 @@ final class SAWindowTitlebarTintTests: XCTestCase {
             appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .black : .white
         }
 
-        let tint = SAWindowTitlebarTint(favoriteColor: dynamic)
+        let tint = SAWindowTitlebarTint(favoriteColor: dynamic, isEnabled: true)
 
         XCTAssertIdentical(tint.backgroundColor, dynamic)
     }
@@ -57,20 +61,51 @@ final class SAWindowTitlebarTintTests: XCTestCase {
     // MARK: - No colour restores the stock title bar
 
     func testNilColorRestoresAnOpaqueTitlebar() {
-        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+        let tint = SAWindowTitlebarTint(favoriteColor: nil, isEnabled: true)
 
         XCTAssertFalse(tint.titlebarAppearsTransparent)
     }
 
     func testNilColorRestoresTheWindowBackgroundColor() {
-        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+        let tint = SAWindowTitlebarTint(favoriteColor: nil, isEnabled: true)
 
         XCTAssertEqual(tint.backgroundColor, .windowBackgroundColor)
     }
 
     func testNilColorRestoresTheAutomaticSeparator() {
-        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+        let tint = SAWindowTitlebarTint(favoriteColor: nil, isEnabled: true)
 
         XCTAssertEqual(tint.separatorStyle, .automatic)
+    }
+
+    // MARK: - The preference gates the whole thing
+
+    func testDisabledLeavesTheTitlebarOpaqueEvenWithAFavoriteColor() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: false)
+
+        XCTAssertFalse(tint.titlebarAppearsTransparent)
+    }
+
+    func testDisabledKeepsTheWindowBackgroundColorEvenWithAFavoriteColor() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: false)
+
+        XCTAssertEqual(tint.backgroundColor, .windowBackgroundColor)
+    }
+
+    func testDisabledKeepsTheTitlebarSeparatorEvenWithAFavoriteColor() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: false)
+
+        XCTAssertEqual(tint.separatorStyle, .automatic)
+    }
+
+    /// Off is the shipped default, so this is what an untouched install gets:
+    /// identical chrome whether or not the connection has a colour.
+    func testDisabledMatchesTheNoColorCaseExactly() {
+        let colored = SAWindowTitlebarTint(favoriteColor: favoriteRed, isEnabled: false)
+        let uncolored = SAWindowTitlebarTint(favoriteColor: nil, isEnabled: false)
+
+        XCTAssertEqual(colored.titlebarAppearsTransparent, uncolored.titlebarAppearsTransparent)
+        XCTAssertEqual(colored.backgroundColor, uncolored.backgroundColor)
+        XCTAssertEqual(colored.separatorStyle, uncolored.separatorStyle)
     }
 }

--- a/UnitTests/SAWindowTitlebarTintTests.swift
+++ b/UnitTests/SAWindowTitlebarTintTests.swift
@@ -1,0 +1,76 @@
+//
+//  SAWindowTitlebarTintTests.swift
+//  Unit Tests
+//
+//  Pins the chrome decision behind the connection-colour title bar (#1856).
+//  The reset path is the load-bearing part: a tinted window has three
+//  properties changed, and clearing the colour has to restore all three -
+//  leaving `titlebarAppearsTransparent` on over `windowBackgroundColor`
+//  produces a flat, non-standard title bar instead of the stock one.
+//
+//  Whether the tint *looks* right, and whether it follows the selected tab,
+//  is not testable here (no window server in the test bundle) and stays a
+//  manual check - same split as SAWindowTitleBuilder, which pins the strings
+//  and not its ObjC caller.
+//
+
+import XCTest
+import AppKit
+
+final class SAWindowTitlebarTintTests: XCTestCase {
+
+    private let favoriteRed = NSColor(srgbRed: 0.894, green: 0.455, blue: 0.400, alpha: 1)
+
+    // MARK: - A favourite colour tints the whole window top
+
+    func testFavoriteColorMakesTheTitlebarTransparent() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+
+        XCTAssertTrue(tint.titlebarAppearsTransparent)
+    }
+
+    func testFavoriteColorBecomesTheWindowBackground() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+
+        XCTAssertEqual(tint.backgroundColor, favoriteRed)
+    }
+
+    func testFavoriteColorDropsTheTitlebarSeparator() {
+        let tint = SAWindowTitlebarTint(favoriteColor: favoriteRed)
+
+        XCTAssertEqual(tint.separatorStyle, .none)
+    }
+
+    /// The favourite colours are asset colours carrying a light/dark pair, so
+    /// the colour has to reach the window unresolved or a tinted window would
+    /// keep whichever appearance happened to be active when it connected.
+    func testColorIsPassedThroughUnresolved() {
+        let dynamic = NSColor(name: NSColor.Name("testDynamic")) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .black : .white
+        }
+
+        let tint = SAWindowTitlebarTint(favoriteColor: dynamic)
+
+        XCTAssertIdentical(tint.backgroundColor, dynamic)
+    }
+
+    // MARK: - No colour restores the stock title bar
+
+    func testNilColorRestoresAnOpaqueTitlebar() {
+        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+
+        XCTAssertFalse(tint.titlebarAppearsTransparent)
+    }
+
+    func testNilColorRestoresTheWindowBackgroundColor() {
+        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+
+        XCTAssertEqual(tint.backgroundColor, .windowBackgroundColor)
+    }
+
+    func testNilColorRestoresTheAutomaticSeparator() {
+        let tint = SAWindowTitlebarTint(favoriteColor: nil)
+
+        XCTAssertEqual(tint.separatorStyle, .automatic)
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -265,6 +265,9 @@
 		5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
 		5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */; };
 		5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */; };
+		5147B1022F8C000100C4C14A /* SAWindowTitlebarTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B1012F8C000100C4C14A /* SAWindowTitlebarTint.swift */; };
+		5147B1032F8C000100C4C14A /* SAWindowTitlebarTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B1012F8C000100C4C14A /* SAWindowTitlebarTint.swift */; };
+		5147B1052F8C000100C4C14A /* SAWindowTitlebarTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B1042F8C000100C4C14A /* SAWindowTitlebarTintTests.swift */; };
 		5147B0072F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */; };
 		5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */; };
 		5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */; };
@@ -1173,6 +1176,8 @@
 		5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SADatabaseListManagerTests.swift; sourceTree = "<group>"; };
 		5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilder.swift; sourceTree = "<group>"; };
 		5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitleBuilderTests.swift; sourceTree = "<group>"; };
+		5147B1012F8C000100C4C14A /* SAWindowTitlebarTint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitlebarTint.swift; sourceTree = "<group>"; };
+		5147B1042F8C000100C4C14A /* SAWindowTitlebarTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAWindowTitlebarTintTests.swift; sourceTree = "<group>"; };
 		5147B0062F8C000200C4C14A /* SAFavoriteSearchMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcher.swift; sourceTree = "<group>"; };
 		5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAFavoriteSearchMatcherTests.swift; sourceTree = "<group>"; };
 		5147B00B2F8C000300C4C14A /* SAConnectionDetailsValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConnectionDetailsValidator.swift; sourceTree = "<group>"; };
@@ -2071,6 +2076,7 @@
 				5132930925F586A900D803AD /* NotificationToken.swift */,
 				51BC14F725BE135500F1CDC9 /* SPWindowController.swift */,
 				5147B0012F8C000100C4C14A /* SAWindowTitleBuilder.swift */,
+				5147B1012F8C000100C4C14A /* SAWindowTitlebarTint.swift */,
 				5132930A25F586A900D803AD /* TabManager.swift */,
 			);
 			path = Window;
@@ -2842,6 +2848,7 @@
 				5146E04B2F7A640C00C4C14A /* SAViewModeTests.swift */,
 				5146E0542F7A640C00C4C14A /* SADatabaseListManagerTests.swift */,
 				5147B0042F8C000100C4C14A /* SAWindowTitleBuilderTests.swift */,
+				5147B1042F8C000100C4C14A /* SAWindowTitlebarTintTests.swift */,
 				5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */,
 				5147B0092F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift */,
 				5AF0C2000000000000000031 /* SAFavoriteItemTests.swift */,
@@ -3628,6 +3635,8 @@
 				CF0000172F8C000600C4C14A /* SPRuleFilterController.m in Sources */,
 				5147B0032F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
 				5147B0052F8C000100C4C14A /* SAWindowTitleBuilderTests.swift in Sources */,
+				5147B1032F8C000100C4C14A /* SAWindowTitlebarTint.swift in Sources */,
+				5147B1052F8C000100C4C14A /* SAWindowTitlebarTintTests.swift in Sources */,
 				0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */,
 				5147B0082F8C000200C4C14A /* SAFavoriteSearchMatcher.swift in Sources */,
 				5147B00A2F8C000200C4C14A /* SAFavoriteSearchMatcherTests.swift in Sources */,
@@ -3896,6 +3905,7 @@
 				5146E0502F7A640C00C4C14A /* SADatabaseListManager.swift in Sources */,
 				5AF0C3000000000000000002 /* SATaskController.swift in Sources */,
 				5147B0022F8C000100C4C14A /* SAWindowTitleBuilder.swift in Sources */,
+				5147B1022F8C000100C4C14A /* SAWindowTitlebarTint.swift in Sources */,
 				BC2777A011514B940034DF6A /* SPNavigatorController.m in Sources */,
 				589582151154F8F400EDCC28 /* SPMainThreadTrampoline.m in Sources */,
 				51B09FDF2F767A53003BAFFF /* SADatabaseDocumentProviding.swift in Sources */,


### PR DESCRIPTION
## Changes:
- The window title bar, unified toolbar and native tab bar now take the favorite color of the connection, so the color stays visible when the tab bar is hidden or only one connection is open. Previously the color showed only as a 5pt line on the tab accessory. This makes it clearer which host you are working on if connected to multiple (eg Prod: Red, develop: green)
- The color clears again when a tab is no longer connected.
- Off by default, behind a new General › Appearance preference.

## Closes following issues:
- Closes: #1856

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English (no new or changed strings)
- Xcode Version: 26.6

Verified against live MySQL connections: two tabs on differently colored favorites, switching between them, and a tab returning to the connection view.

## Screenshots:
<img width="1210" height="106" alt="Screenshot 2026-09-04 at 23 30 55" src="https://github.com/user-attachments/assets/64234a10-1ef3-4ca4-99cb-fe46cc633af2" />
<img width="1210" height="112" alt="Screenshot 2026-09-04 at 23 30 42" src="https://github.com/user-attachments/assets/27a065df-b247-4819-aeb8-8ed5e6f16142" />


## Additional notes:
- Each tab is its own `NSWindow`, so the tint follows the selected tab.
- The chrome decision is extracted into `SAWindowTitlebarTint` (AppKit only, no project ObjC types) so it compiles into the Unit Tests target, same split as `SAWindowTitleBuilder`. 7 tests cover it, mostly the reset path - clearing the colour has to restore all three window properties. Whether the tint looks right and follows the selected tab is not testable without a window server, so that stayed a manual check.
- Opt-in behind **Color the title bar with the connection color** in General › Appearance, **default off**, so an untouched install is unchanged. Toggling it repaints open windows immediately.
- Fitting the extra row exposed two pre-existing layout problems in `Preferences.xib`, both fixed here: the Connection Strings row was pinned only to the view's bottom with nothing linking it to the Analytics row above (IB's own frames had them overlapping by 1pt already), and the Appearance box had no height constraint while its contentView translates its autoresizing mask, so constraints inside it could not size it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Appearance preference to optionally color the title bar, toolbar, and tab bar with the connection’s favorite color.
  - Title bar tinting updates automatically when the preference changes.

- **Bug Fixes**
  - Favorite-color tinting now clears while connecting or disconnected.
  - Improved window rendering with an opaque background behind document content.
  - Title bar separators, transparency, and background colors now update consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

