### PR TITLE
SPTextView reaches its delegate's document and tables list through a formal protocol

### DIFF
--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -115,6 +115,7 @@ typedef enum {
 	NSMutableIndexSet *nullableNumericFieldsMapIndex;
 }
 
+@property (readonly, weak) SPDatabaseDocument *tableDocumentInstance;
 @property (readonly, strong) SPTablesList *tablesListInstance;
 
 // IBAction methods

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -53,7 +53,7 @@
 
 #define SP_FILE_READ_ERROR_STRING NSLocalizedString(@"File read error", @"File read error title (Import Dialog)")
 
-@interface SPDataImport ()
+@interface SPDataImport () <SATextViewDelegate>
 
 - (void)_startBackgroundImportTaskForFilename:(NSString *)filename;
 - (void)_importBackgroundProcess:(NSDictionary *)userInfo;
@@ -67,6 +67,7 @@
 @implementation SPDataImport
 
 @synthesize fileManager;
+@synthesize tableDocumentInstance = tableDocumentInstance;
 @synthesize tablesListInstance;
 
 #pragma mark -

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.h
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.h
@@ -30,6 +30,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPDatabaseContentViewDelegate.h"
+#import "SPTextView.h"
 
 #define SP_SAVE_ALL_FAVORTITE_MENUITEM_TAG       100001
 #define SP_SAVE_SELECTION_FAVORTITE_MENUITEM_TAG 100000
@@ -45,14 +46,13 @@
 @class SPFieldEditorController;
 @class SPMySQLConnection;
 @class SPMySQLStreamingResultStore;
-@class SPTextView;
 @class SPDatabaseDocument;
 @class SPTablesList;
 @class SARecordViewController;
 
 @class SPBracketHighlighter;
 
-@interface SPCustomQuery : NSObject <NSTableViewDataSource, NSWindowDelegate, NSTableViewDelegate, SPDatabaseContentViewDelegate>
+@interface SPCustomQuery : NSObject <NSTableViewDataSource, NSWindowDelegate, NSTableViewDelegate, SPDatabaseContentViewDelegate, SPTextViewDelegate>
 {
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
@@ -168,6 +168,7 @@
 
 // Exposed for Swift extensions (see SPCustomQuery+Explain.swift)
 @property (readonly, weak) SPDatabaseDocument *tableDocumentInstance;
+@property (readonly, strong) SPTablesList *tablesListInstance;
 @property (readonly, strong) SPTextView *textView;
 @property (readonly) NSRange currentQueryRange;
 @property (readwrite, strong) NSTableColumn *sortColumn;

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.h
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.h
@@ -30,7 +30,6 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPDatabaseContentViewDelegate.h"
-#import "SPTextView.h"
 
 #define SP_SAVE_ALL_FAVORTITE_MENUITEM_TAG       100001
 #define SP_SAVE_SELECTION_FAVORTITE_MENUITEM_TAG 100000
@@ -46,13 +45,14 @@
 @class SPFieldEditorController;
 @class SPMySQLConnection;
 @class SPMySQLStreamingResultStore;
+@class SPTextView;
 @class SPDatabaseDocument;
 @class SPTablesList;
 @class SARecordViewController;
 
 @class SPBracketHighlighter;
 
-@interface SPCustomQuery : NSObject <NSTableViewDataSource, NSWindowDelegate, NSTableViewDelegate, SPDatabaseContentViewDelegate, SPTextViewDelegate>
+@interface SPCustomQuery : NSObject <NSTableViewDataSource, NSWindowDelegate, NSTableViewDelegate, SPDatabaseContentViewDelegate>
 {
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -100,7 +100,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 
 // Formal conformance for methods AppKit moved off the informal NSObject
 // categories; implementing them without it is deprecated. No behavior change.
-@interface SPCustomQuery () <NSMenuItemValidation, NSFontChanging>
+@interface SPCustomQuery () <NSMenuItemValidation, NSFontChanging, SATextViewDelegate>
 - (id)_resultDataItemAtRow:(NSInteger)row columnIndex:(NSUInteger)column preserveNULLs:(BOOL)preserveNULLs asPreview:(BOOL)asPreview;
 - (NSInteger)_recordViewSelectedRow;
 - (NSTableColumn *)_recordViewColumnAtIndex:(NSInteger)fieldIndex;

--- a/Source/Controllers/MainViewControllers/SPCustomQuery.m
+++ b/Source/Controllers/MainViewControllers/SPCustomQuery.m
@@ -131,6 +131,7 @@ typedef void (^QueryProgressHandler)(QueryProgress *);
 // ivars instead of letting clang autosynthesize fresh `_name` ivars that xib
 // outlets wouldn't reach.
 @synthesize tableDocumentInstance = tableDocumentInstance;
+@synthesize tablesListInstance = tablesListInstance;
 @synthesize textView = textView;
 @synthesize currentQueryRange = currentQueryRange;
 @synthesize sortColumn = sortColumn;

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
@@ -35,9 +35,7 @@
 @class SPMySQLConnection;
 @class SPDatabaseDocument;
 
-#import "SPTextView.h"
-
-@interface SPExtendedTableInfo : NSObject <SPTextViewDelegate>
+@interface SPExtendedTableInfo : NSObject
 {
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.h
@@ -35,7 +35,9 @@
 @class SPMySQLConnection;
 @class SPDatabaseDocument;
 
-@interface SPExtendedTableInfo : NSObject
+#import "SPTextView.h"
+
+@interface SPExtendedTableInfo : NSObject <SPTextViewDelegate>
 {
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
@@ -69,6 +71,8 @@
 }
 
 @property (readwrite, strong) SPMySQLConnection *connection;
+@property (readonly, weak) SPDatabaseDocument *tableDocumentInstance;
+@property (readonly, strong) SPTablesList *tablesListInstance;
 
 // IBAction methods
 - (IBAction)reloadTable:(id)sender;

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -71,6 +71,8 @@ static NSString *SPMySQLCommentField          = @"Comment";
 @implementation SPExtendedTableInfo
 
 @synthesize connection;
+@synthesize tableDocumentInstance = tableDocumentInstance;
+@synthesize tablesListInstance = tablesListInstance;
 
 /**
  * Upon awakening bind the create syntax text view's background colour.

--- a/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
+++ b/Source/Controllers/MainViewControllers/SPExtendedTableInfo.m
@@ -60,7 +60,7 @@ static NSString *SPMySQLUpdateTimeField       = @"Update_time";
 static NSString *SPMySQLCollationField        = @"Collation";
 static NSString *SPMySQLCommentField          = @"Comment";
 
-@interface SPExtendedTableInfo ()
+@interface SPExtendedTableInfo () <SATextViewDelegate>
 
 - (void)_updateDisplayedInfo:(NSNotification *)aNotification;
 - (void)_changeCurrentTableTypeFrom:(NSString *)currentType to:(NSString *)newType;

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.h
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.h
@@ -31,7 +31,9 @@
 @class SPDatabaseDocument;
 @class SPSplitView;
 
-@interface SPContentFilterManager : NSWindowController <NSOpenSavePanelDelegate>
+#import "SPTextView.h"
+
+@interface SPContentFilterManager : NSWindowController <NSOpenSavePanelDelegate, SPTextViewDelegate>
 {
 	NSUserDefaults *prefs;
 	
@@ -60,6 +62,8 @@
 	
 	NSString *filterType;
 }
+
+@property (readonly, strong) SPDatabaseDocument *tableDocumentInstance;
 
 - (instancetype)initWithDatabaseDocument:(SPDatabaseDocument *)document forFilterType:(NSString *)compareType;
 

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.h
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.h
@@ -31,9 +31,7 @@
 @class SPDatabaseDocument;
 @class SPSplitView;
 
-#import "SPTextView.h"
-
-@interface SPContentFilterManager : NSWindowController <NSOpenSavePanelDelegate, SPTextViewDelegate>
+@interface SPContentFilterManager : NSWindowController <NSOpenSavePanelDelegate>
 {
 	NSUserDefaults *prefs;
 	

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.m
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.m
@@ -54,6 +54,8 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 
 @implementation SPContentFilterManager
 
+@synthesize tableDocumentInstance = tableDocumentInstance;
+
 /**
  * Initialize the manager with the supplied document
  */

--- a/Source/Controllers/SubviewControllers/SPContentFilterManager.m
+++ b/Source/Controllers/SubviewControllers/SPContentFilterManager.m
@@ -49,7 +49,7 @@ static NSString *SPExportFilterAction = @"SPExportFilter";
 
 // Formal conformance for methods AppKit moved off the informal NSObject
 // categories; implementing them without it is deprecated. No behavior change.
-@interface SPContentFilterManager () <NSMenuItemValidation, NSControlTextEditingDelegate>
+@interface SPContentFilterManager () <NSMenuItemValidation, NSControlTextEditingDelegate, SATextViewDelegate>
 @end
 
 @implementation SPContentFilterManager

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
@@ -28,12 +28,13 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
-@class SPTextView;
 @class SPDatabaseDocument;
 @class SPCustomQuery;
 @class SPSplitView;
 
-@interface SPQueryFavoriteManager : NSWindowController <NSOpenSavePanelDelegate>
+#import "SPTextView.h"
+
+@interface SPQueryFavoriteManager : NSWindowController <NSOpenSavePanelDelegate, SPTextViewDelegate>
 {
 	NSUserDefaults *prefs;
 	NSURL *delegatesFileURL;
@@ -53,6 +54,8 @@
 
 	BOOL isTableCellEditing;
 }
+
+@property (readonly, strong) SPDatabaseDocument *tableDocumentInstance;
 
 - (instancetype)initWithDelegate:(SPCustomQuery *)managerDelegate;
 

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.h
@@ -28,13 +28,12 @@
 //
 //  More info at <https://github.com/sequelpro/sequelpro>
 
+@class SPTextView;
 @class SPDatabaseDocument;
 @class SPCustomQuery;
 @class SPSplitView;
 
-#import "SPTextView.h"
-
-@interface SPQueryFavoriteManager : NSWindowController <NSOpenSavePanelDelegate, SPTextViewDelegate>
+@interface SPQueryFavoriteManager : NSWindowController <NSOpenSavePanelDelegate>
 {
 	NSUserDefaults *prefs;
 	NSURL *delegatesFileURL;

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -57,6 +57,8 @@
 
 @implementation SPQueryFavoriteManager
 
+@synthesize tableDocumentInstance = tableDocumentInstance;
+
 /**
  * Initialize the manager with the supplied delegate.
  */

--- a/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
+++ b/Source/Controllers/SubviewControllers/SPQueryFavoriteManager.m
@@ -49,7 +49,7 @@
 
 // Formal conformance for methods AppKit moved off the informal NSObject
 // categories; implementing them without it is deprecated. No behavior change.
-@interface SPQueryFavoriteManager () <NSMenuItemValidation, NSControlTextEditingDelegate>
+@interface SPQueryFavoriteManager () <NSMenuItemValidation, NSControlTextEditingDelegate, SATextViewDelegate>
 
 - (void)_initWithNoSelection;
 

--- a/Source/Views/TextViews/SATextViewDelegate.swift
+++ b/Source/Views/TextViews/SATextViewDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  SATextViewDelegate.swift
+//  Sequel Ace
+//
+//  The accessors an SPTextView delegate can offer so the view reaches the
+//  document and tables list it edits against through a declared contract
+//  instead of valueForKeyPath:. Part of the KVC clean-up tracked in #2641.
+//
+
+import AppKit
+
+/// Delegates of an `SPTextView` can hand the view the document and tables list the
+/// text is edited against. Both are optional; a view whose delegate provides neither
+/// still works, it just has no structure data to offer for completion and printing.
+@objc protocol SATextViewDelegate: NSTextViewDelegate {
+    @objc optional var tableDocumentInstance: SPDatabaseDocument? { get }
+    @objc optional var tablesListInstance: SPTablesList? { get }
+}
+
+extension SPTextView {
+    /// The document the delegate works against, or nil if the delegate provides none.
+    @objc var delegateDocument: SPDatabaseDocument? {
+        (delegate as? SATextViewDelegate)?.tableDocumentInstance ?? nil
+    }
+
+    /// The tables list the delegate works against, or nil if the delegate provides none.
+    @objc var delegateTablesList: SPTablesList? {
+        (delegate as? SATextViewDelegate)?.tablesListInstance ?? nil
+    }
+}

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -39,17 +39,6 @@
 @class SPCopyTable;
 @class NoodleLineNumberView;
 
-/**
- * A text view delegate can hand the view the document and tables list the text is
- * edited against. Both are optional; a view whose delegate provides neither still
- * works, it just has no structure data to offer for completion and printing.
- */
-@protocol SPTextViewDelegate <NSTextViewDelegate>
-@optional
-- (SPDatabaseDocument *)tableDocumentInstance;
-- (SPTablesList *)tablesListInstance;
-@end
-
 typedef struct {
 	NSInteger location; // snippet location
 	NSInteger length;   // snippet length

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -39,6 +39,17 @@
 @class SPCopyTable;
 @class NoodleLineNumberView;
 
+/**
+ * A text view delegate can hand the view the document and tables list the text is
+ * edited against. Both are optional; a view whose delegate provides neither still
+ * works, it just has no structure data to offer for completion and printing.
+ */
+@protocol SPTextViewDelegate <NSTextViewDelegate>
+@optional
+- (SPDatabaseDocument *)tableDocumentInstance;
+- (SPTablesList *)tablesListInstance;
+@end
+
 typedef struct {
 	NSInteger location; // snippet location
 	NSInteger length;   // snippet length

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -102,33 +102,6 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 @implementation SPTextView
 
-#pragma mark -
-#pragma mark Delegate accessors
-
-/**
- * The document the delegate works against, or nil if the delegate provides none.
- */
-- (SPDatabaseDocument *)delegateDocument
-{
-	id<SPTextViewDelegate> textDelegate = (id<SPTextViewDelegate>)[self delegate];
-
-	if (![textDelegate respondsToSelector:@selector(tableDocumentInstance)]) return nil;
-
-	return [textDelegate tableDocumentInstance];
-}
-
-/**
- * The tables list the delegate works against, or nil if the delegate provides none.
- */
-- (SPTablesList *)delegateTablesList
-{
-	id<SPTextViewDelegate> textDelegate = (id<SPTextViewDelegate>)[self delegate];
-
-	if (![textDelegate respondsToSelector:@selector(tablesListInstance)]) return nil;
-
-	return [textDelegate tablesListInstance];
-}
-
 @synthesize queryHiliteColor;
 @synthesize queryEditorBackgroundColor;
 @synthesize commentColor;

--- a/Source/Views/TextViews/SPTextView.m
+++ b/Source/Views/TextViews/SPTextView.m
@@ -35,6 +35,7 @@
 #import "SPQueryController.h"
 #import "SPTooltip.h"
 #import "SPTablesList.h"
+#import "SPExtendedTableInfo.h"
 #import "SPNavigatorController.h"
 #import "RegexKitLite.h"
 #import "SPAppController.h"
@@ -100,6 +101,33 @@ static inline CGFloat SPPointDistance(NSPoint a, NSPoint b) { return sqrtf( (a.x
 static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NSMakePoint(a.x*(1.0f-t) + b.x*t, a.y*(1.0f-t) + b.y*t); }
 
 @implementation SPTextView
+
+#pragma mark -
+#pragma mark Delegate accessors
+
+/**
+ * The document the delegate works against, or nil if the delegate provides none.
+ */
+- (SPDatabaseDocument *)delegateDocument
+{
+	id<SPTextViewDelegate> textDelegate = (id<SPTextViewDelegate>)[self delegate];
+
+	if (![textDelegate respondsToSelector:@selector(tableDocumentInstance)]) return nil;
+
+	return [textDelegate tableDocumentInstance];
+}
+
+/**
+ * The tables list the delegate works against, or nil if the delegate provides none.
+ */
+- (SPTablesList *)delegateTablesList
+{
+	id<SPTextViewDelegate> textDelegate = (id<SPTextViewDelegate>)[self delegate];
+
+	if (![textDelegate respondsToSelector:@selector(tablesListInstance)]) return nil;
+
+	return [textDelegate tablesListInstance];
+}
 
 @synthesize queryHiliteColor;
 @synthesize queryEditorBackgroundColor;
@@ -472,7 +500,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 			if(!aDbName) {
 
 				// Try to suggest only items which are uniquely valid for the parsed string
-				NSArray *uniqueSchema = [[SPNavigatorController sharedNavigatorController] getUniqueDbIdentifierFor:[aTableName lowercaseString] andConnection:[[(NSObject*)[self delegate] valueForKeyPath:@"tableDocumentInstance"] connectionID]  ignoreFields:YES];
+				NSArray *uniqueSchema = [[SPNavigatorController sharedNavigatorController] getUniqueDbIdentifierFor:[aTableName lowercaseString] andConnection:[[self delegateDocument] connectionID] ignoreFields:YES];
 				NSInteger uniqueSchemaKind = [[uniqueSchema objectAtIndex:0] intValue];
 
 				// If no db name but table name check if table name is a valid name in the current selected db
@@ -1206,8 +1234,8 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 
 	// If Extended Table Info tab is active delegate the print call to the SPDatabaseDocument
 	// if the user doesn't select anything in self
-	if([[[[self delegate] class] description] isEqualToString:@"SPExtendedTableInfo"] && ![self selectedRange].length) {
-		[[(NSObject*)[self delegate] valueForKeyPath:@"tableDocumentInstance"] printDocument:sender];
+	if([[self delegate] isKindOfClass:[SPExtendedTableInfo class]] && ![self selectedRange].length) {
+		[[self delegateDocument] printDocument];
 		return;
 	}
 
@@ -1620,7 +1648,7 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		// 		}
 		// 	}
 		// } else {
-		arr = [NSArray arrayWithArray:[[(NSObject*)[self delegate] valueForKeyPath:@"tablesListInstance"] allTableAndViewNames]];
+		arr = [NSArray arrayWithArray:[[self delegateTablesList] allTableAndViewNames]];
 		if(arr == nil) {
 			arr = @[];
 		}
@@ -1629,13 +1657,13 @@ static inline NSPoint SPPointOnLine(NSPoint a, NSPoint b, CGFloat t) { return NS
 		// }
 	}
 	else if([kind isEqualToString:@"$SP_ASLIST_ALL_DATABASES"]) {
-		arr = [NSArray arrayWithArray:[[(NSObject*)[self delegate] valueForKeyPath:@"tablesListInstance"] allDatabaseNames]];
+		arr = [NSArray arrayWithArray:[[self delegateTablesList] allDatabaseNames]];
 		if(arr == nil) {
 			arr = @[];
 		}
 		for(id w in arr)
 			[possibleCompletions addObject:[NSDictionary dictionaryWithObjectsAndKeys:w, @"display", @"database-small", @"image", @"", @"isRef", nil]];
-		arr = [NSArray arrayWithArray:[[(NSObject*)[self delegate] valueForKeyPath:@"tablesListInstance"] allSystemDatabaseNames]];
+		arr = [NSArray arrayWithArray:[[self delegateTablesList] allSystemDatabaseNames]];
 		if(arr == nil) {
 			arr = @[];
 		}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		17E6416C0EF01F37001BC333 /* ImageAndTextCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641690EF01F37001BC333 /* ImageAndTextCell.m */; };
 		17E641830EF01FA8001BC333 /* SPImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E6417F0EF01FA8001BC333 /* SPImageView.m */; };
 		17E641840EF01FA8001BC333 /* SPTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17E641810EF01FA8001BC333 /* SPTextView.m */; };
+		32F9E22AF3964434B1429591 /* SATextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB59B1CBC3F48418228E1EC /* SATextViewDelegate.swift */; };
 		17E641D10EF02036001BC333 /* grabber-horizontal.png in Resources */ = {isa = PBXBuildFile; fileRef = 17E6419D0EF02036001BC333 /* grabber-horizontal.png */; };
 		17E641D20EF02036001BC333 /* grabber-vertical.png in Resources */ = {isa = PBXBuildFile; fileRef = 17E6419E0EF02036001BC333 /* grabber-vertical.png */; };
 		17E641F20EF02036001BC333 /* toolbar-switch-to-structure.png in Resources */ = {isa = PBXBuildFile; fileRef = 17E641BE0EF02036001BC333 /* toolbar-switch-to-structure.png */; };
@@ -992,6 +993,7 @@
 		17E6417F0EF01FA8001BC333 /* SPImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPImageView.m; sourceTree = "<group>"; };
 		17E641800EF01FA8001BC333 /* SPTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextView.h; sourceTree = "<group>"; };
 		17E641810EF01FA8001BC333 /* SPTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTextView.m; sourceTree = "<group>"; };
+		1FB59B1CBC3F48418228E1EC /* SATextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATextViewDelegate.swift; sourceTree = "<group>"; };
 		17E6419D0EF02036001BC333 /* grabber-horizontal.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "grabber-horizontal.png"; sourceTree = "<group>"; };
 		17E6419E0EF02036001BC333 /* grabber-vertical.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "grabber-vertical.png"; sourceTree = "<group>"; };
 		17E641BE0EF02036001BC333 /* toolbar-switch-to-structure.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-structure.png"; sourceTree = "<group>"; };
@@ -2244,6 +2246,7 @@
 			children = (
 				17E641800EF01FA8001BC333 /* SPTextView.h */,
 				17E641810EF01FA8001BC333 /* SPTextView.m */,
+				1FB59B1CBC3F48418228E1EC /* SATextViewDelegate.swift */,
 				BC1847E80FE6EC8400094BFB /* SPEditSheetTextView.h */,
 				BC1847E90FE6EC8400094BFB /* SPEditSheetTextView.m */,
 				BC1944CE1297291800A236CD /* SPBundleCommandTextView.h */,
@@ -3790,6 +3793,7 @@
 				623A1F89625ADE681E60B97C /* SAKeychainProviding.swift in Sources */,
 				17E641830EF01FA8001BC333 /* SPImageView.m in Sources */,
 				17E641840EF01FA8001BC333 /* SPTextView.m in Sources */,
+				32F9E22AF3964434B1429591 /* SATextViewDelegate.swift in Sources */,
 				51AC3B7A304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift in Sources */,
 				58FEF16D0F23D66600518E8E /* SPSQLParser.m in Sources */,
 				1789343C0F30C1DD0097539A /* SPStringAdditions.m in Sources */,


### PR DESCRIPTION
Part of #2641 (follow-up to #2603 / #2640). Last of the five; closes #2641 once merged alongside #2642, #2643, #2644 and #2645.

## What changed

`SPTextView` asked whichever delegate it had for `tableDocumentInstance` and `tablesListInstance` through `valueForKeyPath:`. That reached private outlets by KVC's ivar fallback on the delegates that have them, and raised an undefined-key exception on the ones that don't (the filter table controller, and the content filter and favorite managers for the tables list).

- New `Source/Views/TextViews/SATextViewDelegate.swift` declares `@objc protocol SATextViewDelegate: NSTextViewDelegate` with two optional accessors, and an `SPTextView` extension with `delegateDocument` / `delegateTablesList` that return nil when the delegate does not provide the accessor. The four completion sites and the print site in `SPTextView.m` call them.
- `SPCustomQuery`, `SPExtendedTableInfo`, `SPContentFilterManager` and `SPQueryFavoriteManager` expose the outlets they already hold as readonly properties synthesised onto the existing ivars (same pattern `SPCustomQuery` already uses for its Swift-visible properties), and declare conformance in their `.m` class extensions. The headers sit in the bridging header, so they cannot import the generated Swift header.

## Behavior changes

- **Printing from the Extended Table Info tab** with nothing selected sent `printDocument:` to the document, which only implements `printDocument`. That was an unrecognized selector at runtime. The call now uses the declared method.
- **Delegates without a tables list** (filter table window, content filter manager, favorite manager) now get an empty completion list for the `$SP_ASLIST_*` snippet placeholders instead of an undefined-key exception.
- The delegate class check in `printDocument:` uses `isKindOfClass:` instead of comparing the class description string.

For the custom query editor, which is the only text view whose delegate provided both keys, the objects resolved are identical to before.

## Note

Touches `SPQueryFavoriteManager.h` near the lines #2643 also edits. Whichever merges second may need a trivial rebase.

`Sequel Ace Debug` builds clean with no warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL completion, printing, and completion-list behavior by ensuring text views consistently access their associated document and table context.
  - Improved recognition of the Extended Table Info view during printing-related actions.

- **Refactor**
  - Standardized communication between text views and their delegate controllers across query, filtering, favorites, data import, and table-information workflows.
  - Improved type-safe access to document and table context for more reliable controller interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
