### PR TITLE
#fixed XML exports are UTF-8, as their prolog declares

### DIFF
--- a/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
+++ b/Source/Controllers/DataExport/Exporters/SPXMLExporter.m
@@ -251,9 +251,10 @@
                 BOOL dataIsNULL = NO;
                 id data = [xmlRow safeObjectAtIndex:i];
 
-                // Retrieve the contents of this tag
+                // Retrieve the contents of this tag. Raw bytes came from the server in the connection
+                // encoding; the file itself is written in the output encoding (UTF-8, as the prolog declares).
                 if ([data isKindOfClass:[NSData class]]) {
-                    dataConversionString = [[NSString alloc] initWithData:data encoding:[self exportOutputEncoding]];
+                    dataConversionString = [[NSString alloc] initWithData:data encoding:[connection stringEncoding]];
 
                     if (dataConversionString == nil) {
                         dataConversionString = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];

--- a/Source/Controllers/DataExport/SAExportOutputEncoding.swift
+++ b/Source/Controllers/DataExport/SAExportOutputEncoding.swift
@@ -26,9 +26,10 @@ import Foundation
 ///   here used to leave the DROP/LOCK statements and comments in one encoding and the rest of
 ///   the dump in UTF-8 (#2609).
 /// - DOT files are UTF-8 as well; the exporter switches the connection the same way.
+/// - XML files declare `encoding="utf-8"` in their prolog, so the body is UTF-8 too (#2637).
+///   The XML exporter does not switch the connection: cells that arrive as raw bytes are decoded
+///   with the connection encoding and re-encoded on the way out.
 /// - CSV has no way to declare an encoding and follows the connection encoding.
-/// - XML follows the connection encoding for now; its header claims UTF-8, which is a separate
-///   fix (#2637).
 @objc final class SAExportOutputEncoding: NSObject {
 
     private static let utf8 = String.Encoding.utf8.rawValue
@@ -40,9 +41,9 @@ import Foundation
     @objc(outputEncodingForFormat:connectionEncoding:)
     static func outputEncoding(for format: SAExportOutputFormat, connectionEncoding: UInt) -> UInt {
         switch format {
-        case .sql, .dot:
+        case .sql, .dot, .xml:
             return utf8
-        case .csv, .xml:
+        case .csv:
             return connectionEncoding
         }
     }

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -3819,7 +3819,8 @@ set_input:
 				string = [NSString stringWithFormat:@"</%@>\n", [self.exportDatabaseName HTMLEscapeString]];
 			}
 
-			[[exporter exportOutputFile] writeData:[string dataUsingEncoding:[connection stringEncoding]]];
+			// The closing tag has to match the body and the prolog, not the connection
+			[[exporter exportOutputFile] writeData:[string dataUsingEncoding:[exporter exportOutputEncoding]]];
 			[[exporter exportOutputFile] close];
 		}
 
@@ -3840,7 +3841,8 @@ set_input:
 			string = [NSString stringWithFormat:@"</%@>\n", [self.exportDatabaseName HTMLEscapeString]];
 		}
 
-		[[exporter exportOutputFile] writeData:[string dataUsingEncoding:[connection stringEncoding]]];
+		// The closing tag has to match the body and the prolog, not the connection
+		[[exporter exportOutputFile] writeData:[string dataUsingEncoding:[exporter exportOutputEncoding]]];
 		[[exporter exportOutputFile] close];
 
 		[self exportEnded];

--- a/Source/Controllers/DataExport/SPExportController.m
+++ b/Source/Controllers/DataExport/SPExportController.m
@@ -1877,8 +1877,9 @@ set_input:
 
 /**
  * The encoding the exporters write their files in. SQL and DOT dumps are always UTF-8 (they switch
- * the connection to utf8mb4 and, for SQL, declare it in the file); CSV and XML follow the connection
- * encoding. The decision itself lives in SAExportOutputEncoding so it can be unit tested.
+ * the connection to utf8mb4 and, for SQL, declare it in the file), XML is UTF-8 because its prolog
+ * says so, and CSV follows the connection encoding. The decision itself lives in
+ * SAExportOutputEncoding so it can be unit tested.
  */
 - (NSStringEncoding)outputEncodingForCurrentExportType
 {

--- a/UnitTests/SAExportOutputEncodingTests.swift
+++ b/UnitTests/SAExportOutputEncodingTests.swift
@@ -39,16 +39,19 @@ final class SAExportOutputEncodingTests: XCTestCase {
         XCTAssertEqual(encoding(.dot, connection: latin1), utf8)
     }
 
-    // MARK: - CSV and XML follow the connection
+    // MARK: - XML declares encoding="utf-8" in its prolog, so the body is UTF-8 (#2637)
+
+    func testXMLIsUTF8RegardlessOfConnection() {
+        XCTAssertEqual(encoding(.xml, connection: utf8), utf8)
+        XCTAssertEqual(encoding(.xml, connection: latin1), utf8)
+        XCTAssertEqual(encoding(.xml, connection: shiftJIS), utf8)
+    }
+
+    // MARK: - CSV has no declaration and follows the connection
 
     func testCSVFollowsTheConnectionEncoding() {
         XCTAssertEqual(encoding(.csv, connection: utf8), utf8)
         XCTAssertEqual(encoding(.csv, connection: latin1), latin1)
         XCTAssertEqual(encoding(.csv, connection: shiftJIS), shiftJIS)
-    }
-
-    func testXMLFollowsTheConnectionEncoding() {
-        XCTAssertEqual(encoding(.xml, connection: utf8), utf8)
-        XCTAssertEqual(encoding(.xml, connection: latin1), latin1)
     }
 }


### PR DESCRIPTION
Stacked on #2638 (base is `bugfix/sql-export-encoding-2609`; GitHub retargets to `main` once that merges). Only the last commit is this PR.

## Changes:
- **XML exports are UTF-8 throughout.** `SPExportController` writes the prolog `<?xml version="1.0" encoding="utf-8" ?>` as UTF-8, but every body write in `SPXMLExporter` went through `writeString:` with the connection encoding. A latin1 or sjis connection produced a file whose declaration and bytes disagree, which a conforming parser rejects for any non-ASCII table name, field name or value. `SAExportOutputEncoding` now returns UTF-8 for XML, so body and prolog agree.
- **Raw-bytes cells decode with the connection encoding.** The XML exporter deliberately does *not* switch the connection to utf8mb4 the way SQL and DOT do: the filtered-table and custom-query exports hand it an already-fetched array, whose `NSData` cells were fetched in the connection's encoding, and a mid-export switch would not change those bytes. So the `NSData` branch decodes with `[connection stringEncoding]` (the source) and the string is re-encoded as UTF-8 on the way out. Text cells were already `NSString` and are unaffected.
- **The closing tags match too.** `xmlExportProcessComplete:` in `SPExportController` writes `</database></mysqldump>` / `</name>` when an exporter finishes; it used the connection encoding and now uses the exporter's output encoding (review follow-up).
- CSV is unchanged: it has no declaration, and header and body both still follow the connection encoding.

## Closes following issues:
- Closes: #2637

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: Xcode 26 beta (macOS 27.0 SDK)

Full "Unit Tests" suite green; `SAExportOutputEncodingTests` updated (XML now asserted UTF-8 for UTF-8, latin1 and Shift-JIS connections).

## Screenshots:

## Additional notes:
- **Behaviour parity.** For UTF-8 connections (the default) the output is byte-identical. Only non-UTF-8 connections change, and only in that the body is now encoded the way the prolog already claimed.
- **Text outside the connection charset** (a "犬" fetched over latin1) still arrives from the server as "?", exactly as the content view shows it. Making the XML exporter switch to utf8mb4 for the streaming path would fix that too, but it needs the array path to carry its own source encoding first. Out of scope here; the issue text proposed the switch, this PR takes the narrower fix for the reason above.
- **Manual pass not done yet.** Same limitation as #2638: the export dialog can't be driven from the shell harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
