### PR TITLE
#fixed Relieve the main thread of three profiling-found hot spots

### DIFF
--- a/Source/Controllers/SPAppController.m
+++ b/Source/Controllers/SPAppController.m
@@ -107,14 +107,12 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
         [fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"tmp"] withIntermediateDirectories:true attributes:nil error:nil];
         [fileManager createDirectoryAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@".keys"] withIntermediateDirectories:true attributes:nil error:nil];
 
-        //Handle Appearance on macOS 10.14+
-        if (@available(macOS 10.14, *)) {
-            //Switch Appearance on Application startup (prevent Appearance blink)
-            [self switchAppearance];
+        //Apply the appearance preference on startup (prevents an appearance blink);
+        //the former @available(macOS 10.14) wrapper was dead code, target is 13.5+
+        [self switchAppearance];
 
-            //Register an observer to switch Appearance at runtime
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
-        }
+        //Register an observer to re-apply it when defaults change at runtime
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
         [NSApp setDelegate:self];
     }
     return self;
@@ -146,21 +144,15 @@ static const double SPDelayBeforeCheckingForNewReleases = 10;
 }
 
 /**
- * Called when need to switch application appearance - on startup and when userDefaults changed
+ * Applies the appearance preference - on startup and when userDefaults change.
+ * NSUserDefaultsDidChangeNotification fires for every defaults write anywhere
+ * in the app, so SAAppearancePreference caches the applied selection and only
+ * pushes real changes to NSApp. (The former @available(10.14) check was dead
+ * code - the deployment target is 13.5.)
  */
 - (void)switchAppearance {
     SPMainQSync(^{
-        if (@available(macOS 10.14, *)) {
-            NSInteger appearance = [[NSUserDefaults standardUserDefaults] integerForKey:SPAppearance];
-
-            if (appearance == 1) {
-                NSApp.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
-            } else if (appearance == 2) {
-                NSApp.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
-            } else {
-                NSApp.appearance = nil;
-            }
-        }
+        [SAAppearancePreference applyIfChanged];
     });
 }
 

--- a/Source/Controllers/SubviewControllers/SAQueryHistoryMerger.swift
+++ b/Source/Controllers/SubviewControllers/SAQueryHistoryMerger.swift
@@ -21,7 +21,7 @@ import Foundation
 @objc public final class SAQueryHistoryMerger: NSObject {
     /// - Parameters:
     ///   - newEntries: The entries to add, most recent intent first.
-    ///   - existing: The stored history, oldest first. Sourced from plists a
+    ///   - existing: The stored history, newest first. Sourced from plists a
     ///     user can hand-edit (preferences, .spf session files), so elements
     ///     are accepted as `Any` and anything that is not a string is dropped
     ///     rather than trapping in the ObjC-to-Swift array bridge.

--- a/Source/Controllers/SubviewControllers/SAQueryHistoryMerger.swift
+++ b/Source/Controllers/SubviewControllers/SAQueryHistoryMerger.swift
@@ -1,0 +1,53 @@
+//
+//  SAQueryHistoryMerger.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.09.09.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+/// Merges new query-history entries into an existing list - the replacement
+/// for the old trick of abusing a hidden `NSPopUpButton` as a de-duplicator,
+/// which allocated a control (plus its debug description for logging) on
+/// every saved query. Replicates the popup semantics exactly: existing
+/// entries keep their order with a later duplicate winning, new entries are
+/// inserted at the front one by one - several new entries therefore end up
+/// in reverse order, as the old `insertItemWithTitle:atIndex:0` loop
+/// produced - and an older duplicate of a new entry is removed. The result
+/// is trimmed to `limit` from the end (a negative limit never trims; a limit
+/// of 0 empties the list, both as before).
+@objc public final class SAQueryHistoryMerger: NSObject {
+    /// - Parameters:
+    ///   - newEntries: The entries to add, most recent intent first.
+    ///   - existing: The stored history, oldest first. Sourced from plists a
+    ///     user can hand-edit (preferences, .spf session files), so elements
+    ///     are accepted as `Any` and anything that is not a string is dropped
+    ///     rather than trapping in the ObjC-to-Swift array bridge.
+    ///   - limit: Maximum number of entries to keep.
+    /// - Returns: The merged, de-duplicated, trimmed history.
+    @objc(mergedHistoryWithNewEntries:existing:limit:)
+    public static func merged(newEntries: [Any], existing: [Any], limit: Int) -> [String] {
+        // NSPopUpButton de-duplicates by title but keeps repeated EMPTY
+        // titles, so empty strings are exempt from the removal - parity for
+        // hand-edited history lists.
+        var list: [String] = []
+        for entry in existing.compactMap({ $0 as? String }) {
+            if !entry.isEmpty {
+                list.removeAll { $0 == entry }
+            }
+            list.append(entry)
+        }
+        for entry in newEntries.compactMap({ $0 as? String }) {
+            if !entry.isEmpty {
+                list.removeAll { $0 == entry }
+            }
+            list.insert(entry, at: 0)
+        }
+        if limit >= 0, list.count > limit {
+            list.removeLast(list.count - limit)
+        }
+        return list
+    }
+}

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -1015,9 +1015,24 @@ static SPQueryController *sharedQueryController = nil;
 		// The prefs array may never have been written - the old
 		// addItemsWithTitles:nil was a no-op, the Swift bridge would trap.
 		BOOL useSQLiteHistory = (_SQLiteHistoryManager.migratedPrefsToDB == YES);
-		NSArray *existingHistory = useSQLiteHistory
-			? _SQLiteHistoryManager.queryHist.allValues
-			: ([prefs objectForKey:SPQueryHistory] ?: @[]);
+		NSArray *existingHistory;
+		if (useSQLiteHistory) {
+			// allKeys specifies no order - sort newest first (highest id),
+			// the same ordering the history menu uses, so the merger trims
+			// the actual oldest entries at the limit. NSNumber compare: keeps
+			// the full Int64 width of the row ids.
+			NSArray *sortedKeys = [_SQLiteHistoryManager.queryHist.allKeys sortedArrayUsingComparator:^NSComparisonResult(NSNumber *key1, NSNumber *key2) {
+				return [key2 compare:key1];
+			}];
+			NSMutableArray *sortedValues = [NSMutableArray arrayWithCapacity:sortedKeys.count];
+			for (NSNumber *key in sortedKeys) {
+				[sortedValues addObject:[_SQLiteHistoryManager.queryHist objectForKey:key]];
+			}
+			existingHistory = sortedValues;
+		}
+		else {
+			existingHistory = [prefs objectForKey:SPQueryHistory] ?: @[];
+		}
 		NSArray *merged = [SAQueryHistoryMerger mergedHistoryWithNewEntries:@[history]
 		                                                           existing:existingHistory
 		                                                              limit:maxHistoryItems];

--- a/Source/Controllers/SubviewControllers/SPQueryController.m
+++ b/Source/Controllers/SubviewControllers/SPQueryController.m
@@ -988,7 +988,7 @@ static SPQueryController *sharedQueryController = nil;
 
 - (void)addHistory:(NSString *)history forFileURL:(NSURL *)fileURL
 {
-	NSUInteger maxHistoryItems = [[prefs objectForKey:SPCustomQueryMaxHistoryItems] integerValue];
+	NSInteger maxHistoryItems = [[prefs objectForKey:SPCustomQueryMaxHistoryItems] integerValue];
 
     NSString *fileURLStr = [fileURL absoluteString];
 
@@ -997,52 +997,35 @@ static SPQueryController *sharedQueryController = nil;
 	// Save each history item due to its document source
 	if (fileURLStr != nil && [historyContainer safeObjectForKey:fileURLStr]) {
 
-		// Remove all duplicates by using a NSPopUpButton
-		NSPopUpButton *uniquifier = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0,0,0,0) pullsDown:YES];
-
-        SPLog(@"uniquifier = %@\nAdding: %@", uniquifier.debugDescription, [historyContainer safeObjectForKey:fileURLStr]);
-
-        // add current history
-		[uniquifier addItemsWithTitles:[historyContainer safeObjectForKey:fileURLStr]];
-
-        // add new history
-        NSArray *histArr = [_SQLiteHistoryManager normalizeQueryHistoryWithArrayToNormalise:@[history]];
-        for(NSString *str in histArr){
-            [uniquifier insertItemWithTitle:str atIndex:0];
-        }
-
-		while ((NSUInteger)[uniquifier numberOfItems] > maxHistoryItems)
-		{
-			[uniquifier removeItemAtIndex:[uniquifier numberOfItems]-1];
-		}
-
-		[self replaceHistoryByArray:[uniquifier itemTitles] forFileURL:fileURL];
+		// Merge into the stored history; SAQueryHistoryMerger replicates the
+		// de-duplication the old hidden NSPopUpButton performed, without
+		// allocating a control (and logging its debug description) per save.
+		NSArray *newEntries = [_SQLiteHistoryManager normalizeQueryHistoryWithArrayToNormalise:@[history]];
+		NSArray *merged = [SAQueryHistoryMerger mergedHistoryWithNewEntries:newEntries
+		                                                           existing:[historyContainer safeObjectForKey:fileURLStr]
+		                                                              limit:maxHistoryItems];
+		[self replaceHistoryByArray:merged forFileURL:fileURL];
 	}
 
 	// Save history items coming from each Untitled document in the global Preferences successively
 	// regardingless of the source document.
 	if (![fileURL isFileURL]) {
 
-		// Remove all duplicates by using a NSPopUpButton
-		NSPopUpButton *uniquifier = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0,0,0,0) pullsDown:YES];
-		if(_SQLiteHistoryManager.migratedPrefsToDB == YES){
-			[uniquifier addItemsWithTitles:_SQLiteHistoryManager.queryHist.allValues];
+		// Same merge for the global history of Untitled documents.
+		// The prefs array may never have been written - the old
+		// addItemsWithTitles:nil was a no-op, the Swift bridge would trap.
+		BOOL useSQLiteHistory = (_SQLiteHistoryManager.migratedPrefsToDB == YES);
+		NSArray *existingHistory = useSQLiteHistory
+			? _SQLiteHistoryManager.queryHist.allValues
+			: ([prefs objectForKey:SPQueryHistory] ?: @[]);
+		NSArray *merged = [SAQueryHistoryMerger mergedHistoryWithNewEntries:@[history]
+		                                                           existing:existingHistory
+		                                                              limit:maxHistoryItems];
+		if(useSQLiteHistory){
+			[_SQLiteHistoryManager updateQueryHistoryWithNewHist:merged];
 		}
 		else{
-			[uniquifier addItemsWithTitles:[prefs objectForKey:SPQueryHistory]];
-		}
-		[uniquifier insertItemWithTitle:history atIndex:0];
-
-		while ((NSUInteger)[uniquifier numberOfItems] > maxHistoryItems)
-		{
-			[uniquifier removeItemAtIndex:[uniquifier numberOfItems] - 1];
-		}
-
-		if(_SQLiteHistoryManager.migratedPrefsToDB == YES){
-			[_SQLiteHistoryManager updateQueryHistoryWithNewHist:[uniquifier itemTitles]];
-		}
-		else{
-			[prefs setObject:[uniquifier itemTitles] forKey:SPQueryHistory];
+			[prefs setObject:merged forKey:SPQueryHistory];
 		}
 	}
 }

--- a/Source/Model/SATooltipDismissal.swift
+++ b/Source/Model/SATooltipDismissal.swift
@@ -1,0 +1,140 @@
+//
+//  SATooltipDismissal.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.09.09.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+/// Decides when a tooltip closes in response to user activity. Pure logic,
+/// extracted from SPTooltip's former nested event loop so it is testable.
+@objc public final class SATooltipDismissalPolicy: NSObject {
+    /// Mouse movement within this period after opening never closes the
+    /// tooltip (parity with the old loop's grace period).
+    static let ignorePeriod: TimeInterval = 0.05
+    /// The pointer must travel this far from its anchor before the tooltip
+    /// closes.
+    static let moveThreshold: CGFloat = 10
+
+    /// Whether an event of this type closes the tooltip immediately.
+    static func closesImmediately(_ type: NSEvent.EventType) -> Bool {
+        switch type {
+        case .keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Evaluates a mouse-moved event: within the grace period nothing
+    /// happens; the first movement afterwards only anchors the position;
+    /// later movements close once they leave a 10 pt radius around the
+    /// anchor. Returns the close decision and the (possibly newly set)
+    /// anchor.
+    static func evaluateMouseMove(openedAt: Date, now: Date, anchor: NSPoint?, location: NSPoint) -> (close: Bool, anchor: NSPoint?) {
+        guard now.timeIntervalSince(openedAt) >= ignorePeriod else {
+            return (false, anchor)
+        }
+        guard let anchor else {
+            return (false, location)
+        }
+        let dx = anchor.x - location.x
+        let dy = anchor.y - location.y
+        return ((dx * dx + dy * dy).squareRoot() > moveThreshold, anchor)
+    }
+}
+
+/// Watches for the user activity that dismisses a tooltip - the replacement
+/// for SPTooltip's nested `nextEventMatchingMask:` loop, which pumped every
+/// application event itself while a tooltip was visible and thereby delayed
+/// normal event delivery (measured while profiling the content filter).
+/// Local event monitors leave dispatch untouched: the closing event still
+/// reaches its original target.
+@objc public final class SATooltipDismissalMonitor: NSObject {
+    private var eventMonitor: Any?
+    private var observers: [NSObjectProtocol] = []
+    private weak var watchedWindow: NSWindow?
+    private var restoreAcceptsMouseMoved = false
+    private var onClose: (() -> Void)?
+    private let openedAt = Date()
+    private var mouseAnchor: NSPoint?
+
+    /// Starts watching immediately. `keyWindow` (if any) is switched to
+    /// accept mouse-moved events for the tooltip's lifetime and closes the
+    /// tooltip when it resigns key - both mirroring the old loop.
+    @objc public init(keyWindow: NSWindow?, onClose: @escaping () -> Void) {
+        self.onClose = onClose
+        self.watchedWindow = keyWindow
+        super.init()
+
+        if let keyWindow {
+            restoreAcceptsMouseMoved = keyWindow.acceptsMouseMovedEvents
+            keyWindow.acceptsMouseMovedEvents = true
+            observers.append(NotificationCenter.default.addObserver(forName: NSWindow.didResignKeyNotification, object: keyWindow, queue: .main) { [weak self] _ in
+                self?.close()
+            })
+        } else {
+            // No key window at show time: the old loop's "key window changed"
+            // check also closed on the nil -> some-window transition, so a
+            // window becoming key dismisses the tooltip as well.
+            observers.append(NotificationCenter.default.addObserver(forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main) { [weak self] _ in
+                self?.close()
+            })
+        }
+        observers.append(NotificationCenter.default.addObserver(forName: NSApplication.didResignActiveNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.close()
+        })
+        let mask: NSEvent.EventTypeMask = [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel, .mouseMoved]
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.handle(event)
+            return event
+        }
+    }
+
+    /// Routes one monitored event through the dismissal policy.
+    private func handle(_ event: NSEvent) {
+        if SATooltipDismissalPolicy.closesImmediately(event.type) {
+            close()
+            return
+        }
+        if event.type == .mouseMoved {
+            let verdict = SATooltipDismissalPolicy.evaluateMouseMove(openedAt: openedAt, now: Date(), anchor: mouseAnchor, location: NSEvent.mouseLocation)
+            mouseAnchor = verdict.anchor
+            if verdict.close {
+                close()
+            }
+        }
+    }
+
+    /// Tears down and fires the close handler exactly once.
+    private func close() {
+        guard let handler = onClose else { return }
+        stop()
+        handler()
+    }
+
+    /// Detaches all monitoring without firing the close handler - used when a
+    /// new tooltip replaces the current one in the shared window.
+    @objc public func stop() {
+        onClose = nil
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
+        eventMonitor = nil
+        observers.forEach(NotificationCenter.default.removeObserver(_:))
+        observers.removeAll()
+        if let watchedWindow {
+            watchedWindow.acceptsMouseMovedEvents = restoreAcceptsMouseMoved
+        }
+        watchedWindow = nil
+    }
+
+    deinit {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
+        observers.forEach(NotificationCenter.default.removeObserver(_:))
+    }
+}

--- a/Source/Model/SPTooltip.h
+++ b/Source/Model/SPTooltip.h
@@ -37,13 +37,7 @@
 	NSTimer*		animationTimer;
 	NSDate*			animationStart;
 
-	// ignore mouse moves for the next second
-	NSDate*			didOpenAtDate;
-	
-	NSPoint			mousePositionWhenOpened;
-	
 	NSString* 		SPTooltipPreferencesIdentifier;
-	
 }
 
 @property (nonatomic, class, readonly, strong) SPTooltip *sharedInstance;

--- a/Source/Model/SPTooltip.m
+++ b/Source/Model/SPTooltip.m
@@ -74,7 +74,8 @@ static CGFloat slow_in_out (CGFloat t)
 @interface SPTooltip ()
 
 - (void)setContent:(NSString *)content withOptions:(NSDictionary *)displayOptions;
-- (void)runUntilUserActivity;
+- (void)beginDismissalMonitoring;
+- (void)detachDismissalMonitor;
 - (void)stopAnimation:(id)sender;
 - (void)sizeToContent;
 + (NSPoint)caretPosition;
@@ -83,6 +84,10 @@ static CGFloat slow_in_out (CGFloat t)
 
 @property (nonatomic, assign) BOOL gotHeight;
 @property (nonatomic, assign) BOOL gotWidth;
+
+/// Watches for the user activity that dismisses the visible tooltip;
+/// replaces the former nested event loop (see SATooltipDismissalMonitor).
+@property (nonatomic, strong) SATooltipDismissalMonitor *dismissalMonitor;
 
 @end
 
@@ -150,8 +155,31 @@ static CGFloat slow_in_out (CGFloat t)
 - (void)showWithObject:(id)content atLocation:(NSPoint)point ofType:(NSString *)type displayOptions:(NSDictionary *)displayOptions
 {
 
+	// A new tooltip reuses the shared window - tear down whatever remains of
+	// the previous one. Three states are possible here: it is visible and
+	// watched (detach the monitor without closing, the fresh content takes
+	// over), it is fading out (finish that close instantly: the event that
+	// closed it is forwarded to the app - the removed nested loop did the
+	// same via sendEvent: - and may request this new tooltip right away, e.g.
+	// a bundle bound to a key equivalent; a later animationTick would other-
+	// wise see the incremented counter, hide the window and nil out the fresh
+	// contentView, leaving an invisible tooltip whose monitor swallows the
+	// next trigger's close), or its WebView is still loading and the monitor
+	// was never armed. None of these ever reach the decrement in
+	// animationTick, so reset the counter outright instead of trying to
+	// balance the individual cases (the removed nested loop achieved this by
+	// breaking on spTooltipCounter > 1 and ordering the old tooltip out).
+	if (self.dismissalMonitor) {
+		[self detachDismissalMonitor];
+	}
+	else if (animationTimer) {
+		[super orderOut:self];
+		[self stopAnimation:self];
+	}
+	spTooltipCounter = 0;
+
 	spTooltipCounter++;
-	
+
 	self.gotWidth = NO;
 	self.gotHeight = NO;
 	
@@ -248,7 +276,7 @@ static CGFloat slow_in_out (CGFloat t)
 		[self setFrameTopLeftPoint:point];
 		[self sizeToContent];
 		[self orderFront:self];
-		[self performSelector:@selector(runUntilUserActivity) withObject:nil afterDelay:0];
+		[self beginDismissalMonitoring];
 	}
 	else {
 		[self setContent:(NSString*)content withOptions:displayOptions];
@@ -283,18 +311,36 @@ static CGFloat slow_in_out (CGFloat t)
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(null_unspecified WKNavigation *)navigation {
+	// A late callback from a WebView that a newer show already replaced must
+	// not touch the shared window (guards all three delegate methods).
+	if (webView != wkWebView) return;
 	SPLog(@"didFinishNavigation FINISHING LOAD");
-	
+
 	[self sizeToContent];
 	[self orderFront:self];
-	[self performSelector:@selector(runUntilUserActivity) withObject:nil afterDelay:0];
-	
+	[self beginDismissalMonitoring];
+
 }
+/**
+ * A failed load leaves nothing to show - close the shared window. Without
+ * this, a tooltip that replaced a visible one would keep an empty
+ * status-level window on screen with no dismissal monitor attached
+ * (didFinishNavigation, which arms the monitor, never fires on failure).
+ */
 - (void)webView:(WKWebView *)webView didFailNavigation:(null_unspecified WKNavigation *)navigation withError:(NSError *)error {
+	if (webView != wkWebView) return;
 	SPLog(@"didFailNavigation. error is: %@", error);
+	// A navigation superseded by one the page itself started (possible in
+	// HTML tooltips with JavaScript enabled) reports NSURLErrorCancelled -
+	// the replacement is still loading, so there is nothing to close.
+	if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) return;
+	[self orderOut:self];
 }
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(null_unspecified WKNavigation *)navigation withError:(NSError *)error {
+	if (webView != wkWebView) return;
 	SPLog(@"didFailProvisionalNavigation. error is: %@", error);
+	if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) return;
+	[self orderOut:self];
 }
 
 - (void)dealloc
@@ -452,61 +498,36 @@ static CGFloat slow_in_out (CGFloat t)
 // ==================
 // = Event handling =
 // ==================
-- (BOOL)shouldCloseForMousePosition:(NSPoint)aPoint
+
+/**
+ * Starts the Swift dismissal monitor: it closes the tooltip on key presses,
+ * clicks, scrolling, mouse movement past a small threshold, when the key
+ * window resigns or the app deactivates - the same triggers the removed
+ * nested `nextEventMatchingMask:` loop reacted to, but without pumping the
+ * application's events itself (which delayed normal event delivery for as
+ * long as a tooltip was visible).
+ */
+- (void)beginDismissalMonitoring
 {
-	CGFloat ignorePeriod = 0.05f;
-	if(-[didOpenAtDate timeIntervalSinceNow] < ignorePeriod)
-		return NO;
-
-	if(NSEqualPoints(mousePositionWhenOpened, NSZeroPoint))
-	{
-		mousePositionWhenOpened = aPoint;
-		return NO;
-	}
-
-	NSPoint p = mousePositionWhenOpened;
-	CGFloat deltaX = p.x - aPoint.x;
-	CGFloat deltaY = p.y - aPoint.y;
-	CGFloat dist = sqrt(deltaX * deltaX + deltaY * deltaY);
-
-	CGFloat moveThreshold = 10;
-	return dist > moveThreshold;
+	[self detachDismissalMonitor];
+	__weak SPTooltip *weakSelf = self;
+	self.dismissalMonitor = [[SATooltipDismissalMonitor alloc] initWithKeyWindow:[NSApp keyWindow] onClose:^{
+		SPTooltip *tooltip = weakSelf;
+		if (!tooltip) return;
+		[tooltip detachDismissalMonitor];
+		[tooltip orderOut:tooltip];
+	}];
 }
 
-- (void)runUntilUserActivity
+/**
+ * Stops the dismissal monitor (idempotent) and lets go of it - the single
+ * teardown spot shared by replacement, close and the monitor's own close
+ * callback.
+ */
+- (void)detachDismissalMonitor
 {
-	[self setValue:[NSDate date] forKey:@"didOpenAtDate"];
-	mousePositionWhenOpened = NSZeroPoint;
-
-	NSWindow* appKeyWindow = [NSApp keyWindow];
-	BOOL didAcceptMouseMovedEvents = [appKeyWindow acceptsMouseMovedEvents];
-	[appKeyWindow setAcceptsMouseMovedEvents:YES];
-	NSEvent* event = nil;
-	NSInteger eventType;
-	while((event = [NSApp nextEventMatchingMask:NSEventMaskAny untilDate:[NSDate distantFuture] inMode:NSDefaultRunLoopMode dequeue:YES]))
-	{
-		eventType = [event type];
-		if(eventType == NSEventTypeKeyDown || eventType == NSEventTypeLeftMouseDown || eventType == NSEventTypeRightMouseDown || eventType == NSEventTypeOtherMouseDown || eventType == NSEventTypeScrollWheel)
-			break;
-
-		if(eventType == NSEventTypeMouseMoved && [self shouldCloseForMousePosition:[NSEvent mouseLocation]])
-			break;
-
-		if(appKeyWindow != [NSApp keyWindow] || ![NSApp isActive])
-			break;
-		
-		if(spTooltipCounter > 1)
-			break;
-		[NSApp sendEvent:event];
-
-	}
-
-	[appKeyWindow setAcceptsMouseMovedEvents:didAcceptMouseMovedEvents];
-
-	[self orderOut:self];
-
-	// If we still have an event, pass it on to the app to ensure all actions are performed
-	if (event) [NSApp sendEvent:event];
+	[self.dismissalMonitor stop];
+	self.dismissalMonitor = nil;
 }
 
 // =============
@@ -514,6 +535,9 @@ static CGFloat slow_in_out (CGFloat t)
 // =============
 - (void)orderOut:(id)sender
 {
+	// stop watching for dismissal activity, no matter who closes us
+	[self detachDismissalMonitor];
+
 	// must set this to nil here
 	// otherwise subsequent tootips do not display
 	self.contentView = nil;

--- a/Source/Other/Utility/SAAppearancePreference.swift
+++ b/Source/Other/Utility/SAAppearancePreference.swift
@@ -1,0 +1,56 @@
+//
+//  SAAppearancePreference.swift
+//  Sequel Ace
+//
+//  Created by Sequel-Ace contributors on 2026.09.09.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+
+/// Applies the "Appearance" preference (system / light / dark) to the app,
+/// skipping redundant work: `NSUserDefaultsDidChangeNotification` fires for
+/// every defaults write anywhere in the app, and re-applying an unchanged
+/// appearance on each of them added up to seconds of main-thread work in
+/// profiling. The applied selection is cached, so only real changes reach
+/// `NSApp`.
+@objc public final class SAAppearancePreference: NSObject {
+    /// Keep in sync with `SPAppearance` in SPConstants.m - inlined as a
+    /// literal because this file is also compiled into the Unit Tests
+    /// target, which has no bridging header for project ObjC globals
+    /// (the established workaround, see AGENTS.md).
+    private static let preferenceKey = "Appearance"
+    /// Sentinel distinct from every valid selection so the first call applies.
+    private static var lastAppliedSelection = Int.min
+
+    /// The appearance for a preference selection: 1 = Aqua, 2 = Dark Aqua,
+    /// anything else follows the system (`nil`).
+    static func appearanceName(for selection: Int) -> NSAppearance.Name? {
+        switch selection {
+        case 1: return .aqua
+        case 2: return .darkAqua
+        default: return nil
+        }
+    }
+
+    /// Whether `selection` differs from the last applied one; records it as
+    /// applied when it does.
+    static func shouldApply(_ selection: Int) -> Bool {
+        guard selection != lastAppliedSelection else { return false }
+        lastAppliedSelection = selection
+        return true
+    }
+
+    /// Test hook: forget the cached selection.
+    static func resetForTesting() {
+        lastAppliedSelection = .min
+    }
+
+    /// Reads the preference and pushes it to `NSApp` when it changed.
+    /// Main thread only.
+    @objc public static func applyIfChanged() {
+        let selection = UserDefaults.standard.integer(forKey: preferenceKey)
+        guard shouldApply(selection) else { return }
+        NSApp.appearance = appearanceName(for: selection).flatMap { NSAppearance(named: $0) }
+    }
+}

--- a/UnitTests/SAProfilingFollowupTests.swift
+++ b/UnitTests/SAProfilingFollowupTests.swift
@@ -1,0 +1,133 @@
+//
+//  SAProfilingFollowupTests.swift
+//  Unit Tests
+//
+//  Created by Sequel-Ace contributors on 2026.09.09.
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import AppKit
+import XCTest
+
+final class SAAppearancePreferenceTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        SAAppearancePreference.resetForTesting()
+    }
+
+    override func tearDown() {
+        SAAppearancePreference.resetForTesting()
+        super.tearDown()
+    }
+
+    /// Verifies the preference selections map to the documented appearances.
+    func testSelectionMapsToAppearanceName() {
+        XCTAssertEqual(SAAppearancePreference.appearanceName(for: 1), .aqua)
+        XCTAssertEqual(SAAppearancePreference.appearanceName(for: 2), .darkAqua)
+        XCTAssertNil(SAAppearancePreference.appearanceName(for: 0), "0 follows the system")
+        XCTAssertNil(SAAppearancePreference.appearanceName(for: 3))
+        XCTAssertNil(SAAppearancePreference.appearanceName(for: -1))
+    }
+
+    /// Verifies repeated identical selections are skipped and changes always apply.
+    func testRedundantSelectionsAreSkipped() {
+        XCTAssertTrue(SAAppearancePreference.shouldApply(2), "first application always runs")
+        XCTAssertFalse(SAAppearancePreference.shouldApply(2), "unchanged selection is skipped")
+        XCTAssertTrue(SAAppearancePreference.shouldApply(1))
+        XCTAssertFalse(SAAppearancePreference.shouldApply(1))
+        XCTAssertTrue(SAAppearancePreference.shouldApply(2), "flipping back applies again")
+    }
+}
+
+final class SATooltipDismissalPolicyTests: XCTestCase {
+
+    /// Verifies the event types that close a tooltip outright.
+    func testImmediateCloseEvents() {
+        XCTAssertTrue(SATooltipDismissalPolicy.closesImmediately(.keyDown))
+        XCTAssertTrue(SATooltipDismissalPolicy.closesImmediately(.leftMouseDown))
+        XCTAssertTrue(SATooltipDismissalPolicy.closesImmediately(.rightMouseDown))
+        XCTAssertTrue(SATooltipDismissalPolicy.closesImmediately(.otherMouseDown))
+        XCTAssertTrue(SATooltipDismissalPolicy.closesImmediately(.scrollWheel))
+        XCTAssertFalse(SATooltipDismissalPolicy.closesImmediately(.mouseMoved))
+        XCTAssertFalse(SATooltipDismissalPolicy.closesImmediately(.leftMouseUp))
+        XCTAssertFalse(SATooltipDismissalPolicy.closesImmediately(.keyUp))
+    }
+
+    /// Verifies movement within the grace period neither closes nor anchors.
+    func testMouseMoveIgnoredWithinGracePeriod() {
+        let opened = Date()
+        let verdict = SATooltipDismissalPolicy.evaluateMouseMove(openedAt: opened, now: opened.addingTimeInterval(0.01), anchor: nil, location: NSPoint(x: 100, y: 100))
+        XCTAssertFalse(verdict.close)
+        XCTAssertNil(verdict.anchor)
+    }
+
+    /// Verifies the first movement after the grace period only anchors.
+    func testFirstMoveAnchorsWithoutClosing() {
+        let opened = Date()
+        let verdict = SATooltipDismissalPolicy.evaluateMouseMove(openedAt: opened, now: opened.addingTimeInterval(0.1), anchor: nil, location: NSPoint(x: 100, y: 100))
+        XCTAssertFalse(verdict.close)
+        XCTAssertEqual(verdict.anchor, NSPoint(x: 100, y: 100))
+    }
+
+    /// Verifies only movement beyond the 10 pt radius around the anchor closes.
+    func testMoveBeyondThresholdCloses() {
+        let opened = Date()
+        let now = opened.addingTimeInterval(0.1)
+        let anchor = NSPoint(x: 100, y: 100)
+        XCTAssertFalse(SATooltipDismissalPolicy.evaluateMouseMove(openedAt: opened, now: now, anchor: anchor, location: NSPoint(x: 107, y: 107)).close, "~9.9 pt stays open")
+        XCTAssertTrue(SATooltipDismissalPolicy.evaluateMouseMove(openedAt: opened, now: now, anchor: anchor, location: NSPoint(x: 111, y: 100)).close)
+        let kept = SATooltipDismissalPolicy.evaluateMouseMove(openedAt: opened, now: now, anchor: anchor, location: NSPoint(x: 111, y: 100))
+        XCTAssertEqual(kept.anchor, anchor, "the anchor never moves once set")
+    }
+}
+
+final class SAQueryHistoryMergerTests: XCTestCase {
+
+    /// Verifies a new entry lands at the front of the stored history.
+    func testNewEntryGoesToFront() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["c"], existing: ["a", "b"], limit: 10), ["c", "a", "b"])
+    }
+
+    /// Verifies an older duplicate of a new entry is removed from its old position.
+    func testDuplicateOfNewEntryMovesToFront() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["b"], existing: ["a", "b", "c"], limit: 10), ["b", "a", "c"])
+    }
+
+    /// Verifies several new entries end up in reverse order - parity with the
+    /// old insertItemWithTitle:atIndex:0 loop the popup performed.
+    func testSeveralNewEntriesEndUpReversed() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["x", "y"], existing: ["a"], limit: 10), ["y", "x", "a"])
+    }
+
+    /// Verifies duplicates inside the existing list keep the later occurrence,
+    /// as NSPopUpButton's addItemsWithTitles: did.
+    func testExistingDuplicatesKeepTheLaterOccurrence() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: [], existing: ["a", "b", "a"], limit: 10), ["b", "a"])
+    }
+
+    /// Verifies trimming drops the oldest (rearmost) entries.
+    func testLimitTrimsFromTheEnd() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["d"], existing: ["a", "b", "c"], limit: 3), ["d", "a", "b"])
+    }
+
+    /// Verifies the historic edge cases: limit 0 empties, a negative limit never trims.
+    func testZeroAndNegativeLimits() {
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["a"], existing: ["b"], limit: 0), [])
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["a"], existing: ["b", "c"], limit: -1), ["a", "b", "c"])
+    }
+
+    /// Verifies non-string elements - possible in hand-edited preference or
+    /// .spf session plists - are dropped instead of trapping in the bridge.
+    func testNonStringElementsAreDropped() {
+        let existing: [Any] = ["a", NSNumber(value: 42), NSNull(), "b"]
+        XCTAssertEqual(SAQueryHistoryMerger.merged(newEntries: ["c"], existing: existing, limit: 10), ["c", "a", "b"])
+    }
+
+    /// Verifies repeated empty strings survive, as NSPopUpButton keeps
+    /// duplicate empty titles while de-duplicating every other title.
+    func testEmptyStringsAreNotDeduplicated() {
+        let merged = SAQueryHistoryMerger.merged(newEntries: ["SELECT 2;"], existing: ["", "SELECT 1;", ""], limit: 3)
+        XCTAssertEqual(merged, ["SELECT 2;", "", "SELECT 1;"])
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D10000002F8C000600C4C14A /* SAAppearancePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000022F8C000600C4C14A /* SAAppearancePreference.swift */; };
+		D10000012F8C000600C4C14A /* SAAppearancePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000022F8C000600C4C14A /* SAAppearancePreference.swift */; };
+		D10000032F8C000600C4C14A /* SATooltipDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000052F8C000600C4C14A /* SATooltipDismissal.swift */; };
+		D10000042F8C000600C4C14A /* SATooltipDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000052F8C000600C4C14A /* SATooltipDismissal.swift */; };
+		D10000062F8C000600C4C14A /* SAQueryHistoryMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000082F8C000600C4C14A /* SAQueryHistoryMerger.swift */; };
+		D10000072F8C000600C4C14A /* SAQueryHistoryMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000082F8C000600C4C14A /* SAQueryHistoryMerger.swift */; };
+		D10000092F8C000600C4C14A /* SAProfilingFollowupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000102F8C000600C4C14A /* SAProfilingFollowupTests.swift */; };
 		03B3C091388E27E56C58B846 /* SAMCPToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE1A7F618E708C87E8FAC85 /* SAMCPToolDefinitions.swift */; };
 		063E86F1008F2FB5B4B8C400 /* SASSHTunnelPeerValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3BA23047656C00BCE2B9 /* SASSHTunnelPeerValidator.swift */; };
 		07B880FE95D9F64B77BAF768 /* SASSHTunnelAuthMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B79304760D900BCE2B9 /* SASSHTunnelAuthMessage.swift */; };
@@ -850,6 +857,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D10000022F8C000600C4C14A /* SAAppearancePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAAppearancePreference.swift; sourceTree = "<group>"; };
+		D10000052F8C000600C4C14A /* SATooltipDismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATooltipDismissal.swift; sourceTree = "<group>"; };
+		D10000082F8C000600C4C14A /* SAQueryHistoryMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAQueryHistoryMerger.swift; sourceTree = "<group>"; };
+		D10000102F8C000600C4C14A /* SAProfilingFollowupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAProfilingFollowupTests.swift; sourceTree = "<group>"; };
 		0002BD43DA307433795D7EBA /* SATypeAheadSelectionLoadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SATypeAheadSelectionLoadTests.swift; sourceTree = "<group>"; };
 		01F157CAED03AA780923D362 /* SAKeychainStoreCharacterizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAKeychainStoreCharacterizationTests.swift; sourceTree = "<group>"; };
 		0830448F21CA14E21CB9D255 /* SACompletionWindowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SACompletionWindowLayout.swift; sourceTree = "<group>"; };
@@ -1947,6 +1958,7 @@
 				50A9F8B019EAD4B90053E571 /* SPGotoDatabaseController.m */,
 				506CE92F1A311C6C0039F736 /* SPRuleFilterController.h */,
 				506CE9301A311C6C0039F736 /* SPRuleFilterController.m */,
+				D10000082F8C000600C4C14A /* SAQueryHistoryMerger.swift */,
 				CF0000322F8C000600C4C14A /* SARuleFilterRootConjunction.swift */,
 				9BE76A3D5C9830E2F7738770 /* SPFilterTableController.m */,
 				9BE76F9BF9BDA2921CDD05AF /* SPFilterTableController.h */,
@@ -2365,6 +2377,7 @@
 				17D3C670128AD8160047709F /* SPSingleton.m */,
 				BCA6271A1031B9D40047E5D5 /* SPTooltip.h */,
 				BCA6271B1031B9D40047E5D5 /* SPTooltip.m */,
+				D10000052F8C000600C4C14A /* SATooltipDismissal.swift */,
 				1798F192155017FB004B0AB8 /* Tree Nodes */,
 				5AF0C3020000000000000002 /* SAPHPSerializedValue.swift */,
 				51B09FD62F767A3E003BAFFF /* SAConnectionInfo.swift */,
@@ -2805,6 +2818,7 @@
 				5AB3422CB850D1768BBDEFC9 /* SADragPasteboard.swift */,
 				2617B1FEDA3776DCA242666C /* SAMarkedTextInputState.swift */,
 				1AA5B97BE9E063395AB12888 /* SAAnalyticsConsentPolicy.swift */,
+				D10000022F8C000600C4C14A /* SAAppearancePreference.swift */,
 				F001AB41C248FB0C94ECB906 /* SAAnalyticsConsentPolicy+Firebase.swift */,
 				3EDCC01965F2A0E35B9547D8 /* SATypeAheadSelectionLoad.swift */,
 			);
@@ -2840,6 +2854,7 @@
 				CF0000162F8C000600C4C14A /* SACellFilterOperatorRoundTripControllerTests.m */,
 				CF0000222F8C000600C4C14A /* SACellFilterRuleControllerStubs.m */,
 				CF00000A2F8C000600C4C14A /* SACellFilterMergeTests.swift */,
+				D10000102F8C000600C4C14A /* SAProfilingFollowupTests.swift */,
 				CF0000342F8C000600C4C14A /* SARuleFilterRootConjunctionTests.swift */,
 				CF0000142F8C000600C4C14A /* SACellFilterMenuBuilderTests.swift */,
 				AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */,
@@ -3633,6 +3648,10 @@
 				C3A2875D9BB7411F87F05EA3 /* SPCustomQuerySQLClassifierTests.swift in Sources */,
 				CF0000052F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				CF00000D2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
+				D10000012F8C000600C4C14A /* SAAppearancePreference.swift in Sources */,
+				D10000042F8C000600C4C14A /* SATooltipDismissal.swift in Sources */,
+				D10000072F8C000600C4C14A /* SAQueryHistoryMerger.swift in Sources */,
+				D10000092F8C000600C4C14A /* SAProfilingFollowupTests.swift in Sources */,
 				CF0000312F8C000600C4C14A /* SARuleFilterRootConjunction.swift in Sources */,
 				CF0000122F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,
 				CF0000252F8C000600C4C14A /* SACellFilterColumnIdentifier.swift in Sources */,
@@ -3760,6 +3779,9 @@
 				CF0000032F8C000600C4C14A /* SACellFilterOperator.swift in Sources */,
 				51BE68DC3017550E00AF389C /* SAImageRenderer.swift in Sources */,
 				CF00000B2F8C000600C4C14A /* SACellFilterMerge.swift in Sources */,
+				D10000002F8C000600C4C14A /* SAAppearancePreference.swift in Sources */,
+				D10000032F8C000600C4C14A /* SATooltipDismissal.swift in Sources */,
+				D10000062F8C000600C4C14A /* SAQueryHistoryMerger.swift in Sources */,
 				CF0000302F8C000600C4C14A /* SARuleFilterRootConjunction.swift in Sources */,
 				CF00000E2F8C000600C4C14A /* SACellFilterAction.swift in Sources */,
 				CF0000102F8C000600C4C14A /* SACellFilterMenuBuilder.swift in Sources */,


### PR DESCRIPTION
## Changes:
All three fixes address main-thread hot spots found while profiling the content-filter work for #2600 (`sample` at 1 ms over 90 s of normal use):

- **Appearance is only re-applied when it changed.** `NSUserDefaultsDidChangeNotification` fires for every defaults write anywhere in the app, and `-[SPAppController switchAppearance]` re-read the preference and re-assigned `NSApp.appearance` on each of them — 2.4 s of accumulated main-thread work in the profile. The new `SAAppearancePreference` (Swift, unit-tested) caches the applied selection and only pushes real changes; the dead `@available(macOS 10.14)` check is gone (deployment target is 13.5). The analytics-consent half of the same observer already had exactly this guard.
- **SPTooltip no longer runs a nested event loop.** While a tooltip was visible, `-runUntilUserActivity` pumped *every* application event through its own `nextEventMatchingMask:` loop on the main thread (2 s in the profile), delaying normal event delivery. It is replaced by `SATooltipDismissalMonitor` (Swift): a local event monitor plus window/app notifications close the tooltip on the same triggers as before — key press, click, scroll, mouse movement past 10 pt after a 0.05 s grace period, key-window change, app deactivation — while events keep flowing through normal dispatch untouched. The decision logic lives in a pure, unit-tested `SATooltipDismissalPolicy`; the WebView size-wait helpers (`runInBackground:`/`wakeUpMainThreadRunloop:`) are unrelated to this loop and remain. While testing this, a latent race in the shared-window reuse surfaced (it exists on `main` too, since the nested loop also forwarded the closing event via `sendEvent:`): when the event that closes a tooltip immediately triggers a new one — e.g. a bundle bound to a key equivalent — the still-running fade-out's `animationTick` saw the incremented counter, hid the window and nilled the fresh `contentView`, leaving an invisible tooltip that swallowed the next trigger. `showWithObject:` now finishes an in-flight fade-out instantly (hide, stop timer, balance the counter) before the new content takes over.
- **Query-history saves no longer allocate an `NSPopUpButton` as a de-duplicator.** `-[SPQueryController addHistory:forFileURL:]` built a hidden popup (and logged its `debugDescription`) on every saved query just to de-duplicate titles. `SAQueryHistoryMerger` (Swift, unit-tested) replicates the popup semantics exactly — later duplicate wins within the existing list, new entries are front-inserted one by one (so multiple new entries end up reversed, as `insertItemWithTitle:atIndex:0` produced), trimming keeps the historic edge cases (limit 0 empties, negative never trims).

Deliberately not touched: the one-off `[historyControl sizeToFit]` in the toolbar factory (once per window, guarded by a versioned-sizing comment; no measurable repeat cost), the WebView size-wait loop in SPTooltip (separate mechanism, out of scope here), and the `NSUserDefaultsDidChangeNotification` subscription itself - replacing it with KVO on the specific keys would remove the per-write callback entirely and could unify the three change-guards (appearance, analytics consent, MCP state), but that is a broader refactor than this hot-spot fix.

## Closes following issues:
- Closes: —

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

## Screenshots:
_(timing/behaviour changes, nothing visual to show)_

## Additional notes:
- New Swift files are members of both the "Sequel Ace" and "Unit Tests" targets and free of project ObjC types; `project.pbxproj` was edited by hand following the established id pattern and verified with `plutil -lint` plus a build and test run executing the new tests.
- Unit tests cover the appearance mapping/skip logic, the tooltip dismissal policy (immediate-close events, grace period, anchor/threshold behaviour) and the history-merge parity cases. Full "Unit Tests" scheme on the final state: 1471 tests, 64 environment-skipped, 0 failures.
- Manually verified with a Debug build against real databases: appearance no longer re-applies on unrelated defaults writes ("faster than before" per tester), query-history de-duplication behaves as before, and tooltips (via a text-tooltip bundle bound to a key equivalent) close on click/key/scroll/mouse movement while the app stays responsive - including rapid re-triggering, which is what surfaced the latent replace race described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved query history with newest-first ordering, duplicate removal, and entry limits.
  * Added more responsive tooltip dismissal based on user activity and mouse movement.
  * Added consistent appearance preference handling for system, light, and dark modes.

* **Bug Fixes**
  * Prevented stale tooltip content and incorrect history trimming.

* **Tests**
  * Added coverage for appearance changes, tooltip dismissal, and query-history behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->