### PR TITLE
#fixed Add connection error button spacing

### DIFF
--- a/Source/Interfaces/ConnectionErrorDialog.xib
+++ b/Source/Interfaces/ConnectionErrorDialog.xib
@@ -32,7 +32,7 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                        <rect key="frame" x="365" y="12" width="154" height="32"/>
+                        <rect key="frame" x="373" y="12" width="146" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="push" title="Reconnect" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="12">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

Please use one of these hashtags for your PR title:
- #added - Used for new features and things that have been added into the project
- #fixed - Used for bugfixes
- #changed - Used for PRs changing current or existing features
- #removed - Used for PRs removing existing features
- #infra - Used for PRs that are (usually) not product work
-->

## Changes:
- 

## Closes following issues:
- Closes: 

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version:
  
## Screenshots:

| Before | After |
| --- | --- |
|  <img width="1062" height="294" alt="PixelSnap 2026-09-11 at 15 17 26@2x" src="https://github.com/user-attachments/assets/a3dfe784-0fb4-436a-98ec-25771c52efee" /> | <img width="1062" height="294" alt="PixelSnap 2026-09-11 at 15 14 55@2x" src="https://github.com/user-attachments/assets/9d339fa1-c7db-4ca9-bfdd-94b95f460bc2" /> |

## Additional notes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the size and positioning of the “Reconnect” button in the Connection Error dialog for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->