### PR TITLE
SPQueryFavoriteManager takes its SPCustomQuery delegate by type

### DIFF
--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
@@ -30,6 +30,7 @@
 
 @class SPTextView;
 @class SPDatabaseDocument;
+@class SPCustomQuery;
 @class SPSplitView;
 
 @interface SPQueryFavoriteManager : NSWindowController <NSOpenSavePanelDelegate>
@@ -53,7 +54,7 @@
 	BOOL isTableCellEditing;
 }
 
-- (instancetype)initWithDelegate:(id)managerDelegate;
+- (instancetype)initWithDelegate:(SPCustomQuery *)managerDelegate;
 
 // Accessors
 - (NSMutableArray *)queryFavoritesForFileURL:(NSURL *)fileURL;

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -34,6 +34,7 @@
 #import "SPEncodingPopupAccessory.h"
 #import "SPQueryController.h"
 #import "SPDatabaseDocument.h"
+#import "SPCustomQuery.h"
 #import "SPConnectionController.h"
 #import "RegexKitLite.h"
 #import "SPTextView.h"
@@ -59,7 +60,7 @@
 /**
  * Initialize the manager with the supplied delegate.
  */
-- (instancetype)initWithDelegate:(id)managerDelegate
+- (instancetype)initWithDelegate:(SPCustomQuery *)managerDelegate
 {
 	if ((self = [super initWithWindowNibName:@"QueryFavoriteManager"])) {
 
@@ -72,7 +73,7 @@
 			NSLog(@"Query Favorite Manager was called without a delegate.");
 			return nil;
 		}
-		tableDocumentInstance = [managerDelegate valueForKeyPath:@"tableDocumentInstance"];
+		tableDocumentInstance = [managerDelegate tableDocumentInstance];
 		delegatesFileURL = [tableDocumentInstance fileURL];
 	}
 	


### PR DESCRIPTION
Part of #2641 (follow-up to #2603 / #2640).

`SPQueryFavoriteManager` is only ever created by `SPCustomQuery`, which exposes `tableDocumentInstance` as a public readonly property. The `valueForKeyPath:@"tableDocumentInstance"` call resolved to the same object through KVC's private-ivar fallback. The initialiser now declares its parameter as `SPCustomQuery *` and calls the property directly, so the compiler checks the access.

No behavior change. `Sequel Ace Debug` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when managing query favorites by using the query manager’s defined interface.
  * Added stronger validation for the component responsible for coordinating favorite queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->