### PR TITLE
SPMySQLFramework: one byte-to-string conversion, truncated column names trimmed again, kill query without trailing NUL

### DIFF
--- a/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SAByteStringDecoderTests.swift
+++ b/Frameworks/SPMySQLFramework/SPMySQL Unit Tests/SAByteStringDecoderTests.swift
@@ -1,0 +1,90 @@
+//
+//  SAByteStringDecoderTests.swift
+//  SPMySQLFramework
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import Foundation
+import XCTest
+@testable import SPMySQL
+
+final class SAByteStringDecoderTests: XCTestCase {
+    private let utf8 = String.Encoding.utf8.rawValue
+
+    /// エスキューエル in UTF-8: seven characters of three bytes each.
+    private let katakana: [UInt8] = [
+        0xE3, 0x82, 0xA8, 0xE3, 0x82, 0xB9, 0xE3, 0x82, 0xAD, 0xE3, 0x83, 0xA5,
+        0xE3, 0x83, 0xBC, 0xE3, 0x82, 0xA8, 0xE3, 0x83, 0xAB,
+    ]
+
+    private func data(_ bytes: [UInt8], dropLast: Int = 0) -> String {
+        bytes.withUnsafeBytes { SAByteStringDecoder.string(forDataBytes: $0.baseAddress, length: bytes.count - dropLast, encoding: utf8) }
+    }
+
+    private func identifier(_ bytes: [UInt8], dropLast: Int = 0) -> String {
+        bytes.withUnsafeBytes { SAByteStringDecoder.string(forIdentifierBytes: $0.baseAddress, length: bytes.count - dropLast, encoding: utf8) }
+    }
+
+    // MARK: Data
+
+    func testDataDecodesValidBytesUntouched() {
+        XCTAssertEqual(data(katakana), "エスキューエル")
+        XCTAssertEqual(data([]), "")
+        XCTAssertEqual(SAByteStringDecoder.string(forDataBytes: nil, length: 0, encoding: utf8), "")
+    }
+
+    func testDataPreservesEmbeddedNul() {
+        XCTAssertEqual(data([0x61, 0x00, 0x62]), "a\u{0}b")
+    }
+
+    func testDataKeepsEveryByteVisibleWhenInvalid() {
+        // Cut one byte into the last character: the data decode must not trim.
+        let converted = data(katakana, dropLast: 2)
+        XCTAssertEqual(converted.utf16.count, katakana.count - 2, "fallback maps each byte to one code point")
+        XCTAssertEqual(Array(converted.unicodeScalars.prefix(3)).map(\.value), [0xE3, 0x82, 0xA8], "fallback keeps the byte values as Latin 1 code points")
+        XCTAssertFalse(converted.hasSuffix("…"))
+    }
+
+    func testDataDecodesBytesInvalidInEveryUnicodeEncoding() {
+        XCTAssertEqual(data([0xFF, 0xFE]), "\u{FF}\u{FE}")
+    }
+
+    // MARK: Identifiers
+
+    func testIdentifierEmptyInputs() {
+        XCTAssertEqual(SAByteStringDecoder.string(forIdentifierBytes: nil, length: 0, encoding: utf8), "")
+        XCTAssertEqual(identifier(katakana, dropLast: katakana.count), "")
+    }
+
+    func testIdentifierDecodesValidNameUntouched() {
+        XCTAssertEqual(identifier(katakana), "エスキューエル")
+    }
+
+    func testIdentifierCutOneByteIntoCharacterIsTrimmedAndMarked() {
+        XCTAssertEqual(identifier(katakana, dropLast: 2), "エスキューエ…")
+    }
+
+    func testIdentifierCutTwoBytesIntoCharacterIsTrimmedAndMarked() {
+        XCTAssertEqual(identifier(katakana, dropLast: 1), "エスキューエ…")
+    }
+
+    func testIdentifierWithUnrepairableBytesFallsBackToDataDecode() {
+        // Invalid bytes in the middle cannot be repaired by trimming the tail; every byte must stay visible.
+        let broken: [UInt8] = [0x61, 0x62, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x63, 0x64]
+        let converted = identifier(broken)
+        XCTAssertEqual(converted.utf16.count, broken.count)
+        XCTAssertTrue(converted.hasPrefix("ab") && converted.hasSuffix("cd"))
+        XCTAssertFalse(converted.hasSuffix("…"))
+    }
+
+    func testIdentifierOnlyPartialBytesIsNotTrimmedToNothing() {
+        // A name consisting solely of a partial character has nothing left to show once trimmed,
+        // so it falls back to the byte-preserving decode rather than returning a bare ellipsis.
+        let converted = identifier([0xE3, 0x82])
+        XCTAssertEqual(converted.utf16.count, 2)
+        XCTAssertFalse(converted.hasSuffix("…"))
+    }
+}

--- a/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
+++ b/Frameworks/SPMySQLFramework/SPMySQLFramework.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1A96314E25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A96314C25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.m */; };
 		1A96314F25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A96314D25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4042B04787F88BF732CD28B9 /* SAProxyReconnectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */; };
+		444079C96AC4FD43045605F3 /* SAByteStringDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24479924A60A2B0D69DBBCD /* SAByteStringDecoder.swift */; };
 		507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF1811BC0C64100104523 /* DataConversion_Tests.m */; };
 		507FF23B1BC0E8CA00104523 /* SPMySQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* SPMySQL.framework */; };
 		507FF23D1BC157B500104523 /* SPMySQLStringAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */; };
@@ -93,6 +94,7 @@
 		9615D85C2D5EDF530095F55A /* mysqld_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 9615D8472D5EDF530095F55A /* mysqld_error.h */; };
 		96A5DDB32D63C8AE0079105E /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 96A5DDB22D63C89A0079105E /* libc++.tbd */; };
 		A296B829FB2005B17DB7EA5E /* SADatabaseAssertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D13511F12C772CB1BD60E6 /* SADatabaseAssertionTests.swift */; };
+		AB48E5C81EBB3D12966CCEC1 /* SAByteStringDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B177FE6ABE7EBC554A5905A4 /* SAByteStringDecoderTests.swift */; };
 		D88652282912E88D23A56A1C /* SADatabaseAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386B159A6D535F0686530898 /* SADatabaseAssertion.swift */; };
 		FD4211952918779400941BFE /* SPMySQLGeometryDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */; };
 /* End PBXBuildFile section */
@@ -124,6 +126,7 @@
 
 /* Begin PBXFileReference section */
 		008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SAProxyReconnectCoordinator.swift; path = Source/SAProxyReconnectCoordinator.swift; sourceTree = "<group>"; };
+		A24479924A60A2B0D69DBBCD /* SAByteStringDecoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SAByteStringDecoder.swift; path = Source/SAByteStringDecoder.swift; sourceTree = "<group>"; };
 		0867D69BFE84028FC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		0EA5700AA759774A87FC447F /* SPMySQL.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = SPMySQL.modulemap; path = Source/SPMySQL.modulemap; sourceTree = "<group>"; };
@@ -138,6 +141,7 @@
 		1A96314D25B9CE9900BF2E91 /* SPMySQLMutableDictionaryAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPMySQLMutableDictionaryAdditions.h; path = Source/SPMySQLMutableDictionaryAdditions.h; sourceTree = "<group>"; };
 		1B61BFAD76569C2412169CE7 /* MySQLClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = MySQLClient.modulemap; path = Source/MySQLClient/module.modulemap; sourceTree = "<group>"; };
 		20D13511F12C772CB1BD60E6 /* SADatabaseAssertionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SADatabaseAssertionTests.swift; sourceTree = "<group>"; };
+		B177FE6ABE7EBC554A5905A4 /* SAByteStringDecoderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAByteStringDecoderTests.swift; sourceTree = "<group>"; };
 		32DBCF5E0370ADEE00C91783 /* SPMySQLFramework_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPMySQLFramework_Prefix.pch; path = Source/SPMySQLFramework_Prefix.pch; sourceTree = "<group>"; };
 		386B159A6D535F0686530898 /* SADatabaseAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SADatabaseAssertion.swift; path = Source/SADatabaseAssertion.swift; sourceTree = "<group>"; };
 		507FF1811BC0C64100104523 /* DataConversion_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DataConversion_Tests.m; sourceTree = "<group>"; };
@@ -335,6 +339,7 @@
 				0EA5700AA759774A87FC447F /* SPMySQL.modulemap */,
 				1B61BFAD76569C2412169CE7 /* MySQLClient.modulemap */,
 				008C80E8220F48778123E2B7 /* SAProxyReconnectCoordinator.swift */,
+				A24479924A60A2B0D69DBBCD /* SAByteStringDecoder.swift */,
 			);
 			name = "Other Sources";
 			sourceTree = "<group>";
@@ -347,6 +352,7 @@
 				507FF23C1BC157B500104523 /* SPMySQLStringAdditions_Tests.m */,
 				FD4211942918779400941BFE /* SPMySQLGeometryDataTests.m */,
 				20D13511F12C772CB1BD60E6 /* SADatabaseAssertionTests.swift */,
+				B177FE6ABE7EBC554A5905A4 /* SAByteStringDecoderTests.swift */,
 			);
 			name = "Unit Tests";
 			path = "SPMySQL Unit Tests";
@@ -703,6 +709,7 @@
 				FD4211952918779400941BFE /* SPMySQLGeometryDataTests.m in Sources */,
 				507FF1E51BC0D82300104523 /* DataConversion_Tests.m in Sources */,
 				A296B829FB2005B17DB7EA5E /* SADatabaseAssertionTests.swift in Sources */,
+				AB48E5C81EBB3D12966CCEC1 /* SAByteStringDecoderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -737,6 +744,7 @@
 				583C734E17B0778A0056B284 /* Data Conversion.m in Sources */,
 				D88652282912E88D23A56A1C /* SADatabaseAssertion.swift in Sources */,
 				4042B04787F88BF732CD28B9 /* SAProxyReconnectCoordinator.swift in Sources */,
+				444079C96AC4FD43045605F3 /* SAByteStringDecoder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Frameworks/SPMySQLFramework/Source/SAByteStringDecoder.swift
+++ b/Frameworks/SPMySQLFramework/Source/SAByteStringDecoder.swift
@@ -1,0 +1,59 @@
+//
+//  SAByteStringDecoder.swift
+//  SPMySQLFramework
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+//  More info at <https://github.com/Sequel-Ace/Sequel-Ace>
+//
+
+import Foundation
+
+/// Byte-to-string conversion for everything the server sends back: cell values and
+/// result-set metadata (column, alias, table and database names). Both entry points
+/// preserve embedded NUL bytes and never return nil.
+@objcMembers
+public final class SAByteStringDecoder: NSObject {
+    /// The longest partial character the server can leave behind when it truncates
+    /// an identifier at a byte boundary, across every charset the framework maps
+    /// (UTF-8, UTF-16, UTF-32 and GB18030 all top out at four bytes per character).
+    static let maxPartialCharacterBytes = 4
+
+    /// Decodes cell data. Bytes that are not valid in `encoding` fall back to a
+    /// byte-preserving ISO Latin 1 decode so that every byte stays visible: data
+    /// must never be shortened.
+    @objc(stringForDataBytes:length:encoding:)
+    public static func string(forDataBytes bytes: UnsafeRawPointer?, length: Int, encoding: UInt) -> String {
+        if let string = decode(bytes, length: length, encoding: encoding) {
+            return string
+        }
+        // ISO Latin 1 maps every byte 0-255 to a code point, so this cannot fail.
+        return decode(bytes, length: length, encoding: String.Encoding.isoLatin1.rawValue) ?? ""
+    }
+
+    /// Decodes an identifier. The server truncates over-long identifiers, aliases in
+    /// particular, at a byte boundary, which can split a multibyte character; NSString
+    /// then rejects the whole sequence. Drops up to `maxPartialCharacterBytes` trailing
+    /// bytes and marks the loss with an ellipsis. If that does not yield a valid string,
+    /// falls back to the byte-preserving decode used for data.
+    @objc(stringForIdentifierBytes:length:encoding:)
+    public static func string(forIdentifierBytes bytes: UnsafeRawPointer?, length: Int, encoding: UInt) -> String {
+        guard let bytes, length > 0 else { return "" }
+        if let string = decode(bytes, length: length, encoding: encoding) {
+            return string
+        }
+        var removed = 1
+        while removed <= maxPartialCharacterBytes && removed < length {
+            if let string = decode(bytes, length: length - removed, encoding: encoding) {
+                return string + "\u{2026}"
+            }
+            removed += 1
+        }
+        return string(forDataBytes: bytes, length: length, encoding: encoding)
+    }
+
+    private static func decode(_ bytes: UnsafeRawPointer?, length: Int, encoding: UInt) -> String? {
+        guard let bytes, length > 0 else { return "" }
+        return NSString(bytes: bytes, length: length, encoding: encoding) as String?
+    }
+}

--- a/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQL Private APIs.h
@@ -110,7 +110,6 @@
 @interface SPMySQLResult (Private_API)
 
 - (NSString *)_stringWithBytes:(const void *)bytes length:(NSUInteger)length;
-- (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy;
 - (void)_setQueryExecutionTime:(double)theExecutionTime;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.h
@@ -33,7 +33,6 @@
 
 @interface SPMySQLConnection (Conversion)
 
-+ (const char *)_cStringForString:(NSString *)aString usingEncoding:(NSStringEncoding)anEncoding returningLengthAs:(NSUInteger *)cStringLengthPointer;
 + (NSString *)_stringForCString:(const char *)cString usingEncoding:(NSStringEncoding)encoding;
 
 - (NSString *)_stringForCString:(const char *)cString;

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Conversion.m
@@ -35,39 +35,6 @@
 @implementation SPMySQLConnection (Conversion)
 
 /**
- * Converts an NSString to a null-terminated C string, using the supplied encoding.
- * Uses lossy conversion, so if a string cannot be entirely converted using
- * the current encoding, a representation will be returned rather than null.
- * The returned cString will correctly preserve any nul characters within the string,
- * which prevents the use of faster functions like [NSString cStringUsingEncoding:].
- * Pass in the third parameter to receive the length of the converted string (INCLUDING
- * the terminating \0 character), or pass in NULL if you do not want this information.
- */
-// TODO (#2604): this method doesn't make sense — its only addition over
-// [str dataUsingEncoding:allowLossyConversion:] is the terminating NUL byte,
-// but the "string" can already contain NUL bytes, so it's not a valid c string anyway.
-+ (const char *)_cStringForString:(NSString *)aString usingEncoding:(NSStringEncoding)anEncoding returningLengthAs:(NSUInteger *)cStringLengthPointer
-{
-	// Don't try and convert nil strings
-	if (!aString) return NULL;
-
-	// Perform a lossy conversion, using NSData to do the hard work
-	NSData *convertedData = [aString dataUsingEncoding:anEncoding allowLossyConversion:YES];
-	NSUInteger convertedDataLength = [convertedData length];
-
-	// Take the converted data - not null-terminated - and copy it to a null-terminated buffer
-	char *cStringBytes = malloc(convertedDataLength + 1);
-	memcpy(cStringBytes, [convertedData bytes], convertedDataLength);
-	cStringBytes[convertedDataLength] = '\0';
-
-	if (cStringLengthPointer) *cStringLengthPointer = convertedDataLength+1;
-
-	// Ensure the memory is autoreleased when needed, and return.
-	[NSData dataWithBytesNoCopy:cStringBytes length:convertedDataLength+1 freeWhenDone:YES]; 	
-	return cStringBytes;
-}
-
-/**
  * Converts a C string to an NSString using the current connection encoding.
  * This method *will not* correctly preserve nul characters within c strings; instead
  * the first nul character within the string will be treated as the line ending. This

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -127,8 +127,17 @@ databaseContextIsRequired:(BOOL)databaseContextIsRequired;
 	// any nul characters contained in the string.
 	NSData *escapedData;
 	if (includeQuotes) {
-		// TODO (#2604): this code assumes that the encoding cData is in is still ASCII-compatible,
-		// which may not be the case (e.g. for UTF16, EBCDIC)
+		// The quotes are written as single raw bytes, which relies on the connection
+		// encoding being ASCII-compatible.  That always holds: the server refuses ucs2,
+		// utf16, utf16le and utf32 as client character sets (SET NAMES fails, so
+		// stringEncoding is never updated to them), and every other charset MySQL
+		// offers is a superset of ASCII.  Assert the invariant rather than pay for a
+		// per-call conversion of the quote character.
+		NSAssert(stringEncoding != NSUTF16StringEncoding && stringEncoding != NSUTF16BigEndianStringEncoding
+		         && stringEncoding != NSUTF16LittleEndianStringEncoding && stringEncoding != NSUTF32StringEncoding
+		         && stringEncoding != NSUTF32BigEndianStringEncoding && stringEncoding != NSUTF32LittleEndianStringEncoding,
+		         @"escapeString: quoting requires an ASCII-compatible connection encoding");
+
 		// Add quotes if requested
 		escBuffer[0] = '\'';
 		escBuffer[escapedLength+1] = '\'';

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLConnection Categories/Querying & Preparation.m
@@ -695,12 +695,12 @@ databaseContextIsRequired:(BOOL)databaseContextIsRequired
 		}
 		[killQuery appendFormat:@" QUERY %lu", mySQLConnection->thread_id];
 
-		// Convert to a C string
-		NSUInteger killQueryCStringLength;
-		const char *killQueryCString = [SPMySQLConnection _cStringForString:killQuery usingEncoding:aStringEncoding returningLengthAs:&killQueryCStringLength];
+		// Convert to a byte buffer in the killer connection's encoding.  mysql_real_query takes
+		// an explicit length, so no terminator is appended (see the main query path).
+		NSData *killQueryData = [killQuery dataUsingEncoding:aStringEncoding allowLossyConversion:YES];
 
 		// Run the query
-		int killQueryStatus = mysql_real_query(killerConnection, killQueryCString, killQueryCStringLength);
+		int killQueryStatus = mysql_real_query(killerConnection, [killQueryData bytes], [killQueryData length]);
 
 		// Close the temporary connection
 		mysql_close(killerConnection);

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLEmptyResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLEmptyResult.m
@@ -114,12 +114,7 @@
 {
 }
 
-- (id)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
-{
-	return nil;
-}
-
-- (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy
+- (NSString *)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
 {
 	return nil;
 }

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Field Definitions.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult Categories/Field Definitions.m
@@ -361,7 +361,7 @@ const SPMySQLResultCharset SPMySQLCharsetMap[] =
 		
 		// Record the column name, or alias if one is being used
 		if (mysqlField.name) {
-			[eachField setObject:[self _lossyStringWithBytes:mysqlField.name length:mysqlField.name_length wasLossy:NULL] forKey:@"name"];
+			[eachField setObject:[self _stringWithBytes:mysqlField.name length:mysqlField.name_length] forKey:@"name"];
 		}
 		
 		// Record the original column name if using an alias

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLResult.m
@@ -30,6 +30,7 @@
 
 #import "SPMySQLResult.h"
 #import "SPMySQL Private APIs.h"
+#import "SPMySQLStringAdditions.h"
 #include <stdlib.h>
 
 static id NSNullPointer;
@@ -303,46 +304,14 @@ static id NSNullPointer;
 @implementation SPMySQLResult (Private_API)
 
 /**
- * Support internal string conversions which take a supplied byte sequence and length
- * and convert them to an NSString using the instance encoding.  Will preserve nul
- * characters within the string.
+ * Convert a byte sequence and length from the result set's metadata - column, alias,
+ * table and database names - to an NSString using the instance encoding.  Preserves nul
+ * characters and never returns nil; see +[NSString stringForIdentifierBytes:length:encoding:]
+ * for how names the server truncated mid-character are handled.
  */
-- (id)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
+- (NSString *)_stringWithBytes:(const void *)bytes length:(NSUInteger)length
 {
-    NSString *str = [[NSString alloc] initWithBytes:bytes length:length encoding:stringEncoding];
-    
-    return (str == nil) ? @"" : str;
-}
-// TODO (#2604): duplicate code with Data Conversion.m stringForDataBytes:length:encoding: (↑, ↓)
-- (NSString *)_lossyStringWithBytes:(const void *)bytes length:(NSUInteger)length wasLossy:(BOOL *)outLossy
-{
-	if(!bytes || !length) return @""; //to match -[NSString initWithBytes:length:encoding:]
-	
-	//mysql protocol limits column names to 256 bytes.
-	//with inline columns and multibyte charsets this can result in a character
-	//being split in half at which the method above will fail.
-	//Let's first try removing stuff from the end to create something valid.
-	NSUInteger removed = 0;
-	do {
-		NSString *res = [self _stringWithBytes:bytes length:(length-removed)];
-		if(res) {
-			if(outLossy) *outLossy = (removed != 0);
-			return (removed? [NSString stringWithFormat:@"%@…",res] : res);
-		}
-		removed++;
-	} while(removed <= 10 && removed < length); // 10 is arbitrary
-	
-	//if that fails, ascii should accept all values from 0-255 as input
-	NSString *ascii = [[NSString alloc] initWithBytes:bytes length:length encoding:NSASCIIStringEncoding];
-	if(ascii){
-		if(outLossy) *outLossy = YES;
-		return ascii;
-	}
-	
-	//if even that failed we lose.
-	NSDictionary *info = @{ @"data": [NSData dataWithBytes:bytes length:length] };
-	NSString *reason = [NSString stringWithFormat:@"Failed to convert byte sequence %@ to string (encoding = %lu)",[info objectForKey:@"data"],stringEncoding];
-	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:info];
+	return [NSString stringForIdentifierBytes:bytes length:length encoding:stringEncoding];
 }
 
 /**

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.h
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.h
@@ -33,5 +33,6 @@
 - (NSString *)mySQLBacktickQuotedString;
 - (NSString *)mySQLTickQuotedString;
 + (NSString *)stringForDataBytes:(const void *)dataBytes length:(NSUInteger)dataLength encoding:(NSStringEncoding)aStringEncoding;
++ (NSString *)stringForIdentifierBytes:(const void *)identifierBytes length:(NSUInteger)identifierLength encoding:(NSStringEncoding)aStringEncoding;
 
 @end

--- a/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.m
+++ b/Frameworks/SPMySQLFramework/Source/SPMySQLStringAdditions.m
@@ -29,6 +29,7 @@
 //  More info at <https://github.com/sequelpro/sequelpro>
 
 #import "SPMySQLStringAdditions.h"
+#import <SPMySQL/SPMySQL-Swift.h>
 
 @implementation NSString (SPMySQLStringAdditions)
 
@@ -53,17 +54,20 @@
 }
 
 /**
- * Returns the string for the bytes according to the encoding, decode in ASCII if failed
+ * Byte-to-string conversion for cell values; see SAByteStringDecoder.
  */
 + (NSString *) stringForDataBytes:(const void *)dataBytes length:(NSUInteger)dataLength encoding:(NSStringEncoding)aStringEncoding
 {
-	NSString *string = [[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:aStringEncoding];
+	return [SAByteStringDecoder stringForDataBytes:dataBytes length:dataLength encoding:aStringEncoding];
+}
 
-	if (string == nil) {
-		return [[NSString alloc] initWithBytes:dataBytes length:dataLength encoding:NSASCIIStringEncoding];
-	}
-
-	return string;
+/**
+ * Byte-to-string conversion for identifiers the server may have truncated
+ * mid-character; see SAByteStringDecoder.
+ */
++ (NSString *) stringForIdentifierBytes:(const void *)identifierBytes length:(NSUInteger)identifierLength encoding:(NSStringEncoding)aStringEncoding
+{
+	return [SAByteStringDecoder stringForIdentifierBytes:identifierBytes length:identifierLength encoding:aStringEncoding];
 }
 
 @end


### PR DESCRIPTION
Closes #2604. Three commits, ordered from safest to the one behaviour change, so the last can be reverted alone.

## What changed

1. **Kill query sent without a trailing NUL.** `cancelCurrentQuery` was the last caller of `_cStringForString:usingEncoding:returningLengthAs:`, which appended a terminator and reported a length that included it, so `mysql_real_query` received one byte more than the statement. The main query path stopped doing this in 2015 (upstream sequel-pro #2184). The kill path now converts with `dataUsingEncoding:` like the main path, and the helper is deleted.

2. **`escapeString:` documents why raw ASCII quotes are safe.** The connection encoding can only ever be ASCII-compatible: the server refuses ucs2, utf16, utf16le and utf32 as client character sets, so `SET NAMES` fails before `stringEncoding` is updated, and MySQL offers no EBCDIC charsets. The TODO is replaced by that invariant plus a debug assertion.

3. **Column names the server truncated mid-character are trimmed again instead of shown empty.** `SPMySQLResult` carried its own byte-to-string conversion, `_lossyStringWithBytes:wasLossy:`, whose purpose was to rescue identifiers whose multibyte character the server split when truncating an over-long alias (upstream sequel-pro #2150, 2015). In 2020 the plain helper it called was changed to return `@""` instead of nil, so the rescue loop became dead code and such names came back empty. There is now one implementation, `SAByteStringDecoder` in Swift, with the `NSString (SPMySQLStringAdditions)` class methods reduced to one-line trampolines:
   - `stringForDataBytes:length:encoding:` keeps its byte-preserving contract for cell values, which must never be shortened. Its fallback is now an explicit ISO Latin 1 decode instead of lenient ASCII decoding; the output is byte-for-byte identical.
   - New `stringForIdentifierBytes:length:encoding:` trims up to four trailing bytes and appends an ellipsis, falling back to the data decode if that does not help.
   - `SPMySQLResult`'s `_stringWithBytes:` routes every field, alias, table and database name through the identifier decode, so `fieldNames` gets the handling too (it never had it). The lossy method, its `SPMySQLEmptyResult` stub and its private declaration are deleted; the only caller passed NULL for the flag.

## Verification

- SPMySQL framework unit tests: 38 executed, 0 failures, in an isolated DerivedData path. New `SAByteStringDecoderTests` (10 tests) cover both decodes: NULL/zero length, embedded NUL, valid names, a name cut one and two bytes into a character, unrepairable bytes in the middle, a name that is only a partial character, and the byte-count guarantee of the data decode.
- Live run of a small program linking the built framework against MySQL 8.4.11:
  - `SELECT SLEEP(15)` cancelled from another thread returned after 1.5 s with `Query cancelled.`, and the connection thread id was unchanged, so the rewritten KILL QUERY was accepted rather than the reconnect fallback firing.
  - A 300-byte utf8mb4 alias came back as 85 whole characters; the same for 2- and 4-byte characters. MySQL 8.4 truncates aliases on a character boundary, so the split-character case that #2150 fixed comes from older servers. The trimming is cheap and only runs when the full decode has already failed.

## Notes

- The issue body links to `docs/development/warnings-elimination-plan.md`, which was retired on 2026-09-07; the modernization follow-up plan is the current home for this work.
- Behaviour change is limited to result-set metadata names that are invalid in the connection encoding. Cell values are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of server-provided text and identifiers across different encodings.
  - Invalid byte sequences are preserved more reliably instead of being unnecessarily replaced or lost.
  - Truncated identifiers are displayed safely with an ellipsis when appropriate.
  - Empty values now produce consistent empty-string results.

- **Bug Fixes**
  - Improved metadata and column-name decoding for non-standard or invalid UTF-8 data.
  - Query cancellation now works more reliably with varied connection encodings.

- **Tests**
  - Added coverage for embedded null bytes, invalid data, encoding fallbacks, and truncated identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
