### PR TITLE
SPFieldMapperController reads the tables list and database data through properties

### DIFF
--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -115,6 +115,8 @@ typedef enum {
 	NSMutableIndexSet *nullableNumericFieldsMapIndex;
 }
 
+@property (readonly, strong) SPTablesList *tablesListInstance;
+
 // IBAction methods
 - (IBAction)closeSheet:(id)sender;
 - (IBAction)cancelProgressBar:(id)sender;

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -67,6 +67,7 @@
 @implementation SPDataImport
 
 @synthesize fileManager;
+@synthesize tablesListInstance;
 
 #pragma mark -
 #pragma mark Initialisation

--- a/Source/Controllers/DataImport/SPFieldMapperController.h
+++ b/Source/Controllers/DataImport/SPFieldMapperController.h
@@ -31,6 +31,8 @@
 @class SPTextView;
 @class SPTableView;
 @class SPTablesList;
+@class SPDataImport;
+@class SPDatabaseData;
 @class SPMySQLConnection;
 
 @interface SPFieldMapperController : NSWindowController <NSTokenFieldCellDelegate, NSMenuDelegate>
@@ -96,7 +98,7 @@
 	id theDelegate;
 	id customQueryInstance;
 	id fieldMappingImportArray;
-	id databaseDataInstance;
+	SPDatabaseData *databaseDataInstance;
 	SPTablesList *tablesListInstance;
 
 	NSMutableArray *fieldMappingArray;
@@ -149,7 +151,7 @@
 @property (copy) NSString* sourcePath;
 @property (copy) NSString *databaseName;
 
-- (instancetype)initWithDelegate:(id)managerDelegate;
+- (instancetype)initWithDelegate:(SPDataImport *)managerDelegate;
 
 - (void)setConnection:(SPMySQLConnection *)theConnection;
 - (void)setImportDataArray:(id)theFieldMappingImportArray hasHeader:(BOOL)hasHeader isPreview:(BOOL)isPreview;

--- a/Source/Controllers/DataImport/SPFieldMapperController.m
+++ b/Source/Controllers/DataImport/SPFieldMapperController.m
@@ -67,7 +67,7 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 #pragma mark -
 #pragma mark Initialisation
 
-- (instancetype)initWithDelegate:(id)managerDelegate
+- (instancetype)initWithDelegate:(SPDataImport *)managerDelegate
 {
 	if ((self = [super initWithWindowNibName:@"DataMigrationDialog"])) {
 
@@ -104,8 +104,8 @@ static NSUInteger SPSourceColumnTypeInteger     = 1;
 
 		prefs = [NSUserDefaults standardUserDefaults];
 
-		tablesListInstance = [theDelegate valueForKeyPath:@"tablesListInstance"];
-		databaseDataInstance = [tablesListInstance valueForKeyPath:@"databaseDataInstance"];
+		tablesListInstance = [managerDelegate tablesListInstance];
+		databaseDataInstance = [tablesListInstance databaseDataInstance];
 
 		if(![prefs objectForKey:SPLastImportIntoNewTableType])
 			[prefs setObject:@"Default" forKey:SPLastImportIntoNewTableType];

--- a/Source/Controllers/SubviewControllers/SPTablesList.h
+++ b/Source/Controllers/SubviewControllers/SPTablesList.h
@@ -133,6 +133,8 @@
 	SPCharsetCollationHelper *addTableCharsetHelper;
 }
 
+@property (readonly, strong, nullable) SPDatabaseData *databaseDataInstance;
+
 // IBAction methods
 - (IBAction)updateTables:(nullable id)sender;
 - (IBAction)addTable:(nullable id)sender;

--- a/Source/Controllers/SubviewControllers/SPTablesList.m
+++ b/Source/Controllers/SubviewControllers/SPTablesList.m
@@ -86,6 +86,7 @@ static NSString *SPNewTableCollation    = @"SPNewTableCollation";
 #pragma mark Initialisation
 
 @synthesize _SQLitePinnedTableManager;
+@synthesize databaseDataInstance;
 
 - (instancetype)init
 {


### PR DESCRIPTION
Part of #2641 (follow-up to #2603 / #2640).

`SPFieldMapperController` is only ever created by `SPDataImport`, so the initialiser now declares its parameter as `SPDataImport *`. Two readonly properties back the lookups it needs:

- `SPDataImport.tablesListInstance` exposes the existing IBOutlet ivar.
- `SPTablesList.databaseDataInstance` exposes the existing IBOutlet ivar (nullable, since the header carries explicit nullability annotations and the outlet is nil before nib load).

Both replace `valueForKeyPath:` calls that reached the same ivars through KVC's private-ivar fallback. The field mapper's `databaseDataInstance` ivar is typed `SPDatabaseData *` instead of `id`. The `theDelegate` ivar stays `id` because it is also handed to a text view as its delegate.

No behavior change. `Sequel Ace Debug` builds clean with no warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved type safety and consistency across data import and field-mapping workflows.
  - Strengthened communication between import, table-list, and database-data components.
  - Added read-only access to relevant table and database information for connected workflow components.
  - Clarified initialization contracts to support more reliable field-mapping setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->