### PR TITLE
Import progress no longer blocks the import thread for every row or statement

### DIFF
--- a/Source/Controllers/DataImport/SAImportProgressReporter.swift
+++ b/Source/Controllers/DataImport/SAImportProgressReporter.swift
@@ -1,0 +1,82 @@
+//
+//  SAImportProgressReporter.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+
+/// One progress-sheet update: the bar's new value and the text beneath it.
+@objc final class SAImportProgressUpdate: NSObject {
+
+    @objc let barValue: Double
+    @objc let text: String
+
+    init(barValue: Double, text: String) {
+        self.barValue = barValue
+        self.text = text
+        super.init()
+    }
+}
+
+/// Throttles and formats the progress an import pushes to its sheet.
+///
+/// The importer calls `update(...)` after every row or statement; the reporter
+/// answers with an update at most once per `minimumInterval` and `nil` the rest
+/// of the time. Elapsed time is measured on a monotonic clock so a wall-clock
+/// change during a long import cannot suppress updates.
+@objc final class SAImportProgressReporter: NSObject {
+
+    static let defaultMinimumInterval: TimeInterval = 0.1
+
+    private let unknownTotalFormat: String
+    private let knownTotalFormat: String
+    private let minimumInterval: TimeInterval
+    private let clock: () -> TimeInterval
+    private var lastUpdateTime: TimeInterval?
+
+    /// - Parameter unknownTotalFormat: format used when the file is compressed
+    ///   and the decompressed total is unknown. Takes one `%@`, the formatted
+    ///   decompressed position.
+    @objc convenience init(unknownTotalFormat: String) {
+        self.init(unknownTotalFormat: unknownTotalFormat,
+                  minimumInterval: SAImportProgressReporter.defaultMinimumInterval,
+                  clock: { ProcessInfo.processInfo.systemUptime })
+    }
+
+    init(unknownTotalFormat: String, minimumInterval: TimeInterval, clock: @escaping () -> TimeInterval) {
+        self.unknownTotalFormat = unknownTotalFormat
+        self.knownTotalFormat = NSLocalizedString("Imported %@ of %@", comment: "import progress text")
+        self.minimumInterval = minimumInterval
+        self.clock = clock
+        super.init()
+    }
+
+    /// Returns the update to show, or `nil` when the last one is too recent.
+    ///
+    /// - Parameters:
+    ///   - bytesProcessed: position in the decompressed data.
+    ///   - totalBytes: the file's size on disk.
+    ///   - isCompressed: whether the file is compressed, in which case the bar
+    ///     tracks `compressedBytesRead` against `totalBytes` and the text uses
+    ///     the unknown-total format.
+    ///   - compressedBytesRead: the file handle's position in the compressed file.
+    @objc(updateForBytesProcessed:totalBytes:isCompressed:compressedBytesRead:)
+    func update(bytesProcessed: UInt, totalBytes: UInt, isCompressed: Bool, compressedBytesRead: UInt) -> SAImportProgressUpdate? {
+        let now = clock()
+        if let last = lastUpdateTime, now - last < minimumInterval {
+            return nil
+        }
+        lastUpdateTime = now
+
+        let processedText = ByteCountFormatter.string(fromByteCount: Int64(bytesProcessed), countStyle: .file)
+        if isCompressed {
+            return SAImportProgressUpdate(barValue: Double(compressedBytesRead),
+                                          text: String(format: unknownTotalFormat, processedText))
+        }
+        let totalText = ByteCountFormatter.string(fromByteCount: Int64(totalBytes), countStyle: .file)
+        return SAImportProgressUpdate(barValue: Double(bytesProcessed),
+                                      text: String(format: knownTotalFormat, processedText, totalText))
+    }
+}

--- a/Source/Controllers/DataImport/SAImportProgressReporter.swift
+++ b/Source/Controllers/DataImport/SAImportProgressReporter.swift
@@ -22,6 +22,9 @@ import Foundation
 
 /// Throttles and formats the progress an import pushes to its sheet.
 ///
+/// Byte counts use the app's binary `ByteCountFormatter.string(byteSize:)`
+/// extension, the same formatter the importer used before this type existed.
+///
 /// The importer calls `update(...)` after every row or statement; the reporter
 /// answers with an update at most once per `minimumInterval` and `nil` the rest
 /// of the time. Elapsed time is measured on a monotonic clock so a wall-clock
@@ -70,12 +73,12 @@ import Foundation
         }
         lastUpdateTime = now
 
-        let processedText = ByteCountFormatter.string(fromByteCount: Int64(bytesProcessed), countStyle: .file)
+        let processedText = ByteCountFormatter.string(byteSize: Int64(bytesProcessed)) as String
         if isCompressed {
             return SAImportProgressUpdate(barValue: Double(compressedBytesRead),
                                           text: String(format: unknownTotalFormat, processedText))
         }
-        let totalText = ByteCountFormatter.string(fromByteCount: Int64(totalBytes), countStyle: .file)
+        let totalText = ByteCountFormatter.string(byteSize: Int64(totalBytes)) as String
         return SAImportProgressUpdate(barValue: Double(bytesProcessed),
                                       text: String(format: knownTotalFormat, processedText, totalText))
     }

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -46,13 +46,25 @@ typedef enum {
 
 @interface SPDataImport : NSObject <NSOpenSavePanelDelegate>
 {
-	// TODO (#2606): outlets belong to multiple xib files, so each xib load overwrites part of this set
+	// Wired by DBView.xib, which instantiates this object.
 	IBOutlet __weak SPDatabaseDocument *tableDocumentInstance;
 	IBOutlet SPTablesList *tablesListInstance;
 	IBOutlet SPTableStructure *tableSourceInstance;
 	IBOutlet SPTableData *tableDataInstance;
 	IBOutlet SPCustomQuery *customQueryInstance;
 
+	IBOutlet NSWindow *errorsSheet;
+	IBOutlet NSTextView *errorsView;
+
+	IBOutlet NSPanel *singleProgressSheet;
+	IBOutlet NSProgressIndicator *singleProgressBar;
+	IBOutlet NSTextField *singleProgressTitle;
+	IBOutlet NSTextField *singleProgressText;
+
+	// Wired by ImportAccessory.xib, which awakeFromNib loads with this object as its owner.
+	// The two sets are disjoint, so neither load touches the other's outlets, but this
+	// object still doubles as the accessory view's controller.
+	// TODO (#2606): move the accessory view into its own controller
 	IBOutlet id importView;
 	IBOutlet id importTabView;
 	IBOutlet NSButton *importFieldNamesSwitch;
@@ -70,14 +82,6 @@ typedef enum {
 	IBOutlet id importFromClipboardAccessoryView;
 	
 	IBOutlet NSTextView *importFromClipboardTextView;
-	
-	IBOutlet NSWindow *errorsSheet;
-	IBOutlet NSTextView *errorsView;
-
-	IBOutlet NSPanel *singleProgressSheet;
-	IBOutlet NSProgressIndicator *singleProgressBar;
-	IBOutlet NSTextField *singleProgressTitle;
-	IBOutlet NSTextField *singleProgressText;
 
 	SPMySQLConnection *mySQLConnection;
 
@@ -105,6 +109,7 @@ typedef enum {
 	NSUserDefaults *prefs;
 
 	BOOL progressCancelled;
+	CFAbsoluteTime importProgressLastUpdate;
 	BOOL mainNibLoaded;
 
 	NSMutableArray *geometryFields;

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -109,7 +109,8 @@ typedef enum {
 
 	NSUserDefaults *prefs;
 
-	BOOL progressCancelled;
+	// Written by the Cancel button on the main thread and read by the import thread.
+	_Atomic(BOOL) progressCancelled;
 	SAImportProgressReporter *importProgressReporter;
 	BOOL mainNibLoaded;
 

--- a/Source/Controllers/DataImport/SPDataImport.h
+++ b/Source/Controllers/DataImport/SPDataImport.h
@@ -37,6 +37,7 @@
 @class SPTableData;
 @class SPTableStructure;
 @class SPTablesList;
+@class SAImportProgressReporter;
 
 typedef enum {
 	SPFieldMapperInProgress = 1,
@@ -109,7 +110,7 @@ typedef enum {
 	NSUserDefaults *prefs;
 
 	BOOL progressCancelled;
-	CFAbsoluteTime importProgressLastUpdate;
+	SAImportProgressReporter *importProgressReporter;
 	BOOL mainNibLoaded;
 
 	NSMutableArray *geometryFields;

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -1691,16 +1691,22 @@
  * Pushes the import's position to the progress sheet through the import's
  * SAImportProgressReporter, which throttles the updates. The push is
  * asynchronous so the import thread never waits on the main thread.
+ *
+ * Each import creates its own reporter, so the reporter doubles as the
+ * import's identity: an update queued by an earlier import is dropped once a
+ * later import has replaced the reporter and reset the sheet.
  */
 - (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle
 {
-	SAImportProgressUpdate *update = [importProgressReporter updateForBytesProcessed:bytesProcessed
-	                                                                       totalBytes:totalBytes
-	                                                                     isCompressed:([fileHandle compressionFormat] != SPNoCompression)
-	                                                              compressedBytesRead:[fileHandle realDataReadLength]];
+	SAImportProgressReporter *reporter = importProgressReporter;
+	SAImportProgressUpdate *update = [reporter updateForBytesProcessed:bytesProcessed
+	                                                        totalBytes:totalBytes
+	                                                      isCompressed:([fileHandle compressionFormat] != SPNoCompression)
+	                                               compressedBytesRead:[fileHandle realDataReadLength]];
 	if (!update) return;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
+		if (self->importProgressReporter != reporter) return;
 		[self->singleProgressBar setDoubleValue:update.barValue];
 		[self->singleProgressText setStringValue:update.text];
 	});

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -58,6 +58,7 @@
 - (void)_startBackgroundImportTaskForFilename:(NSString *)filename;
 - (void)_importBackgroundProcess:(NSDictionary *)userInfo;
 - (void)_closeAndStopProgressSheet;
+- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle unknownTotalFormat:(NSString *)unknownTotalFormat;
 - (NSString *)_getLineEndingForFile:(NSString *)filePath;
 
 @property (readwrite, strong) NSFileManager *fileManager;
@@ -373,7 +374,6 @@
 	NSInteger dataBufferLength = 0;
 	NSInteger dataBufferPosition = 0;
 	NSInteger dataBufferLastQueryEndPosition = 0;
-	BOOL fileIsCompressed;
 	BOOL allDataRead = NO;
 	BOOL ignoreSQLErrors = ([[importSQLErrorHandlingPopup onMainThread] selectedTag] == SPSQLImportIgnoreErrors);
 	BOOL ignoreCharsetError = NO;
@@ -389,12 +389,12 @@
 			[fileManager removeItemAtPath:filename error:nil];
 		return;
 	}
-	fileIsCompressed = ([sqlFileHandle compressionFormat] != SPNoCompression);
 
 	// Grab the file length
 	fileTotalLength = (NSUInteger)[[[fileManager attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 
+	importProgressLastUpdate = 0;
 	SPMainQSync(^{
 		// Reset progress interface
 		[self->errorsView setString:@""];
@@ -669,16 +669,10 @@
                 SPLog(@"Import time taken: %@, for %ld queries", [NSString stringWithFormat:@"%.3f", interval], (long)queriesPerformed);
 #endif
                 // Update the progress bar
-                if (fileIsCompressed) {
-                    [[singleProgressBar onMainThread] setDoubleValue:[sqlFileHandle realDataReadLength]];
-                    [[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown"),
-                                                                       [NSByteCountFormatter stringWithByteSize:fileProcessedLength]]];
-                } else {
-                    [[singleProgressBar onMainThread] setDoubleValue:fileProcessedLength];
-                    [[singleProgressText onMainThread] setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"),
-                                                                       [NSByteCountFormatter stringWithByteSize:fileProcessedLength],
-                                                                       [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
-                }
+                [self _updateProgressForBytesProcessed:fileProcessedLength
+                                            totalBytes:fileTotalLength
+                                            fileHandle:sqlFileHandle
+                                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown")];
             }
 
             // If all the data has been read, break out of the processing loop
@@ -796,7 +790,6 @@
 	NSUInteger csvRowsPerQuery = 1000;
 	NSUInteger csvRowsThisQuery;
 	NSUInteger fileTotalLength = 0;
-	BOOL fileIsCompressed;
 	NSInteger rowsImported = 0;
 	NSUInteger i;
 	BOOL allDataRead = NO;
@@ -826,9 +819,9 @@
 	// Grab the file length and status
 	fileTotalLength = (NSUInteger)[[[fileManager attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
-	fileIsCompressed = ([csvFileHandle compressionFormat] != SPNoCompression);
 
 	// Reset progress interface
+	importProgressLastUpdate = 0;
 	SPMainQSync(^{
 		[self->errorsView setString:@""];
 		[self->singleProgressTitle setStringValue:NSLocalizedString(@"Importing CSV", @"text showing that the application is importing CSV")];
@@ -1114,16 +1107,10 @@
 
 						rowsImported++;
 						csvRowsThisQuery++;
-						// TODO (#2606): updating the UI for every single row is likely a performance killer (even without synchronization)
-						SPMainQSync(^{
-							if (fileIsCompressed) {
-								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
-							} else {
-								[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:i] doubleValue]];
-                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"CSV import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
-							}
-						});
+						[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:i] unsignedIntegerValue]
+						                            totalBytes:fileTotalLength
+						                            fileHandle:csvFileHandle
+						                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
 					}
 				}
 
@@ -1152,30 +1139,18 @@
 								[[SPQueryController sharedQueryController] showErrorInConsole:mySQLConnection.lastErrorMessage connection:mySQLConnection.host database:databaseName];
 							}
 						}
-						// TODO (#2606): duplicate progress-update code (see above)
 						rowsImported++;
-						SPMainQSync(^{
-							if (fileIsCompressed) {
-								[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]]]];
-							} else {
-								[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:i] doubleValue]];
-                                [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:i] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
-							}
-						});
+						[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:i] unsignedIntegerValue]
+						                            totalBytes:fileTotalLength
+						                            fileHandle:csvFileHandle
+						                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
 					}
 				} else {
 					rowsImported += csvRowsThisQuery;
-					// TODO (#2606): duplicate progress-update code (see above)
-					SPMainQSync(^{
-						if (fileIsCompressed) {
-							[self->singleProgressBar setDoubleValue:[csvFileHandle realDataReadLength]];
-                            [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]]]];
-						} else {
-							[self->singleProgressBar setDoubleValue:[[parsePositions objectAtIndex:csvRowsThisQuery-1] doubleValue]];
-                            [self->singleProgressText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"SQL import progress text"), [NSByteCountFormatter stringWithByteSize:[[parsePositions objectAtIndex:csvRowsThisQuery-1] longValue]], [NSByteCountFormatter stringWithByteSize:fileTotalLength]]];
-						}
-					});
+					[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:csvRowsThisQuery-1] unsignedIntegerValue]
+					                            totalBytes:fileTotalLength
+					                            fileHandle:csvFileHandle
+					                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
 				}
 
 				// Update the arrays
@@ -1713,6 +1688,38 @@
 		[self->singleProgressSheet orderOut:nil];
 		[self->singleProgressBar stopAnimation:self];
 		[self->singleProgressBar setMaxValue:100];
+	});
+}
+
+/**
+ * Pushes the import's position to the progress sheet, at most ten times a second and
+ * without blocking the import thread on the main thread.
+ *
+ * bytesProcessed is the position in the decompressed data and totalBytes the file's
+ * size on disk. For a compressed file the bar tracks the handle's compressed read
+ * position against the on-disk size, and the text uses unknownTotalFormat, which
+ * takes the decompressed position as its only argument.
+ */
+- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle unknownTotalFormat:(NSString *)unknownTotalFormat
+{
+	CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+	if (now - importProgressLastUpdate < 0.1) return;
+	importProgressLastUpdate = now;
+
+	BOOL fileIsCompressed = ([fileHandle compressionFormat] != SPNoCompression);
+	double barValue = fileIsCompressed ? [fileHandle realDataReadLength] : bytesProcessed;
+	NSString *text;
+	if (fileIsCompressed) {
+		text = [NSString stringWithFormat:unknownTotalFormat, [NSByteCountFormatter stringWithByteSize:bytesProcessed]];
+	} else {
+		text = [NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"import progress text"),
+		        [NSByteCountFormatter stringWithByteSize:bytesProcessed],
+		        [NSByteCountFormatter stringWithByteSize:totalBytes]];
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self->singleProgressBar setDoubleValue:barValue];
+		[self->singleProgressText setStringValue:text];
 	});
 }
 

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -1143,7 +1143,8 @@
 						                            fileHandle:csvFileHandle];
 					}
 				} else {
-					rowsImported += csvRowsThisQuery;
+					// The update loop above already counted its rows one by one.
+					if (!importMethodIsUpdate) rowsImported += csvRowsThisQuery;
 					[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:csvRowsThisQuery-1] unsignedIntegerValue]
 					                            totalBytes:fileTotalLength
 					                            fileHandle:csvFileHandle];

--- a/Source/Controllers/DataImport/SPDataImport.m
+++ b/Source/Controllers/DataImport/SPDataImport.m
@@ -58,7 +58,7 @@
 - (void)_startBackgroundImportTaskForFilename:(NSString *)filename;
 - (void)_importBackgroundProcess:(NSDictionary *)userInfo;
 - (void)_closeAndStopProgressSheet;
-- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle unknownTotalFormat:(NSString *)unknownTotalFormat;
+- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle;
 - (NSString *)_getLineEndingForFile:(NSString *)filePath;
 
 @property (readwrite, strong) NSFileManager *fileManager;
@@ -394,7 +394,7 @@
 	fileTotalLength = (NSUInteger)[[[fileManager attributesOfItemAtPath:filename error:NULL] objectForKey:NSFileSize] longLongValue];
 	if (!fileTotalLength) fileTotalLength = 1;
 
-	importProgressLastUpdate = 0;
+	importProgressReporter = [[SAImportProgressReporter alloc] initWithUnknownTotalFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown")];
 	SPMainQSync(^{
 		// Reset progress interface
 		[self->errorsView setString:@""];
@@ -671,8 +671,7 @@
                 // Update the progress bar
                 [self _updateProgressForBytesProcessed:fileProcessedLength
                                             totalBytes:fileTotalLength
-                                            fileHandle:sqlFileHandle
-                                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of SQL", @"SQL import progress text where total size is unknown")];
+                                            fileHandle:sqlFileHandle];
             }
 
             // If all the data has been read, break out of the processing loop
@@ -821,7 +820,7 @@
 	if (!fileTotalLength) fileTotalLength = 1;
 
 	// Reset progress interface
-	importProgressLastUpdate = 0;
+	importProgressReporter = [[SAImportProgressReporter alloc] initWithUnknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
 	SPMainQSync(^{
 		[self->errorsView setString:@""];
 		[self->singleProgressTitle setStringValue:NSLocalizedString(@"Importing CSV", @"text showing that the application is importing CSV")];
@@ -1109,8 +1108,7 @@
 						csvRowsThisQuery++;
 						[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:i] unsignedIntegerValue]
 						                            totalBytes:fileTotalLength
-						                            fileHandle:csvFileHandle
-						                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
+						                            fileHandle:csvFileHandle];
 					}
 				}
 
@@ -1142,15 +1140,13 @@
 						rowsImported++;
 						[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:i] unsignedIntegerValue]
 						                            totalBytes:fileTotalLength
-						                            fileHandle:csvFileHandle
-						                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
+						                            fileHandle:csvFileHandle];
 					}
 				} else {
 					rowsImported += csvRowsThisQuery;
 					[self _updateProgressForBytesProcessed:[[parsePositions objectAtIndex:csvRowsThisQuery-1] unsignedIntegerValue]
 					                            totalBytes:fileTotalLength
-					                            fileHandle:csvFileHandle
-					                    unknownTotalFormat:NSLocalizedString(@"Imported %@ of CSV data", @"CSV import progress text where total size is unknown")];
+					                            fileHandle:csvFileHandle];
 				}
 
 				// Update the arrays
@@ -1692,34 +1688,21 @@
 }
 
 /**
- * Pushes the import's position to the progress sheet, at most ten times a second and
- * without blocking the import thread on the main thread.
- *
- * bytesProcessed is the position in the decompressed data and totalBytes the file's
- * size on disk. For a compressed file the bar tracks the handle's compressed read
- * position against the on-disk size, and the text uses unknownTotalFormat, which
- * takes the decompressed position as its only argument.
+ * Pushes the import's position to the progress sheet through the import's
+ * SAImportProgressReporter, which throttles the updates. The push is
+ * asynchronous so the import thread never waits on the main thread.
  */
-- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle unknownTotalFormat:(NSString *)unknownTotalFormat
+- (void)_updateProgressForBytesProcessed:(NSUInteger)bytesProcessed totalBytes:(NSUInteger)totalBytes fileHandle:(SPFileHandle *)fileHandle
 {
-	CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
-	if (now - importProgressLastUpdate < 0.1) return;
-	importProgressLastUpdate = now;
-
-	BOOL fileIsCompressed = ([fileHandle compressionFormat] != SPNoCompression);
-	double barValue = fileIsCompressed ? [fileHandle realDataReadLength] : bytesProcessed;
-	NSString *text;
-	if (fileIsCompressed) {
-		text = [NSString stringWithFormat:unknownTotalFormat, [NSByteCountFormatter stringWithByteSize:bytesProcessed]];
-	} else {
-		text = [NSString stringWithFormat:NSLocalizedString(@"Imported %@ of %@", @"import progress text"),
-		        [NSByteCountFormatter stringWithByteSize:bytesProcessed],
-		        [NSByteCountFormatter stringWithByteSize:totalBytes]];
-	}
+	SAImportProgressUpdate *update = [importProgressReporter updateForBytesProcessed:bytesProcessed
+	                                                                       totalBytes:totalBytes
+	                                                                     isCompressed:([fileHandle compressionFormat] != SPNoCompression)
+	                                                              compressedBytesRead:[fileHandle realDataReadLength]];
+	if (!update) return;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[self->singleProgressBar setDoubleValue:barValue];
-		[self->singleProgressText setStringValue:text];
+		[self->singleProgressBar setDoubleValue:update.barValue];
+		[self->singleProgressText setStringValue:update.text];
 	});
 }
 

--- a/UnitTests/SAImportProgressReporterTests.swift
+++ b/UnitTests/SAImportProgressReporterTests.swift
@@ -18,8 +18,9 @@ final class SAImportProgressReporterTests: XCTestCase {
                                  clock: { self.now })
     }
 
+    /// The app's binary byte formatter, which the importer has always used for progress text.
     private func bytes(_ count: UInt) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(count), countStyle: .file)
+        ByteCountFormatter.string(byteSize: Int64(count)) as String
     }
 
     // MARK: - Formatting
@@ -36,6 +37,16 @@ final class SAImportProgressReporterTests: XCTestCase {
 
         XCTAssertEqual(update?.barValue, 300)
         XCTAssertEqual(update?.text, "Imported \(bytes(2_500)) of test data")
+    }
+
+    func testByteCountsKeepTheImporterBinaryUnits() {
+        let update = makeReporter().update(bytesProcessed: 1_048_576, totalBytes: 3 * 1_073_741_824, isCompressed: false, compressedBytesRead: 0)
+
+        // The exact digits depend on the locale's decimal separator; the units do not.
+        let words = update?.text.split(separator: " ").map(String.init) ?? []
+        XCTAssertTrue(words.contains("MiB"), update?.text ?? "nil")
+        XCTAssertTrue(words.contains("GiB"), update?.text ?? "nil")
+        XCTAssertFalse(words.contains("MB"), update?.text ?? "nil")
     }
 
     // MARK: - Throttling

--- a/UnitTests/SAImportProgressReporterTests.swift
+++ b/UnitTests/SAImportProgressReporterTests.swift
@@ -1,0 +1,95 @@
+//
+//  SAImportProgressReporterTests.swift
+//  Sequel Ace
+//
+//  Copyright © 2026 Sequel-Ace. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+final class SAImportProgressReporterTests: XCTestCase {
+
+    private var now: TimeInterval = 1_000
+
+    private func makeReporter(minimumInterval: TimeInterval = 0.1) -> SAImportProgressReporter {
+        SAImportProgressReporter(unknownTotalFormat: "Imported %@ of test data",
+                                 minimumInterval: minimumInterval,
+                                 clock: { self.now })
+    }
+
+    private func bytes(_ count: UInt) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(count), countStyle: .file)
+    }
+
+    // MARK: - Formatting
+
+    func testUncompressedUpdateTracksTheDecompressedPositionAgainstTheTotal() {
+        let update = makeReporter().update(bytesProcessed: 2_500, totalBytes: 10_000, isCompressed: false, compressedBytesRead: 0)
+
+        XCTAssertEqual(update?.barValue, 2_500)
+        XCTAssertEqual(update?.text, String(format: NSLocalizedString("Imported %@ of %@", comment: ""), bytes(2_500), bytes(10_000)))
+    }
+
+    func testCompressedUpdateTracksTheCompressedPositionAndUsesTheUnknownTotalFormat() {
+        let update = makeReporter().update(bytesProcessed: 2_500, totalBytes: 800, isCompressed: true, compressedBytesRead: 300)
+
+        XCTAssertEqual(update?.barValue, 300)
+        XCTAssertEqual(update?.text, "Imported \(bytes(2_500)) of test data")
+    }
+
+    // MARK: - Throttling
+
+    func testTheFirstUpdateIsNeverThrottled() {
+        XCTAssertNotNil(makeReporter().update(bytesProcessed: 1, totalBytes: 2, isCompressed: false, compressedBytesRead: 0))
+    }
+
+    func testUpdatesWithinTheMinimumIntervalAreSuppressed() {
+        let reporter = makeReporter()
+        XCTAssertNotNil(reporter.update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+
+        now += 0.05
+        XCTAssertNil(reporter.update(bytesProcessed: 2, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+        now += 0.049
+        XCTAssertNil(reporter.update(bytesProcessed: 3, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+    }
+
+    func testAnUpdateIsDeliveredOnceTheMinimumIntervalHasElapsed() {
+        let reporter = makeReporter()
+        XCTAssertNotNil(reporter.update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+
+        now += 0.1
+        let update = reporter.update(bytesProcessed: 4, totalBytes: 10, isCompressed: false, compressedBytesRead: 0)
+        XCTAssertEqual(update?.barValue, 4)
+    }
+
+    func testASuppressedUpdateDoesNotRestartTheInterval() {
+        let reporter = makeReporter()
+        XCTAssertNotNil(reporter.update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+
+        now += 0.08
+        XCTAssertNil(reporter.update(bytesProcessed: 2, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+        now += 0.02
+        XCTAssertNotNil(reporter.update(bytesProcessed: 3, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+    }
+
+    func testTheDeliveredUpdateCarriesTheLatestPositionNotTheSuppressedOnes() {
+        let reporter = makeReporter()
+        _ = reporter.update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0)
+        now += 0.01
+        _ = reporter.update(bytesProcessed: 5, totalBytes: 10, isCompressed: false, compressedBytesRead: 0)
+        now += 0.1
+        XCTAssertEqual(reporter.update(bytesProcessed: 9, totalBytes: 10, isCompressed: false, compressedBytesRead: 0)?.barValue, 9)
+    }
+
+    func testEachReporterStartsWithAFreshInterval() {
+        let first = makeReporter()
+        XCTAssertNotNil(first.update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+
+        XCTAssertNotNil(makeReporter().update(bytesProcessed: 1, totalBytes: 10, isCompressed: false, compressedBytesRead: 0))
+    }
+
+    func testTheDefaultMinimumIntervalIsATenthOfASecond() {
+        XCTAssertEqual(SAImportProgressReporter.defaultMinimumInterval, 0.1)
+    }
+}

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -294,6 +294,9 @@
 		51974D07304B23B400C5D23D /* SACSVImportStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */; };
 		9C34DCDAAFC52D3EF15C0B2B /* SACSVImportStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */; };
 		51974D0C304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */; };
+		4785E13A4BCF828DED8BA3A1 /* SAImportProgressReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25047F243EB51288B9242EE3 /* SAImportProgressReporter.swift */; };
+		ADD8B19D3D629DE277D2163B /* SAImportProgressReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25047F243EB51288B9242EE3 /* SAImportProgressReporter.swift */; };
+		C15BC205A797F1C3C14733CB /* SAImportProgressReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7383424B751DCE7B1E781C44 /* SAImportProgressReporterTests.swift */; };
 		519788CC30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */; };
 		519788CD30502FBB00C5D23D /* SAExportOutputEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */; };
 		519788D130502FC700C5D23D /* SAExportOutputEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */; };
@@ -1209,6 +1212,8 @@
 		5193502E2567D2FB001272B5 /* CollectionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtension.swift; sourceTree = "<group>"; };
 		51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACSVImportStreamDecoder.swift; sourceTree = "<group>"; };
 		51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SACSVImportStreamDecoderTests.swift; sourceTree = "<group>"; };
+		25047F243EB51288B9242EE3 /* SAImportProgressReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAImportProgressReporter.swift; sourceTree = "<group>"; };
+		7383424B751DCE7B1E781C44 /* SAImportProgressReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAImportProgressReporterTests.swift; sourceTree = "<group>"; };
 		519788CB30502FBB00C5D23D /* SAExportOutputEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAExportOutputEncoding.swift; sourceTree = "<group>"; };
 		519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAExportOutputEncodingTests.swift; sourceTree = "<group>"; };
 		5199783E27760147008DEB7B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2102,6 +2107,7 @@
 				BCE0025B11173D2A009DA533 /* SPFieldMapperController.h */,
 				BCE0025C11173D2A009DA533 /* SPFieldMapperController.m */,
 				51974D06304B23B400C5D23D /* SACSVImportStreamDecoder.swift */,
+				25047F243EB51288B9242EE3 /* SAImportProgressReporter.swift */,
 			);
 			name = "Data Import";
 			path = DataImport;
@@ -2777,6 +2783,7 @@
 				812D779A61DFF497CD129924 /* SAQueryFavoriteStoreTests.swift */,
 				93E86B9CAE3B927AC789893E /* SAFieldEditorCommitPolicyTests.swift */,
 				51974D0B304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift */,
+				7383424B751DCE7B1E781C44 /* SAImportProgressReporterTests.swift */,
 				0002BD43DA307433795D7EBA /* SATypeAheadSelectionLoadTests.swift */,
 				519788D030502FC700C5D23D /* SAExportOutputEncodingTests.swift */,
 			);
@@ -3523,6 +3530,8 @@
 				51AC3B8D3047622700BCE2B9 /* SASSHTunnelSocketClient.swift in Sources */,
 				51974D0C304B23DA00C5D23D /* SACSVImportStreamDecoderTests.swift in Sources */,
 				9C34DCDAAFC52D3EF15C0B2B /* SACSVImportStreamDecoder.swift in Sources */,
+				ADD8B19D3D629DE277D2163B /* SAImportProgressReporter.swift in Sources */,
+				C15BC205A797F1C3C14733CB /* SAImportProgressReporterTests.swift in Sources */,
 				51AC3B8B3047621900BCE2B9 /* SASSHTunnelSocketServer.swift in Sources */,
 				517BFF442F7DA38F00F6D812 /* SAConnectionServiceTests.swift in Sources */,
 				9EF08F69717C447F6B39B6D0 /* SAKeychainStoreCharacterizationTests.swift in Sources */,
@@ -3985,6 +3994,7 @@
 				17D3C671128AD8160047709F /* SPSingleton.m in Sources */,
 				17D3C6D3128B1C900047709F /* SPFavoritesOutlineView.m in Sources */,
 				51974D07304B23B400C5D23D /* SACSVImportStreamDecoder.swift in Sources */,
+				4785E13A4BCF828DED8BA3A1 /* SAImportProgressReporter.swift in Sources */,
 				50D3C3521A77135F00B5429C /* SPParserUtils.c in Sources */,
 				1A8B53572584520800526DED /* SPURLAdditions.m in Sources */,
 				FD0E72EC2C391F44007EF348 /* SQLiteDisplayFormatManager.swift in Sources */,


### PR DESCRIPTION
## Changes:
- **`SAImportProgressReporter`** (new Swift type) owns the import progress throttle and text formatting. It answers at most ten times a second on a monotonic clock and is covered by `SAImportProgressReporterTests`, which pin the bar value and text for compressed and uncompressed files and the throttle behaviour.
- **`SPDataImport` keeps a thin bridge.** One private method replaces the three byte-identical CSV progress blocks and the per-statement SQL block. It asks the reporter for an update and pushes it to the main queue asynchronously, so the import thread never blocks on the main thread. The exporters already throttle the same way.
- **The SQL importer** previously did two synchronous `performSelectorOnMainThread:waitUntilDone:YES` hops per executed statement. It now goes through the same bridge.
- **Header outlets are grouped by the xib that wires them.** Parsing both xibs shows the two sets are disjoint, so the old comment about one nib load overwriting the other's outlets was wrong. The remaining TODO is to give the accessory view its own controller.
- The two `fileIsCompressed` locals whose only readers were the removed blocks are gone.

## Closes following issues:
- Closes: #2606

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 27.0

## Screenshots:

## Additional notes:
- Progress text and bar values are unchanged; only cadence and threading differ. The compressed-file branch still tracks the bar against compressed bytes read and formats the text from the decompressed position.
- The shared `Imported %@ of %@` key and the two compressed-file keys already exist in `en.lproj`, so no localisation work is needed.
- Review follow-ups: the Cancel flag is now an atomic ivar, since the old synchronous progress hop was the only barrier between the main thread's write and the import thread's polls. A progress block queued by an earlier import is dropped once a later import has replaced the reporter.
- Pre-existing bug fixed in passing: update-mode CSV imports counted every batch twice (once per row in the update loop, then again as a batch), which skewed the row numbers in error messages and the "Only N rows were imported" alerts. The batch increment now applies only to insert-mode imports.
- Not changed: the reporter does not force a final update before the sheet closes. The close runs as the very next main-queue block, before any drawing, so a forced final value could never be painted.
- Verified with a clean Debug build and the new unit tests. A manual import of a large CSV and SQL dump against a live server has not been done yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
