### PR TITLE
SPDatabaseStructure reads the tables list through the document's property

### DIFF
--- a/Source/Controllers/DataControllers/SPDatabaseStructure.m
+++ b/Source/Controllers/DataControllers/SPDatabaseStructure.m
@@ -248,15 +248,16 @@
 		}
 
 		// Retrieve the tables and views for this database from SPTablesList
+		SPTablesList *tablesList = [self.delegate tablesListInstance];
 		NSMutableArray *tablesAndViews = [NSMutableArray array];
-		for (id aTable in [[self.delegate valueForKeyPath:@"tablesListInstance"] allTableNames]) {
+		for (id aTable in [tablesList allTableNames]) {
 			NSDictionary *aTableDict = [NSDictionary dictionaryWithObjectsAndKeys:
 				aTable, @"name",
 				@(SPTableTypeTable), @"type",
 					nil];
 			[tablesAndViews addObject:aTableDict];
 		}
-		for (id aView in [[self.delegate valueForKeyPath:@"tablesListInstance"] allViewNames]) {
+		for (id aView in [tablesList allViewNames]) {
 			NSDictionary *aViewDict = [NSDictionary dictionaryWithObjectsAndKeys:
 				aView, @"name",
 				@(SPTableTypeView), @"type",


### PR DESCRIPTION
Part of #2641 (follow-up to #2603 / #2640).

`SPDatabaseStructure`'s delegate is already typed `SPDatabaseDocument *`, and the document exposes `tablesListInstance` as a public readonly property. The two `valueForKeyPath:@"tablesListInstance"` calls resolved to the same object through KVC's private-ivar fallback. They now call the property, captured once before the two loops.

No behavior change. `Sequel Ace Debug` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal table and view discovery implementation while preserving existing structure retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->