### PR TITLE
#added Auto-detect JSON values in the field editor pop-up

### DIFF
--- a/Source/Controllers/SubviewControllers/SPFieldEditorController.m
+++ b/Source/Controllers/SubviewControllers/SPFieldEditorController.m
@@ -427,6 +427,11 @@ typedef enum {
 			[usedSheet makeFirstResponder:image == nil || _isGeometry ? editTextView : editImage];
 			[self refreshPHPSerializedEditorAvailability];
 			[self performSelector:@selector(openPHPSerializedEditorIfCurrentTextIsStructured) withObject:nil afterDelay:0.15];
+
+			// Only when no image was decoded, since that keeps its own segment selected.
+			if (image == nil) {
+				[self selectJsonSegmentIfValueIsJSON:stringValue];
+			}
 		}
 
 		editSheetWillBeInitialized = NO;
@@ -1486,6 +1491,22 @@ typedef enum {
 		[self showJsonText:hidden];
 		[self showImage:hidden];
 	}
+}
+
+/**
+ * Selects the JSON segment when the value is a JSON object or array.
+ *
+ * `_isJSON` only covers columns declared with MySQL's JSON type. JSON is just as often kept in a
+ * text column - MariaDB's `longtext ... CHECK (json_valid(<column>))`, for example - and those had
+ * to be switched to the JSON segment by hand on every open.
+ */
+- (void)selectJsonSegmentIfValueIsJSON:(NSString *)value {
+	if (![SAJSONValueDetector isJSONContainer:value]) {
+		return;
+	}
+
+	[editSheetSegmentControl setSelectedSegment:JsonSegment];
+	[self segmentControllerChanged:editSheetSegmentControl];
 }
 
 - (void)showJsonText:(BOOL)show {

--- a/Source/Other/Parsing/SAJSONValueDetector.swift
+++ b/Source/Other/Parsing/SAJSONValueDetector.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Decides whether a field value should be presented on the field editor's JSON segment.
+///
+/// `SPFieldEditorController` recognizes MySQL's JSON column type from the field type, but JSON is
+/// just as often kept in a plain text column - MariaDB's `longtext ... CHECK (json_valid(<column>))`,
+/// for instance - where the column type carries no hint at all. Sniffing the value covers those.
+@objc final class SAJSONValueDetector: NSObject {
+    /// Values longer than this are not sniffed, so that opening the field editor on a large blob
+    /// does not pay for a full JSON parse it is unlikely to need.
+    private static let maximumDetectableByteCount = 5 * 1024 * 1024
+
+    /// Returns whether `value` is a JSON object or array.
+    ///
+    /// Top-level scalars (`42`, `"text"`, `true`, `null`) are deliberately not treated as JSON.
+    /// They are indistinguishable from ordinary column values, and the JSON segment rejects them
+    /// too, because it parses without `NSJSONReadingFragmentsAllowed`.
+    @objc static func isJSONContainer(_ value: String?) -> Bool {
+        guard let value = value, !value.isEmpty, value.utf8.count <= maximumDetectableByteCount else { return false }
+
+        // Cheap rejection before parsing: JSON containers can only start with these.
+        guard let firstCharacter = value.first(where: { !$0.isWhitespace }),
+              firstCharacter == "{" || firstCharacter == "[" else { return false }
+
+        guard let data = value.data(using: .utf8) else { return false }
+
+        return (try? JSONSerialization.jsonObject(with: data)) != nil
+    }
+}

--- a/UnitTests/SAJSONValueDetectorTests.swift
+++ b/UnitTests/SAJSONValueDetectorTests.swift
@@ -1,0 +1,83 @@
+//  SAJSONValueDetectorTests.swift
+//  Sequel Ace
+//
+//  Tests for detecting JSON values stored in columns that are not declared with
+//  MySQL's JSON type (issue #2514).
+//
+
+import XCTest
+
+final class SAJSONValueDetectorTests: XCTestCase {
+
+    func testDetectsJSONObject() {
+        XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"a":1,"b":"two"}"#))
+    }
+
+    func testDetectsJSONArray() {
+        XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"[1,2,3]"#))
+    }
+
+    func testDetectsPrettyPrintedJSONWithLeadingWhitespace() {
+        XCTAssertTrue(SAJSONValueDetector.isJSONContainer("\n  {\n    \"a\" : 1\n  }\n"))
+    }
+
+    func testDetectsNestedContainers() {
+        XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"rows":[{"id":1},{"id":2}],"total":2}"#))
+    }
+
+    func testDetectsUnicodeContent() {
+        XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"name":"Ünïcødé ✅"}"#))
+    }
+
+    // Top-level scalars are valid JSON fragments but are indistinguishable from ordinary
+    // column values, so they must not pull the editor onto the JSON segment.
+    func testRejectsTopLevelScalars() {
+        for scalar in ["42", "-1.5", #""text""#, "true", "false", "null"] {
+            XCTAssertFalse(SAJSONValueDetector.isJSONContainer(scalar), "should reject \(scalar)")
+        }
+    }
+
+    func testRejectsMalformedJSON() {
+        for malformed in [#"{"a":}"#, #"{"a":1"#, "[1,2,", #"{'a':1}"#] {
+            XCTAssertFalse(SAJSONValueDetector.isJSONContainer(malformed), "should reject \(malformed)")
+        }
+    }
+
+    func testRejectsPlainText() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer("Lorem ipsum dolor sit amet"))
+    }
+
+    // PHP serialized values have their own editor and must not be claimed by the JSON segment.
+    func testRejectsPHPSerializedValue() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer(#"a:2:{s:1:"a";i:1;s:1:"b";i:2;}"#))
+    }
+
+    // The geometry branch of the field editor puts WKT into the text view.
+    func testRejectsWellKnownText() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer("POLYGON((0 0,10 0,10 10,0 10,0 0))"))
+    }
+
+    // The binary branch of the field editor renders values as a hex string.
+    func testRejectsHexString() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer("0x5B315D"))
+    }
+
+    func testRejectsEmptyAndWhitespaceOnlyValues() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer(""))
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer("   \n\t "))
+    }
+
+    func testRejectsNil() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer(nil))
+    }
+
+    // A value that merely opens with a brace must still be parsed before being claimed.
+    func testRejectsBraceLeadingNonJSON() {
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer("{this is not json}"))
+    }
+
+    func testRejectsValuesBeyondTheSizeLimit() {
+        let oversized = "[\"" + String(repeating: "a", count: 5 * 1024 * 1024) + "\"]"
+        XCTAssertFalse(SAJSONValueDetector.isJSONContainer(oversized))
+    }
+}

--- a/UnitTests/SAJSONValueDetectorTests.swift
+++ b/UnitTests/SAJSONValueDetectorTests.swift
@@ -9,73 +9,86 @@ import XCTest
 
 final class SAJSONValueDetectorTests: XCTestCase {
 
+    /// Verifies a JSON object is detected as a container.
     func testDetectsJSONObject() {
         XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"a":1,"b":"two"}"#))
     }
 
+    /// Verifies a JSON array is detected as a container.
     func testDetectsJSONArray() {
         XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"[1,2,3]"#))
     }
 
+    /// Verifies leading whitespace and newlines do not prevent detection.
     func testDetectsPrettyPrintedJSONWithLeadingWhitespace() {
         XCTAssertTrue(SAJSONValueDetector.isJSONContainer("\n  {\n    \"a\" : 1\n  }\n"))
     }
 
+    /// Verifies containers nested inside containers are detected.
     func testDetectsNestedContainers() {
         XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"rows":[{"id":1},{"id":2}],"total":2}"#))
     }
 
+    /// Verifies non-ASCII content does not prevent detection.
     func testDetectsUnicodeContent() {
         XCTAssertTrue(SAJSONValueDetector.isJSONContainer(#"{"name":"Ünïcødé ✅"}"#))
     }
 
-    // Top-level scalars are valid JSON fragments but are indistinguishable from ordinary
-    // column values, so they must not pull the editor onto the JSON segment.
+    /// Verifies top-level scalars are rejected.
+    ///
+    /// They are valid JSON fragments but indistinguishable from ordinary column
+    /// values, and the JSON segment rejects them too because it parses without
+    /// `NSJSONReadingFragmentsAllowed`.
     func testRejectsTopLevelScalars() {
         for scalar in ["42", "-1.5", #""text""#, "true", "false", "null"] {
             XCTAssertFalse(SAJSONValueDetector.isJSONContainer(scalar), "should reject \(scalar)")
         }
     }
 
+    /// Verifies values that only look like JSON are rejected.
     func testRejectsMalformedJSON() {
         for malformed in [#"{"a":}"#, #"{"a":1"#, "[1,2,", #"{'a':1}"#] {
             XCTAssertFalse(SAJSONValueDetector.isJSONContainer(malformed), "should reject \(malformed)")
         }
     }
 
+    /// Verifies ordinary prose is rejected.
     func testRejectsPlainText() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer("Lorem ipsum dolor sit amet"))
     }
 
-    // PHP serialized values have their own editor and must not be claimed by the JSON segment.
+    /// Verifies PHP serialized values are rejected, since they have their own editor.
     func testRejectsPHPSerializedValue() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer(#"a:2:{s:1:"a";i:1;s:1:"b";i:2;}"#))
     }
 
-    // The geometry branch of the field editor puts WKT into the text view.
+    /// Verifies well-known text is rejected, as the geometry branch puts WKT into the text view.
     func testRejectsWellKnownText() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer("POLYGON((0 0,10 0,10 10,0 10,0 0))"))
     }
 
-    // The binary branch of the field editor renders values as a hex string.
+    /// Verifies hex strings are rejected, as the binary branch renders values that way.
     func testRejectsHexString() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer("0x5B315D"))
     }
 
+    /// Verifies empty and whitespace-only values are rejected.
     func testRejectsEmptyAndWhitespaceOnlyValues() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer(""))
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer("   \n\t "))
     }
 
+    /// Verifies a nil value is rejected rather than trapping.
     func testRejectsNil() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer(nil))
     }
 
-    // A value that merely opens with a brace must still be parsed before being claimed.
+    /// Verifies a value that merely opens with a brace is still parsed before being claimed.
     func testRejectsBraceLeadingNonJSON() {
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer("{this is not json}"))
     }
 
+    /// Verifies values beyond the sniff size limit are rejected without being parsed.
     func testRejectsValuesBeyondTheSizeLimit() {
         let oversized = "[\"" + String(repeating: "a", count: 5 * 1024 * 1024) + "\"]"
         XCTAssertFalse(SAJSONValueDetector.isJSONContainer(oversized))

--- a/sequel-ace.xcodeproj/project.pbxproj
+++ b/sequel-ace.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		0F2381A80270EFDE50D73890 /* SAParserUtilsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD5C55FC47FCBFA6D183688 /* SAParserUtilsTestSupport.swift */; };
 		0FA952B1549148DF8C1B7E61 /* SAStaleBookmarkAlertContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438EBE13DEF4D968F600054 /* SAStaleBookmarkAlertContentTests.swift */; };
 		10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */; };
+		C3CC038CEF7E1E23F9448349 /* SAJSONValueDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A471CEAAB050FAB47FBF8503 /* SAJSONValueDetector.swift */; };
+		D2DB930F73CAAFB441CE1D69 /* SAJSONValueDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A471CEAAB050FAB47FBF8503 /* SAJSONValueDetector.swift */; };
+		C17EF61E834C16119E11D39D /* SAJSONValueDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6AC6EFCE36C119AA1E0174D /* SAJSONValueDetectorTests.swift */; };
 		1141A389117BBFF200126A28 /* SPTableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1141A388117BBFF200126A28 /* SPTableCopy.m */; };
 		1196D9FED5B52DE6CD6B0C76 /* SASSHTunnelAuthSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC3B6C30475E9800BCE2B9 /* SASSHTunnelAuthSource.swift */; };
 		1198F5B31174EDD500670590 /* SPDatabaseCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1198F5B21174EDD500670590 /* SPDatabaseCopy.m */; };
@@ -1497,6 +1500,8 @@
 		AEA35A884E0C42E4A2AF12EF /* SPCustomQuerySQLClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifier.swift; sourceTree = "<group>"; };
 		AEA35A884E0C42E4A2AF12F0 /* SPCustomQuerySQLClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCustomQuerySQLClassifierTests.swift; sourceTree = "<group>"; };
 		AEFB3FFA0EBB99359D3ECA23 /* SAAsyncResultBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAAsyncResultBox.swift; sourceTree = "<group>"; };
+		A471CEAAB050FAB47FBF8503 /* SAJSONValueDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAJSONValueDetector.swift; sourceTree = "<group>"; };
+		C6AC6EFCE36C119AA1E0174D /* SAJSONValueDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SAJSONValueDetectorTests.swift; sourceTree = "<group>"; };
 		B51D6B9D114C310C0074704E /* toolbar-switch-to-table-triggers.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "toolbar-switch-to-table-triggers.png"; sourceTree = "<group>"; };
 		B52460D30F8EF92300171639 /* SPArrayAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPArrayAdditions.h; sourceTree = "<group>"; };
 		B52460D40F8EF92300171639 /* SPArrayAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPArrayAdditions.m; sourceTree = "<group>"; };
@@ -2821,6 +2826,7 @@
 				1A4152ED25AF530F00B17249 /* GeneralSwiftTests.swift */,
 				50D3C35B1A771C4C00B5429C /* SPParserUtilsTest.m */,
 				CAE8AEB5768B402AAF04C961 /* SAEditorTokensTests.swift */,
+				C6AC6EFCE36C119AA1E0174D /* SAJSONValueDetectorTests.swift */,
 				5147B0152F8D000100C4C14A /* SPCSVParserTests.m */,
 				503B02CE1AE95C2C0060CAB1 /* SPTableFilterParserTest.m */,
 				50837F731E50DCD4004FAE8A /* SPJSONFormatterTests.m */,
@@ -3009,6 +3015,7 @@
 				503B02C91AE82C5E0060CAB1 /* SPTableFilterParser.m */,
 				73F70A941E4E547500636550 /* SPJSONFormatter.h */,
 				73F70A951E4E547500636550 /* SPJSONFormatter.m */,
+				A471CEAAB050FAB47FBF8503 /* SAJSONValueDetector.swift */,
 			);
 			path = Parsing;
 			sourceTree = "<group>";
@@ -3699,6 +3706,8 @@
 				81B906DAF9B997FA30469210 /* SAHelpViewerModel.swift in Sources */,
 				60111925195F940E7252B376 /* SAHelpViewerModelTests.swift in Sources */,
 				10E61D41B1CA258A66686820 /* SAAsyncResultBox.swift in Sources */,
+				D2DB930F73CAAFB441CE1D69 /* SAJSONValueDetector.swift in Sources */,
+				C17EF61E834C16119E11D39D /* SAJSONValueDetectorTests.swift in Sources */,
 				8BE925D095CAA6341924C92F /* SAAsyncResultBoxTests.swift in Sources */,
 				2A0129AA121A225FB6CCA2AA /* SAKeyboardShortcut.swift in Sources */,
 				190CAC547AADBBBB8BB28750 /* SAKeyboardShortcutTests.swift in Sources */,
@@ -4054,6 +4063,7 @@
 				56B8282C3F2B2EAD9499D12F /* SAHelpViewerView.swift in Sources */,
 				B0595D7939BDBEBD29E0E617 /* SAHelpViewerWindowController.swift in Sources */,
 				9FAB1CF8AFD6A6D9D3F89171 /* SAAsyncResultBox.swift in Sources */,
+				C3CC038CEF7E1E23F9448349 /* SAJSONValueDetector.swift in Sources */,
 				16C621C7049FAECBAC96972E /* SAKeyboardShortcut.swift in Sources */,
 				410065F67228AD394D48A156 /* SADragPasteboard.swift in Sources */,
 				2E69A3914D17A0971CD68A09 /* SATypeAheadMatcher.swift in Sources */,


### PR DESCRIPTION
## Changes:
- The field editor now selects the **JSON** segment when the value is a JSON object or array, instead of only when the column is declared with MySQL's `json` type.
- Detection is by content, in a new `SAJSONValueDetector`. Top-level scalars (`42`, `"text"`, `true`, `null`) are deliberately **not** treated as JSON — they are indistinguishable from ordinary column values, and the JSON segment already rejects them, since it parses without `NSJSONReadingFragmentsAllowed`.
- Values over 5 MB are not sniffed, so opening the editor on a large blob does not pay for a JSON parse it is unlikely to need.
- Hooked in next to the existing PHP-serialized auto-open in `SPFieldEditorController`, and skipped when an image was decoded so that branch keeps its own segment.

`_isJSON` only ever covered the `json` column type. JSON is just as often kept in a text column — the issue's `longtext ... CHECK (json_valid(<column>))` is the common MariaDB shape — and those had to be switched to the JSON segment by hand on every open.

Two notes for reviewers, both deliberate but worth a second opinion:
- Detection is content-based, so it also fires on real `json` columns, which previously opened on Text with pretty-printed content. One uniform rule seemed easier to reason about than special-casing, but I am happy to restrict it to non-`json` columns if you prefer.
- The JSON text view is `editable="NO"`, so this cannot change what gets saved — the value still comes from `editTextView`. It does mean an editable JSON field now opens on a read-only view and needs one click on **Text** to edit. That matches what the issue asks for, but it is a real trade-off.

## Closes following issues:
- Closes: #2514

## Tested:
- Processors:
  - [ ] Intel
  - [x] Apple Silicon
- macOS Versions:
  - [ ] 13.5+ (Ventura)
  - [ ] 14.x (Sonoma)
  - [ ] 15.x (Sequoia)
  - [x] 26.x (Tahoe)
  - [ ] 27.x (Golden Gate)
- Localizations:
  - [x] English
  - [ ] Spanish
  - [ ] Other (please specify)
- Xcode Version: 26.6 (17F113)

Verified against MariaDB 11.8 using the schema from the issue:

```sql
`parameters` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
    DEFAULT NULL CHECK (json_valid(`parameters`)),
`notes`      longtext DEFAULT NULL,
```

15 unit tests added for the detector. Full suite: 1474 tests, 0 failures.

## Screenshots:


<img width="2632" height="1672" alt="2514-json-longtext png" src="https://github.com/user-attachments/assets/0a001bfa-43b2-4bc6-9ed0-2b158efbc29b" />

<img width="2624" height="1670" alt="2514-text-longtext png" src="https://github.com/user-attachments/assets/b2c0427c-b227-4add-8a6d-ea96070a2aff" />



Both cells are the same `LONGTEXT(1073741823) utf8mb4` type; only the content differs. `parameters` opens on JSON, pretty-printed; `notes` stays on Text.

## Additional notes:
While testing I hit an unrelated pre-existing deadlock in `+[SPNavigatorController sharedNavigatorController]`, which `dispatch_sync`es to the main thread while holding the `@synchronized(self)` class lock. If the main thread calls the same accessor concurrently (it does, from `-[SPTablesList tableViewSelectionDidChange:]`), the app hangs permanently. Happy to open that as a separate issue with the sampled stacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The field editor automatically switches to the JSON view when an edited value is a valid JSON object or array, including values in non-JSON fields.
  - Image content continues to open in its dedicated view when detected.
  - JSON values with leading whitespace, byte order marks, nested structures, and Unicode content are recognized.

- **Bug Fixes**
  - Improved recognition of JSON objects and arrays while avoiding incorrect detection of plain text, malformed content, scalar values, oversized values, and other non-JSON formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->