### PR TITLE
#fixed SQL dumps are written in one encoding, UTF-8

### DIFF
--- a/Source/Controllers/DataExport/Exporters/SPDotExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPDotExporter.m
@@ -105,7 +105,7 @@
     [metaString appendString:@"\trankdir = LR;\n"];
     
     // Write information to the file
-    [self writeUTF8String:metaString];
+    [self writeString:metaString];
     
     NSMutableArray *fkInfo = [[NSMutableArray alloc] init];
     
@@ -159,7 +159,7 @@
         [metaString appendString:@"\t\t];\n"];
         [metaString appendString:@"\t}\n"];
         
-        [self writeUTF8String:metaString];
+        [self writeString:metaString];
         
         // Check if any relations are available for the table
         NSArray *tableConstraints = [tableInfo objectForKey:@"constraints"];
@@ -217,7 +217,7 @@
     [metaString appendString:@"}\n"];
     
     // Write information to the file
-    [self writeUTF8String:metaString];
+    [self writeString:metaString];
     
     // Write data to disk
     [[self exportOutputFile] close];

--- a/Source/Controllers/DataExport/Exporters/SPExporter.h
+++ b/Source/Controllers/DataExport/Exporters/SPExporter.h
@@ -149,14 +149,4 @@
  */
 - (void)writeString:(NSString *)input;
 
-/**
- * Write a string to the current output file using UTF-8 encoding
- * @param input The string to write
- */
-// TODO (#2609): this method mainly exists to shorten some old code which sometimes uses
-// [self exportOutputEncoding] and sometimes NSUTF8StringEncoding. In general there should
-// be no need to have more than one encoding in a file; someone needs to check whether
-// that was an oversight or intentional.
-- (void)writeUTF8String:(NSString *)input;
-
 @end

--- a/Source/Controllers/DataExport/Exporters/SPExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPExporter.m
@@ -123,13 +123,6 @@
     }
 }
 
-- (void)writeUTF8String:(NSString *)input
-{
-    if([self exportOutputFile].fileHandleError == nil){
-        [[self exportOutputFile] writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
-    }
-}
-
 /**
  * Get rid of the export data.
  */

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -153,7 +153,9 @@
         [metaString appendString:@"\xef\xbb\xbf"];
     }
 
-    // we require utf8mb4
+    // we require utf8mb4: the dump declares "SET NAMES utf8mb4" below, so everything fetched from the
+    // server has to arrive as UTF-8 and everything written has to be UTF-8. SPExportController sets
+    // the output encoding to UTF-8 for SQL dumps (SAExportOutputEncoding), so writeString: matches.
     [connection setEncoding:@"utf8mb4"];
 
     // Add the dump header to the dump file
@@ -290,7 +292,7 @@
 
             NSUInteger lastProgressValue = 0;
 
-            id createTableSyntax = nil;
+            NSString *createTableSyntax = nil;
             SPTableType tableType = SPTableTypeTable;
             // Determine whether this table is a table or a view via the CREATE TABLE command, and keep the create table syntax
             {
@@ -320,7 +322,7 @@
                 if ([connection queryErrored]) {
                     [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
 
-                    [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n\n\n", [connection lastErrorMessage]]];
+                    [self writeString:[NSString stringWithFormat:@"# Error: %@\n\n\n", [connection lastErrorMessage]]];
 
                     continue;
                 }
@@ -341,20 +343,13 @@
             // Add the create syntax for the table if specified in the export dialog
             if (sqlOutputIncludeStructure && createTableSyntax && tableType == SPTableTypeTable) {
 
-                if ([createTableSyntax isKindOfClass:[NSData class]]) {
-                    // TODO (#2609): this doesn't make sense — if the NSData really contains a string it would be
-                    // in utf8, utf8mb4 or a mysql pre-4.1 legacy charset, but not in the export output charset.
-                    // This whole if() is likely a side effect of the BINARY flag confusion (upstream sequelpro#2700).
-                    createTableSyntax = [[NSString alloc] initWithData:createTableSyntax encoding:[self exportOutputEncoding]];
-                }
-
                 // If necessary strip out the AUTO_INCREMENT from the table structure definition
                 if (![self sqlOutputIncludeAutoIncrement]) {
                     createTableSyntax = [createTableSyntax stringByReplacingOccurrencesOfRegex:[NSString stringWithFormat:@"AUTO_INCREMENT=[0-9]+ "] withString:@""];
                 }
 
-                [self writeUTF8String:createTableSyntax];
-                [self writeUTF8String:@";\n\n"];
+                [self writeString:createTableSyntax];
+                [self writeString:@";\n\n"];
             }
 
             // Add the table content if required
@@ -441,7 +436,7 @@
 
                 if ([connection queryErrored] || ![rowArray count]) {
                     [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
-                    [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n\n\n", [connection lastErrorMessage]]];
+                    [self writeString:[NSString stringWithFormat:@"# Error: %@\n\n\n", [connection lastErrorMessage]]];
                     free(useRawDataForColumnAtIndex);
                     free(useRawHexDataForColumnAtIndex);
                     continue;
@@ -465,7 +460,7 @@
                     [self writeString:metaString];
 
                     // Construct the start of the insertion command
-                    [self writeUTF8String:[NSString stringWithFormat:@"INSERT INTO %@ (%@)\nVALUES", [tableName backtickQuotedString], [rawColumnNames componentsJoinedAndBacktickQuoted]]];
+                    [self writeString:[NSString stringWithFormat:@"INSERT INTO %@ (%@)\nVALUES", [tableName backtickQuotedString], [rawColumnNames componentsJoinedAndBacktickQuoted]]];
 
                     // Iterate through the rows to construct a VALUES group for each
                     NSUInteger rowsWrittenForTable = 0;
@@ -602,20 +597,20 @@
                         queryLength += [sqlString length];
 
                         // Write this row to the file
-                        [self writeUTF8String:sqlString];
+                        [self writeString:sqlString];
 
                         rowsWrittenForTable++;
                         rowsWrittenForCurrentStmt++;
                     }
 
                     // Complete the command
-                    [self writeUTF8String:@";\n\n"];
+                    [self writeString:@";\n\n"];
 
                     // Unlock the table and re-enable keys if supported
                     [metaString setString:@""];
                     [metaString appendFormat:@"/*!40000 ALTER TABLE %@ ENABLE KEYS */;\nUNLOCK TABLES;\n", [tableName backtickQuotedString]];
 
-                    [self writeUTF8String:metaString];
+                    [self writeString:metaString];
 
                     // Release the result set
                 }
@@ -627,7 +622,7 @@
                     [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
 
                     if ([self sqlOutputIncludeErrors]) {
-                        [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
+                        [self writeString:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
                     }
                 }
             }
@@ -677,20 +672,20 @@
 
                     [metaString appendString:@"DELIMITER ;\n/*!50003 SET SESSION SQL_MODE=@OLD_SQL_MODE */;\n"];
 
-                    [self writeUTF8String:metaString];
+                    [self writeString:metaString];
                 }
 
                 if ([connection queryErrored]) {
                     [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
 
                     if ([self sqlOutputIncludeErrors]) {
-                        [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
+                        [self writeString:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
                     }
                 }
             }
 
             // Add an additional separator between tables
-            [self writeUTF8String:@"\n\n"];
+            [self writeString:@"\n\n"];
         }
     }
 
@@ -719,7 +714,7 @@
         // Add the View create statement
         [metaString appendFormat:@"%@;\n\n", [viewSyntaxes objectForKey:viewName]];
 
-        [self writeUTF8String:metaString];
+        [self writeString:metaString];
     }
 
     // Export procedures and functions
@@ -836,7 +831,7 @@
                         [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
 
                         if ([self sqlOutputIncludeErrors]) {
-                            [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
+                            [self writeString:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
                         }
                         continue;
                     }
@@ -852,7 +847,7 @@
                         NSString *errorString = [NSString stringWithFormat:NSLocalizedString(@"Could not export the %@ '%@' because of a permissions error.\n", @"Procedure/function export permission error"), procedureType, procedureName];
                         [errors appendString:errorString];
                         if ([self sqlOutputIncludeErrors]) {
-                            [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n", errorString]];
+                            [self writeString:[NSString stringWithFormat:@"# Error: %@\n", errorString]];
                         }
                         continue;
                     }
@@ -873,14 +868,14 @@
 
             [metaString appendString:@"DELIMITER ;\n"];
 
-            [self writeUTF8String:metaString];
+            [self writeString:metaString];
         }
 
         if ([connection queryErrored]) {
             [errors appendFormat:@"%@\n", [connection lastErrorMessage]];
 
             if ([self sqlOutputIncludeErrors]) {
-                [self writeUTF8String:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
+                [self writeString:[NSString stringWithFormat:@"# Error: %@\n", [connection lastErrorMessage]]];
             }
         }
     }
@@ -897,7 +892,7 @@
     [metaString appendString:@"/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;\n"];
 
     // Write footer-type information to the file
-    [self writeUTF8String:metaString];
+    [self writeString:metaString];
 
     // Set export errors
     [self setSqlExportErrors:errors];

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -578,13 +578,9 @@
                                         [sqlString appendString:[connection escapeAndQuoteData:object]];
                                     }
                                     else {
-                                        NSString *fieldTypeGroup = [fieldDetails objectForKey:@"typegrouping"];
-                                        if ([fieldTypeGroup isEqualToString:@"textdata"] || [fieldTypeGroup isEqualToString:@"string"]) {
-                                            [sqlString appendStringOrNil:[connection escapeAndQuoteString:data]];
-                                        } else {
-                                            // it's possible that the fieldType could eq to blob
-                                            [sqlString appendFormat:@"'%@'", data];
-                                        }
+                                        // Whatever the column type, the decoded value is a string literal
+                                        // in the dump and has to be escaped like one.
+                                        [sqlString appendStringOrNil:[connection escapeAndQuoteString:data]];
                                     }
                                 }
                             }

--- a/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPSQLExporter.m
@@ -567,19 +567,24 @@
                                     [sqlString appendString:[connection escapeAndQuoteData:object]];
                                 }
                                 else {
-                                    NSString *data = [[NSString alloc] initWithData:object encoding:[self exportOutputEncoding]];
+                                    // Raw bytes arrive in the connection encoding (utf8mb4, set above), which is
+                                    // independent of the file's output encoding. Text with a binary collation decodes
+                                    // and is written as a string; anything that is not valid in that encoding (real
+                                    // BLOB / VARBINARY content) keeps every byte through the hex form instead of a
+                                    // lossy re-decode.
+                                    NSString *data = [[NSString alloc] initWithData:object encoding:[connection stringEncoding]];
 
                                     if (data == nil) {
-                                    // warning This can corrupt data! Check if this case ever happens and if so, export as hex-string
-                                      data = [[NSString alloc] initWithData:object encoding:NSASCIIStringEncoding];
+                                        [sqlString appendString:[connection escapeAndQuoteData:object]];
                                     }
-                                  
-                                    NSString *fieldTypeGroup = [fieldDetails objectForKey:@"typegrouping"];
-                                  	if ([fieldTypeGroup isEqualToString:@"textdata"] || [fieldTypeGroup isEqualToString:@"string"]) {
-                                      [sqlString appendStringOrNil:[connection escapeAndQuoteString:data]];
-                                    } else {
-                                      // it's possible that the fieldType could eq to blob
-                                      [sqlString appendFormat:@"'%@'", data];
+                                    else {
+                                        NSString *fieldTypeGroup = [fieldDetails objectForKey:@"typegrouping"];
+                                        if ([fieldTypeGroup isEqualToString:@"textdata"] || [fieldTypeGroup isEqualToString:@"string"]) {
+                                            [sqlString appendStringOrNil:[connection escapeAndQuoteString:data]];
+                                        } else {
+                                            // it's possible that the fieldType could eq to blob
+                                            [sqlString appendFormat:@"'%@'", data];
+                                        }
                                     }
                                 }
                             }

--- a/Source/Controllers/DataExport/SAExportOutputEncoding.swift
+++ b/Source/Controllers/DataExport/SAExportOutputEncoding.swift
@@ -1,0 +1,49 @@
+//
+//  SAExportOutputEncoding.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+/// The export formats that write text files. Mirrors the subset of `SPExportType`
+/// (SPConstants.h) that has an exporter; SPExportController maps between the two.
+@objc enum SAExportOutputFormat: Int {
+    case sql
+    case csv
+    case xml
+    case dot
+}
+
+/// Decides which encoding an exporter writes its output file in.
+///
+/// A file has one encoding. Which one depends on the format:
+///
+/// - SQL dumps declare `SET NAMES utf8mb4` in their header and the exporter switches the
+///   connection to utf8mb4 before fetching anything, so the file is UTF-8 whatever the
+///   connection encoding was when the export started. Using the pre-export connection encoding
+///   here used to leave the DROP/LOCK statements and comments in one encoding and the rest of
+///   the dump in UTF-8 (#2609).
+/// - DOT files are UTF-8 as well; the exporter switches the connection the same way.
+/// - CSV has no way to declare an encoding and follows the connection encoding.
+/// - XML follows the connection encoding for now; its header claims UTF-8, which is a separate
+///   fix (#2637).
+@objc final class SAExportOutputEncoding: NSObject {
+
+    private static let utf8 = String.Encoding.utf8.rawValue
+
+    /// - Parameters:
+    ///   - format: The export format being written.
+    ///   - connectionEncoding: The connection's `stringEncoding` at the time the exporters are set up.
+    /// - Returns: The `NSStringEncoding` the exporter's `writeString:` has to use.
+    @objc(outputEncodingForFormat:connectionEncoding:)
+    static func outputEncoding(for format: SAExportOutputFormat, connectionEncoding: UInt) -> UInt {
+        switch format {
+        case .sql, .dot:
+            return utf8
+        case .csv, .xml:
+            return connectionEncoding
+        }
+    }
+}

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1698,7 +1698,7 @@ set_input:
 		[exporter setConnection:connection];
 		[exporter setDatabaseName:databaseName];
 		[exporter setServerSupport:[self serverSupport]];
-		[exporter setExportOutputEncoding:[connection stringEncoding]];
+		[exporter setExportOutputEncoding:[self outputEncodingForCurrentExportType]];
 		[exporter setExportMaxProgress:(NSInteger)[exportProgressIndicator bounds].size.width];
 		[exporter setExportUsingLowMemoryBlockingStreaming:([exportProcessLowMemoryButton state] == NSControlStateValueOn)];
 		[exporter setExportOutputCompressionFormat:(SPFileCompressionFormat)[exportOutputCompressionFormatPopupButton indexOfSelectedItem]];
@@ -1880,6 +1880,26 @@ set_input:
  *
  * @param file The export file to write the header to.
  */
+/**
+ * The encoding the exporters write their files in. SQL and DOT dumps are always UTF-8 (they switch
+ * the connection to utf8mb4 and, for SQL, declare it in the file); CSV and XML follow the connection
+ * encoding. The decision itself lives in SAExportOutputEncoding so it can be unit tested.
+ */
+- (NSStringEncoding)outputEncodingForCurrentExportType
+{
+	SAExportOutputFormat format;
+
+	switch (exportType) {
+		case SPSQLExport: format = SAExportOutputFormatSql; break;
+		case SPXMLExport: format = SAExportOutputFormatXml; break;
+		case SPDotExport: format = SAExportOutputFormatDot; break;
+		case SPCSVExport:
+		default:          format = SAExportOutputFormatCsv; break;
+	}
+
+	return [SAExportOutputEncoding outputEncodingForFormat:format connectionEncoding:[connection stringEncoding]];
+}
+
 - (void)writeCSVHeaderToExportFile:(SPExportFile *)file
 {
 	NSMutableString *lineEnding = [NSMutableString stringWithString:[exportCSVLinesTerminatedField stringValue]];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1876,11 +1876,6 @@ set_input:
 #pragma mark - SPExportFileUtilitiesPrivateAPI
 
 /**
- * Writes the CSV file header to the supplied export file.
- *
- * @param file The export file to write the header to.
- */
-/**
  * The encoding the exporters write their files in. SQL and DOT dumps are always UTF-8 (they switch
  * the connection to utf8mb4 and, for SQL, declare it in the file); CSV and XML follow the connection
  * encoding. The decision itself lives in SAExportOutputEncoding so it can be unit tested.
@@ -1900,6 +1895,11 @@ set_input:
 	return [SAExportOutputEncoding outputEncodingForFormat:format connectionEncoding:[connection stringEncoding]];
 }
 
+/**
+ * Writes the CSV file header to the supplied export file.
+ *
+ * @param file The export file to write the header to.
+ */
 - (void)writeCSVHeaderToExportFile:(SPExportFile *)file
 {
 	NSMutableString *lineEnding = [NSMutableString stringWithString:[exportCSVLinesTerminatedField stringValue]];

--- a/UnitTests/SAExportOutputEncodingTests.swift
+++ b/UnitTests/SAExportOutputEncodingTests.swift
@@ -1,0 +1,54 @@
+//
+//  SAExportOutputEncodingTests.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+final class SAExportOutputEncodingTests: XCTestCase {
+
+    private let utf8 = String.Encoding.utf8.rawValue
+    private let latin1 = String.Encoding.windowsCP1252.rawValue // what SPMySQL maps MySQL's latin1 to
+    private let shiftJIS = String.Encoding.shiftJIS.rawValue
+
+    private func encoding(_ format: SAExportOutputFormat, connection: UInt) -> UInt {
+        SAExportOutputEncoding.outputEncoding(for: format, connectionEncoding: connection)
+    }
+
+    // MARK: - SQL dumps declare utf8mb4, so they are UTF-8 whatever the connection was (#2609)
+
+    func testSQLDumpIsUTF8ForAUTF8Connection() {
+        XCTAssertEqual(encoding(.sql, connection: utf8), utf8)
+    }
+
+    func testSQLDumpStaysUTF8ForALatin1Connection() {
+        XCTAssertEqual(encoding(.sql, connection: latin1), utf8)
+    }
+
+    func testSQLDumpStaysUTF8ForAMultibyteConnection() {
+        XCTAssertEqual(encoding(.sql, connection: shiftJIS), utf8)
+    }
+
+    // MARK: - DOT files are UTF-8 too
+
+    func testDotFileIsUTF8RegardlessOfConnection() {
+        XCTAssertEqual(encoding(.dot, connection: utf8), utf8)
+        XCTAssertEqual(encoding(.dot, connection: latin1), utf8)
+    }
+
+    // MARK: - CSV and XML follow the connection
+
+    func testCSVFollowsTheConnectionEncoding() {
+        XCTAssertEqual(encoding(.csv, connection: utf8), utf8)
+        XCTAssertEqual(encoding(.csv, connection: latin1), latin1)
+        XCTAssertEqual(encoding(.csv, connection: shiftJIS), shiftJIS)
+    }
+
+    func testXMLFollowsTheConnectionEncoding() {
+        XCTAssertEqual(encoding(.xml, connection: utf8), utf8)
+        XCTAssertEqual(encoding(.xml, connection: latin1), latin1)
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -293,6 +293,9 @@
 		51974D07304B23B400C5D23D /* SACSVImportStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */; };
 		9C34DCDAAFC52D3EF15C0B2B /* SACSVImportStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */; };
 		51974D0C304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */; };
+		519788CC30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */; };
+		519788CD30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */; };
+		519788D130502FC700C5D23D /* SAExportOutputEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */; };
 		51A709392565B99F001F1D2F /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51A709382565B99F001F1D2F /* Images.xcassets */; };
 		51AA84022FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
 		51AA84032FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA84012FDE000100C4C14A /* SAAutoIncrementRuleSupport.swift */; };
@@ -1204,6 +1207,8 @@
 		5193502E2567D2FB001272B5 /* CollectionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtension.swift; sourceTree = "<group>"; };
 		51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACSVImportStreamDecoder.swift; sourceTree = "<group>"; };
 		51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACSVImportStreamDecoderTests.swift; sourceTree = "<group>"; };
+		519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAExportOutputEncoding.swift; sourceTree = "<group>"; };
+		519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAExportOutputEncodingTests.swift; sourceTree = "<group>"; };
 		5199783E27760147008DEB7B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		519F2829261A5A1800370B14 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		51A709382565B99F001F1D2F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -2607,6 +2612,7 @@
 				582F02301370B52600B30621 /* SPExportFileNameTokenObject.m */,
 				17F90E451210B41100274C98 /* Model */,
 				173C836C11AAD24300B8B084 /* Exporters */,
+				519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */,
 			);
 			name = "Data Export";
 			path = DataExport;
@@ -2769,6 +2775,7 @@
 				93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */,
 				51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */,
 				0002BD43DA307433795D7EBA /* SATypeAheadSelectionLoadTests.swift */,
+				519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */,
 			);
 			name = "Unit Tests";
 			path = UnitTests;
@@ -3666,6 +3673,8 @@
 				51AC3BA93047658D00BCE2B9 /* SASSHTunnelPeerValidatorTests.swift in Sources */,
 				5147B0172F8D000100C4C14A /* SPCSVParser.m in Sources */,
 				5147B0182F8D000100C4C14A /* SPNotLoaded.m in Sources */,
+				519788D130502FC700C5D23D /* SAExportOutputEncodingTests.swift in Sources */,
+				519788CD30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */,
 				1717FA401558313A0065C036 /* RegexKitLite.m in Sources */,
 				50D3C35C1A771C4C00B5429C /* SPParserUtilsTest.m in Sources */,
 				794358DD6B1C4070943C021B /* SAEditorTokensTests.swift in Sources */,
@@ -3985,6 +3994,7 @@
 				583CA21512EC8B2200C9E763 /* SPWindow.m in Sources */,
 				1A9EB9AE25651F5000FE60FF /* SQLiteHistoryManager.swift in Sources */,
 				582F02311370B52600B30621 /* SPExportFileNameTokenObject.m in Sources */,
+				519788CC30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */,
 				500DA4BC1BF0CD57000773FE /* SPScreenAdditions.m in Sources */,
 				584D878B15140FEB00F24774 /* SPObjectAdditions.m in Sources */,
 				584D87921514101E00F24774 /* SPDatabaseStructure.m in Sources */,


### PR DESCRIPTION
## Changes:
- **SQL dumps are written in one encoding, UTF-8.** The SQL exporter writes `SET NAMES utf8mb4` and switches the connection to utf8mb4 before fetching, but `exportOutputEncoding` was captured from the connection *before* that switch (`SPExportController.m`, exporter setup loop) and never updated. Five write sites went through `writeString:` with that stale encoding (dump header, "Dump of table" / "Dump of view" comments, `DROP TABLE`, `LOCK TABLES`) while the other 18 went through `writeUTF8String:`. Every one of the five embeds the table name, so a latin1 (or any non-UTF-8) connection exporting a table with a non-ASCII name produced a dump with two encodings in one file that re-imports to the wrong table or not at all.
- **The same stale encoding decoded raw cell bytes** on the "encode BLOB as hex" *off* path (`SPSQLExporter.m`, the `NSData` cell branch). Those bytes arrive over the utf8mb4 connection, so `_bin`-collated / BINARY-attribute text columns were mojibaked for non-UTF-8 connections. Decoding now uses the connection encoding (the source of the bytes, kept separate from the output encoding per review), and bytes that are not valid text fall back to the byte-preserving `X'..'` hex form instead of the old ASCII re-decode that dropped every byte above 0x7F. Values that do decode are escaped with `escapeAndQuoteString:` whatever the column type; the old non-text branch pasted them between bare quotes (pre-existing, caught in review).
- **One write path.** `writeUTF8String:` is removed from `SPExporter`; the SQL and DOT exporters use `writeString:`. The output encoding is decided per format in a new Swift type, `SAExportOutputEncoding` (SQL and DOT → UTF-8, CSV and XML → connection encoding, unchanged for those two), consulted by `SPExportController` through a thin ObjC bridge.
- **Dead code removed.** The `isKindOfClass:[NSData class]` branch on the `SHOW CREATE TABLE` result could not execute: the result is read with `setReturnDataAsStrings:YES`, which the framework honours before building the row (`Data Conversion.m`, `_getObjectFromBytes:…`), so the value is always an `NSString`. Verified against MySQL 8.4 that the `Create Table` column carries no BINARY flag either. The upstream BINARY_FLAG confusion (sequelpro/sequelpro#2700) is real but has no bearing here.
- The two `TODO (#2609)` markers are gone with the code they annotated.

## Closes following issues:
- Closes: #2609

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Xcode 26 beta (macOS 27.0 SDK)

Full "Unit Tests" suite green, including the new `SAExportOutputEncodingTests`.

## Screenshots:

## Additional notes:
- **Why a policy type instead of an exporter fixture test.** The Unit Tests target compiles app sources directly and contains none of the exporter chain (`SPExporter`, `SPExportFile`, `SPMySQLResult`…), and the repo rule is no new ObjC. The encoding decision is therefore extracted to `SAExportOutputEncoding` (pure Swift, no project ObjC types, so it is test-eligible) and pinned there. The exporters' single `writeString:` path then makes "one encoding per file" structural rather than something each call site has to remember.
- **Behaviour parity.** CSV and XML output is byte-identical to before: both still get the connection encoding. DOT was already all-UTF-8 and stays so. Only SQL dumps from non-UTF-8 connections change, and only in the five sites above plus the raw-bytes decode.
- **Manual pass not done yet.** A live verification (latin1 connection, non-ASCII table name, `_bin` column, BLOB-as-hex off, then re-import) needs the export dialog, which the shell harness can't drive. Worth doing before release.
- **Follow-up:** the XML exporter has the same split (UTF-8 prolog, connection-encoded body), tracked in #2637 with a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Exported SQL, DOT, CSV, and XML files now use format-appropriate encoding rules.
  * SQL and DOT exports consistently use UTF-8.
  * CSV and XML exports follow the connection’s encoding.
  * Binary cell values that cannot be decoded are preserved as hexadecimal data instead of using an ASCII fallback.
  * SQL values are escaped more consistently to improve export reliability.
* **Bug Fixes**
  * Improved consistency and reliability when writing exported data across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->