### PR TITLE
Replace KVC private-ivar access with typed calls in SPWindowAdditions and SPImageView

### DIFF
--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.h
@@ -437,6 +437,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewTriggers;
 - (void)toggleRecordView:(id)sender;
 - (void)backForwardInHistory:(id)sender;
+- (void)goBackInHistory;
+- (void)goForwardInHistory;
 - (void)toggleConsole;
 - (void)showConsole;
 - (void)toggleNavigator;

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -359,19 +359,38 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Go backward or forward in the history depending on the menu item selected.
  */
 - (void)backForwardInHistory:(id)sender {
+    switch ([sender tag]) {
+        case 0: // Go backward
+            [self goBackInHistory];
+            break;
+        case 1: // Go forward
+            [self goForwardInHistory];
+            break;
+    }
+}
+
+/**
+ * Go back one step in the table history, after ending any editing and saving as required.
+ */
+- (void)goBackInHistory {
     // Ensure history navigation is permitted - trigger end editing and any required saves
     if (![self couldCommitCurrentViewActions]) {
         return;
     }
 
-    switch ([sender tag]) {
-        case 0: // Go backward
-            [spHistoryControllerInstance goBackInHistory];
-            break;
-        case 1: // Go forward
-            [spHistoryControllerInstance goForwardInHistory];
-            break;
+    [spHistoryControllerInstance goBackInHistory];
+}
+
+/**
+ * Go forward one step in the table history, after ending any editing and saving as required.
+ */
+- (void)goForwardInHistory {
+    // Ensure history navigation is permitted - trigger end editing and any required saves
+    if (![self couldCommitCurrentViewActions]) {
+        return;
     }
+
+    [spHistoryControllerInstance goForwardInHistory];
 }
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -373,6 +373,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Go back one step in the table history, after ending any editing and saving as required.
  */
 - (void)goBackInHistory {
+    // Nothing to navigate to - leave any in-progress editing alone
+    if (![spHistoryControllerInstance countPrevious]) {
+        return;
+    }
+
     // Ensure history navigation is permitted - trigger end editing and any required saves
     if (![self couldCommitCurrentViewActions]) {
         return;
@@ -385,6 +390,11 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
  * Go forward one step in the table history, after ending any editing and saving as required.
  */
 - (void)goForwardInHistory {
+    // Nothing to navigate to - leave any in-progress editing alone
+    if (![spHistoryControllerInstance countForward]) {
+        return;
+    }
+
     // Ensure history navigation is permitted - trigger end editing and any required saves
     if (![self couldCommitCurrentViewActions]) {
         return;

--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.h
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.h
@@ -30,8 +30,9 @@
 
 #import <Quartz/Quartz.h> // QuickLookUI
 
+#import "SPImageView.h"
+
 @class SABaseFormatter;
-@class SPImageView;
 
 //This is an informal protocol
 @protocol _QLPreviewPanelController
@@ -52,7 +53,7 @@
  * This class offers a sheet for editing different kind of data such as text, blobs (including images) as 
  * editSheet and bit fields as bitSheet. 
  */
-@interface SPFieldEditorController : NSWindowController <NSComboBoxDataSource, QLPreviewPanelDataSource, QLPreviewPanelDelegate, _QLPreviewPanelController>
+@interface SPFieldEditorController : NSWindowController <NSComboBoxDataSource, QLPreviewPanelDataSource, QLPreviewPanelDelegate, _QLPreviewPanelController, SPImageViewDelegate>
 {
 	IBOutlet id editSheetProgressBar;
 	IBOutlet id editSheetSegmentControl;

--- a/Source/Other/CategoryAdditions/SPWindowAdditions.m
+++ b/Source/Other/CategoryAdditions/SPWindowAdditions.m
@@ -72,17 +72,15 @@
 {
 	if (![[self delegate] isKindOfClass:[SPWindowController class]]) return;
 
-	id frontDoc = [(SPWindowController *)[self delegate] databaseDocument];
+	SPDatabaseDocument *frontDoc = [(SPWindowController *)[self delegate] databaseDocument];
 
-	if (frontDoc && [frontDoc isKindOfClass:[SPDatabaseDocument class]] && [frontDoc valueForKeyPath:@"spHistoryControllerInstance"] && ![frontDoc isWorking])
-	{
-		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
-		if ([event deltaX] == -1.0f) {
-			[[frontDoc valueForKeyPath:@"spHistoryControllerInstance"] valueForKey:@"goForwardInHistory"];
-		}
-		else if ([event deltaX] == 1.0f) {
-			[[frontDoc valueForKeyPath:@"spHistoryControllerInstance"] valueForKey:@"goBackInHistory"];
-		}
+	if (!frontDoc || [frontDoc isWorking]) return;
+
+	if ([event deltaX] == -1.0f) {
+		[frontDoc goForwardInHistory];
+	}
+	else if ([event deltaX] == 1.0f) {
+		[frontDoc goBackInHistory];
 	}
 }
 

--- a/Source/Views/SPImageView.h
+++ b/Source/Views/SPImageView.h
@@ -38,7 +38,7 @@
 
 @interface SPImageView : NSImageView 
 {
-	IBOutlet id delegate;
+	IBOutlet id<SPImageViewDelegate> delegate;
 }
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender;

--- a/Source/Views/SPImageView.m
+++ b/Source/Views/SPImageView.m
@@ -41,23 +41,12 @@
  */
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender
 {
-	id<SPImageViewDelegate> delegateForUse = nil;
-
-	// If the delegate or the delegate's content instance doesn't implement processUpdatedImageData:,
-	// return the super's implementation
-	if (delegate) {
-		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
-			delegateForUse = delegate;
-		}
-		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
-		else if ( [delegate valueForKey:@"tableContentInstance"]
-					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
-			delegateForUse = [delegate valueForKey:@"tableContentInstance"];
-		}
-	}
-	if (!delegateForUse) {
+	// If the delegate doesn't implement processUpdatedImageData:, return the super's implementation
+	if (![delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
 		return [super performDragOperation:sender];
 	}
+
+	id<SPImageViewDelegate> delegateForUse = delegate;
 
 	// If a filename is available, attempt to read it and pass it to the delegate
 	NSArray *droppedFileURLs = [[sender draggingPasteboard] readObjectsForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
@@ -106,23 +95,8 @@
 
 - (void)paste:(id)sender
 {
-	// [super paste:sender];
-	id<SPImageViewDelegate> delegateForUse = nil;
-
-	// If the delegate or the delegate's content instance doesn't implement processUpdatedImageData:,
-	// return the super's implementation
-	if (delegate) {
-		if ([delegate respondsToSelector:@selector(processUpdatedImageData:)]) {
-			delegateForUse = delegate;
-		}
-		// TODO (#2603): private ivar accessed from outside via KVC (upstream sequelpro#2978)
-		else if ( [delegate valueForKey:@"tableContentInstance"]
-					&& [[delegate valueForKey:@"tableContentInstance"] respondsToSelector:@selector(processUpdatedImageData:)] ) {
-			delegateForUse = [delegate valueForKey:@"tableContentInstance"];
-		}
-	}
-	if (delegateForUse) {
-		[delegateForUse processPasteImageData];
+	if ([delegate respondsToSelector:@selector(processPasteImageData)]) {
+		[delegate processPasteImageData];
 	}
 }
 


### PR DESCRIPTION
Closes #2603.

## What changed

**Table history navigation**
- `SPDatabaseDocument` gains public `goBackInHistory` / `goForwardInHistory`. Each runs the `couldCommitCurrentViewActions` check and then forwards to the history controller. The existing `backForwardInHistory:` menu action now dispatches to them.
- The three-finger swipe handler in `SPWindowAdditions` calls those methods directly instead of pulling the private `spHistoryControllerInstance` ivar out via `valueForKeyPath:` and triggering navigation through `valueForKey:` (which only worked because KVC falls back to calling zero-argument methods).

**Image view drag and paste**
- `SPImageView` drops its fallback that looked up `tableContentInstance` on the delegate through KVC. The view's only delegate is `SPFieldEditorController` (wired in `FieldEditorSheet.xib`), which implements both protocol methods, and nothing else implements `processUpdatedImageData:`, so the branch was unreachable. Had it ever run it would have raised an undefined-key exception rather than degrade.
- The delegate outlet is now typed `id<SPImageViewDelegate>`, the field editor declares the conformance, and `paste:` checks `processPasteImageData` rather than the drag selector before calling it.

## Behavior change

A swipe while editing a cell now ends editing and prompts for unsaved changes, the same as the History menu items and the toolbar segmented control already did. Previously the swipe path skipped that check. A swipe at either end of the history (no previous or no forward entry) is a no-op and does not touch in-progress editing, matching the disabled state of the menu and toolbar controls.

## Verification

- `Sequel Ace Debug` builds clean with no new warnings in the touched files.
- `grep -rn 2603 Source` is empty; no TODO markers for this issue remain.
- Not exercised by hand in this PR: three-finger swipe navigation and image drag/paste in the field editor. Both are pure call-site substitutions of the same methods the KVC path resolved to at runtime, but a manual pass on a trackpad is worth doing before merge.

## Follow-up

The same `valueForKeyPath:` pattern remains in `SPFieldMapperController`, `SPQueryFavoriteManager`, `SPDatabaseStructure`, `SPCopyTable`, and `SPTextView` (fetching `tablesListInstance` / `tableDocumentInstance` from a delegate). Those are out of scope for #2603 and should get their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct back and forward navigation through database view history.
  - Swipe gestures now navigate database history more reliably.

- **Bug Fixes**
  - Improved drag-and-drop and paste handling in image views.
  - Actions now correctly fall back when the active view cannot handle them.

- **Refactor**
  - Improved consistency and reliability of image view delegate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
