### PR TITLE
SPCopyTable reads the tables list through an SPTableContent property

### DIFF
--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.h
@@ -169,6 +169,8 @@ typedef NS_ENUM(NSInteger, SPTableContentFilterSource) {
     IBOutlet NSButton *toggleRuleFilterButton;
 }
 
+@property (readonly, strong) SPTablesList *tablesListInstance;
+
 - (void)setFieldEditorSelectedRange:(NSRange)aRange;
 - (NSRange)fieldEditorSelectedRange;
 

--- a/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
+++ b/Source/Controllers/MainViewControllers/TableContent/SPTableContent.m
@@ -133,6 +133,8 @@ static void *TableContentKVOContext = &TableContentKVOContext;
 
 @implementation SPTableContent
 
+@synthesize tablesListInstance;
+
 #pragma mark -
 
 - (instancetype)init

--- a/Source/Views/TableViews/SPCopyTable.m
+++ b/Source/Views/TableViews/SPCopyTable.m
@@ -155,10 +155,16 @@ NSString *kFieldTypeGroup = @"FIELDGROUP";
  */
 - (BOOL)isCellEditingMode
 {
-	return ([[self delegate] isKindOfClass:[SPCustomQuery class]] 
-		|| ([[self delegate] isKindOfClass:[SPTableContent class]] 
-				&& [(NSObject*)[self delegate] valueForKeyPath:@"tablesListInstance"] 
-				&& [(SPTablesList*)([(NSObject*)[self delegate] valueForKeyPath:@"tablesListInstance"]) tableType] == SPTableTypeView));
+	id delegate = [self delegate];
+
+	if ([delegate isKindOfClass:[SPCustomQuery class]]) return YES;
+
+	if ([delegate isKindOfClass:[SPTableContent class]]) {
+		SPTablesList *tablesList = [(SPTableContent *)delegate tablesListInstance];
+		return tablesList && [tablesList tableType] == SPTableTypeView;
+	}
+
+	return NO;
 }
 
 /**


### PR DESCRIPTION
Part of #2641 (follow-up to #2603 / #2640).

`isCellEditingMode` already checked that the delegate is an `SPTableContent` before reaching into it, but then fetched the private `tablesListInstance` outlet through `valueForKeyPath:`. `SPTableContent` now exposes that outlet as a readonly property, and the check casts the delegate and calls it.

The method is restructured as early returns so the custom-query case and the table-content case read separately. The truth table is unchanged: custom query delegate is always editing mode, table content delegate is editing mode only when the tables list reports a view, anything else is not.

No behavior change. `Sequel Ace Debug` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of editing mode when copying table content.
  - Copy-table behavior now more reliably handles table views and avoids incorrectly enabling editing for unsupported table types.
  - Improved consistency when accessing table-list information during copy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->