### PR TITLE
#infra Format one instant in testOldvsNewDateFormat

### DIFF
--- a/UnitTests/SPDateAdditionsTests.m
+++ b/UnitTests/SPDateAdditionsTests.m
@@ -93,45 +93,48 @@
 
 
 - (void)testOldvsNewDateFormat {
-	
+
+	// Format one instant on both sides, so the clock cannot tick between the two calls
+	NSDate *now = [NSDate date];
+
 	NSString *str1 = [NSString stringWithFormat:@"%@%@",
 									SPImportClipboardTempFileNamePrefix,
-									[[NSDate  date] descriptionWithCalendarFormat:@"%H%M%S"
+									[now descriptionWithCalendarFormat:@"%H%M%S"
 											timeZone:nil
 											locale:[[NSUserDefaults standardUserDefaults] dictionaryRepresentation]]];
 
 	
 	NSString *str3 = [NSString stringWithFormat:@"%@%@",
 									SPImportClipboardTempFileNamePrefix,
-									[[NSDate date] stringWithFormat:@"HHmmss"
+									[now stringWithFormat:@"HHmmss"
 																	locale:[NSLocale autoupdatingCurrentLocale]
 														   timeZone:[NSTimeZone localTimeZone]]];
 	
 	
 	XCTAssertEqualObjects(str1, str3);
 
-	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil];
-	str3 = [[NSDate date] stringWithFormat:@"yyyy-MM-dd" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
+	str1 = [now descriptionWithCalendarFormat:@"%Y-%m-%d" timeZone:nil locale:nil];
+	str3 = [now stringWithFormat:@"yyyy-MM-dd" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
 
 	XCTAssertEqualObjects(str1, str3);
 
-	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil];
-	str3 = [[NSDate date] stringWithFormat:@"yyyy" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
+	str1 = [now descriptionWithCalendarFormat:@"%Y" timeZone:nil locale:nil];
+	str3 = [now stringWithFormat:@"yyyy" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
 
 	XCTAssertEqualObjects(str1, str3);
 
-	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil];
-	str3 = [[NSDate date] stringWithFormat:@"MM" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
+	str1 = [now descriptionWithCalendarFormat:@"%m" timeZone:nil locale:nil];
+	str3 = [now stringWithFormat:@"MM" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
 
 	XCTAssertEqualObjects(str1, str3);
 
-	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil];
-	str3 = [[NSDate date] stringWithFormat:@"dd" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
+	str1 = [now descriptionWithCalendarFormat:@"%d" timeZone:nil locale:nil];
+	str3 = [now stringWithFormat:@"dd" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
 
 	XCTAssertEqualObjects(str1, str3);
 
-	str1 = [[NSDate date] descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil];
-	str3 = [[NSDate date] stringWithFormat:@"HH:mm:ss" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
+	str1 = [now descriptionWithCalendarFormat:@"%H:%M:%S" timeZone:nil locale:nil];
+	str3 = [now stringWithFormat:@"HH:mm:ss" locale:[NSLocale autoupdatingCurrentLocale] timeZone:[NSTimeZone localTimeZone]];
 
 	XCTAssertEqualObjects(str1, str3);
 


### PR DESCRIPTION
`testOldvsNewDateFormat` in `UnitTests/SPDateAdditionsTests.m` is flaky. Each assertion built two strings from two separate `[NSDate date]` calls, one through the legacy `descriptionWithCalendarFormat:timeZone:locale:` and one through the project's `stringWithFormat:locale:timeZone:` category. The first pair formats to the second, so the test failed whenever the wall clock crossed a second boundary between the two calls. Seen in CI on 2026-09-09:

```
"~/tmp/_SP_ClipBoard_Import_File_071741" is not equal to "~/tmp/_SP_ClipBoard_Import_File_071742"
```

The test now captures a single `NSDate *now` at the top and formats it on both sides of every comparison. The assertions and formats are unchanged, since the point of the test is to pin the category's output against the legacy formatter.

`Unit Tests` scheme, `SPDateAdditionsTests/testOldvsNewDateFormat` passes in a separate DerivedData.

🤖 Generated with [Claude Code](https://claude.com/claude-code)